### PR TITLE
feat: bulk CSV export for assignments and users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,6 @@ tsconfig.tsbuildinfo
 # Next.js auto-generated
 next-env.d.ts
 
-# Claude Code local settings
+# Claude Code
 .claude/settings.local.json
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-02
 - Neon PostgreSQL (serverless) via @neondatabase/serverless 1.0.2 (003-enhance-core-features)
 - TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui + radix-ui, React Hook Form 7.71.2, Zod 4.3.6, date-fns 4.1.0, bcryptjs, sonner (toasts) (004-bulk-license-import)
 - Neon PostgreSQL (serverless) via @neondatabase/serverless 1.0.2 + Drizzle ORM (004-bulk-license-import)
+- TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, date-fns 4.1.0, shadcn/ui + Lucide React (005-bulk-export)
+- Neon PostgreSQL (serverless) via @neondatabase/serverless 1.0.2 + Drizzle ORM (005-bulk-export)
 
 - **Language**: TypeScript 5.x (strict mode), Node.js LTS
 - **Framework**: Next.js 15 (App Router, Server Components, Server Actions)
@@ -73,9 +75,9 @@ pnpm lighthouse        # Lighthouse CI
 - Server Components by default — `"use client"` only when client interactivity needed
 
 ## Recent Changes
+- 005-bulk-export: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, date-fns 4.1.0, shadcn/ui + Lucide React
 - 004-bulk-license-import: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui + radix-ui, React Hook Form 7.71.2, Zod 4.3.6, date-fns 4.1.0, bcryptjs, sonner (toasts)
 - 003-enhance-core-features: Added TypeScript 5.9.3 (strict mode), Node.js LTS, React 19.2.4 + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui + radix-ui, React Hook Form 7.71.2, Zod 4.3.6, TanStack Table 8.21.3, Recharts 2.15.4, date-fns 4.1.0, react-day-picker 9.14.0
-- 002-retro-glitch-themes: Added TypeScript 5.x (strict mode), React 19, Node.js LTS + Next.js 15.5.12 (App Router), Tailwind CSS 4.2.1, shadcn/ui (new-york style), next-themes 0.4.6, Lucide React 0.576.0, class-variance-authority
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ pnpm lighthouse        # Lighthouse CI
 - 005-bulk-export: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, date-fns 4.1.0, shadcn/ui + Lucide React
 - 004-bulk-license-import: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui + radix-ui, React Hook Form 7.71.2, Zod 4.3.6, date-fns 4.1.0, bcryptjs, sonner (toasts)
 - 003-enhance-core-features: Added TypeScript 5.9.3 (strict mode), Node.js LTS, React 19.2.4 + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui + radix-ui, React Hook Form 7.71.2, Zod 4.3.6, TanStack Table 8.21.3, Recharts 2.15.4, date-fns 4.1.0, react-day-picker 9.14.0
+- 002-retro-glitch-themes: Added TypeScript 5.x (strict mode), React 19, Node.js LTS + Next.js 15.5.12 (App Router), Tailwind CSS 4.2.1, shadcn/ui (new-york style), next-themes 0.4.6, Lucide React 0.576.0, class-variance-authority; Neon PostgreSQL via Drizzle ORM (user preferences), localStorage (unauthenticated preference fallback)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/005-bulk-export/checklists/requirements.md
+++ b/specs/005-bulk-export/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Bulk Data Export (Round-Trip)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- FR-004 (decrypted API key export) depends on the existence of a decryption utility — this is documented in Assumptions.
+- The assumption about exporting all records regardless of status may warrant clarification if the user wants to filter by active-only.

--- a/specs/005-bulk-export/contracts/server-actions.md
+++ b/specs/005-bulk-export/contracts/server-actions.md
@@ -1,0 +1,65 @@
+# Server Contracts: Bulk Data Export
+
+**Feature Branch**: `005-bulk-export`
+**Date**: 2026-03-05
+
+## API Route Handlers
+
+### GET `/api/export/assignments`
+
+Exports all license assignments as a CSV file.
+
+**Authentication**: Requires authenticated admin session (checked via `requireAdmin()`).
+
+**Response (200)**:
+- `Content-Type: text/csv; charset=utf-8`
+- `Content-Disposition: attachment; filename="assignments-export-YYYY-MM-DD.csv"`
+- Body: UTF-8 CSV with BOM, headers: `email,tool,tier,workspace,api_key,assigned_at`
+
+**Response (401)**:
+- Redirect to sign-in page (unauthenticated)
+
+**Response (403)**:
+- JSON: `{ "error": "Unauthorized" }` (authenticated but not admin)
+
+**CSV Row Format**:
+```csv
+email,tool,tier,workspace,api_key,assigned_at
+user@example.com,ChatGPT,Enterprise,"My Workspace",sk-abc123,2026-01-15
+user2@example.com,Claude,Pro,Default,,2026-02-01
+```
+
+- Fields containing commas, quotes, or newlines are wrapped in double quotes
+- Double quotes within fields are escaped as `""`
+- Null/empty optional fields are empty (no quotes needed)
+- Dates formatted as `YYYY-MM-DD`
+
+---
+
+### GET `/api/export/users`
+
+Exports all users as a CSV file.
+
+**Authentication**: Requires authenticated admin session (checked via `requireAdmin()`).
+
+**Response (200)**:
+- `Content-Type: text/csv; charset=utf-8`
+- `Content-Disposition: attachment; filename="users-export-YYYY-MM-DD.csv"`
+- Body: UTF-8 CSV with BOM, headers: `name,email,circle,role,github_username,profile`
+
+**Response (401)**:
+- Redirect to sign-in page (unauthenticated)
+
+**Response (403)**:
+- JSON: `{ "error": "Unauthorized" }` (authenticated but not admin)
+
+**CSV Row Format**:
+```csv
+name,email,circle,role,github_username,profile
+Alice Smith,alice@example.com,Engineering,admin,alicegh,boost
+Bob Jones,bob@example.com,Design,viewer,,
+```
+
+- Same RFC 4180 escaping rules as assignment export
+- Optional fields (`github_username`, `profile`) are empty strings when null
+- Role is always present (`admin` or `viewer`)

