### PR TITLE
feat(reports): add time-range filter to trends chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-﻿# AI Developer Hub Development Guidelines
+# AI Developer Hub Development Guidelines
 
 Auto-generated from all feature plans. Last updated: 2026-03-02
 
@@ -11,6 +11,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-02
 - Neon PostgreSQL (serverless) via @neondatabase/serverless 1.0.2 (003-enhance-core-features)
 - TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui + radix-ui, React Hook Form 7.71.2, Zod 4.3.6, date-fns 4.1.0, bcryptjs, sonner (toasts) (004-bulk-license-import)
 - Neon PostgreSQL (serverless) via @neondatabase/serverless 1.0.2 + Drizzle ORM (004-bulk-license-import)
+- TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Recharts 2.15.4 (already installed), shadcn/ui ChartContainer, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30 (005-rich-reports)
+- Neon PostgreSQL (serverless) — no schema changes; all report data derived from `annual_budgets`, `budget_periods`, `billed_costs`, `license_assignments`, `ai_tools` (005-rich-reports)
 
 - **Language**: TypeScript 5.x (strict mode), Node.js LTS
 - **Framework**: Next.js 15 (App Router, Server Components, Server Actions)
@@ -73,9 +75,9 @@ pnpm lighthouse        # Lighthouse CI
 - Server Components by default — `"use client"` only when client interactivity needed
 
 ## Recent Changes
+- 005-rich-reports: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Recharts 2.15.4 (already installed), shadcn/ui ChartContainer, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30
 - 004-bulk-license-import: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui + radix-ui, React Hook Form 7.71.2, Zod 4.3.6, date-fns 4.1.0, bcryptjs, sonner (toasts)
 - 003-enhance-core-features: Added TypeScript 5.9.3 (strict mode), Node.js LTS, React 19.2.4 + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui + radix-ui, React Hook Form 7.71.2, Zod 4.3.6, TanStack Table 8.21.3, Recharts 2.15.4, date-fns 4.1.0, react-day-picker 9.14.0
-- 002-retro-glitch-themes: Added TypeScript 5.x (strict mode), React 19, Node.js LTS + Next.js 15.5.12 (App Router), Tailwind CSS 4.2.1, shadcn/ui (new-york style), next-themes 0.4.6, Lucide React 0.576.0, class-variance-authority
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/src/components/reports/trends-chart.tsx
+++ b/src/components/reports/trends-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts";
 import {
   ChartContainer,
@@ -12,6 +12,7 @@ import {
 import type { ChartConfig } from "@/components/ui/chart";
 import { Button } from "@/components/ui/button";
 import type { PeriodSpendPoint } from "@/types";
+import { parseMonthLabel } from "@/lib/forecast";
 
 const trendsConfig = {
   billedCents: { label: "Billed", color: "var(--chart-1)" },
@@ -19,29 +20,68 @@ const trendsConfig = {
   plannedCents: { label: "Planned", color: "var(--chart-3)" },
 } satisfies ChartConfig;
 
-type Range = "3m" | "6m" | "12m";
+type Range = "3m" | "6m" | "12m" | "all";
+
+const RANGE_MAP = { "3m": 3, "6m": 6, "12m": 12 } as const;
+
+const RANGE_LABELS: Record<Range, string> = {
+  "3m": "3 months",
+  "6m": "6 months",
+  "12m": "12 months",
+  "all": "All",
+};
+
+function getMonthFromLabel(label: string): { year: number; month: number } | null {
+  const monthly = parseMonthLabel(label);
+  if (monthly) return monthly;
+  const q = label.match(/^Q([1-4])\s+(\d{4})$/);
+  if (q) {
+    const year = parseInt(q[2], 10);
+    if (!isNaN(year)) return { year, month: (parseInt(q[1], 10) - 1) * 3 };
+  }
+  return null;
+}
+
+function findCurrentIndex(data: PeriodSpendPoint[]): number {
+  const now = new Date();
+  const cy = now.getFullYear();
+  const cm = now.getMonth();
+  let idx = data.length - 1;
+  for (let i = 0; i < data.length; i++) {
+    const parsed = getMonthFromLabel(data[i].month);
+    if (!parsed) continue;
+    if (parsed.year < cy || (parsed.year === cy && parsed.month <= cm)) {
+      idx = i;
+    }
+  }
+  return idx;
+}
 
 interface TrendsChartProps {
   data: PeriodSpendPoint[];
 }
 
 export function TrendsChart({ data }: TrendsChartProps) {
-  const [range, setRange] = useState<Range>("6m");
+  const [range, setRange] = useState<Range>("3m");
 
-  const rangeMap: Record<Range, number> = { "3m": 3, "6m": 6, "12m": 12 };
-  const filtered = data.slice(-rangeMap[range]);
+  const filtered = useMemo(() => {
+    if (range === "all") return data;
+    const n = RANGE_MAP[range];
+    const end = findCurrentIndex(data);
+    return data.slice(Math.max(0, end - n + 1), end + 1);
+  }, [data, range]);
 
   return (
     <div className="space-y-4">
       <div className="flex gap-2">
-        {(["3m", "6m", "12m"] as Range[]).map((r) => (
+        {(["3m", "6m", "12m", "all"] as Range[]).map((r) => (
           <Button
             key={r}
             variant={range === r ? "default" : "outline"}
             size="sm"
             onClick={() => setRange(r)}
           >
-            {r === "3m" ? "3 months" : r === "6m" ? "6 months" : "12 months"}
+            {RANGE_LABELS[r]}
           </Button>
         ))}
       </div>


### PR DESCRIPTION
## Summary

- Adds **3m / 6m / 12m / All** range selector buttons to the Trends chart
- Selected window anchors at the current period (resolved from both `MMM YYYY` and `Qn YYYY` period labels), so future planned-only periods are excluded from short-range views
- Updates `CLAUDE.md` with 005-rich-reports tech stack entries

## Test plan

- [ ] Navigate to Reports → Trends tab
- [ ] Verify the 4 range buttons render above the chart
- [ ] Select 3m — chart shows last 3 periods up to today
- [ ] Select 6m / 12m — chart adjusts accordingly
- [ ] Select All — chart shows all periods
- [ ] Confirm quarterly budgets (`Q1 YYYY` labels) resolve correctly for range anchoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)