### PR TITLE
fix: handle bulk user import errors and validate role field

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -228,23 +228,32 @@ export async function bulkImportUsers(input: {
       continue;
     }
 
-    // Default password for bulk import
-    const passwordHash = await hash("changeme123", 12);
+    try {
+      // Default password for bulk import
+      const passwordHash = await hash("changeme123", 12);
 
-    const [user] = await db
-      .insert(users)
-      .values({
-        name,
+      const [user] = await db
+        .insert(users)
+        .values({
+          name,
+          email,
+          passwordHash,
+          circle,
+          role: role ?? "viewer",
+          githubUsername: githubUsername ?? null,
+        })
+        .returning({ id: users.id });
+
+      await recordCreation("user", user.id, Number(admin.id));
+      imported++;
+    } catch (err) {
+      errors.push({
+        row: i + 1,
         email,
-        passwordHash,
-        circle,
-        role: role ?? "viewer",
-        githubUsername: githubUsername ?? null,
-      })
-      .returning({ id: users.id });
-
-    await recordCreation("user", user.id, Number(admin.id));
-    imported++;
+        error:
+          err instanceof Error ? err.message : "Database insert failed",
+      });
+    }
   }
 
   revalidatePath("/users");

--- a/src/app/users/import/bulk-import-form.tsx
+++ b/src/app/users/import/bulk-import-form.tsx
@@ -46,11 +46,14 @@ function parseCSV(text: string): ParsedUser[] {
       row[h] = values[i] || "";
     });
 
+    const rawRole = (row.role || "").trim().toLowerCase();
+    const validRoles = ["admin", "viewer"];
+
     const user: ParsedUser = {
       name: row.name || "",
       email: row.email || "",
       circle: row.circle || row.department || "",
-      role: row.role || "viewer",
+      role: rawRole || "viewer",
       githubUsername: row.github_username || row.githubusername || "",
       valid: true,
     };
@@ -64,6 +67,9 @@ function parseCSV(text: string): ParsedUser[] {
     } else if (!user.circle) {
       user.valid = false;
       user.error = "Circle is required";
+    } else if (rawRole && !validRoles.includes(rawRole)) {
+      user.valid = false;
+      user.error = "Role must be 'admin' or 'viewer'";
     }
 
     return user;


### PR DESCRIPTION
## Summary
- Wrap DB insert in try/catch so a single row failure no longer crashes the entire bulk import — failed rows are reported individually while the rest proceed
- Normalize CSV role values to lowercase and validate against allowed enum (`admin`, `viewer`) client-side, showing clear errors in the preview table before submission

## Test plan
- [ ] Upload CSV with mixed-case roles (e.g., "Viewer", "ADMIN") — should normalize and import successfully
- [ ] Upload CSV with invalid roles (e.g., "manager") — should show validation error in preview
- [ ] Upload CSV with a duplicate email already in DB — should report that row as failed, import the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)