--- a/specs/005-bulk-export/contracts/ui-contracts.md
+++ b/specs/005-bulk-export/contracts/ui-contracts.md
@@ -1,0 +1,56 @@
+# UI Contracts: Bulk Data Export
+
+**Feature Branch**: `005-bulk-export`
+**Date**: 2026-03-05
+
+## Export Button Components
+
+### Assignment Import Page (`/assignments/import`)
+
+Add an "Export Current Assignments" button to the existing import page, positioned above or alongside the import form.
+
+**Button behavior**:
+- Label: "Export Current Assignments"
+- Icon: Download icon (Lucide `Download`)
+- Action: Navigates to `GET /api/export/assignments` (triggers file download)
+- State: No loading state needed — browser handles the download natively
+- Post-action: User stays on the same page (no navigation)
+
+**Placement**: Above the file upload area, visually separated as a secondary action. Use shadcn/ui `Button` with `variant="outline"` to distinguish from the primary import action.
+
+---
+
+### User Import Page (`/users/import`)
+
+Add an "Export Current Users" button to the existing import page, positioned above or alongside the import form.
+
+**Button behavior**:
+- Label: "Export Current Users"
+- Icon: Download icon (Lucide `Download`)
+- Action: Navigates to `GET /api/export/users` (triggers file download)
+- State: No loading state needed — browser handles the download natively
+- Post-action: User stays on the same page (no navigation)
+
+**Placement**: Same pattern as assignment export button. Use shadcn/ui `Button` with `variant="outline"`.
+
+---
+
+## Layout Pattern
+
+Both import pages should follow this layout:
+
+```
+┌─────────────────────────────────────────┐
+│  Page Title                             │
+├─────────────────────────────────────────┤
+│  [↓ Export Current {Entity}]            │  ← outline button, top of page
+│                                         │
+│  ┌─── Import Form Card ──────────────┐  │
+│  │  File upload input                 │  │
+│  │  Preview table                     │  │
+│  │  Import button                     │  │
+│  └────────────────────────────────────┘  │
+└─────────────────────────────────────────┘
+```
+
+The export button is a simple anchor-style button (or `<a>` styled as a button) that triggers the GET endpoint. No client-side state management is needed.

--- a/specs/005-bulk-export/data-model.md
+++ b/specs/005-bulk-export/data-model.md
@@ -1,0 +1,53 @@
+# Data Model: Bulk Data Export (Round-Trip)
+
+**Feature Branch**: `005-bulk-export`
+**Date**: 2026-03-05
+
+## Overview
+
+This feature introduces **no new database tables or schema changes**. It reads from existing tables and transforms data into CSV format matching the bulk import schemas.
+
+## Existing Entities (Read-Only)
+
+### License Assignments (`licenseAssignments`)
+
+Source table for assignment CSV export. Requires joins to resolve foreign keys.
+
+| DB Field | CSV Column | Transformation |
+|----------|------------|----------------|
+| `userId` → `users.email` | `email` | JOIN users ON userId = users.id |
+| `toolId` → `aiTools.name` | `tool` | JOIN aiTools ON toolId = aiTools.id |
+| `tierId` → `accessTiers.name` | `tier` | JOIN accessTiers ON tierId = accessTiers.id |
+| `workspace` | `workspace` | Direct (varchar → string) |
+| `apiKeyEncrypted` | `api_key` | Decrypt via `decryptApiKey()`, empty string if null |
+| `assignedAt` | `assigned_at` | Format as `YYYY-MM-DD` |
+
+**Query scope**: All rows (no status filter). Ordered by `assignedAt` descending for predictable output.
+
+### Users (`users`)
+
+Source table for user CSV export. Direct field mapping, no joins needed.
+
+| DB Field | CSV Column | Transformation |
+|----------|------------|----------------|
+| `name` | `name` | Direct (varchar → string) |
+| `email` | `email` | Direct (varchar → string) |
+| `circle` | `circle` | Direct (varchar → string) |
+| `role` | `role` | Direct (enum already matches: `admin` / `viewer`) |
+| `githubUsername` | `github_username` | Direct, empty string if null |
+| `profile` | `profile` | Direct (enum already matches: `boost` / `maxed` / `indie`), empty string if null |
+
+**Query scope**: All rows (no status filter). Ordered by `name` ascending for predictable output.
+
+### Supporting Tables (Join-Only)
+
+- **`aiTools`**: Provides `name` field for tool name resolution in assignment export.
+- **`accessTiers`**: Provides `name` field for tier name resolution in assignment export.
+
+## Data Flow
+
+```
+Database → Drizzle Query (with joins) → Row transformation → CSV escaping → HTTP Response
+```
+
+No data is written back to the database. No new indexes are needed — the existing foreign key indexes support the join queries efficiently.

