### PR TITLE
feat: rich visual reports dashboard with four-tab UI and OLS forecast

### DIFF
--- a/specs/005-rich-reports/checklists/requirements.md
+++ b/specs/005-rich-reports/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Rich Visual Reports
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All checklist items pass after clarification session (2026-03-05). Ready for `/speckit.plan`.
+
+Clarifications resolved:
+- Chart aggregation granularity: auto-scale (daily/weekly/monthly) — reflected in FR-008
+- Forecast baseline window: up to 12 months of history — reflected in FR-006
+- Role-based access: none — all tabs visible to all authenticated users
+- Usage tab scale: top 10 default, "show all" available — reflected in FR-005 and SC-004
+- Loading state: skeleton screens — reflected in FR-011

--- a/specs/005-rich-reports/contracts/server-actions.md
+++ b/specs/005-rich-reports/contracts/server-actions.md
@@ -1,0 +1,178 @@
+# Contract: Server Actions — Rich Visual Reports
+
+**Feature**: 005-rich-reports | **Date**: 2026-03-05
+
+This document defines the interface contracts for all new Server Action functions
+and the pure utility module introduced by this feature.
+
+---
+
+## New Server Action Functions
+
+### `getBilledCostsTimeSeries(budgetId: number)`
+
+**File**: `src/actions/budget.ts`
+**Type**: Read function (no `revalidatePath`, no auth restriction beyond session)
+**Returns**: `PeriodSpendPoint[]`
+
+```typescript
+interface PeriodSpendPoint {
+  month: string;          // budgetPeriods.period_label, e.g. "Jan 2026"
+  billedCents: number;    // SUM(billed_costs.amount_cents) for this period — integer
+  expectedCents: number;  // SUM(active license cost_at_assignment_cents) overlapping period — integer
+  plannedCents: number;   // budgetPeriods.planned_amount_cents — integer
+  periodIndex: number;    // budgetPeriods.period_index — for client-side sort verification
+}
+
+function getBilledCostsTimeSeries(budgetId: number): Promise<PeriodSpendPoint[]>
+```
+
+**Behaviour**:
+- Returns all periods for the given budget, ordered by `period_index` ascending.
+- Periods with no billed costs return `billedCents: 0` (not omitted).
+- `expectedCents` is computed the same way as the existing `getExpectedSpendForPeriod()` — sum of `cost_at_assignment_cents` for active assignments overlapping the period date range.
+- Returns `[]` if `budgetId` does not exist.
+
+**Error handling**: Returns `[]` on DB error (non-throwing read function, consistent with existing read actions).
+
+---
+
+### `getLicenseUtilizationByTool()`
+
+**File**: `src/actions/assignments.ts`
+**Type**: Read function
+**Returns**: `ToolUtilization[]`
+
+```typescript
+interface ToolUtilization {
+  toolId: number;
+  toolName: string;
+  vendor: string;
+  assignedCount: number;          // COUNT of active license_assignments per tool
+  maxLicenses: number | null;     // ai_tools.max_licenses — null = unlimited
+  utilizationPct: number;         // (assignedCount / maxLicenses) * 100; 0 if maxLicenses is null
+  expectedMonthlyCents: number;   // SUM(cost_at_assignment_cents) for active assignments
+}
+
+function getLicenseUtilizationByTool(): Promise<ToolUtilization[]>
+```
+
+**Behaviour**:
+- Includes all `active` tools, even those with zero active assignments (`assignedCount: 0`).
+- Pre-sorted by `expectedMonthlyCents` descending.
+- `utilizationPct` is a plain number (0–100+); values over 100 indicate over-assignment relative to `maxLicenses`.
+- Tools with `maxLicenses = null` receive `utilizationPct: 0`.
+
+**Error handling**: Returns `[]` on DB error.
+
+---
+
+### `getBudgetForecast(budgetId: number)`
+
+**File**: `src/actions/budget.ts`
+**Type**: Read function
+**Returns**: `ActionResult<BudgetForecast>`
+
+```typescript
+// See src/lib/forecast.ts for full BudgetForecast type definition
+type BudgetForecastResult =
+  | { success: true; data: BudgetForecast }
+  | { success: false; error: string }
+
+function getBudgetForecast(budgetId: number): Promise<BudgetForecastResult>
+```
+
+**Behaviour**:
+- Loads budget + all periods with billed costs via `getBudgetWithCosts(budgetId)`.
+- Filters to completed periods (`endDate < today` AND `billedTotalCents > 0`) for the OLS input.
+- Computes `actualSpendToDateCents` as the sum of all completed period billed totals.
+- Passes data to `forecastBudget()` from `src/lib/forecast.ts`.
+- `monthsToProject` is derived from how many months remain in the fiscal year (clamped to 3–6).
+- Returns `{ success: false, error: "Budget not found" }` if the budget does not exist.
+- Returns `{ success: true, data: { ..., insufficientData: "..." } }` when history has fewer than 3 months — the caller must check `data.insufficientData` to decide whether to show the empty state.
+
+---
+
+## Pure Utility Module
+
+### `forecastBudget(options: ForecastOptions): BudgetForecast`
+
+**File**: `src/lib/forecast.ts`
+**Type**: Pure function — no DB access, no side effects, server-only (no `"use client"`)
+
+```typescript
+interface ForecastOptions {
+  history: MonthlySpend[];          // chronological, max 12 entries
+  monthsToProject?: number;         // default 3, clamped to [3, 6]
+  actualSpendToDateCents: number;   // integer cents
+  budgetCeilingCents: number;       // integer cents from annual_budgets.total_amount_cents
+  today: Date;                      // injected for testability
+}
+
+interface MonthlySpend {
+  month: string;        // "MMM YYYY" format, e.g. "Jan 2026"
+  amountCents: number;  // integer
+}
+
+interface ForecastPoint {
+  month: string;                  // "MMM YYYY" format
+  projectedAmountCents: number;   // integer, floored at 0
+}
+
+interface BudgetForecast {
+  slopeCents: number;
+  interceptCents: number;
+  projections: ForecastPoint[];
+  projectedRemainingCents: number;
+  actualSpendToDateCents: number;
+  projectedAnnualTotalCents: number;
+  budgetCeilingCents: number;
+  status: "on_track" | "at_risk";
+  insufficientData?: string;      // present when history.length < 3
+}
+```
+
+**Guarantees**:
+- All returned monetary values are integers (Math.round applied to regression output).
+- Projected values are never negative (floored at 0).
+- When `history.length < 3`, returns without running regression; `projections` is `[]`.
+- Pure OLS: x = month index (0-based), y = amountCents.
+
+---
+
+## URL Contract
+
+**Route**: `/reports`
+**Tab state via query parameter**: `?tab=<value>`
+
+| Query value | Active tab | Notes |
+|-------------|-----------|-------|
+| (absent) | Overview | Default; clean URL |
+| `?tab=overview` | Overview | Normalized to absent on next navigation |
+| `?tab=trends` | Trends | |
+| `?tab=usage` | Usage | |
+| `?tab=forecast` | Forecast | |
+| `?tab=<anything else>` | Overview | Invalid values coerce to default |
+
+**Navigation method**: `router.replace(pathname + queryString, { scroll: false })`
+**History behavior**: Tab switches do not create new browser history entries (uses `replace`, not `push`).
+**Refresh behavior**: URL is preserved; Server Component re-reads `searchParams` and activates the correct tab.
+
+---
+
+## Component Props Contract
+
+The Server Component assembles all data and passes it to the client tab bar as typed props:
+
+```typescript
+// src/app/reports/reports-tab-bar.tsx
+interface ReportsTabBarProps {
+  activeTab: "overview" | "trends" | "usage" | "forecast";
+  overviewData: ReportOverviewData;
+  trendsData: PeriodSpendPoint[];           // full history; client filters by range
+  usageData: ToolUtilization[];             // all tools; client renders top 10 by default
+  forecastData: BudgetForecast | null;      // null if no active budget
+}
+```
+
+**Serialization constraint**: All props must be JSON-serializable (no `Date` objects, no functions). The `today` date used for forecast computation is the server's `new Date()` — only the resulting `BudgetForecast` record (with string month labels) is passed to the client.

--- a/specs/005-rich-reports/data-model.md
+++ b/specs/005-rich-reports/data-model.md
@@ -1,0 +1,192 @@
+# Data Model: Rich Visual Reports
+
+**Feature**: 005-rich-reports | **Date**: 2026-03-05
+
+## Schema Changes
+
+**None.** All report data is derived from existing tables. No migrations required.
+
+## Existing Tables Used
+
+### `annual_budgets`
+Used by: Overview (budget ceiling), Forecast (ceiling for on-track/at-risk)
+
+| Column | Type | Usage |
+|--------|------|-------|
+| `id` | integer PK | Lookup key |
+| `fiscal_year` | integer | Display label |
+| `total_amount_cents` | integer | Budget ceiling for forecast and overview |
+| `period_type` | enum `monthly\|quarterly` | Determines period granularity |
+| `status` | enum `active\|archived` | Filter for active budget |
+
+### `budget_periods`
+Used by: Trends (time-series x-axis), Forecast (history baseline)
+
+| Column | Type | Usage |
+|--------|------|-------|
+| `id` | integer PK | Join key to `billed_costs` |
+| `budget_id` | integer FK | Links to `annual_budgets` |
+| `period_label` | varchar(20) | Human-readable label (e.g. "Jan 2026") — used as chart x-axis tick |
+| `period_index` | integer | Sort order for chronological display |
+| `start_date` | date | Used to compute `expectedSpendCents` via assignment overlap |
+| `end_date` | date | Used to determine completed periods for forecast baseline |
+| `planned_amount_cents` | integer | Optional planned budget per period (displayed on Trends chart) |
+
+### `billed_costs`
+Used by: Trends (actual spend line), Forecast (OLS input), Overview (YTD billed total)
+
+| Column | Type | Usage |
+|--------|------|-------|
+| `id` | integer PK | — |
+| `period_id` | integer FK | Groups costs by budget period |
+| `amount_cents` | integer | Actual invoiced amount (aggregated per period for charts) |
+| `invoice_date` | date | Could be used for daily granularity if needed |
+| `description` | varchar(500) | Not used in charts |
+
+### `license_assignments`
+Used by: Overview (active license count), Usage (assigned seats per tool), Trends (expected spend)
+
+| Column | Type | Usage |
+|--------|------|-------|
+| `tool_id` | integer FK | Group by tool for utilization |
+| `status` | enum `active\|inactive` | Filter for active assignments |
+| `cost_at_assignment_cents` | integer | Per-assignment monthly cost (sum → expected spend) |
+| `assigned_at` | timestamp | Could be used for assignment trend over time |
+| `revoked_at` | timestamp | Marks end of active period |
+
+### `ai_tools`
+Used by: Usage (utilization denominator), Trends (per-tool spend breakdown optional)
+
+| Column | Type | Usage |
+|--------|------|-------|
+| `id` | integer PK | Join key |
+| `name` | varchar(255) | Chart label |
+| `vendor` | varchar(255) | Optional grouping |
+| `max_licenses` | integer | Seat capacity — utilization denominator (may be null for unlimited) |
+| `status` | enum `active\|archived` | Filter active tools for usage report |
+
+---
+
+## New Computed Data Shapes (TypeScript Interfaces)
+
+These types are produced by new Server Action functions and consumed by chart components. They live in `src/types/index.ts` (alongside existing types) or are exported directly from the action files.
+
+### `PeriodSpendPoint`
+Output of `getBilledCostsTimeSeries()` — one entry per budget period.
+
+```typescript
+interface PeriodSpendPoint {
+  month: string;          // e.g. "Jan 2026" — from budgetPeriods.periodLabel
+  billedCents: number;    // sum of billedCosts.amount_cents for this period (integer)
+  expectedCents: number;  // sum of active assignment costs overlapping this period (integer)
+  plannedCents: number;   // budgetPeriods.planned_amount_cents (integer)
+  periodIndex: number;    // budgetPeriods.period_index — for sorting
+}
+```
+
+**Aggregation rule**: For monthly period type, one `PeriodSpendPoint` per period. For quarterly, one per quarter. The granularity selector on the Trends tab filters this array client-side (slicing the last N months).
+
+### `ToolUtilization`
+Output of `getLicenseUtilizationByTool()` — one entry per active tool.
+
+```typescript
+interface ToolUtilization {
+  toolId: number;
+  toolName: string;
+  vendor: string;
+  assignedCount: number;    // count of active license_assignments for this tool
+  maxLicenses: number | null; // ai_tools.max_licenses — null means unlimited
+  utilizationPct: number;   // (assignedCount / maxLicenses) * 100, null-safe (0 if maxLicenses is null)
+  expectedMonthlyCents: number; // sum of cost_at_assignment_cents for active assignments
+}
+```
+
+**Sorting**: Returned pre-sorted by `expectedMonthlyCents` descending (highest-cost tools first). The Usage tab default view shows the top 10; the "show all" toggle renders the full array.
+
+### `BudgetForecast`
+Output of `getBudgetForecast()` — full forecast result including OLS coefficients and projected points.
+
+```typescript
+interface MonthlySpend {
+  month: string;        // e.g. "Jan 2026"
+  amountCents: number;  // integer cents
+}
+
+interface ForecastPoint {
+  month: string;                  // e.g. "Apr 2026"
+  projectedAmountCents: number;   // integer cents, floored at 0
+}
+
+interface BudgetForecast {
+  slopeCents: number;                       // OLS slope in cents/month (rounded integer)
+  interceptCents: number;                   // OLS intercept at x=0 (rounded integer)
+  projections: ForecastPoint[];             // 3–6 projected months
+  projectedRemainingCents: number;          // sum of projections (integer)
+  actualSpendToDateCents: number;           // sum of billed costs in completed periods (integer)
+  projectedAnnualTotalCents: number;        // actualSpendToDateCents + projectedRemainingCents
+  budgetCeilingCents: number;               // annual_budgets.total_amount_cents
+  status: "on_track" | "at_risk";
+  insufficientData?: string;                // present if history.length < 3
+}
+```
+
+### `ReportOverviewData`
+Aggregated from multiple sources for the Overview tab summary cards.
+
+```typescript
+interface ReportOverviewData {
+  totalActiveUsers: number;
+  totalActiveTools: number;
+  totalActiveLicenses: number;
+  expectedMonthlyCents: number;   // sum of active assignment costs
+  billedYtdCents: number;         // sum of all billed costs in current fiscal year
+  budgetCeilingCents: number;     // annual_budgets.total_amount_cents (0 if no active budget)
+  budgetRemainingCents: number;   // budgetCeilingCents - billedYtdCents (may be negative)
+  utilizationPct: number;         // (billedYtdCents / budgetCeilingCents) * 100
+  // Trend indicators: current period vs. prior period
+  spendTrend: "up" | "down" | "flat";
+  spendTrendPct: number;          // percentage change vs. prior period (signed)
+}
+```
+
+### `ForecastChartPoint`
+Merged data shape for the composite forecast chart (historical + projected on same x-axis).
+
+```typescript
+interface ForecastChartPoint {
+  month: string;
+  historical: number | null;   // billedCents — null for future months
+  projected: number | null;    // projectedAmountCents — null for past months (except last historical)
+}
+```
+
+**Construction rule**: The last historical month has both `historical` and `projected` values set to visually connect the two lines. All future months have `historical: null`.
+
+---
+
+## Data Flow Diagram
+
+```
+Database Tables               Server Actions              Chart Components
+─────────────────             ──────────────              ────────────────
+annual_budgets ─────────────► getActiveBudget()    ──►   Overview cards
+                              getBudgetForecast()  ──►   Forecast chart
+budget_periods ──────────────►
+billed_costs ────────────────► getBilledCostsTimeSeries() ──► Trends chart
+                                                          ──► Forecast (history)
+license_assignments ─────────►
+                              getLicenseUtilizationByTool() ──► Usage chart
+ai_tools ────────────────────►                            ──► Usage table
+
+All ──────────────────────────► page.tsx (Server) ──► reports-tab-bar.tsx (Client)
+                                                  └──► ReportsChartsPanel (lazy)
+```
+
+---
+
+## Constraints
+
+- **Integer cents everywhere**: No floating-point monetary values at any layer. Division by 100 for display only, inside chart formatter callbacks.
+- **`maxLicenses` nullable**: Tools with `maxLicenses = null` are treated as "unlimited" — `utilizationPct` is 0 and the bar chart shows only the `assignedCount` with no capacity segment.
+- **Active budget assumption**: The reports page fetches `getActiveBudget()` first. If no active budget exists, Forecast and budget-related Overview fields show empty states.
+- **Period label format**: `"MMM YYYY"` (e.g. "Jan 2026") is the canonical format used in `budgetPeriods.period_label` and expected by `src/lib/forecast.ts` `parseMonthLabel()`.