--- a/specs/005-bulk-export/plan.md
+++ b/specs/005-bulk-export/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Bulk Data Export (Round-Trip)
+
+**Branch**: `005-bulk-export` | **Date**: 2026-03-05 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/005-bulk-export/spec.md`
+
+## Summary
+
+Add CSV export endpoints for license assignments and users that produce files in the exact same format as the existing bulk import. This enables a round-trip workflow: export → edit in spreadsheet → re-import. Implementation uses Next.js API route handlers returning CSV responses, a shared CSV utility for RFC 4180 escaping, and existing `decryptApiKey()` for API key handling. No new database tables or dependencies are needed.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3 (strict mode)
+**Primary Dependencies**: Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, date-fns 4.1.0, shadcn/ui + Lucide React
+**Storage**: Neon PostgreSQL (serverless) via Drizzle ORM — read-only for this feature
+**Testing**: Vitest (unit/integration), Playwright (e2e)
+**Target Platform**: Web (Node.js server + browser client)
+**Project Type**: Web application (Next.js App Router)
+**Performance Goals**: Export of 1,000 records in < 5 seconds
+**Constraints**: CSV must be RFC 4180 compliant; round-trip compatible with existing import schemas
+**Scale/Scope**: Up to 10,000 rows per export; 2 new API routes, 1 new utility, 2 UI modifications
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Type-Safe Code Quality | PASS | All new code in TypeScript strict mode. CSV utility will export well-defined types. |
+| II. UX Consistency | PASS | Export buttons use shadcn/ui `Button` with `variant="outline"` and Lucide `Download` icon. No ad-hoc styling. |
+| III. Performance Budgets | PASS | Export is a file download via API route — no impact on page JS bundle. No new client-side JS beyond a button click. |
+| IV. Accessibility-First | PASS | Export buttons are standard `<a>` elements styled as buttons — fully keyboard accessible with native browser download behavior. |
+| V. Simplicity & Maintainability | PASS | No new dependencies. Single shared CSV utility. API route handlers follow existing patterns. No speculative abstractions. |
+
+**Post-Phase 1 re-check**: All principles still pass. No violations introduced by the design.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-bulk-export/
+├── plan.md              # This file
+├── research.md          # Phase 0: CSV strategy, delivery mechanism, crypto, queries
+├── data-model.md        # Phase 1: Entity-to-CSV field mappings
+├── quickstart.md        # Phase 1: Implementation guide
+├── contracts/
+│   ├── server-actions.md  # Phase 1: API route handler contracts
+│   └── ui-contracts.md    # Phase 1: Export button placement and behavior
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   ├── api/
+│   │   └── export/
+│   │       ├── assignments/
+│   │       │   └── route.ts          # NEW: GET handler for assignment CSV export
+│   │       └── users/
+│   │           └── route.ts          # NEW: GET handler for user CSV export
+│   ├── assignments/
+│   │   └── import/
+│   │       ├── page.tsx              # MODIFY: Add export button
+│   │       └── bulk-assignment-import-form.tsx  # (existing)
+│   └── users/
+│       └── import/
+│           ├── page.tsx              # MODIFY: Add export button
+│           └── bulk-import-form.tsx  # (existing)
+├── lib/
+│   ├── csv.ts                        # NEW: Shared CSV generation utility
+│   ├── crypto.ts                     # (existing: decryptApiKey)
+│   ├── auth-helpers.ts               # (existing: requireAdmin)
+│   └── db/
+│       └── schema.ts                 # (existing: table definitions)
+└── actions/                          # (no changes needed)
+
+tests/
+├── unit/
+│   └── csv.test.ts                   # NEW: CSV utility tests
+└── integration/
+    └── export.test.ts                # NEW: Export endpoint tests
+```
+
+**Structure Decision**: Follows existing Next.js App Router convention. New API routes under `src/app/api/export/`. Shared CSV utility in `src/lib/` alongside existing utilities.
+
+## Complexity Tracking
+
+No constitution violations. This table is intentionally empty.

--- a/specs/005-bulk-export/quickstart.md
+++ b/specs/005-bulk-export/quickstart.md
@@ -1,0 +1,49 @@
+# Quickstart: Bulk Data Export (Round-Trip)
+
+**Feature Branch**: `005-bulk-export`
+**Date**: 2026-03-05
+
+## What This Feature Does
+
+Adds CSV export buttons to the bulk import pages for license assignments and users. Exported files use the exact same format as the import, enabling a round-trip workflow: export → edit in spreadsheet → re-import.
+
+## Key Files to Create
+
+1. **`src/app/api/export/assignments/route.ts`** — API route handler for assignment CSV export
+2. **`src/app/api/export/users/route.ts`** — API route handler for user CSV export
+3. **`src/lib/csv.ts`** — Shared CSV generation utility (RFC 4180 escaping)
+
+## Key Files to Modify
+
+1. **`src/app/assignments/import/bulk-assignment-import-form.tsx`** — Add export button
+2. **`src/app/users/import/bulk-import-form.tsx`** — Add export button
+3. Alternatively, add the export button at the page level (`page.tsx`) if the form components shouldn't own the export action.
+
+## Implementation Order
+
+1. Create `src/lib/csv.ts` — CSV escaping and row generation utility
+2. Create assignment export API route (`/api/export/assignments`)
+3. Create user export API route (`/api/export/users`)
+4. Add export buttons to both import pages
+5. Write tests for CSV generation and export endpoints
+
+## Critical Patterns
+
+- **Auth**: Use `requireAdmin()` from `src/lib/auth-helpers.ts` in API route handlers
+- **Crypto**: Use `decryptApiKey()` from `src/lib/crypto.ts` for API key decryption
+- **Dates**: Use `date-fns` `format(date, "yyyy-MM-dd")` for consistent date formatting
+- **Response**: Return `new Response(csvContent, { headers })` with `Content-Type: text/csv` and `Content-Disposition: attachment`
+- **BOM**: Prepend `\uFEFF` to CSV content for Excel compatibility
+- **Null handling**: Convert null/undefined to empty string `""` — never output "null" or "undefined"
+
+## Database Queries
+
+**Assignments**: Single query joining `licenseAssignments` → `users` (email), `aiTools` (name), `accessTiers` (name)
+
+**Users**: Simple `SELECT` from `users` table — all fields map directly to CSV columns
+
+## Testing Strategy
+
+- Unit test `src/lib/csv.ts` for escaping edge cases (commas, quotes, newlines, null values)
+- Integration test export endpoints return valid CSV with correct headers
+- Round-trip test: export → parse with import validator → verify zero errors

--- a/specs/005-bulk-export/research.md
+++ b/specs/005-bulk-export/research.md
@@ -1,0 +1,77 @@
+# Research: Bulk Data Export (Round-Trip)
+
+**Feature Branch**: `005-bulk-export`
+**Date**: 2026-03-05
+
+## R1: CSV Generation Strategy
+
+**Decision**: Use manual CSV generation with RFC 4180 escaping — no external library.
+
+**Rationale**: The existing import uses manual CSV parsing (`.split(",")` in the client forms). Since the export only needs to *generate* CSV (not parse it), manual generation is simpler and avoids a new dependency. RFC 4180 escaping is straightforward: wrap fields containing commas, quotes, or newlines in double quotes, and escape internal double quotes by doubling them.
+
+**Alternatives considered**:
+- `papaparse` library: Adds ~47KB to bundle. Overkill for generation-only; its main value is robust *parsing* of edge cases.
+- `csv-stringify` (Node.js): Server-only, would work for server action approach but adds an unnecessary dependency for simple CSV output.
+
+## R2: Export Delivery Mechanism
+
+**Decision**: Use Next.js API Route handlers (GET endpoints) that return CSV as a streamed response with `Content-Disposition: attachment` header.
+
+**Rationale**: Server Actions are designed for mutations (POST), not file downloads. API route handlers in Next.js App Router naturally support streaming responses and setting headers for file downloads. The client triggers the download via a simple `<a href>` link or `window.location` redirect — no complex client-side blob handling needed.
+
+**Alternatives considered**:
+- Server Action returning CSV string + client-side Blob download: Works but requires client-side JavaScript to create a Blob, generate an object URL, and trigger download. More complex and less reliable across browsers.
+- Server Action with `redirect()`: Cannot set Content-Disposition headers via redirect.
+
+**Implementation pattern**:
+```
+GET /api/export/assignments → CSV response with Content-Disposition header
+GET /api/export/users → CSV response with Content-Disposition header
+```
+
+## R3: API Key Decryption for Export
+
+**Decision**: Use existing `decryptApiKey()` from `src/lib/crypto.ts` to decrypt API keys during export.
+
+**Rationale**: The function already exists and is used by the `revealApiKey()` server action in `src/actions/assignments.ts` (line 476). It handles the AES-256-GCM decryption with scrypt key derivation. No new cryptographic code needed.
+
+**Security consideration**: Export endpoints MUST verify admin authentication before returning decrypted keys. The API route handler must call `requireAdmin()` before processing.
+
+**Alternatives considered**:
+- Export masked keys only: Would break round-trip import since masked keys aren't valid. Defeats the feature purpose.
+- Export without API keys: Users would lose API key data on re-import. Could be an option but the spec requires decrypted keys (FR-004).
+
+## R4: Database Query Strategy for Assignment Export
+
+**Decision**: Use a single Drizzle query with joins to resolve user emails, tool names, and tier names in one database round-trip.
+
+**Rationale**: The assignment export requires resolving 3 foreign keys (userId → email, toolId → tool name, tierId → tier name). A single query with joins is the most efficient approach, matching the pattern used in the existing assignment list page.
+
+**Query shape**:
+```
+SELECT la.*, u.email, at2.name as toolName, at3.name as tierName
+FROM licenseAssignments la
+JOIN users u ON la.userId = u.id
+JOIN aiTools at2 ON la.toolId = at2.id
+JOIN accessTiers at3 ON la.tierId = at3.id
+```
+
+**Alternatives considered**:
+- Separate queries + in-memory join (like bulk import uses lookup maps): More code, multiple round-trips, but familiar pattern. Not needed since we're reading, not writing.
+- Raw SQL: Unnecessary — Drizzle's query builder handles joins well.
+
+## R5: File Naming Convention
+
+**Decision**: Use `{entity}-export-{YYYY-MM-DD}.csv` format (e.g., `assignments-export-2026-03-05.csv`).
+
+**Rationale**: Descriptive, sortable by date, and matches the convention suggested in the spec (FR-010). Uses the server's current date (UTC) to avoid timezone ambiguity.
+
+## R6: UTF-8 BOM for Excel Compatibility
+
+**Decision**: Prepend UTF-8 BOM (`\uFEFF`) to CSV output for Excel compatibility.
+
+**Rationale**: Microsoft Excel on Windows does not auto-detect UTF-8 encoding in CSV files without a BOM. Since SC-004 requires compatibility with Excel, Google Sheets, and LibreOffice Calc, adding the BOM ensures all three handle the file correctly. Google Sheets and LibreOffice ignore the BOM gracefully.
+
+**Alternatives considered**:
+- No BOM: Works for Google Sheets and LibreOffice but Excel may show garbled characters for non-ASCII data (e.g., accented names).
+- Export as .xlsx: Much more complex, requires a library like `exceljs`. Overkill for this feature.