--- a/specs/005-rich-reports/plan.md
+++ b/specs/005-rich-reports/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Rich Visual Reports
+
+**Branch**: `005-rich-reports` | **Date**: 2026-03-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/005-rich-reports/spec.md`
+
+## Summary
+
+Add a four-tab visual reporting dashboard (Overview, Trends, Usage, Forecast) to the existing `/reports` page. The existing Server Component is restructured to pass aggregated data to a new client-side `ReportsTabBar` with URL-reflected tab state (`?tab=<value>`). Charts are built with the already-installed Recharts 2.15.4 library via shadcn/ui `ChartContainer` wrappers, lazy-loaded as a single dynamic bundle to respect the 150 KB JS budget. A new `src/lib/forecast.ts` provides OLS linear regression for budget projections. Three new Server Action query functions deliver time-series spend, license utilization, and forecast data. **No database schema changes are required.**
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3 (strict mode), Node.js LTS
+**Primary Dependencies**: Next.js 15.5.12 (App Router), Recharts 2.15.4 (already installed), shadcn/ui ChartContainer, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30
+**Storage**: Neon PostgreSQL (serverless) — no schema changes; all report data derived from `annual_budgets`, `budget_periods`, `billed_costs`, `license_assignments`, `ai_tools`
+**Testing**: Vitest (unit tests for `forecast.ts` OLS logic), Playwright (E2E tab navigation and chart rendering)
+**Target Platform**: Web application — desktop-first (1280px+ primary), authenticated admin route
+**Project Type**: Web application (Next.js App Router)
+**Performance Goals**: Tab content within 2 seconds; Recharts lazy-loaded as single ~80 KB gzip chunk; LCP < 2.5s, INP < 200ms, CLS < 0.1
+**Constraints**: 150 KB gzipped JS per route; Recharts must not appear in Server Components or SSR path; all monetary values in integer cents; no new DB tables
+**Scale/Scope**: Up to 12 months of history for Trends/Forecast; top-10 default in Usage; one active budget per fiscal year
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Type-Safe Code Quality | PASS | TypeScript strict throughout; `ChartConfig` uses `satisfies`; `forecastBudget()` fully typed; no `any` |
+| II. UX Consistency | PASS | shadcn/ui `Tabs`, `Card`, `Skeleton`, `ChartContainer`, `ChartTooltipContent` used exclusively; no ad-hoc styling; design tokens only |
+| III. Performance Budgets | PASS | Recharts lazy-loaded via single `dynamic({ ssr: false })` boundary; sparklines use raw `LineChart` with `isAnimationActive={false}`; `min-h-[300px]` on chart containers prevents CLS |
+| IV. Accessibility-First | PASS | `accessibilityLayer` on all Recharts root components; shadcn `Tabs` is keyboard-navigable; status indicated by text + color (not color alone); ARIA roles from Radix UI Tabs |
+| V. Simplicity & Maintainability | PASS | OLS in one 100-line pure utility file; no external ML libraries; no new abstractions beyond the minimum; each chart component has a single responsibility |
+
+*Gate: PASS — no violations. Proceeding to Phase 1 design.*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-rich-reports/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+│   └── server-actions.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code
+
+```text
+src/
+├── app/
+│   └── reports/
+│       ├── page.tsx                          # MODIFY — add searchParams, new fetches, ReportsTabBar
+│       ├── reports-tab-bar.tsx               # NEW — "use client", URL-reflected tab nav + data passing
+│       └── loading.tsx                       # MODIFY — add chart-shaped skeleton placeholders
+│
+├── components/
+│   └── reports/
+│       ├── reports-charts-panel.tsx          # NEW — aggregates chart imports (single lazy-load boundary)
+│       ├── trends-chart.tsx                  # NEW — "use client", LineChart time-series
+│       ├── utilization-chart.tsx             # NEW — "use client", BarChart vertical stacked
+│       ├── forecast-chart.tsx                # NEW — "use client", composite LineChart + ReferenceLine
+│       └── sparkline.tsx                     # NEW — "use client", raw inline LineChart 80×32
+│
+├── lib/
+│   └── forecast.ts                           # NEW — OLS linear regression, pure utility (server-only)
+│
+└── actions/
+    ├── budget.ts                             # MODIFY — add getBilledCostsTimeSeries(), getBudgetForecast()
+    └── assignments.ts                        # MODIFY — add getLicenseUtilizationByTool()
+
+tests/
+├── unit/
+│   └── forecast.test.ts                      # NEW — Vitest unit tests for OLS module
+└── e2e/
+    └── reports-tabs.spec.ts                  # NEW — Playwright E2E for tab navigation
+```
+
+**Structure Decision**: Single Next.js App Router project (Option 1 from template). Chart components grouped in `src/components/reports/` as a domain sub-folder — consistent with how assignments groups related components. `reports-tab-bar.tsx` co-located with `page.tsx` following the `assignments-client.tsx` pattern.
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/005-rich-reports/quickstart.md
+++ b/specs/005-rich-reports/quickstart.md
@@ -1,0 +1,157 @@
+# Quickstart: Rich Visual Reports (005-rich-reports)
+
+**Branch**: `005-rich-reports` | **Date**: 2026-03-05
+
+## Prerequisites
+
+- Node.js LTS + pnpm installed
+- Neon PostgreSQL connection string in `.env.local` (copy from `.env.example`)
+- Existing database seeded (previous features 001–004 must be applied)
+
+## Setup
+
+```bash
+# Install dependencies (already installed if working on the main repo)
+pnpm install
+
+# Ensure DB schema is current (no new migrations for this feature)
+pnpm db:push
+
+# Start dev server
+pnpm dev
+```
+
+Navigate to `http://localhost:3000/reports` — you should see the existing Reports page (4 summary cards + tables). This feature adds tabs above that content.
+
+## What Gets Built
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/forecast.ts` | Pure OLS linear regression utility |
+| `src/app/reports/reports-tab-bar.tsx` | Client tab navigation component |
+| `src/components/reports/reports-charts-panel.tsx` | Lazy-loaded chart bundle boundary |
+| `src/components/reports/trends-chart.tsx` | Time-series line chart |
+| `src/components/reports/utilization-chart.tsx` | Stacked horizontal bar chart |
+| `src/components/reports/forecast-chart.tsx` | Composite forecast line chart |
+| `src/components/reports/sparkline.tsx` | Inline mini trend chart for cards |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/app/reports/page.tsx` | Add `searchParams`, 3 new data fetches, pass props to `ReportsTabBar` |
+| `src/app/reports/loading.tsx` | Add chart-shaped skeleton placeholders |
+| `src/actions/budget.ts` | Add `getBilledCostsTimeSeries()`, `getBudgetForecast()` |
+| `src/actions/assignments.ts` | Add `getLicenseUtilizationByTool()` |
+
+## Development Order (Task Sequence)
+
+1. **`src/lib/forecast.ts`** — Write and unit-test the OLS module first (pure function, no deps).
+2. **New Server Actions** — `getBilledCostsTimeSeries`, `getLicenseUtilizationByTool`, `getBudgetForecast`.
+3. **`src/app/reports/page.tsx`** — Update to read `searchParams`, call new actions, assemble `ReportsTabBarProps`.
+4. **`src/app/reports/reports-tab-bar.tsx`** — Client tab bar with URL routing; verify tab switching works with mock data.
+5. **Chart components** — Build each chart in isolation (`trends-chart.tsx`, `utilization-chart.tsx`, `forecast-chart.tsx`, `sparkline.tsx`).
+6. **`src/components/reports/reports-charts-panel.tsx`** — Assemble charts + lazy-load boundary.
+7. **`src/app/reports/loading.tsx`** — Update with chart-shaped skeletons.
+8. **Tests** — Vitest unit tests for `forecast.ts`; Playwright E2E for tab navigation.
+
+## Testing
+
+### Unit Tests (Vitest)
+
+```bash
+pnpm test
+```
+
+Key test file: `tests/unit/forecast.test.ts`
+
+Test cases to cover:
+- OLS with valid 12-month history → correct slope, intercept, projections
+- `history.length < 3` → `insufficientData` returned, no projections
+- All-zero history → all projections are 0
+- Negative projected values → floored at 0
+- `status: "on_track"` when `projectedAnnualTotal <= ceiling`
+- `status: "at_risk"` when `projectedAnnualTotal > ceiling`
+
+### E2E Tests (Playwright)
+
+```bash
+pnpm test:e2e
+```
+
+Key E2E scenarios:
+- Navigate to `/reports` → Overview tab active by default
+- Click "Trends" → URL changes to `?tab=trends`, chart is visible
+- Refresh at `?tab=usage` → Usage tab remains active
+- Invalid tab param (`?tab=bogus`) → falls back to Overview
+- Time range selector in Trends → chart updates without full page reload
+
+### Type Check
+
+```bash
+pnpm typecheck
+```
+
+No `any` types should be introduced. All chart `data` arrays must be typed against the interfaces in `data-model.md`.
+
+### Linting
+
+```bash
+pnpm lint
+```
+
+## Seeding Test Data
+
+The Forecast tab requires at least 3 months of completed `budget_periods` with `billed_costs` entries. If the dev database lacks this, use the seed script or manually insert:
+
+```sql
+-- Quick check: how many completed periods with billed costs exist?
+SELECT bp.period_label, SUM(bc.amount_cents) as billed_total
+FROM budget_periods bp
+JOIN billed_costs bc ON bc.period_id = bp.id
+WHERE bp.end_date < NOW()
+GROUP BY bp.id, bp.period_label
+ORDER BY bp.period_index;
+```
+
+If fewer than 3 rows are returned, the Forecast tab will show the "insufficient data" state (this is valid behavior — not a bug).
+
+## Lighthouse
+
+```bash
+pnpm lighthouse
+```
+
+The `/reports` route must maintain:
+- LCP < 2.5s (charts lazy-load after initial paint — skeleton shows first)
+- INP < 200ms (tab switching uses `router.replace` — React reconciliation, not full render)
+- CLS < 0.1 (skeleton heights match chart `className` heights to prevent layout shift)
+- JS bundle per route < 150 KB gzip (Recharts ~80 KB lazy-loaded separately from main bundle)
+
+## Key Implementation Notes
+
+### Money formatting
+Never pass fractional values to charts. Always pass integer cents and format in Recharts `tickFormatter`/`formatter` callbacks:
+```tsx
+tickFormatter={(v) => `$${(v / 100).toFixed(0)}`}
+```
+
+### Recharts + Server Components
+Never import `recharts` or chart component files in Server Components. All chart imports go through `reports-charts-panel.tsx` which is loaded via `next/dynamic({ ssr: false })`.
+
+### ChartContainer colors
+Use `var(--chart-1)` through `var(--chart-5)` for data series colors. Use `var(--color-<key>)` inside Recharts props (these are scoped by `ChartStyle`). Use `var(--chart-5)` for the budget ceiling reference line (neutral/warning color).
+
+### `satisfies ChartConfig`
+Always write chart config objects as:
+```typescript
+const config = {
+  spend: { label: "Monthly Spend", color: "var(--chart-1)" },
+} satisfies ChartConfig
+```
+This gives full TypeScript narrowing of the config keys.
+
+### Tab default
+The default tab is Overview. When rendering the default, the URL should be `/reports` (no `?tab=` param). The `handleTabChange` function should skip setting the param when the value is `"overview"`.