--- a/specs/005-bulk-export/spec.md
+++ b/specs/005-bulk-export/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Bulk Data Export (Round-Trip)
+
+**Feature Branch**: `005-bulk-export`
+**Created**: 2026-03-05
+**Status**: Draft
+**Input**: User description: "I want to add export functions for the bulk import of the license assignments and the bulk import for the users. Both export functions should provide the exact same format that the import expects. This will allow me to export, then edit the file and re-import it."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Export License Assignments as CSV (Priority: P1)
+
+An administrator wants to export all current license assignments as a CSV file that uses the exact same format as the bulk assignment import. This allows the admin to review current assignments in a spreadsheet, make edits (e.g., change tiers, update workspaces, remove rows), and re-import the modified file to apply changes in bulk.
+
+**Why this priority**: This is the core value proposition — enabling round-trip editing of license assignments. License assignments are the most frequently bulk-managed data and have the most complex format (6 columns including optional API key and date).
+
+**Independent Test**: Can be fully tested by triggering an export, opening the resulting CSV in a spreadsheet editor, verifying all column headers match the import format, then re-importing the unmodified file without errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** there are active license assignments in the system, **When** an admin clicks the export assignments button, **Then** a CSV file is downloaded containing all assignments with headers: `email`, `tool`, `tier`, `workspace`, `api_key`, `assigned_at`.
+2. **Given** a freshly exported assignments CSV, **When** the admin re-imports it without modifications, **Then** the import processes without format validation errors (business-rule errors like duplicates are expected and acceptable).
+3. **Given** assignments exist with and without API keys, **When** the export runs, **Then** rows without API keys have an empty value in the `api_key` column, and rows with API keys include the decrypted key value.
+4. **Given** the system has no license assignments, **When** the admin triggers an export, **Then** a CSV file is downloaded containing only the header row.
+
+---
+
+### User Story 2 - Export Users as CSV (Priority: P1)
+
+An administrator wants to export all current users as a CSV file that uses the exact same format as the bulk user import. This allows the admin to review users, make edits (e.g., change roles, update circles, add GitHub usernames), and re-import the file.
+
+**Why this priority**: Equal priority to assignment export — users are the other bulk-managed entity and the export format is simpler (6 columns). Together with Story 1, this completes the round-trip capability for all bulk-importable data.
+
+**Independent Test**: Can be fully tested by triggering a user export, verifying CSV headers match the import format (`name`, `email`, `circle`, `role`, `github_username`, `profile`), and re-importing the unmodified file.
+
+**Acceptance Scenarios**:
+
+1. **Given** there are active users in the system, **When** an admin clicks the export users button, **Then** a CSV file is downloaded containing all users with headers: `name`, `email`, `circle`, `role`, `github_username`, `profile`.
+2. **Given** a freshly exported users CSV, **When** the admin re-imports it without modifications, **Then** the import processes without format validation errors (duplicate email errors are expected and acceptable).
+3. **Given** users exist with optional fields empty (no GitHub username, no profile), **When** the export runs, **Then** those fields are empty in the CSV rather than containing "null" or "undefined".
+4. **Given** the system has no users, **When** the admin triggers an export, **Then** a CSV file is downloaded containing only the header row.
+
+---
+
+### User Story 3 - Export Actions Accessible from Import Pages (Priority: P2)
+
+An administrator navigating to the bulk import pages (for assignments or users) can see an export button alongside the import form, making the round-trip workflow discoverable and convenient.
+
+**Why this priority**: Without a clear UI entry point, the export feature is not discoverable. Placing it on the import pages creates a natural workflow: export → edit → re-import.
+
+**Independent Test**: Can be tested by navigating to each import page and verifying the export button is visible and functional.
+
+**Acceptance Scenarios**:
+
+1. **Given** an admin navigates to the assignment import page, **When** the page loads, **Then** an "Export Current Assignments" button is visible alongside the import form.
+2. **Given** an admin navigates to the user import page, **When** the page loads, **Then** an "Export Current Users" button is visible alongside the import form.
+3. **Given** an admin clicks the export button, **When** the export completes, **Then** the file download begins automatically and the admin remains on the same page.
+
+---
+
+### Edge Cases
+
+- What happens when exported data contains commas, quotes, or newlines in field values (e.g., workspace names)? The CSV must properly escape these using standard RFC 4180 quoting rules.
+- What happens when the export file is very large (thousands of rows)? The system should handle exports up to 10,000 rows without timeout or memory issues.
+- What happens when an assignment has an encrypted API key? The export must include the decrypted (original) key so that re-import works correctly.
+- What happens when date values in assignments vary in timezone? Dates must be exported in the exact `YYYY-MM-DD` format the import expects.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide an export function that generates a CSV file of all license assignments using the exact column headers expected by the assignment bulk import: `email`, `tool`, `tier`, `workspace`, `api_key`, `assigned_at`.
+- **FR-002**: System MUST provide an export function that generates a CSV file of all users using the exact column headers expected by the user bulk import: `name`, `email`, `circle`, `role`, `github_username`, `profile`.
+- **FR-003**: Assignment export MUST resolve internal identifiers to human-readable values: user IDs to email addresses, tool IDs to tool names, tier IDs to tier names.
+- **FR-004**: Assignment export MUST include decrypted API keys so that re-import produces functional assignments.
+- **FR-005**: Assignment export MUST format the `assigned_at` date as `YYYY-MM-DD` to match the import's expected format.
+- **FR-006**: User export MUST map the `role` field to the import-compatible values (`admin` or `viewer`).
+- **FR-007**: User export MUST map the `profile` field to the import-compatible values (`boost`, `maxed`, or `indie`) or leave empty if not set.
+- **FR-008**: Both export functions MUST produce valid CSV with proper escaping per RFC 4180 (quoted fields for values containing commas, quotes, or newlines).
+- **FR-009**: Both export functions MUST be accessible only to authenticated administrators.
+- **FR-010**: Both export functions MUST generate a downloadable file with a descriptive filename (e.g., `assignments-export-2026-03-05.csv`, `users-export-2026-03-05.csv`).
+- **FR-011**: Export buttons MUST be placed on the respective bulk import pages for discoverability.
+- **FR-012**: Optional/nullable fields MUST export as empty strings (not "null", "undefined", or "N/A").
+
+### Key Entities
+
+- **License Assignment**: Represents a user's access to a specific AI tool tier within a workspace. Key export fields: user email, tool name, tier name, workspace, API key (decrypted), assignment date.
+- **User**: Represents a system user. Key export fields: name, email, circle, role, GitHub username, profile classification.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An administrator can export assignments, make no changes, and re-import the file with zero format validation errors.
+- **SC-002**: An administrator can export users, make no changes, and re-import the file with zero format validation errors.
+- **SC-003**: Export of 1,000 records completes and downloads within 5 seconds.
+- **SC-004**: Exported CSV files open correctly in common spreadsheet applications (Excel, Google Sheets, LibreOffice Calc) without encoding or formatting issues.
+- **SC-005**: 100% of exported rows pass the existing import validation schema when re-imported.
+
+## Assumptions
+
+- The existing bulk import format and validation schemas (from feature 004) are stable and will not change concurrently with this feature.
+- API keys can be decrypted for export purposes using the existing decryption utility (inverse of the encryption used during import).
+- The export will include all records regardless of status (active/inactive). If filtering is desired, it can be added as a future enhancement.
+- CSV is the only export format needed (no Excel/JSON export required).
+- The export is a client-initiated download (not a background job or email delivery).