--- a/specs/005-rich-reports/research.md
+++ b/specs/005-rich-reports/research.md
@@ -1,0 +1,133 @@
+# Research: Rich Visual Reports
+
+**Feature**: 005-rich-reports | **Date**: 2026-03-05
+
+## Decision Log
+
+### D-001: Tab Navigation — URL-Reflected State Strategy
+
+**Decision**: Server Component `page.tsx` reads `searchParams` (a `Promise` in Next.js 15) to determine the active tab. A thin `"use client"` `ReportsTabBar` component receives `activeTab` as a prop and uses `router.replace` + shadcn/ui `Tabs` (controlled via `value`) to update the URL on tab click.
+
+**Rationale**: Keeps all data fetching in the Server Component (consistent with the existing `reports/page.tsx`, `budget/page.tsx`, `assignments/page.tsx` pattern). No `useSearchParams` is needed in the client component — it receives the active tab as a prop — which avoids the Next.js 15 Suspense requirement for `useSearchParams`. Tab switches use `router.replace` with `{ scroll: false }` so no new browser history entries are created and the page does not scroll to the top.
+
+**Alternatives considered**:
+- Full client component page (`"use client"` on `page.tsx`): Rejected — loses server-side parallel data fetching; all `await` calls would become `useEffect`/SWR fetches, a significant regression from the existing pattern.
+- Parallel routes / intercepting routes: Rejected — designed for modal overlays and slot-level loading, not tab UIs; adds unnecessary routing complexity.
+- `nuqs` library for search-param state: Rejected — adds a dependency for a problem solvable with two lines of `URLSearchParams` + `router.replace`.
+
+**URL format**: `?tab=trends` | `?tab=usage` | `?tab=forecast` | (omit for default Overview to keep clean URLs)
+
+**Next.js 15 gotcha**: `searchParams` is a `Promise<{...}>` — must be `await`ed in the Server Component. This makes the route dynamically rendered, which is already the case for authenticated admin pages.
+
+---
+
+### D-002: Chart Library — Recharts via shadcn/ui ChartContainer
+
+**Decision**: Use Recharts 2.15.4 (already installed) exclusively through the shadcn/ui `ChartContainer` wrapper, except for sparklines which use raw `LineChart` with fixed pixel dimensions.
+
+**Rationale**: Recharts is already a production dependency. The shadcn/ui `ChartContainer` wrapper provides theme-aware CSS variables (`var(--chart-1)` through `var(--chart-5)`), eliminates the need to add `ResponsiveContainer` manually, and keeps light/dark mode consistent with the rest of the UI.
+
+**Component choices per tab**:
+
+| Tab | Recharts Component | Wrapper |
+|-----|-------------------|---------|
+| Trends (time-series) | `LineChart` + `Line` | `ChartContainer`, `ChartTooltip`, `ChartTooltipContent` |
+| Overview (sparklines) | `LineChart` (raw, fixed 80×32px, no decorations) | None — `ChartContainer` adds `ResponsiveContainer` which doesn't work in constrained inline contexts |
+| Usage (utilization) | `BarChart layout="vertical"` + 2 stacked `Bar` components | `ChartContainer`, `ChartTooltip`, `ChartLegend` |
+| Forecast (composite) | `LineChart` + 2 `Line` (one solid, one `strokeDasharray`) + `ReferenceLine` | `ChartContainer`, `ChartTooltip`, `ChartLegend` |
+
+**Forecast chart technique**: Split data into two series — `historical` (null for future months) and `projected` (null for past months). Set `connectNulls={false}` on both. The last historical month also receives a `projected` value to visually connect the two lines without a gap.
+
+**ReferenceLine for budget ceiling**: `y={budgetCeilingCents}` with `strokeDasharray="4 2"` and `ifOverflow="extendDomain"` to ensure the ceiling line is always visible.
+
+**Alternatives considered**:
+- Recharts `ComposedChart` for forecast: Not needed — `LineChart` with two `Line` children achieves the same result more simply.
+- Pure SVG for sparklines: Valid approach, but raw Recharts `LineChart` at 80×32 with `isAnimationActive={false}` is simpler to implement given the dependency is already present.
+- Recharts v3: Would require upgrading a production dependency mid-feature; rejected.
+
+---
+
+### D-003: Bundle Strategy — Single Lazy Boundary for all Charts
+
+**Decision**: All four chart components are imported directly inside a single `src/components/reports/reports-charts-panel.tsx` file. That panel is lazy-loaded from `reports-tab-bar.tsx` via `next/dynamic({ ssr: false })`. A single `<Skeleton>` fallback covers the loading state.
+
+**Rationale**: Recharts 2.x is ~80 KB gzip and cannot be tree-shaken by chart type. A single `dynamic()` boundary produces one chunk containing the full Recharts cost paid once per reports page visit. Multiple `dynamic()` imports would still cost the same total size but introduce multiple network waterfalls. The reports route is already admin-only, so this chunk is isolated from all other routes.
+
+**Performance notes**:
+- `isAnimationActive={false}` on sparklines (no CLS from animation).
+- `accessibilityLayer` on every chart root component (Recharts built-in keyboard/screen reader support — no extra bundle cost).
+- All chart data values remain in integer cents; division by 100 for display happens only in formatter callbacks.
+- `ChartConfig` objects use `satisfies ChartConfig` for full TypeScript narrowing.
+
+---
+
+### D-004: OLS Forecast — Pure TypeScript Utility Module
+
+**Decision**: Implement ordinary least squares (OLS) linear regression in `src/lib/forecast.ts` as a pure server-side utility. The Server Action `getBudgetForecast(budgetId)` in `src/actions/budget.ts` calls `forecastBudget()` from this module.
+
+**Rationale**: No external ML library needed; OLS is ~30 lines of arithmetic. The module is pure (no DB access, no browser APIs), making it trivially unit-testable with Vitest. Monetary arithmetic stays in integer cents throughout; regression coefficients are floats internally (acceptable for a linear fit), but all returned projected values are `Math.round()`-ed to integers and floored at 0 with `Math.max(0, ...)`.
+
+**Baseline window**: Up to 12 months of historical `billedCosts` data, sourced from completed `budgetPeriods` (periods where `endDate < today` and `billedTotalCents > 0`).
+
+**Edge cases**:
+- `history.length < 3`: Returns early with `insufficientData` message; still computes `"on_track"` / `"at_risk"` from actual spend vs. ceiling.
+- All-zero history: OLS runs normally; slope = 0, projections = 0.
+- Negative projected values: Floored to 0 via `Math.max(0, Math.round(raw))`.
+- Malformed period label: Falls back to `today`'s year/month as calendar base.
+
+**On-track / at-risk formula**:
+```
+projectedRemainingCents = Σ projection[i].projectedAmountCents
+projectedAnnualTotal    = actualSpendToDateCents + projectedRemainingCents
+status = projectedAnnualTotal <= budgetCeilingCents ? "on_track" : "at_risk"
+```
+
+**Alternatives considered**:
+- Simple moving average: More intuitive but ignores trend direction (can't detect accelerating spend). OLS captures slope, which is exactly what a budget forecast needs.
+- Exponential smoothing (Holt-Winters): Better for seasonality but overkill for a 12-month dataset; adds implementation complexity with no corresponding benefit at this scale.
+- External library (ml-regression, simple-statistics): Adds a dependency for 30 lines of math; rejected per Constitution Principle V (Simplicity).
+
+---
+
+### D-005: New Server Actions Required
+
+**Decision**: Three new query functions added to existing actions files; no new action files created.
+
+| Function | File | Purpose |
+|----------|------|---------|
+| `getBilledCostsTimeSeries(budgetId)` | `src/actions/budget.ts` | Returns per-period `{month, billedTotalCents, expectedSpendCents}` for the Trends chart |
+| `getLicenseUtilizationByTool()` | `src/actions/assignments.ts` | Returns `{toolId, toolName, assigned, maxLicenses, utilizationPct}` for the Usage chart |
+| `getBudgetForecast(budgetId)` | `src/actions/budget.ts` | Wraps `forecastBudget()` from `src/lib/forecast.ts`; returns `ActionResult<BudgetForecast>` |
+
+**Rationale for reusing existing files**: The codebase has one file per domain (`budget.ts`, `assignments.ts`). Adding to existing files keeps the domain boundary clear and avoids a new file for what is ultimately a query function.
+
+**No schema changes required**: All data exists in `billedCosts`, `budgetPeriods`, `licenseAssignments`, and `aiTools` (`maxLicenses` column). The utilization percentage is computed in application code, not the DB.
+
+---
+
+### D-006: Skeleton Loading Pattern
+
+**Decision**: Tab content area shows layout-matching skeleton screens while data loads. Each tab's skeleton mirrors the shape of its content (card grid for Overview, tall chart placeholder for Trends/Forecast, shorter stacked-bar placeholder for Usage).
+
+**Implementation**: Use the existing `src/components/ui/skeleton.tsx` (`animate-pulse`, `bg-accent`) following the established pattern in `src/app/reports/loading.tsx` and other loading files. The `dynamic()` loading fallback for `ReportsChartsPanel` passes `<ReportsSkeleton />` as its `loading` prop.
+
+**Rationale**: All other pages in the project use this exact pattern. CLS is minimized because skeleton dimensions match final content dimensions (`min-h-[300px]` on chart containers matches the `className` on `ChartContainer`).
+
+---
+
+### D-007: Existing Reports Content Migration
+
+**Decision**: The existing Overview content (4 summary cards + Tool Adoption table + Circle Report table) moves into the Overview tab verbatim. No data is removed; it is reorganized under a tab.
+
+**Rationale**: The spec states existing content should be reorganized under Overview, not replaced. The summary cards become enhanced with sparkline trend indicators. The Tool Adoption table becomes the Usage tab's table view (with a chart toggle added).
+
+---
+
+## Research Sources
+
+- Next.js 15 `searchParams` API: https://nextjs.org/docs/app/api-reference/file-conventions/page
+- Next.js `useRouter` App Router: https://nextjs.org/docs/app/api-reference/functions/use-router
+- shadcn/ui Tabs: https://ui.shadcn.com/docs/components/radix/tabs
+- shadcn/ui Chart: https://ui.shadcn.com/docs/components/chart
+- Recharts API (local installation): src/components/ui/chart.tsx
+- OLS linear regression: standard statistics (no external source required)

--- a/specs/005-rich-reports/spec.md
+++ b/specs/005-rich-reports/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: Rich Visual Reports
+
+**Feature Branch**: `005-rich-reports`
+**Created**: 2026-03-05
+**Status**: Draft
+**Input**: User description: "I want to add richer and more visual reports. To not overload the current reports page, consider adding a subnavigation or tabs or any other concept that seems reasonable. The goal is to see at a glance the current trends, the current usage, and potentially forecasts about the budget situation."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - At-a-Glance Overview (Priority: P1)
+
+A manager opens the Reports section and immediately sees an Overview dashboard with summary cards: total spend this period, budget remaining, active license count, and sparkline trend indicators showing whether spend is going up or down. No need to click further — the most critical information is visible at once.
+
+**Why this priority**: The primary stated goal is "at a glance" visibility. Without this, none of the other views deliver value on their own to a time-pressured manager.
+
+**Independent Test**: Can be fully tested by navigating to Reports and verifying summary cards display correct aggregated values and trend direction indicators, delivering an immediately actionable budget health snapshot.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is on the Reports page, **When** the page loads, **Then** they see summary cards for total budget, amount spent, amount remaining, and a percentage utilization indicator — all without any additional clicks.
+2. **Given** spending is trending upward, **When** the user views the Overview, **Then** an upward trend indicator is visible alongside the spend card.
+3. **Given** there is no spending data yet, **When** the user views the Overview, **Then** empty-state messaging explains that data will appear once tool assignments are recorded.
+
+---
+
+### User Story 2 - Navigating Between Report Views (Priority: P1)
+
+A user sees a tab bar (or sub-navigation) at the top of the Reports section with labels such as Overview, Trends, Usage, and Forecast. They click "Trends" and the content area updates to show a time-series chart — no full page reload occurs.
+
+**Why this priority**: The navigation structure is the foundation that makes all other report views accessible without overloading a single page.
+
+**Independent Test**: Can be fully tested by clicking each tab and verifying the correct content section appears, including correct URL state or query parameter reflection so sharing or refreshing the page returns to the same tab.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the Reports page, **When** they click any tab in the sub-navigation, **Then** the content area updates without a full page reload and the selected tab is visually highlighted.
+2. **Given** the user is on the Trends tab, **When** they refresh the page, **Then** the Trends tab remains active.
+3. **Given** the user navigates away and returns to Reports, **When** the page loads, **Then** the default tab (Overview) is displayed.
+
+---
+
+### User Story 3 - Trends Over Time (Priority: P2)
+
+A team lead navigates to the Trends tab and sees a line chart or bar chart showing spending and/or license usage over time. They can select a time range (e.g., last 30 days, last 3 months, last 6 months) to zoom in or out, helping them spot seasonal patterns or unexpected spikes. Data points are automatically grouped by day (≤30 days), week (≤90 days), or month (longer ranges) to keep the chart readable.
+
+**Why this priority**: Trends give context to the current snapshot. Without historical perspective, the overview numbers are hard to evaluate.
+
+**Independent Test**: Can be fully tested by viewing the Trends tab with at least two months of seeded data and verifying charts render correctly with period-selector controls and auto-scaled granularity.
+
+**Acceptance Scenarios**:
+
+1. **Given** historical spending data exists, **When** the user opens the Trends tab, **Then** a chart displays spending over time with clearly labeled axes and a legend.
+2. **Given** the user selects "Last 3 months" from the time range selector, **When** the selection is applied, **Then** the chart updates to show only data within that period, aggregated by week.
+3. **Given** fewer than 2 data points exist for the selected period, **When** the user views the chart, **Then** a message indicates insufficient data for a meaningful trend line while showing the available points.
+
+---
+
+### User Story 4 - Current Usage Breakdown (Priority: P2)
+
+A license administrator navigates to the Usage tab and sees a breakdown of license utilization per tool or category — how many licenses are assigned vs. available, and which tools account for the largest share of spend. They can identify underutilized or over-allocated tools quickly.
+
+**Why this priority**: Usage visibility helps administrators make data-driven reallocation decisions, a core operational need.
+
+**Independent Test**: Can be fully tested by navigating to the Usage tab with active license assignments and verifying per-tool utilization data renders as charts and/or a data table.
+
+**Acceptance Scenarios**:
+
+1. **Given** licenses are assigned, **When** the user opens the Usage tab, **Then** they see each tool with its assigned count, total available count, and utilization percentage.
+2. **Given** a tool has 0 assignments, **When** it appears in the Usage view, **Then** it is visually distinguished (e.g., shown as 0% utilized) to highlight underutilization.
+3. **Given** the user wants a different view, **When** they toggle between chart view and table view, **Then** the same data is presented in the selected format.
+
+---
+
+### User Story 5 - Budget Forecast (Priority: P3)
+
+A budget owner navigates to the Forecast tab and sees a projection of expected spending for the next 3–6 months based on current usage patterns. The projection is presented as a chart with a confidence band, and a summary states whether the team is on track to stay within their annual budget.
+
+**Why this priority**: Forecasting is the highest-value but most data-dependent view. It requires sufficient historical data to be meaningful, making it secondary to the foundational views above.
+
+**Independent Test**: Can be fully tested with at least 3 months of seeded historical data by verifying a projected spend line extends beyond the current date and a "within budget" or "over budget" status message is shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** at least 3 months of spending history exists, **When** the user opens the Forecast tab, **Then** a chart shows historical spend plus a projected spend line for the next 3–6 months.
+2. **Given** the projected spending would exceed the annual budget, **When** the user views the Forecast tab, **Then** a prominent warning message is displayed indicating the projected overrun amount.
+3. **Given** insufficient data for a reliable forecast (less than 3 months), **When** the user opens the Forecast tab, **Then** an informational message explains that more usage data is needed and shows the current month-to-date spend instead.
+
+---
+
+### Edge Cases
+
+- What happens when there is no spending or usage data at all (brand-new system)?
+- How does the system handle mid-period budget changes that affect trend continuity?
+- What if a tool is removed but historical data still references it — is it shown in Trends/Usage with a "deleted" label?
+- How does the forecast behave when the budget period is annual but data only spans a few months?
+- What if a user bookmarks a specific tab URL and that tab is later renamed or removed?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Reports section MUST present content through a tabbed sub-navigation with at minimum four sections: Overview, Trends, Usage, and Forecast.
+- **FR-002**: The Overview tab MUST display summary cards showing: total budget for the current period, total amount spent, remaining budget, and active license count — all visible without scrolling on a standard desktop screen.
+- **FR-003**: The Overview tab MUST include at-a-glance trend indicators (e.g., sparklines or directional arrows) on spend-related cards showing whether values are increasing or decreasing compared to the prior period.
+- **FR-004**: The Trends tab MUST display a time-series chart of spending and/or usage with a time range selector offering at least: Last 30 days, Last 3 months, Last 6 months, and Last 12 months.
+- **FR-005**: The Usage tab MUST display per-tool license utilization showing assigned count, total available, and utilization percentage, with both a visual (chart) and tabular representation accessible via a toggle. By default the top 10 tools sorted by utilization/spend MUST be shown; a "show all" option or paginated view MUST be available when more than 10 tools exist.
+- **FR-006**: The Forecast tab MUST project future monthly spending for a minimum of 3 months ahead using a linear trend derived from all available historical data (up to 12 months), and MUST display a clear status indicating whether the team is projected to stay within or exceed their budget.
+- **FR-007**: The Forecast tab MUST show a clear empty/insufficient-data state when less than 3 months of spending history is available, and MUST still display current month-to-date spend in that state.
+- **FR-008**: All chart views MUST include labeled axes, a legend where multiple data series are shown, and MUST automatically scale data aggregation granularity: daily for time ranges of 30 days or fewer, weekly for 31–90 days, and monthly for ranges exceeding 90 days.
+- **FR-009**: The selected tab MUST be reflected in the URL (e.g., via a query parameter or path segment) so that the view is bookmarkable and shareable.
+- **FR-010**: All report sections MUST display an appropriate empty-state message when no relevant data is available, guiding the user on how to generate data.
+- **FR-011**: While a tab's data is loading, the system MUST display skeleton screens — placeholder shapes that match the final layout — rather than spinners or blank areas, to minimise perceived wait time and prevent layout shift.
+
+### Key Entities
+
+- **Budget Period**: A defined time window (monthly/annual) with a total budget amount, scoped to the organization or a team.
+- **Spend Record**: An individual cost entry for a tool license or subscription, aggregated by period for charting and forecasting.
+- **License Utilization**: Per-tool summary of total license seats, assigned seats, and active-user count within a reporting period.
+- **Forecast Point**: A projected spend value for a future month, derived from a linear trend calculation over historical spend records.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can identify the current budget health status (total spend, remaining budget, trend direction) within 10 seconds of arriving on the Reports page, without any additional clicks.
+- **SC-002**: Users can switch between all report tabs without a full page reload, with each tab's content appearing within 2 seconds of clicking.
+- **SC-003**: Users can view spending trends over at least four selectable time ranges and see the chart update immediately upon selecting a range, with data automatically grouped at the appropriate granularity (daily / weekly / monthly).
+- **SC-004**: Users can identify the top 3 highest-spend or most-utilized tools from the Usage tab without scrolling or applying filters; up to 10 tools are shown by default with a "show all" option available for larger catalogues.
+- **SC-005**: Users can see a forward-looking budget projection of at least 3 months, including a clear "on track" or "at risk" status, when sufficient historical data exists.
+- **SC-006**: All report sections display their data within 3 seconds of the tab becoming active, including full chart rendering.
+- **SC-007**: Empty and insufficient-data states are shown for every report section when applicable, ensuring users are never presented with blank or broken views.
+
+## Assumptions
+
+- The existing Reports page has at least one active view that will be reorganized under the Overview tab rather than replaced entirely.
+- Budget periods and spending records are already stored in the system from prior features (001-ai-tool-budget-tracker, 003-enhance-core-features).
+- License assignment data from 004-bulk-license-import is available to populate the Usage tab.
+- Forecast projections use a simple linear regression over all available history (up to 12 months) — no complex statistical modeling is required for this feature.
+- All four report tabs are visible to all authenticated users; no role-based tab or data restrictions are introduced by this feature.
+- The primary target viewport is desktop (1280px and wider); mobile layout is a nice-to-have but not a blocking requirement.
+
+## Clarifications
+
+### Session 2026-03-05
+
+- Q: How should Trends chart data be aggregated based on the selected time range? → A: Auto-scale — daily for ≤30 days, weekly for ≤90 days, monthly for longer ranges.
+- Q: How many months of historical data should the forecast baseline use? → A: All available history up to 12 months (linear regression input).
+- Q: Should any report tabs or budget figures be restricted by user role? → A: No — all four tabs and all data are visible to all authenticated users.
+- Q: How should the Usage tab handle large numbers of tools? → A: Show top 10 by default (sorted by utilization/spend), with a "show all" or paginated view for catalogues exceeding 10 tools.
+- Q: What loading state pattern should tabs use while data fetches? → A: Skeleton screens matching the final layout (no spinners, no blank areas).

--- a/specs/005-rich-reports/tasks.md
+++ b/specs/005-rich-reports/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: Rich Visual Reports (005-rich-reports)
+
+**Branch**: `005-rich-reports` | **Date**: 2026-03-05
+
+## Phase 1: Types & Pure Utility
+
+- [X] T-001 Add report data types to `src/types/index.ts` (PeriodSpendPoint, ToolUtilization, BudgetForecast, ReportOverviewData, ForecastChartPoint, ToolSummaryItem, CircleReportItem)
+- [X] T-002 Create `src/lib/forecast.ts` — OLS linear regression pure utility
+
+## Phase 2: Server Actions
+
+- [X] T-003 Add `getBilledCostsTimeSeries(budgetId)` to `src/actions/budget.ts`
+- [X] T-004 Add `getBudgetForecast(budgetId)` to `src/actions/budget.ts`
+- [X] T-005 Add `getLicenseUtilizationByTool()` to `src/actions/assignments.ts`
+
+## Phase 3: Chart Components
+
+- [X] T-006 Create `src/components/reports/sparkline.tsx` — inline 80×32 LineChart
+- [X] T-007 Create `src/components/reports/trends-chart.tsx` — time-series LineChart with range selector
+- [X] T-008 Create `src/components/reports/utilization-chart.tsx` — vertical stacked BarChart
+- [X] T-009 Create `src/components/reports/forecast-chart.tsx` — composite LineChart + ReferenceLine
+
+## Phase 4: Client Components
+
+- [X] T-010 Create `src/components/reports/reports-charts-panel.tsx` — lazy bundle boundary
+- [X] T-011 Create `src/app/reports/reports-tab-bar.tsx` — client tab nav with URL routing
+
+## Phase 5: Page & Loading Updates
+
+- [X] T-012 Update `src/app/reports/page.tsx` — searchParams, new fetches, ReportsTabBar
+- [X] T-013 Update `src/app/reports/loading.tsx` — chart-shaped skeleton placeholders
+
+## Phase 6: Tests & Config
+
+- [X] T-014 Create `vitest.config.ts`
+- [X] T-015 Create `tests/unit/forecast.test.ts` — Vitest unit tests for OLS module
+
+## Notes
+
+- No DB schema changes required
+- All monetary values kept as integer cents throughout
+- Recharts loaded only via next/dynamic({ ssr: false }) boundary

--- a/src/actions/assignments.ts
+++ b/src/actions/assignments.ts
@@ -18,7 +18,7 @@ import {
   assignmentCommentSchema,
   bulkImportAssignmentRowSchema,
 } from "@/lib/validators";
-import type { ActionResult } from "@/types";
+import type { ActionResult, ToolUtilization } from "@/types";
 import { encryptApiKey, decryptApiKey } from "@/lib/crypto";
 import { recordCreation, recordStatusChange, recordUpdate } from "@/actions/history";
 
@@ -589,4 +589,58 @@ export async function getAssignmentsForUser(userId: number) {
     },
     orderBy: (a, { desc }) => [desc(a.assignedAt)],
   });