--- a/specs/005-bulk-export/tasks.md
+++ b/specs/005-bulk-export/tasks.md
@@ -1,0 +1,158 @@
+# Tasks: Bulk Data Export (Round-Trip)
+
+**Input**: Design documents from `/specs/005-bulk-export/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Not explicitly requested in feature specification. Test tasks are omitted.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the shared CSV utility that all export endpoints depend on
+
+- [ ] T001 Create CSV generation utility with RFC 4180 escaping, BOM support, and null-to-empty-string handling in `src/lib/csv.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No additional foundational work needed — auth (`requireAdmin`), crypto (`decryptApiKey`), database schema, and Drizzle ORM are all already in place from feature 004.
+
+**Checkpoint**: Foundation ready — the shared CSV utility from Phase 1 is the only prerequisite for user story work.
+
+---
+
+## Phase 3: User Story 1 — Export License Assignments as CSV (Priority: P1) 🎯 MVP
+
+**Goal**: Admin can export all license assignments as a CSV file with headers `email,tool,tier,workspace,api_key,assigned_at` that is directly re-importable.
+
+**Independent Test**: Trigger assignment export, open CSV in spreadsheet, verify headers match import format, then re-import the unmodified file with zero format validation errors.
+
+### Implementation for User Story 1
+
+- [ ] T002 [US1] Create GET route handler for assignment CSV export with admin auth check, Drizzle join query (licenseAssignments → users, aiTools, accessTiers), API key decryption, date formatting (YYYY-MM-DD), and CSV response with Content-Disposition header in `src/app/api/export/assignments/route.ts`
+
+**Checkpoint**: At this point, assignment export is fully functional via direct URL access (`GET /api/export/assignments`). An admin can hit the endpoint and receive a valid CSV file.
+
+---
+
+## Phase 4: User Story 2 — Export Users as CSV (Priority: P1)
+
+**Goal**: Admin can export all users as a CSV file with headers `name,email,circle,role,github_username,profile` that is directly re-importable.
+
+**Independent Test**: Trigger user export, verify CSV headers match import format, then re-import the unmodified file with zero format validation errors.
+
+### Implementation for User Story 2
+
+- [ ] T003 [P] [US2] Create GET route handler for user CSV export with admin auth check, Drizzle query on users table, null-to-empty-string mapping for optional fields (githubUsername, profile), and CSV response with Content-Disposition header in `src/app/api/export/users/route.ts`
+
+**Checkpoint**: Both export endpoints are functional. Admin can export both assignments and users via direct URL access.
+
+---
+
+## Phase 5: User Story 3 — Export Actions Accessible from Import Pages (Priority: P2)
+
+**Goal**: Export buttons are visible on the import pages so admins can discover and use the round-trip workflow (export → edit → re-import).
+
+**Independent Test**: Navigate to each import page, verify export button is visible, click it, and confirm the file downloads while staying on the same page.
+
+### Implementation for User Story 3
+
+- [ ] T004 [P] [US3] Add "Export Current Assignments" outline button with Lucide Download icon above the import form in `src/app/assignments/import/page.tsx`, linking to `/api/export/assignments`
+- [ ] T005 [P] [US3] Add "Export Current Users" outline button with Lucide Download icon above the import form in `src/app/users/import/page.tsx`, linking to `/api/export/users`
+
+**Checkpoint**: All user stories are complete. The full round-trip workflow is functional and discoverable from the import pages.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation and cleanup across all stories
+
+- [ ] T006 Manually verify round-trip: export assignments CSV → re-import unmodified → confirm zero format errors
+- [ ] T007 Manually verify round-trip: export users CSV → re-import unmodified → confirm zero format errors
+- [ ] T008 Verify exported CSV opens correctly in a spreadsheet application (Excel or LibreOffice) without encoding issues
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Nothing to do — existing infrastructure is sufficient
+- **User Story 1 (Phase 3)**: Depends on Phase 1 (T001 — CSV utility)
+- **User Story 2 (Phase 4)**: Depends on Phase 1 (T001 — CSV utility). Independent of US1.
+- **User Story 3 (Phase 5)**: Depends on Phases 3 & 4 (export endpoints must exist for buttons to link to)
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends only on T001 (CSV utility) — no dependency on other stories
+- **User Story 2 (P1)**: Depends only on T001 (CSV utility) — no dependency on other stories
+- **User Story 3 (P2)**: Depends on US1 and US2 (endpoints must exist for the buttons to link to)
+
+### Parallel Opportunities
+
+- T002 (US1) and T003 (US2) can run in parallel after T001 completes — they are in different files with no shared dependencies
+- T004 and T005 (US3) can run in parallel — they modify different page files
+
+---
+
+## Parallel Example: User Stories 1 & 2
+
+```bash
+# After T001 (CSV utility) completes, launch both export routes in parallel:
+Task: "Create assignment export route in src/app/api/export/assignments/route.ts"
+Task: "Create user export route in src/app/api/export/users/route.ts"
+
+# After both routes exist, launch both UI modifications in parallel:
+Task: "Add export button to src/app/assignments/import/page.tsx"
+Task: "Add export button to src/app/users/import/page.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Create CSV utility (T001)
+2. Complete Phase 3: Assignment export endpoint (T002)
+3. **STOP and VALIDATE**: Test assignment export independently via direct URL
+4. Export is functional — admin can download assignment CSV
+
+### Incremental Delivery
+
+1. T001 → CSV utility ready
+2. T002 → Assignment export works → Validate round-trip (MVP!)
+3. T003 → User export works → Validate round-trip
+4. T004 + T005 → Export buttons on import pages → Full UX complete
+5. T006–T008 → Final validation and polish
+
+### Parallel Execution (with subagents)
+
+1. T001 first (sequential — shared dependency)
+2. T002 + T003 in parallel (different API routes, same utility)
+3. T004 + T005 in parallel (different page files)
+4. T006–T008 sequentially (manual verification)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- No new database tables or dependencies — this feature is purely additive
+- CSV utility (T001) is the single shared foundation; everything else branches from it
+- API key decryption is the most sensitive operation — must be behind admin auth
+- Commit after each task for clean git history

--- a/specs/005-bulk-export/tasks.md
+++ b/specs/005-bulk-export/tasks.md
@@ -19,7 +19,7 @@
 
 **Purpose**: Create the shared CSV utility that all export endpoints depend on
 
-- [ ] T001 Create CSV generation utility with RFC 4180 escaping, BOM support, and null-to-empty-string handling in `src/lib/csv.ts`
+- [X] T001 Create CSV generation utility with RFC 4180 escaping, BOM support, and null-to-empty-string handling in `src/lib/csv.ts`
 
 ---
 
@@ -39,7 +39,7 @@
 
 ### Implementation for User Story 1
 
-- [ ] T002 [US1] Create GET route handler for assignment CSV export with admin auth check, Drizzle join query (licenseAssignments → users, aiTools, accessTiers), API key decryption, date formatting (YYYY-MM-DD), and CSV response with Content-Disposition header in `src/app/api/export/assignments/route.ts`
+- [X] T002 [US1] Create GET route handler for assignment CSV export with admin auth check, Drizzle join query (licenseAssignments → users, aiTools, accessTiers), API key decryption, date formatting (YYYY-MM-DD), and CSV response with Content-Disposition header in `src/app/api/export/assignments/route.ts`
 
 **Checkpoint**: At this point, assignment export is fully functional via direct URL access (`GET /api/export/assignments`). An admin can hit the endpoint and receive a valid CSV file.
 
@@ -53,7 +53,7 @@
 
 ### Implementation for User Story 2
 
-- [ ] T003 [P] [US2] Create GET route handler for user CSV export with admin auth check, Drizzle query on users table, null-to-empty-string mapping for optional fields (githubUsername, profile), and CSV response with Content-Disposition header in `src/app/api/export/users/route.ts`
+- [X] T003 [P] [US2] Create GET route handler for user CSV export with admin auth check, Drizzle query on users table, null-to-empty-string mapping for optional fields (githubUsername, profile), and CSV response with Content-Disposition header in `src/app/api/export/users/route.ts`
 
 **Checkpoint**: Both export endpoints are functional. Admin can export both assignments and users via direct URL access.
 
@@ -67,8 +67,8 @@
 
 ### Implementation for User Story 3
 
-- [ ] T004 [P] [US3] Add "Export Current Assignments" outline button with Lucide Download icon above the import form in `src/app/assignments/import/page.tsx`, linking to `/api/export/assignments`
-- [ ] T005 [P] [US3] Add "Export Current Users" outline button with Lucide Download icon above the import form in `src/app/users/import/page.tsx`, linking to `/api/export/users`
+- [X] T004 [P] [US3] Add "Export Current Assignments" outline button with Lucide Download icon above the import form in `src/app/assignments/import/page.tsx`, linking to `/api/export/assignments`
+- [X] T005 [P] [US3] Add "Export Current Users" outline button with Lucide Download icon above the import form in `src/app/users/import/page.tsx`, linking to `/api/export/users`
 
 **Checkpoint**: All user stories are complete. The full round-trip workflow is functional and discoverable from the import pages.
 

--- a/src/app/api/export/assignments/route.ts
+++ b/src/app/api/export/assignments/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db";
 import { licenseAssignments } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth-helpers";
 import { decryptApiKey } from "@/lib/crypto";
-import { toCsv } from "@/lib/csv";
+import { toCsv, csvResponse } from "@/lib/csv";
 
 export async function GET() {
   const admin = await requireAdmin();
@@ -52,11 +52,5 @@ export async function GET() {
     csvRows
   );
 
-  const today = format(new Date(), "yyyy-MM-dd");
-  return new Response(csv, {
-    headers: {
-      "Content-Type": "text/csv; charset=utf-8",
-      "Content-Disposition": `attachment; filename="assignments-export-${today}.csv"`,
-    },
-  });
+  return csvResponse(csv, "assignments");
 }

--- a/src/app/api/export/assignments/route.ts
+++ b/src/app/api/export/assignments/route.ts
@@ -26,26 +26,33 @@ export async function GET() {
     orderBy: [desc(licenseAssignments.assignedAt)],
   });
 
-  const csvRows = await Promise.all(
-    data.map(async (row) => {
-      let apiKey = "";
-      if (row.apiKeyEncrypted) {
-        try {
-          apiKey = await decryptApiKey(row.apiKeyEncrypted);
-        } catch {
-          apiKey = "";
+  const DECRYPT_BATCH_SIZE = 50;
+  const csvRows: string[][] = [];
+
+  for (let i = 0; i < data.length; i += DECRYPT_BATCH_SIZE) {
+    const batch = data.slice(i, i + DECRYPT_BATCH_SIZE);
+    const batchRows = await Promise.all(
+      batch.map(async (row) => {
+        let apiKey = "";
+        if (row.apiKeyEncrypted) {
+          try {
+            apiKey = await decryptApiKey(row.apiKeyEncrypted);
+          } catch {
+            apiKey = "";
+          }
         }
-      }
-      return [
-        row.user.email,
-        row.tool.name,
-        row.tier.name,
-        row.workspace ?? "",
-        apiKey,
-        format(row.assignedAt, "yyyy-MM-dd"),
-      ];
-    })
-  );
+        return [
+          row.user.email,
+          row.tool.name,
+          row.tier.name,
+          row.workspace ?? "",
+          apiKey,
+          format(row.assignedAt, "yyyy-MM-dd"),
+        ];
+      })
+    );
+    csvRows.push(...batchRows);
+  }
 
   const csv = toCsv(
     ["email", "tool", "tier", "workspace", "api_key", "assigned_at"],

--- a/src/app/api/export/assignments/route.ts
+++ b/src/app/api/export/assignments/route.ts
@@ -1,0 +1,62 @@
+import { format } from "date-fns";
+import { desc } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { licenseAssignments } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth-helpers";
+import { decryptApiKey } from "@/lib/crypto";
+import { toCsv } from "@/lib/csv";
+
+export async function GET() {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const data = await db.query.licenseAssignments.findMany({
+    columns: {
+      workspace: true,
+      apiKeyEncrypted: true,
+      assignedAt: true,
+    },
+    with: {
+      user: { columns: { email: true } },
+      tool: { columns: { name: true } },
+      tier: { columns: { name: true } },
+    },
+    orderBy: [desc(licenseAssignments.assignedAt)],
+  });
+
+  const csvRows = await Promise.all(
+    data.map(async (row) => {
+      let apiKey = "";
+      if (row.apiKeyEncrypted) {
+        try {
+          apiKey = await decryptApiKey(row.apiKeyEncrypted);
+        } catch {
+          apiKey = "";
+        }
+      }
+      return [
+        row.user.email,
+        row.tool.name,
+        row.tier.name,
+        row.workspace ?? "",
+        apiKey,
+        format(row.assignedAt, "yyyy-MM-dd"),
+      ];
+    })
+  );
+
+  const csv = toCsv(
+    ["email", "tool", "tier", "workspace", "api_key", "assigned_at"],
+    csvRows
+  );
+
+  const today = format(new Date(), "yyyy-MM-dd");
+  return new Response(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="assignments-export-${today}.csv"`,
+    },
+  });
+}

--- a/src/app/api/export/users/route.ts
+++ b/src/app/api/export/users/route.ts
@@ -1,9 +1,8 @@
-import { format } from "date-fns";
 import { asc } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth-helpers";
-import { toCsv } from "@/lib/csv";
+import { toCsv, csvResponse } from "@/lib/csv";
 
 export async function GET() {
   const admin = await requireAdmin();
@@ -37,11 +36,5 @@ export async function GET() {
     csvRows
   );
 
-  const today = format(new Date(), "yyyy-MM-dd");
-  return new Response(csv, {
-    headers: {
-      "Content-Type": "text/csv; charset=utf-8",
-      "Content-Disposition": `attachment; filename="users-export-${today}.csv"`,
-    },
-  });
+  return csvResponse(csv, "users");
 }

--- a/src/app/api/export/users/route.ts
+++ b/src/app/api/export/users/route.ts
@@ -1,0 +1,47 @@
+import { format } from "date-fns";
+import { asc } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth-helpers";
+import { toCsv } from "@/lib/csv";
+
+export async function GET() {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const data = await db
+    .select({
+      name: users.name,
+      email: users.email,
+      circle: users.circle,
+      role: users.role,
+      githubUsername: users.githubUsername,
+      profile: users.profile,
+    })
+    .from(users)
+    .orderBy(asc(users.name));
+
+  const csvRows = data.map((row) => [
+    row.name,
+    row.email,
+    row.circle,
+    row.role,
+    row.githubUsername ?? "",
+    row.profile ?? "",
+  ]);
+
+  const csv = toCsv(
+    ["name", "email", "circle", "role", "github_username", "profile"],
+    csvRows
+  );
+
+  const today = format(new Date(), "yyyy-MM-dd");
+  return new Response(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="users-export-${today}.csv"`,
+    },
+  });
+}

--- a/src/app/assignments/import/bulk-assignment-import-form.tsx
+++ b/src/app/assignments/import/bulk-assignment-import-form.tsx
@@ -22,6 +22,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { Download } from "lucide-react";
 
 interface ParsedAssignment {
   email: string;
@@ -143,11 +144,19 @@ export function BulkAssignmentImportForm() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold">Bulk Import Assignments</h1>
-        <p className="text-muted-foreground">
-          Upload a CSV file to import license assignments in bulk.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">Bulk Import Assignments</h1>
+          <p className="text-muted-foreground">
+            Upload a CSV file to import license assignments in bulk.
+          </p>
+        </div>
+        <Button variant="outline" asChild>
+          <a href="/api/export/assignments" download>
+            <Download className="mr-2 h-4 w-4" />
+            Export Current Assignments
+          </a>
+        </Button>
       </div>
 
       <Card>

--- a/src/app/users/import/bulk-import-form.tsx
+++ b/src/app/users/import/bulk-import-form.tsx
@@ -22,6 +22,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { Download } from "lucide-react";
 
 interface ParsedUser {
   name: string;
@@ -138,12 +139,20 @@ export function BulkImportForm() {
 
   return (
     <div className="mx-auto max-w-4xl space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold">Bulk Import Users</h1>
-        <p className="text-muted-foreground">
-          Upload a CSV file with columns: name, email, circle (or department),
-          role, github_username, profile
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">Bulk Import Users</h1>
+          <p className="text-muted-foreground">
+            Upload a CSV file with columns: name, email, circle (or department),
+            role, github_username, profile
+          </p>
+        </div>
+        <Button variant="outline" asChild>
+          <a href="/api/export/users" download>
+            <Download className="mr-2 h-4 w-4" />
+            Export Current Users
+          </a>
+        </Button>
       </div>
 
       <Card>

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -2,6 +2,8 @@
  * CSV generation utility with RFC 4180 escaping and UTF-8 BOM support.
  */
 
+import { format } from "date-fns";
+
 /**
  * Escape a single CSV field per RFC 4180:
  * - Wrap in double quotes if the field contains commas, double quotes, or newlines.
@@ -10,7 +12,7 @@
  */
 export function escapeField(value: string | null | undefined): string {
   const str = value == null ? "" : String(value);
-  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+  if (/[",\n\r]/.test(str)) {
     return `"${str.replace(/"/g, '""')}"`;
   }
   return str;