+}
+
+// 005-rich-reports: License utilization by tool
+export async function getLicenseUtilizationByTool(): Promise<ToolUtilization[]> {
+  try {
+    const activeTools = await db.query.aiTools.findMany({
+      where: eq(aiTools.status, "active"),
+    });
+
+    if (activeTools.length === 0) return [];
+
+    const activeAssignmentsList = await db
+      .select({
+        toolId: licenseAssignments.toolId,
+        costAtAssignmentCents: licenseAssignments.costAtAssignmentCents,
+      })
+      .from(licenseAssignments)
+      .where(eq(licenseAssignments.status, "active"));
+
+    // Group by toolId
+    const byTool = new Map<
+      number,
+      { count: number; totalCost: number }
+    >();
+    for (const a of activeAssignmentsList) {
+      const existing = byTool.get(a.toolId) ?? { count: 0, totalCost: 0 };
+      existing.count += 1;
+      existing.totalCost += a.costAtAssignmentCents;
+      byTool.set(a.toolId, existing);
+    }
+
+    const result: ToolUtilization[] = activeTools.map((tool) => {
+      const stats = byTool.get(tool.id) ?? { count: 0, totalCost: 0 };
+      const utilizationPct =
+        tool.maxLicenses !== null && tool.maxLicenses > 0
+          ? (stats.count / tool.maxLicenses) * 100
+          : 0;
+      return {
+        toolId: tool.id,
+        toolName: tool.name,
+        vendor: tool.vendor,
+        assignedCount: stats.count,
+        maxLicenses: tool.maxLicenses,
+        utilizationPct,
+        expectedMonthlyCents: stats.totalCost,
+      };
+    });
+
+    return result.sort(
+      (a, b) => b.expectedMonthlyCents - a.expectedMonthlyCents
+    );
+  } catch {
+    return [];
+  }
 }

--- a/src/actions/budget.ts
+++ b/src/actions/budget.ts
@@ -20,7 +20,8 @@ import {
   updateBilledCostSchema,
   deleteBilledCostSchema,
 } from "@/lib/validators";
-import type { ActionResult, AnnualBudget, BudgetPeriod, BudgetWithCosts } from "@/types";
+import type { ActionResult, AnnualBudget, BudgetPeriod, BudgetWithCosts, PeriodSpendPoint, BudgetForecast, MonthlySpend } from "@/types";
+import { forecastBudget } from "@/lib/forecast";
 import { recordCreation, recordUpdate } from "@/actions/history";
 
 export async function createBudget(
@@ -537,6 +538,64 @@ export async function getBudgetWithCosts(
     ...budget,
     periods: periodsWithCosts,
   };
+}
+
+// 005-rich-reports: Time-series spend data per period
+export async function getBilledCostsTimeSeries(
+  budgetId: number
+): Promise<PeriodSpendPoint[]> {
+  try {
+    const budgetWithCosts = await getBudgetWithCosts(budgetId);
+    if (!budgetWithCosts) return [];
+    return budgetWithCosts.periods.map((p) => ({
+      month: p.periodLabel,
+      billedCents: p.billedTotalCents,
+      expectedCents: p.expectedSpendCents,
+      plannedCents: p.plannedAmountCents,
+      periodIndex: p.periodIndex,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// 005-rich-reports: Budget forecast using OLS linear regression
+export async function getBudgetForecast(
+  budgetId: number
+): Promise<ActionResult<BudgetForecast>> {
+  const budget = await getBudgetWithCosts(budgetId);
+  if (!budget) return { success: false, error: "Budget not found" };
+
+  const today = new Date();
+
+  const completedPeriods = budget.periods.filter(
+    (p) => new Date(p.endDate) < today && p.billedTotalCents > 0
+  );
+
+  const history: MonthlySpend[] = completedPeriods.map((p) => ({
+    month: p.periodLabel,
+    amountCents: p.billedTotalCents,
+  }));
+
+  const actualSpendToDateCents = completedPeriods.reduce(
+    (s, p) => s + p.billedTotalCents,
+    0
+  );
+
+  const remainingPeriods = budget.periods.filter(
+    (p) => new Date(p.startDate) >= today
+  );
+  const monthsToProject = Math.min(Math.max(remainingPeriods.length, 3), 6);
+
+  const forecastResult = forecastBudget({
+    history,
+    monthsToProject,
+    actualSpendToDateCents,
+    budgetCeilingCents: budget.totalAmountCents,
+    today,
+  });
+
+  return { success: true, data: forecastResult };
 }
 
 // US5: Per-tool spending breakdown for a period

--- a/src/actions/budget.ts
+++ b/src/actions/budget.ts
@@ -547,13 +547,16 @@ export async function getBilledCostsTimeSeries(
   try {
     const budgetWithCosts = await getBudgetWithCosts(budgetId);
     if (!budgetWithCosts) return [];
-    return budgetWithCosts.periods.map((p) => ({
-      month: p.periodLabel,
-      billedCents: p.billedTotalCents,
-      expectedCents: p.expectedSpendCents,
-      plannedCents: p.plannedAmountCents,
-      periodIndex: p.periodIndex,
-    }));
+    const today = new Date();
+    return budgetWithCosts.periods
+      .filter((p) => new Date(p.startDate) <= today)
+      .map((p) => ({
+        month: p.periodLabel,
+        billedCents: p.billedTotalCents,
+        expectedCents: p.expectedSpendCents,
+        plannedCents: p.plannedAmountCents,
+        periodIndex: p.periodIndex,
+      }));
   } catch {
     return [];
   }
@@ -590,6 +593,7 @@ export async function getBudgetForecast(
   const forecastResult = forecastBudget({
     history,
     monthsToProject,
+    totalPeriodsRemaining: remainingPeriods.length,
     actualSpendToDateCents,
     budgetCeilingCents: budget.totalAmountCents,
     today,

--- a/src/app/reports/loading.tsx
+++ b/src/app/reports/loading.tsx
@@ -9,7 +9,15 @@ export default function ReportsLoading() {
         <Skeleton className="mt-2 h-5 w-64" />
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-4">
+      {/* Tab navigation skeleton */}
+      <div className="flex gap-1">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-24 rounded-md" />
+        ))}
+      </div>
+
+      {/* Summary cards skeleton */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
           <Card key={i}>
             <CardContent className="pt-6">
@@ -20,17 +28,14 @@ export default function ReportsLoading() {
         ))}
       </div>
 
+      {/* Chart placeholder skeleton */}
       <Card>
         <CardHeader>
           <Skeleton className="h-6 w-48" />
           <Skeleton className="mt-1 h-4 w-64" />
         </CardHeader>
         <CardContent>
-          <div className="space-y-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-12 w-full" />
-            ))}
-          </div>
+          <Skeleton className="min-h-[300px] w-full rounded-md" />
         </CardContent>
       </Card>
     </div>

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,27 +1,38 @@
 import { getAssignments } from "@/actions/assignments";
 import { getTools } from "@/actions/tools";
 import { getUsers } from "@/actions/users";
-import { getActiveBudget, getBudgetWithCosts } from "@/actions/budget";
-import { formatCurrency } from "@/lib/utils";
+import {
+  getActiveBudget,
+  getBilledCostsTimeSeries,
+  getBudgetForecast,
+} from "@/actions/budget";
+import { getLicenseUtilizationByTool } from "@/actions/assignments";
 import { AuthGuard } from "@/components/auth-guard";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
+import { ReportsTabBar } from "./reports-tab-bar";
+import type {
+  ReportOverviewData,
+  ToolSummaryItem,
+  CircleReportItem,
+} from "@/types";
 
-export default async function ReportsPage() {
+const VALID_TABS = ["overview", "trends", "usage", "forecast"] as const;
+type Tab = (typeof VALID_TABS)[number];
+
+function parseTab(raw: string | undefined): Tab {
+  if (raw && (VALID_TABS as readonly string[]).includes(raw)) {
+    return raw as Tab;
+  }
+  return "overview";
+}
+
+export default async function ReportsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
+  const { tab: rawTab } = await searchParams;
+  const activeTab = parseTab(rawTab);
+
   const [assignments, tools, userList, activeBudget] = await Promise.all([
     getAssignments(),
     getTools(),
@@ -29,17 +40,20 @@ export default async function ReportsPage() {
     getActiveBudget(),
   ]);
 
-  // Load billed costs from active budget (if one exists)
-  const budgetWithCosts = activeBudget
-    ? await getBudgetWithCosts(activeBudget.id)
-    : null;
-  const totalBilledSpend =
-    budgetWithCosts?.periods.reduce((s, p) => s + p.billedTotalCents, 0) ?? 0;
+  const [trendsData, usageData, forecastResult] = await Promise.all([
+    activeBudget ? getBilledCostsTimeSeries(activeBudget.id) : Promise.resolve([]),
+    getLicenseUtilizationByTool(),
+    activeBudget ? getBudgetForecast(activeBudget.id) : Promise.resolve(null),
+  ]);
+
+  const forecastData =
+    forecastResult && "success" in forecastResult && forecastResult.success
+      ? forecastResult.data
+      : null;
 
   const activeAssignments = assignments.filter((a) => a.status === "active");
 
-  // Tool adoption summary
-  const toolSummary = tools.map((tool) => {
+  const toolSummary: ToolSummaryItem[] = tools.map((tool) => {
     const toolAssignments = activeAssignments.filter(
       (a) => a.tool.id === tool.id
     );
@@ -56,9 +70,8 @@ export default async function ReportsPage() {
     };
   });
 
-  // Circle breakdown
   const circles = [...new Set(userList.map((u) => u.circle))];
-  const circleReport = circles.map((circle) => {
+  const circleReport: CircleReportItem[] = circles.map((circle) => {
     const circleUsers = userList.filter((u) => u.circle === circle);
     const circleUserIds = new Set(circleUsers.map((u) => u.id));
     const circleAssignments = activeAssignments.filter((a) =>
@@ -82,6 +95,41 @@ export default async function ReportsPage() {
     (s, a) => s + a.costAtAssignmentCents,
     0
   );
+  const billedYtdCents = trendsData.reduce((s, p) => s + p.billedCents, 0);
+  const budgetCeilingCents = activeBudget?.totalAmountCents ?? 0;
+  const budgetRemainingCents = budgetCeilingCents - billedYtdCents;
+  const utilizationPct =
+    budgetCeilingCents > 0
+      ? (billedYtdCents / budgetCeilingCents) * 100
+      : 0;
+
+  // Compute spend trend: current vs prior period
+  const lastTwo = trendsData.slice(-2);
+  let spendTrend: "up" | "down" | "flat" = "flat";
+  let spendTrendPct = 0;
+  if (lastTwo.length === 2 && lastTwo[0].billedCents > 0) {
+    const diff = lastTwo[1].billedCents - lastTwo[0].billedCents;
+    spendTrendPct = (diff / lastTwo[0].billedCents) * 100;
+    spendTrend =
+      Math.abs(spendTrendPct) < 1
+        ? "flat"
+        : diff > 0
+          ? "up"
+          : "down";
+  }
+
+  const overviewData: ReportOverviewData = {
+    totalActiveUsers,
+    totalActiveTools,
+    totalActiveLicenses: activeAssignments.length,
+    expectedMonthlyCents: totalMonthlySpend,
+    billedYtdCents,
+    budgetCeilingCents,
+    budgetRemainingCents,
+    utilizationPct,
+    spendTrend,
+    spendTrendPct,
+  };
 
   return (
     <AuthGuard requiredRole="admin">
@@ -93,122 +141,15 @@ export default async function ReportsPage() {
           </p>
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">Active Users</p>
-              <p className="text-2xl font-bold">{totalActiveUsers}</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">Active Tools</p>
-              <p className="text-2xl font-bold">{totalActiveTools}</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">Active Licenses</p>
-              <p className="text-2xl font-bold">{activeAssignments.length}</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-sm text-muted-foreground">Expected Monthly Spend</p>
-              <p className="text-2xl font-bold">
-                {formatCurrency(totalMonthlySpend)}
-              </p>
-            </CardContent>
-          </Card>
-          {budgetWithCosts && (
-            <Card>
-              <CardContent className="pt-6">
-                <p className="text-sm text-muted-foreground">Billed Spend (YTD)</p>
-                <p className="text-2xl font-bold">
-                  {formatCurrency(totalBilledSpend)}
-                </p>
-              </CardContent>
-            </Card>
-          )}
-        </div>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Tool Adoption Summary</CardTitle>
-            <CardDescription>
-              Active license count and expected cost per tool
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto rounded-md border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Tool</TableHead>
-                    <TableHead>Vendor</TableHead>
-                    <TableHead>Active Users</TableHead>
-                    <TableHead>Expected Cost</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {toolSummary
-                    .sort((a, b) => b.totalMonthlyCost - a.totalMonthlyCost)
-                    .map((tool) => (
-                      <TableRow key={tool.id}>
-                        <TableCell className="font-medium">
-                          {tool.name}
-                        </TableCell>
-                        <TableCell>{tool.vendor}</TableCell>
-                        <TableCell>{tool.activeUsers}</TableCell>
-                        <TableCell>
-                          {formatCurrency(tool.totalMonthlyCost)}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                </TableBody>
-              </Table>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Circle Report</CardTitle>
-            <CardDescription>
-              License distribution and expected cost by circle
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto rounded-md border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Circle</TableHead>
-                    <TableHead>Users</TableHead>
-                    <TableHead>Licenses</TableHead>
-                    <TableHead>Expected Cost</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {circleReport
-                    .sort((a, b) => b.totalMonthlyCost - a.totalMonthlyCost)
-                    .map((item) => (
-                      <TableRow key={item.circle}>
-                        <TableCell className="font-medium">
-                          {item.circle}
-                        </TableCell>
-                        <TableCell>{item.userCount}</TableCell>
-                        <TableCell>{item.licenseCount}</TableCell>
-                        <TableCell>
-                          {formatCurrency(item.totalMonthlyCost)}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                </TableBody>
-              </Table>
-            </div>
-          </CardContent>
-        </Card>
+        <ReportsTabBar
+          activeTab={activeTab}
+          overviewData={overviewData}
+          trendsData={trendsData}
+          usageData={usageData}
+          forecastData={forecastData}
+          toolSummary={toolSummary}
+          circleReport={circleReport}
+        />
       </div>
     </AuthGuard>
   );

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -103,8 +103,9 @@ export default async function ReportsPage({
       ? (billedYtdCents / budgetCeilingCents) * 100
       : 0;
 
-  // Compute spend trend: current vs prior period
-  const lastTwo = trendsData.slice(-2);
+  // Compute spend trend from last two periods with actual spend
+  const historicalPeriods = trendsData.filter((p) => p.billedCents > 0);
+  const lastTwo = historicalPeriods.slice(-2);
   let spendTrend: "up" | "down" | "flat" = "flat";
   let spendTrendPct = 0;
   if (lastTwo.length === 2 && lastTwo[0].billedCents > 0) {

--- a/src/app/reports/reports-tab-bar.tsx
+++ b/src/app/reports/reports-tab-bar.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Card, CardContent } from "@/components/ui/card";
 import type {
@@ -74,7 +74,7 @@ export function ReportsTabBar({
         <TabsTrigger value="forecast">Forecast</TabsTrigger>
       </TabsList>
 
-      <div className="mt-6">
+      <TabsContent value={activeTab} className="mt-6">
         <ReportsChartsPanel
           activeTab={activeTab}
           overviewData={overviewData}
@@ -84,7 +84,7 @@ export function ReportsTabBar({
           toolSummary={toolSummary}
           circleReport={circleReport}
         />
-      </div>
+      </TabsContent>
     </Tabs>
   );
 }

--- a/src/app/reports/reports-tab-bar.tsx
+++ b/src/app/reports/reports-tab-bar.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent } from "@/components/ui/card";
+import type {
+  ReportOverviewData,
+  PeriodSpendPoint,
+  ToolUtilization,
+  BudgetForecast,
+  ToolSummaryItem,
+  CircleReportItem,
+} from "@/types";
+
+const ReportsChartsPanel = dynamic(
+  () =>
+    import("@/components/reports/reports-charts-panel").then(
+      (m) => m.ReportsChartsPanel
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-6">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="pt-6">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="mt-2 h-8 w-16" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <Skeleton className="min-h-[300px] w-full rounded-lg" />
+      </div>
+    ),
+  }
+);
+
+export interface ReportsTabBarProps {
+  activeTab: "overview" | "trends" | "usage" | "forecast";
+  overviewData: ReportOverviewData;
+  trendsData: PeriodSpendPoint[];
+  usageData: ToolUtilization[];
+  forecastData: BudgetForecast | null;
+  toolSummary: ToolSummaryItem[];
+  circleReport: CircleReportItem[];
+}
+
+export function ReportsTabBar({
+  activeTab,
+  overviewData,
+  trendsData,
+  usageData,
+  forecastData,
+  toolSummary,
+  circleReport,
+}: ReportsTabBarProps) {
+  const router = useRouter();
+
+  function handleTabChange(value: string) {
+    const params = value === "overview" ? "" : `?tab=${value}`;
+    router.replace(`/reports${params}`, { scroll: false });
+  }
+
+  return (
+    <Tabs value={activeTab} onValueChange={handleTabChange}>
+      <TabsList>
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="trends">Trends</TabsTrigger>
+        <TabsTrigger value="usage">Usage</TabsTrigger>
+        <TabsTrigger value="forecast">Forecast</TabsTrigger>
+      </TabsList>
+
+      <div className="mt-6">
+        <ReportsChartsPanel
+          activeTab={activeTab}
+          overviewData={overviewData}
+          trendsData={trendsData}
+          usageData={usageData}
+          forecastData={forecastData}
+          toolSummary={toolSummary}
+          circleReport={circleReport}
+        />
+      </div>
+    </Tabs>
+  );
+}

--- a/src/components/reports/forecast-chart.tsx
+++ b/src/components/reports/forecast-chart.tsx
@@ -18,10 +18,10 @@ const forecastConfig = {
 
 interface ForecastChartProps {
   data: ForecastChartPoint[];
-  budgetCeilingCents: number;
+  monthlyBudgetCents: number;
 }
 
-export function ForecastChart({ data, budgetCeilingCents }: ForecastChartProps) {
+export function ForecastChart({ data, monthlyBudgetCents }: ForecastChartProps) {
   return (
     <ChartContainer config={forecastConfig} className="min-h-[300px]">
       <LineChart data={data} accessibilityLayer>
@@ -35,19 +35,19 @@ export function ForecastChart({ data, budgetCeilingCents }: ForecastChartProps) 
           content={
             <ChartTooltipContent
               formatter={(value) =>
-                `$${((value as number) / 100).toFixed(2)}`
+                value == null ? null : `$${((value as number) / 100).toFixed(2)}`
               }
             />
           }
         />
         <ChartLegend content={<ChartLegendContent />} />
         <ReferenceLine
-          y={budgetCeilingCents}
+          y={monthlyBudgetCents}
           stroke="var(--chart-5)"
           strokeDasharray="4 2"
           ifOverflow="extendDomain"
           label={{
-            value: "Budget Ceiling",
+            value: "Avg. Monthly Budget",
             position: "insideTopRight",
             fontSize: 12,
           }}

--- a/src/components/reports/forecast-chart.tsx
+++ b/src/components/reports/forecast-chart.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, ReferenceLine } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
+import type { ForecastChartPoint } from "@/types";
+
+const forecastConfig = {
+  historical: { label: "Actual", color: "var(--chart-1)" },
+  projected: { label: "Projected", color: "var(--chart-2)" },
+} satisfies ChartConfig;
+
+interface ForecastChartProps {
+  data: ForecastChartPoint[];
+  budgetCeilingCents: number;
+}
+
+export function ForecastChart({ data, budgetCeilingCents }: ForecastChartProps) {
+  return (
+    <ChartContainer config={forecastConfig} className="min-h-[300px]">
+      <LineChart data={data} accessibilityLayer>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="month" tick={{ fontSize: 12 }} />
+        <YAxis
+          tickFormatter={(v: number) => `$${(v / 100).toFixed(0)}`}
+          tick={{ fontSize: 12 }}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              formatter={(value) =>
+                `$${((value as number) / 100).toFixed(2)}`
+              }
+            />
+          }
+        />
+        <ChartLegend content={<ChartLegendContent />} />
+        <ReferenceLine
+          y={budgetCeilingCents}
+          stroke="var(--chart-5)"
+          strokeDasharray="4 2"
+          ifOverflow="extendDomain"
+          label={{
+            value: "Budget Ceiling",
+            position: "insideTopRight",
+            fontSize: 12,
+          }}
+        />
+        <Line
+          type="monotone"
+          dataKey="historical"
+          stroke="var(--color-historical)"
+          strokeWidth={2}
+          dot={false}
+          connectNulls={false}
+        />
+        <Line
+          type="monotone"
+          dataKey="projected"
+          stroke="var(--color-projected)"
+          strokeWidth={2}
+          strokeDasharray="5 5"
+          dot={false}
+          connectNulls={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  );
+}

--- a/src/components/reports/reports-charts-panel.tsx
+++ b/src/components/reports/reports-charts-panel.tsx
@@ -1,0 +1,462 @@
+"use client";
+
+import { useState } from "react";
+import { TrendsChart } from "./trends-chart";
+import { UtilizationChart } from "./utilization-chart";
+import { ForecastChart } from "./forecast-chart";
+import { Sparkline } from "./sparkline";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatCurrency } from "@/lib/utils";
+import type {
+  ReportOverviewData,
+  PeriodSpendPoint,
+  ToolUtilization,
+  BudgetForecast,
+  ForecastChartPoint,
+  ToolSummaryItem,
+  CircleReportItem,
+} from "@/types";
+
+interface ReportsChartsPanelProps {
+  activeTab: "overview" | "trends" | "usage" | "forecast";
+  overviewData: ReportOverviewData;
+  trendsData: PeriodSpendPoint[];
+  usageData: ToolUtilization[];
+  forecastData: BudgetForecast | null;
+  toolSummary: ToolSummaryItem[];
+  circleReport: CircleReportItem[];
+}
+
+function buildForecastChartData(
+  trendsData: PeriodSpendPoint[],
+  forecastData: BudgetForecast
+): ForecastChartPoint[] {
+  const historical: ForecastChartPoint[] = trendsData.map((p, i) => ({
+    month: p.month,
+    historical: p.billedCents,
+    projected:
+      i === trendsData.length - 1 && forecastData.projections.length > 0
+        ? p.billedCents
+        : null,
+  }));
+
+  const projected: ForecastChartPoint[] = forecastData.projections.map((p) => ({
+    month: p.month,
+    historical: null,
+    projected: p.projectedAmountCents,
+  }));
+
+  return [...historical, ...projected];
+}
+
+export function ReportsChartsPanel({
+  activeTab,
+  overviewData,
+  trendsData,
+  usageData,
+  forecastData,
+  toolSummary,
+  circleReport,
+}: ReportsChartsPanelProps) {
+  const [showAllUsage, setShowAllUsage] = useState(false);
+
+  const sparklineData = trendsData.slice(-6).map((p) => p.billedCents);
+
+  if (activeTab === "overview") {
+    return (
+      <div className="space-y-6">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-sm text-muted-foreground">Active Users</p>
+              <p className="text-2xl font-bold">
+                {overviewData.totalActiveUsers}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-sm text-muted-foreground">Active Tools</p>
+              <p className="text-2xl font-bold">
+                {overviewData.totalActiveTools}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-sm text-muted-foreground">Active Licenses</p>
+              <p className="text-2xl font-bold">
+                {overviewData.totalActiveLicenses}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-start justify-between">
+                <div>
+                  <p className="text-sm text-muted-foreground">
+                    Expected Monthly
+                  </p>
+                  <p className="text-2xl font-bold">
+                    {formatCurrency(overviewData.expectedMonthlyCents)}
+                  </p>
+                </div>
+                {sparklineData.length > 1 && (
+                  <Sparkline data={sparklineData} />
+                )}
+              </div>
+              <p
+                className={`mt-1 text-xs ${
+                  overviewData.spendTrend === "up"
+                    ? "text-destructive"
+                    : overviewData.spendTrend === "down"
+                      ? "text-green-600"
+                      : "text-muted-foreground"
+                }`}
+              >
+                {overviewData.spendTrend === "up"
+                  ? `▲ ${overviewData.spendTrendPct.toFixed(1)}% vs last period`
+                  : overviewData.spendTrend === "down"
+                    ? `▼ ${Math.abs(overviewData.spendTrendPct).toFixed(1)}% vs last period`
+                    : "Flat vs last period"}
+              </p>
+            </CardContent>
+          </Card>
+          {overviewData.budgetCeilingCents > 0 && (
+            <>
+              <Card>
+                <CardContent className="pt-6">
+                  <p className="text-sm text-muted-foreground">Billed YTD</p>
+                  <p className="text-2xl font-bold">
+                    {formatCurrency(overviewData.billedYtdCents)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {overviewData.utilizationPct.toFixed(1)}% of budget
+                  </p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <p className="text-sm text-muted-foreground">
+                    Budget Remaining
+                  </p>
+                  <p
+                    className={`text-2xl font-bold ${
+                      overviewData.budgetRemainingCents < 0
+                        ? "text-destructive"
+                        : ""
+                    }`}
+                  >
+                    {formatCurrency(overviewData.budgetRemainingCents)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    of {formatCurrency(overviewData.budgetCeilingCents)} total
+                  </p>
+                </CardContent>
+              </Card>
+            </>
+          )}
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Tool Adoption Summary</CardTitle>
+            <CardDescription>
+              Active license count and expected cost per tool
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Tool</TableHead>
+                    <TableHead>Vendor</TableHead>
+                    <TableHead>Active Users</TableHead>
+                    <TableHead>Expected Cost</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {toolSummary
+                    .sort((a, b) => b.totalMonthlyCost - a.totalMonthlyCost)
+                    .map((tool) => (
+                      <TableRow key={tool.id}>
+                        <TableCell className="font-medium">
+                          {tool.name}
+                        </TableCell>
+                        <TableCell>{tool.vendor}</TableCell>
+                        <TableCell>{tool.activeUsers}</TableCell>
+                        <TableCell>
+                          {formatCurrency(tool.totalMonthlyCost)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Circle Report</CardTitle>
+            <CardDescription>
+              License distribution and expected cost by circle
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Circle</TableHead>
+                    <TableHead>Users</TableHead>
+                    <TableHead>Licenses</TableHead>
+                    <TableHead>Expected Cost</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {circleReport
+                    .sort((a, b) => b.totalMonthlyCost - a.totalMonthlyCost)
+                    .map((item) => (
+                      <TableRow key={item.circle}>
+                        <TableCell className="font-medium">
+                          {item.circle}
+                        </TableCell>
+                        <TableCell>{item.userCount}</TableCell>
+                        <TableCell>{item.licenseCount}</TableCell>
+                        <TableCell>
+                          {formatCurrency(item.totalMonthlyCost)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (activeTab === "trends") {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Spend Over Time</CardTitle>
+          <CardDescription>
+            Billed, expected, and planned spend by period
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {trendsData.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No spending data available yet.
+            </p>
+          ) : (
+            <TrendsChart data={trendsData} />
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (activeTab === "usage") {
+    const displayedTools = showAllUsage ? usageData : usageData.slice(0, 10);
+
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>License Utilization by Tool</CardTitle>
+            <CardDescription>
+              Assigned seats vs. available capacity
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {usageData.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No active tools found.
+              </p>
+            ) : (
+              <UtilizationChart data={displayedTools} />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>Usage Details</CardTitle>
+                <CardDescription>
+                  {showAllUsage
+                    ? `All ${usageData.length} tools`
+                    : `Top ${Math.min(10, usageData.length)} tools by cost`}
+                </CardDescription>
+              </div>
+              {usageData.length > 10 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowAllUsage((v) => !v)}
+                >
+                  {showAllUsage ? "Show top 10" : "Show all"}
+                </Button>
+              )}
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Tool</TableHead>
+                    <TableHead>Vendor</TableHead>
+                    <TableHead>Assigned</TableHead>
+                    <TableHead>Capacity</TableHead>
+                    <TableHead>Utilization</TableHead>
+                    <TableHead>Monthly Cost</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {displayedTools.map((tool) => (
+                    <TableRow key={tool.toolId}>
+                      <TableCell className="font-medium">
+                        {tool.toolName}
+                      </TableCell>
+                      <TableCell>{tool.vendor}</TableCell>
+                      <TableCell>{tool.assignedCount}</TableCell>
+                      <TableCell>
+                        {tool.maxLicenses !== null
+                          ? tool.maxLicenses
+                          : "Unlimited"}
+                      </TableCell>
+                      <TableCell>
+                        {tool.maxLicenses !== null
+                          ? `${tool.utilizationPct.toFixed(0)}%`
+                          : "—"}
+                      </TableCell>
+                      <TableCell>
+                        {formatCurrency(tool.expectedMonthlyCents)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Forecast tab
+  if (!forecastData) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-sm text-muted-foreground">
+            No active budget found. Create a budget to enable forecasting.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (forecastData.insufficientData) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Budget Forecast</CardTitle>
+          <CardDescription>{forecastData.insufficientData}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            The forecast requires at least 3 months of completed billing data.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const forecastChartData = buildForecastChartData(trendsData, forecastData);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">Actual Spend to Date</p>
+            <p className="text-2xl font-bold">
+              {formatCurrency(forecastData.actualSpendToDateCents)}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">Projected Remaining</p>
+            <p className="text-2xl font-bold">
+              {formatCurrency(forecastData.projectedRemainingCents)}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Projected Annual Total
+                </p>
+                <p className="text-2xl font-bold">
+                  {formatCurrency(forecastData.projectedAnnualTotalCents)}
+                </p>
+              </div>
+              <Badge
+                variant={
+                  forecastData.status === "on_track" ? "default" : "destructive"
+                }
+              >
+                {forecastData.status === "on_track" ? "On Track" : "At Risk"}
+              </Badge>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Budget: {formatCurrency(forecastData.budgetCeilingCents)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Spend Forecast</CardTitle>
+          <CardDescription>
+            Historical spend with linear regression projection
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ForecastChart
+            data={forecastChartData}
+            budgetCeilingCents={forecastData.budgetCeilingCents}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/reports/reports-charts-panel.tsx
+++ b/src/components/reports/reports-charts-panel.tsx
@@ -47,11 +47,19 @@ function buildForecastChartData(
   trendsData: PeriodSpendPoint[],
   forecastData: BudgetForecast
 ): ForecastChartPoint[] {
+  let lastHistoricalIndex = trendsData.length - 1;
+  for (let i = trendsData.length - 1; i >= 0; i--) {
+    if (trendsData[i].billedCents > 0) {
+      lastHistoricalIndex = i;
+      break;
+    }
+  }
+
   const historical: ForecastChartPoint[] = trendsData.map((p, i) => ({
     month: p.month,
     historical: p.billedCents,
     projected:
-      i === trendsData.length - 1 && forecastData.projections.length > 0
+      i === lastHistoricalIndex && forecastData.projections.length > 0
         ? p.billedCents
         : null,
   }));
@@ -193,7 +201,7 @@ export function ReportsChartsPanel({
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {toolSummary
+                  {[...toolSummary]
                     .sort((a, b) => b.totalMonthlyCost - a.totalMonthlyCost)
                     .map((tool) => (
                       <TableRow key={tool.id}>
@@ -232,7 +240,7 @@ export function ReportsChartsPanel({
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {circleReport
+                  {[...circleReport]
                     .sort((a, b) => b.totalMonthlyCost - a.totalMonthlyCost)
                     .map((item) => (
                       <TableRow key={item.circle}>
@@ -453,7 +461,7 @@ export function ReportsChartsPanel({
         <CardContent>
           <ForecastChart
             data={forecastChartData}
-            budgetCeilingCents={forecastData.budgetCeilingCents}
+            monthlyBudgetCents={Math.round(forecastData.budgetCeilingCents / 12)}
           />
         </CardContent>
       </Card>

--- a/src/components/reports/sparkline.tsx
+++ b/src/components/reports/sparkline.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { LineChart, Line } from "recharts";
+
+interface SparklineProps {
+  data: number[];
+  color?: string;
+}
+
+export function Sparkline({ data, color = "var(--chart-1)" }: SparklineProps) {
+  const chartData = data.map((v) => ({ value: v }));
+
+  return (
+    <LineChart width={80} height={32} data={chartData} accessibilityLayer>
+      <Line
+        type="monotone"
+        dataKey="value"
+        stroke={color}
+        strokeWidth={1.5}
+        dot={false}
+        isAnimationActive={false}
+      />
+    </LineChart>
+  );
+}

--- a/src/components/reports/trends-chart.tsx
+++ b/src/components/reports/trends-chart.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
+import { Button } from "@/components/ui/button";
+import type { PeriodSpendPoint } from "@/types";
+
+const trendsConfig = {
+  billedCents: { label: "Billed", color: "var(--chart-1)" },
+  expectedCents: { label: "Expected", color: "var(--chart-2)" },
+  plannedCents: { label: "Planned", color: "var(--chart-3)" },
+} satisfies ChartConfig;
+
+type Range = "3m" | "6m" | "12m";
+
+interface TrendsChartProps {
+  data: PeriodSpendPoint[];
+}
+
+export function TrendsChart({ data }: TrendsChartProps) {
+  const [range, setRange] = useState<Range>("6m");
+
+  const rangeMap: Record<Range, number> = { "3m": 3, "6m": 6, "12m": 12 };
+  const filtered = data.slice(-rangeMap[range]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        {(["3m", "6m", "12m"] as Range[]).map((r) => (
+          <Button
+            key={r}
+            variant={range === r ? "default" : "outline"}
+            size="sm"
+            onClick={() => setRange(r)}
+          >
+            {r === "3m" ? "3 months" : r === "6m" ? "6 months" : "12 months"}
+          </Button>
+        ))}
+      </div>
+      <ChartContainer config={trendsConfig} className="min-h-[300px]">
+        <LineChart data={filtered} accessibilityLayer>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" tick={{ fontSize: 12 }} />
+          <YAxis
+            tickFormatter={(v: number) => `$${(v / 100).toFixed(0)}`}
+            tick={{ fontSize: 12 }}
+          />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                formatter={(value) =>
+                  `$${((value as number) / 100).toFixed(2)}`
+                }
+              />
+            }
+          />
+          <ChartLegend content={<ChartLegendContent />} />
+          <Line
+            type="monotone"
+            dataKey="billedCents"
+            stroke="var(--color-billedCents)"
+            strokeWidth={2}
+            dot={false}
+            connectNulls
+          />
+          <Line
+            type="monotone"
+            dataKey="expectedCents"
+            stroke="var(--color-expectedCents)"
+            strokeWidth={2}
+            strokeDasharray="5 5"
+            dot={false}
+            connectNulls
+          />
+          <Line
+            type="monotone"
+            dataKey="plannedCents"
+            stroke="var(--color-plannedCents)"
+            strokeWidth={2}
+            strokeDasharray="2 4"
+            dot={false}
+            connectNulls
+          />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  );
+}

--- a/src/components/reports/utilization-chart.tsx
+++ b/src/components/reports/utilization-chart.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
+import type { ToolUtilization } from "@/types";
+
+const utilizationConfig = {
+  assignedCount: { label: "Assigned", color: "var(--chart-1)" },
+  remaining: { label: "Available", color: "var(--chart-5)" },
+} satisfies ChartConfig;
+
+interface UtilizationChartProps {
+  data: ToolUtilization[];
+}
+
+export function UtilizationChart({ data }: UtilizationChartProps) {
+  const chartData = data.map((t) => ({
+    name: t.toolName,
+    assignedCount: t.assignedCount,
+    remaining:
+      t.maxLicenses !== null
+        ? Math.max(0, t.maxLicenses - t.assignedCount)
+        : 0,
+    maxLicenses: t.maxLicenses,
+  }));
+
+  return (
+    <ChartContainer config={utilizationConfig} className="min-h-[300px]">
+      <BarChart layout="vertical" data={chartData} accessibilityLayer>
+        <CartesianGrid horizontal={false} />
+        <XAxis type="number" tick={{ fontSize: 12 }} />
+        <YAxis
+          type="category"
+          dataKey="name"
+          tick={{ fontSize: 12 }}
+          width={120}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              formatter={(value, name) => {
+                if (name === "assignedCount") return `${value} assigned`;
+                if (name === "remaining") return `${value} available`;
+                return String(value);
+              }}
+            />
+          }
+        />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Bar
+          dataKey="assignedCount"
+          stackId="a"
+          fill="var(--color-assignedCount)"
+        />
+        <Bar
+          dataKey="remaining"
+          stackId="a"
+          fill="var(--color-remaining)"
+          radius={[0, 4, 4, 0]}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/src/lib/forecast.ts
+++ b/src/lib/forecast.ts
@@ -3,6 +3,7 @@ import type { MonthlySpend, ForecastPoint, BudgetForecast } from "@/types";
 export interface ForecastOptions {
   history: MonthlySpend[];
   monthsToProject?: number;
+  totalPeriodsRemaining?: number;
   actualSpendToDateCents: number;
   budgetCeilingCents: number;
   today: Date;
@@ -10,13 +11,22 @@ export interface ForecastOptions {
 
 const MONTH_NAMES = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
 
-function parseMonthLabel(label: string): { year: number; month: number } | null {
+export function parseMonthLabel(label: string): { year: number; month: number } | null {
+  // "MMM YYYY" (e.g. "Jan 2026")
   const parts = label.split(" ");
-  if (parts.length !== 2) return null;
-  const monthIdx = MONTH_NAMES.indexOf(parts[0]);
-  const year = parseInt(parts[1], 10);
-  if (monthIdx === -1 || isNaN(year)) return null;
-  return { year, month: monthIdx };
+  if (parts.length === 2) {
+    const monthIdx = MONTH_NAMES.indexOf(parts[0]);
+    const year = parseInt(parts[1], 10);
+    if (monthIdx !== -1 && !isNaN(year)) return { year, month: monthIdx };
+  }
+  // "Qn YYYY" (e.g. "Q1 2026")
+  const quarterMatch = label.match(/^Q([1-4])\s+(\d{4})$/);
+  if (quarterMatch) {
+    const quarter = parseInt(quarterMatch[1], 10);
+    const year = parseInt(quarterMatch[2], 10);
+    return { year, month: (quarter - 1) * 3 };
+  }
+  return null;
 }
 
 function formatMonthLabel(year: number, monthIdx: number): string {
@@ -60,6 +70,10 @@ export function forecastBudget(options: ForecastOptions): BudgetForecast {
     };
   }
 
+  const annualProjectionCount = options.totalPeriodsRemaining !== undefined
+    ? Math.max(options.totalPeriodsRemaining, monthsToProject)
+    : monthsToProject;
+
   const xs = history.map((_, i) => i);
   const ys = history.map((h) => h.amountCents);
   const { slope, intercept } = olsRegression(xs, ys);
@@ -84,10 +98,11 @@ export function forecastBudget(options: ForecastOptions): BudgetForecast {
     cur = nextMonth(cur.year, cur.month);
   }
 
-  const projectedRemainingCents = projections.reduce(
-    (s, p) => s + p.projectedAmountCents,
-    0
-  );
+  let projectedRemainingCents = 0;
+  for (let i = 0; i < annualProjectionCount; i++) {
+    const rawAmount = slope * (baseX + i) + intercept;
+    projectedRemainingCents += Math.max(0, Math.round(rawAmount));
+  }
   const projectedAnnualTotalCents = actualSpendToDateCents + projectedRemainingCents;
 
   return {

--- a/src/lib/forecast.ts
+++ b/src/lib/forecast.ts
@@ -1,0 +1,103 @@
+import type { MonthlySpend, ForecastPoint, BudgetForecast } from "@/types";
+
+export interface ForecastOptions {
+  history: MonthlySpend[];
+  monthsToProject?: number;
+  actualSpendToDateCents: number;
+  budgetCeilingCents: number;
+  today: Date;
+}
+
+const MONTH_NAMES = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+
+function parseMonthLabel(label: string): { year: number; month: number } | null {
+  const parts = label.split(" ");
+  if (parts.length !== 2) return null;
+  const monthIdx = MONTH_NAMES.indexOf(parts[0]);
+  const year = parseInt(parts[1], 10);
+  if (monthIdx === -1 || isNaN(year)) return null;
+  return { year, month: monthIdx };
+}
+
+function formatMonthLabel(year: number, monthIdx: number): string {
+  return `${MONTH_NAMES[monthIdx]} ${year}`;
+}
+
+function nextMonth(year: number, monthIdx: number): { year: number; month: number } {
+  if (monthIdx === 11) return { year: year + 1, month: 0 };
+  return { year, month: monthIdx + 1 };
+}
+
+function olsRegression(xs: number[], ys: number[]): { slope: number; intercept: number } {
+  const n = xs.length;
+  const sumX = xs.reduce((s, x) => s + x, 0);
+  const sumY = ys.reduce((s, y) => s + y, 0);
+  const sumXY = xs.reduce((s, x, i) => s + x * ys[i], 0);
+  const sumXX = xs.reduce((s, x) => s + x * x, 0);
+  const denom = n * sumXX - sumX * sumX;
+  if (denom === 0) return { slope: 0, intercept: n > 0 ? sumY / n : 0 };
+  const slope = (n * sumXY - sumX * sumY) / denom;
+  const intercept = (sumY - slope * sumX) / n;
+  return { slope, intercept };
+}
+
+export function forecastBudget(options: ForecastOptions): BudgetForecast {
+  const { history, actualSpendToDateCents, budgetCeilingCents, today } = options;
+  const monthsToProject = Math.min(Math.max(options.monthsToProject ?? 3, 3), 6);
+
+  if (history.length < 3) {
+    const projectedAnnualTotalCents = actualSpendToDateCents;
+    return {
+      slopeCents: 0,
+      interceptCents: 0,
+      projections: [],
+      projectedRemainingCents: 0,
+      actualSpendToDateCents,
+      projectedAnnualTotalCents,
+      budgetCeilingCents,
+      status: projectedAnnualTotalCents <= budgetCeilingCents ? "on_track" : "at_risk",
+      insufficientData: `Need at least 3 months of history (currently ${history.length})`,
+    };
+  }
+
+  const xs = history.map((_, i) => i);
+  const ys = history.map((h) => h.amountCents);
+  const { slope, intercept } = olsRegression(xs, ys);
+
+  // Determine start month for projections from last history month
+  const lastEntry = history[history.length - 1];
+  const lastParsed = parseMonthLabel(lastEntry.month) ?? {
+    year: today.getFullYear(),
+    month: today.getMonth(),
+  };
+
+  const projections: ForecastPoint[] = [];
+  let cur = nextMonth(lastParsed.year, lastParsed.month);
+  const baseX = history.length; // x index for first projected month
+
+  for (let i = 0; i < monthsToProject; i++) {
+    const rawAmount = slope * (baseX + i) + intercept;
+    projections.push({
+      month: formatMonthLabel(cur.year, cur.month),
+      projectedAmountCents: Math.max(0, Math.round(rawAmount)),
+    });
+    cur = nextMonth(cur.year, cur.month);
+  }
+
+  const projectedRemainingCents = projections.reduce(
+    (s, p) => s + p.projectedAmountCents,
+    0
+  );
+  const projectedAnnualTotalCents = actualSpendToDateCents + projectedRemainingCents;
+
+  return {
+    slopeCents: Math.round(slope),
+    interceptCents: Math.round(intercept),
+    projections,
+    projectedRemainingCents,
+    actualSpendToDateCents,
+    projectedAnnualTotalCents,
+    budgetCeilingCents,
+    status: projectedAnnualTotalCents <= budgetCeilingCents ? "on_track" : "at_risk",
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,3 +64,79 @@ export type PeriodWithCosts = BudgetPeriod & {
 export type BudgetWithCosts = AnnualBudget & {
   periods: PeriodWithCosts[];
 };
+
+// Report data types for 005-rich-reports
+
+export interface PeriodSpendPoint {
+  month: string;
+  billedCents: number;
+  expectedCents: number;
+  plannedCents: number;
+  periodIndex: number;
+}
+
+export interface ToolUtilization {
+  toolId: number;
+  toolName: string;
+  vendor: string;
+  assignedCount: number;
+  maxLicenses: number | null;
+  utilizationPct: number;
+  expectedMonthlyCents: number;
+}
+
+export interface MonthlySpend {
+  month: string;
+  amountCents: number;
+}
+
+export interface ForecastPoint {
+  month: string;
+  projectedAmountCents: number;
+}
+
+export interface BudgetForecast {
+  slopeCents: number;
+  interceptCents: number;
+  projections: ForecastPoint[];
+  projectedRemainingCents: number;
+  actualSpendToDateCents: number;
+  projectedAnnualTotalCents: number;
+  budgetCeilingCents: number;
+  status: "on_track" | "at_risk";
+  insufficientData?: string;
+}
+
+export interface ReportOverviewData {
+  totalActiveUsers: number;
+  totalActiveTools: number;
+  totalActiveLicenses: number;
+  expectedMonthlyCents: number;
+  billedYtdCents: number;
+  budgetCeilingCents: number;
+  budgetRemainingCents: number;
+  utilizationPct: number;
+  spendTrend: "up" | "down" | "flat";
+  spendTrendPct: number;
+}
+
+export interface ForecastChartPoint {
+  month: string;
+  historical: number | null;
+  projected: number | null;
+}
+
+export interface ToolSummaryItem {
+  id: number;
+  name: string;
+  vendor: string;
+  activeUsers: number;
+  totalMonthlyCost: number;
+}
+
+export interface CircleReportItem {
+  circle: string;
+  userCount: number;
+  licenseCount: number;
+  totalMonthlyCost: number;
+}

--- a/tests/unit/forecast.test.ts
+++ b/tests/unit/forecast.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import { forecastBudget } from "@/lib/forecast";
+import type { MonthlySpend } from "@/types";
+
+const TODAY = new Date("2026-03-05");
+
+function makeHistory(values: number[]): MonthlySpend[] {
+  const months = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  return values.map((v, i) => ({
+    month: `${months[i % 12]} ${2025 + Math.floor(i / 12)}`,
+    amountCents: v,
+  }));
+}
+
+describe("forecastBudget", () => {
+  it("returns insufficientData when history has fewer than 3 months", () => {
+    const result = forecastBudget({
+      history: makeHistory([10000, 12000]),
+      actualSpendToDateCents: 22000,
+      budgetCeilingCents: 120000,
+      today: TODAY,
+    });
+
+    expect(result.insufficientData).toBeDefined();
+    expect(result.projections).toHaveLength(0);
+    expect(result.projectedRemainingCents).toBe(0);
+  });
+
+  it("returns on_track status when insufficientData and spend is below ceiling", () => {
+    const result = forecastBudget({
+      history: makeHistory([10000]),
+      actualSpendToDateCents: 10000,
+      budgetCeilingCents: 120000,
+      today: TODAY,
+    });
+
+    expect(result.status).toBe("on_track");
+  });
+
+  it("returns at_risk status when insufficientData and spend exceeds ceiling", () => {
+    const result = forecastBudget({
+      history: makeHistory([10000]),
+      actualSpendToDateCents: 130000,
+      budgetCeilingCents: 120000,
+      today: TODAY,
+    });
+
+    expect(result.status).toBe("at_risk");
+  });
+
+  it("runs OLS with valid 3-month history and produces 3 projections by default", () => {
+    const history = makeHistory([10000, 11000, 12000]);
+    const result = forecastBudget({
+      history,
+      actualSpendToDateCents: 33000,
+      budgetCeilingCents: 200000,
+      today: TODAY,
+    });
+
+    expect(result.insufficientData).toBeUndefined();
+    expect(result.projections).toHaveLength(3);
+    expect(result.slopeCents).toBeCloseTo(1000, 0);
+  });
+
+  it("projects 6 months when monthsToProject=6", () => {
+    const history = makeHistory([10000, 11000, 12000, 13000]);
+    const result = forecastBudget({
+      history,
+      monthsToProject: 6,
+      actualSpendToDateCents: 46000,
+      budgetCeilingCents: 200000,
+      today: TODAY,
+    });
+
+    expect(result.projections).toHaveLength(6);
+  });
+
+  it("clamps monthsToProject to [3, 6]", () => {
+    const history = makeHistory([10000, 11000, 12000]);
+    const low = forecastBudget({
+      history,
+      monthsToProject: 1,
+      actualSpendToDateCents: 33000,
+      budgetCeilingCents: 200000,
+      today: TODAY,
+    });
+    const high = forecastBudget({
+      history,
+      monthsToProject: 10,
+      actualSpendToDateCents: 33000,
+      budgetCeilingCents: 200000,
+      today: TODAY,
+    });
+
+    expect(low.projections).toHaveLength(3);
+    expect(high.projections).toHaveLength(6);
+  });
+
+  it("floors negative projected values at 0", () => {
+    // Steep downward trend leading to negative projections
+    const history = makeHistory([100000, 50000, 10000]);
+    const result = forecastBudget({
+      history,
+      monthsToProject: 3,
+      actualSpendToDateCents: 160000,
+      budgetCeilingCents: 500000,
+      today: TODAY,
+    });
+
+    for (const p of result.projections) {
+      expect(p.projectedAmountCents).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("all-zero history produces zero projections", () => {
+    const history = makeHistory([0, 0, 0, 0]);
+    const result = forecastBudget({
+      history,
+      actualSpendToDateCents: 0,
+      budgetCeilingCents: 100000,
+      today: TODAY,
+    });
+
+    expect(result.insufficientData).toBeUndefined();
+    for (const p of result.projections) {
+      expect(p.projectedAmountCents).toBe(0);
+    }
+  });
+
+  it("sets status=on_track when projectedAnnualTotal <= ceiling", () => {
+    const history = makeHistory([5000, 5000, 5000]);
+    const result = forecastBudget({
+      history,
+      actualSpendToDateCents: 15000,
+      budgetCeilingCents: 100000,
+      today: TODAY,
+    });
+
+    expect(result.status).toBe("on_track");
+    expect(result.projectedAnnualTotalCents).toBeLessThanOrEqual(100000);
+  });
+
+  it("sets status=at_risk when projectedAnnualTotal > ceiling", () => {
+    const history = makeHistory([30000, 40000, 50000]);
+    const result = forecastBudget({
+      history,
+      actualSpendToDateCents: 120000,
+      budgetCeilingCents: 200000,
+      today: TODAY,
+    });
+
+    expect(result.status).toBe("at_risk");
+    expect(result.projectedAnnualTotalCents).toBeGreaterThan(200000);
+  });
+
+  it("all returned monetary values are integers", () => {
+    const history = makeHistory([10001, 10002, 10003, 10007]);
+    const result = forecastBudget({
+      history,
+      actualSpendToDateCents: 40013,
+      budgetCeilingCents: 200000,
+      today: TODAY,
+    });
+
+    expect(Number.isInteger(result.slopeCents)).toBe(true);
+    expect(Number.isInteger(result.interceptCents)).toBe(true);
+    expect(Number.isInteger(result.projectedRemainingCents)).toBe(true);
+    expect(Number.isInteger(result.projectedAnnualTotalCents)).toBe(true);
+    for (const p of result.projections) {
+      expect(Number.isInteger(p.projectedAmountCents)).toBe(true);
+    }
+  });
+
+  it("generates correct month labels for projections", () => {
+    // History ending in Dec 2025 — projections should start Jan 2026
+    const history: MonthlySpend[] = [
+      { month: "Oct 2025", amountCents: 10000 },
+      { month: "Nov 2025", amountCents: 11000 },
+      { month: "Dec 2025", amountCents: 12000 },
+    ];
+    const result = forecastBudget({
+      history,
+      monthsToProject: 3,
+      actualSpendToDateCents: 33000,
+      budgetCeilingCents: 200000,
+      today: TODAY,
+    });
+
+    expect(result.projections[0].month).toBe("Jan 2026");
+    expect(result.projections[1].month).toBe("Feb 2026");
+    expect(result.projections[2].month).toBe("Mar 2026");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+    include: ["tests/unit/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds a four-tab reporting dashboard (Overview, Trends, Usage, Forecast) to `/reports`, replacing the flat page layout
- Implements OLS linear regression for budget forecasting in a pure server-side utility (`src/lib/forecast.ts`)
- Three new Server Action query functions for time-series spend, license utilization, and budget forecast data
- All Recharts chart components lazy-loaded via a single `next/dynamic({ ssr: false })` boundary to keep the main bundle under budget

## Changes

**Backend**
- `src/types/index.ts` — 9 new interfaces: `PeriodSpendPoint`, `ToolUtilization`, `BudgetForecast`, `ReportOverviewData`, `ForecastChartPoint`, `ToolSummaryItem`, `CircleReportItem`, `MonthlySpend`, `ForecastPoint`
- `src/lib/forecast.ts` — Pure OLS utility; handles `history.length < 3` guard, negative projection floor, integer rounding
- `src/actions/budget.ts` — `getBilledCostsTimeSeries()`, `getBudgetForecast()`
- `src/actions/assignments.ts` — `getLicenseUtilizationByTool()`

**Frontend**
- `src/components/reports/sparkline.tsx` — Inline 80×32 LineChart, `isAnimationActive={false}`
- `src/components/reports/trends-chart.tsx` — LineChart with 3m/6m/12m client-side range selector
- `src/components/reports/utilization-chart.tsx` — Vertical stacked BarChart (assigned vs. available seats)
- `src/components/reports/forecast-chart.tsx` — Composite LineChart (historical + projected) with budget ceiling `ReferenceLine`
- `src/components/reports/reports-charts-panel.tsx` — Single lazy-load boundary; renders full tab content per active tab
- `src/app/reports/reports-tab-bar.tsx` — Client tab bar; URL-reflected tab state via `router.replace(?tab=<value>)`
- `src/app/reports/page.tsx` — Reads `searchParams`, parallel fetches, assembles all data for `ReportsTabBar`
- `src/app/reports/loading.tsx` — Tab nav + chart-shaped skeleton placeholders

**Tests**
- `vitest.config.ts` — Unit test config
- `tests/unit/forecast.test.ts` — 12 unit tests covering OLS correctness, edge cases, status logic, integer guarantees

## Test plan

- [ ] Navigate to `/reports` — Overview tab active, summary cards + tables visible
- [ ] Click Trends tab — URL updates to `?tab=trends`, LineChart renders with range buttons
- [ ] Click Usage tab — UtilizationChart + usage table with "Show all" toggle
- [ ] Click Forecast tab — forecast cards + composite chart with projected line and budget ceiling
- [ ] Refresh at `?tab=usage` — correct tab remains active
- [ ] Navigate to `?tab=bogus` — falls back to Overview
- [ ] Run `pnpm test` — 12/12 unit tests pass
- [ ] Run `pnpm typecheck` — zero errors
- [ ] Run `pnpm lint` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)