@@ -32,4 +34,17 @@ export function toCsv(
 ): string {
   const lines = [toCsvRow(headers), ...rows.map(toCsvRow)];
   return "\uFEFF" + lines.join("\r\n");
+}
+
+/**
+ * Build a CSV download Response with appropriate headers.
+ */
+export function csvResponse(csv: string, filenamePrefix: string): Response {
+  const today = format(new Date(), "yyyy-MM-dd");
+  return new Response(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filenamePrefix}-export-${today}.csv"`,
+    },
+  });
 }

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,35 @@
+/**
+ * CSV generation utility with RFC 4180 escaping and UTF-8 BOM support.
+ */
+
+/**
+ * Escape a single CSV field per RFC 4180:
+ * - Wrap in double quotes if the field contains commas, double quotes, or newlines.
+ * - Double any internal double quotes.
+ * - Convert null/undefined to empty string.
+ */
+export function escapeField(value: string | null | undefined): string {
+  const str = value == null ? "" : String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Convert an array of string values into a CSV row string (no trailing newline).
+ */
+export function toCsvRow(fields: (string | null | undefined)[]): string {
+  return fields.map(escapeField).join(",");
+}
+
+/**
+ * Convert headers and rows into a full CSV string with UTF-8 BOM for Excel compatibility.
+ */
+export function toCsv(
+  headers: string[],
+  rows: (string | null | undefined)[][]
+): string {
+  const lines = [toCsvRow(headers), ...rows.map(toCsvRow)];
+  return "\uFEFF" + lines.join("\r\n");
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -45,6 +45,7 @@ export function csvResponse(csv: string, filenamePrefix: string): Response {
     headers: {
       "Content-Type": "text/csv; charset=utf-8",
       "Content-Disposition": `attachment; filename="${filenamePrefix}-export-${today}.csv"`,
+      "Cache-Control": "no-store, no-cache, must-revalidate",
     },
   });
 }


### PR DESCRIPTION
## Summary

- Add `GET /api/export/assignments` — exports all license assignments with decrypted API keys, joined user/tool/tier names
- Add `GET /api/export/users` — exports all users with all profile fields
- Add **Export** buttons to the assignments and users import pages for a full round-trip import/export workflow
- Add `src/lib/csv.ts` with RFC 4180 escaping, UTF-8 BOM support, and a shared `csvResponse()` helper

Both endpoints are admin-guarded. Exported CSVs use the same column format as the bulk import, enabling round-trip workflows.

## Test plan

- [ ] Log in as admin, navigate to `/assignments/import` — Export button downloads a valid CSV
- [ ] Log in as admin, navigate to `/users/import` — Export button downloads a valid CSV
- [ ] Verify exported CSV can be re-imported without errors
- [ ] Verify non-admin users receive 401 on both export endpoints
- [ ] Verify fields with commas/quotes/newlines are correctly RFC 4180 escaped
- [ ] Verify Excel opens the exported file without encoding issues (UTF-8 BOM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)