### PR TITLE
feat(invoices): duplicate detection and dollar amount display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AI Developer Hub Development Guidelines
+﻿# AI Developer Hub Development Guidelines
 
 Auto-generated from all feature plans. Last updated: 2026-03-02
 
@@ -17,6 +17,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-02
 - Neon PostgreSQL (serverless) via `@neondatabase/serverless` (006-optional-fields-ux)
 - TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6, React Hook Form 7.71.2, TanStack Table 8.21.3, shadcn/ui (new-york), Sonner (toasts), `unzipper` (NEW — zip extraction) (007-invoice-budget-link)
 - Neon PostgreSQL (serverless) via `@neondatabase/serverless` + Cloudflare R2 (PDF blobs) (007-invoice-budget-link)
+- TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, React Hook Form 7.71.2, Zod 4.3.6, TanStack Table 8.21.3, shadcn/ui, Sonner (toasts), @aws-sdk/client-s3 (R2) (008-invoice-duplicate-handling)
+- Neon PostgreSQL (serverless) via Drizzle ORM + Cloudflare R2 (PDF blobs) (008-invoice-duplicate-handling)
 
 - **Language**: TypeScript 5.x (strict mode), Node.js LTS
 - **Framework**: Next.js 15 (App Router, Server Components, Server Actions)
@@ -79,9 +81,9 @@ pnpm lighthouse        # Lighthouse CI
 - Server Components by default — `"use client"` only when client interactivity needed
 
 ## Recent Changes
+- 008-invoice-duplicate-handling: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, React Hook Form 7.71.2, Zod 4.3.6, TanStack Table 8.21.3, shadcn/ui, Sonner (toasts), @aws-sdk/client-s3 (R2)
 - 007-invoice-budget-link: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6, React Hook Form 7.71.2, TanStack Table 8.21.3, shadcn/ui (new-york), Sonner (toasts), `unzipper` (NEW — zip extraction)
 - 006-optional-fields-ux: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6, React Hook Form 7.71.2, TanStack Table 8.21.3, shadcn/ui (new-york style), Lucide React, Sonner (toasts)
-- 005-rich-reports: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Recharts 2.15.4 (already installed), shadcn/ui ChartContainer, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-﻿# AI Developer Hub Development Guidelines
+# AI Developer Hub Development Guidelines
 
 Auto-generated from all feature plans. Last updated: 2026-03-02
 

--- a/specs/008-invoice-duplicate-handling/checklists/requirements.md
+++ b/specs/008-invoice-duplicate-handling/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Invoice Duplicate Handling & Amount Display
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation on first iteration.
+- Spec builds on existing feature 007-invoice-budget-link; references to "billed cost", "budget period", and "batch review screen" are domain concepts from the existing system, not implementation details.
+- No [NEEDS CLARIFICATION] markers were needed — the user description was specific enough and reasonable defaults were documented in the Assumptions section.

--- a/specs/008-invoice-duplicate-handling/contracts/api-contracts.md
+++ b/specs/008-invoice-duplicate-handling/contracts/api-contracts.md
@@ -1,0 +1,211 @@
+# API Contracts: Invoice Duplicate Handling & Amount Display
+
+**Feature**: 008-invoice-duplicate-handling
+**Date**: 2026-03-06
+
+## New Server Actions
+
+### checkInvoiceDuplicate
+
+**Purpose**: Check if an invoice number already exists in the database. Called client-side after extraction or after the admin edits the invoice number field.
+
+**Input**:
+```
+{ invoiceNumber: string }
+```
+
+**Output (success)**:
+```
+{
+  success: true,
+  data: {
+    isDuplicate: false
+  }
+}
+```
+
+**Output (duplicate found)**:
+```
+{
+  success: true,
+  data: {
+    isDuplicate: true,
+    existingInvoice: {
+      id: number,
+      invoiceNumber: string,
+      invoiceDate: string,       // YYYY-MM-DD
+      amountCents: number,
+      vendor: string | null,
+      linkedBilledCostId: number | null
+    }
+  }
+}
+```
+
+**Output (error)**:
+```
+{ success: false, error: string }
+```
+
+---
+
+### checkBulkDuplicates
+
+**Purpose**: Batch check multiple invoice numbers against the database. Called after zip extraction before rendering the batch review screen.
+
+**Input**:
+```
+{ invoiceNumbers: string[] }
+```
+
+**Output (success)**:
+```
+{
+  success: true,
+  data: {
+    duplicates: Record<string, {
+      id: number,
+      invoiceDate: string,
+      amountCents: number,
+      vendor: string | null
+    }>
+  }
+}
+```
+
+The `duplicates` map is keyed by invoice number. Only numbers with existing matches are included. An empty object means no duplicates.
+
+**Output (error)**:
+```
+{ success: false, error: string }
+```
+
+---
+
+### overwriteInvoice (new)
+
+**Purpose**: Replace an existing invoice record with new data. Updates the invoice row, handles R2 blob swap, and updates or re-creates the linked billed cost.
+
+**Input**:
+```
+{
+  existingInvoiceId: number,
+  invoiceNumber: string,
+  invoiceDate: string,          // YYYY-MM-DD
+  amountCents: number,
+  vendor?: string,
+  blobUrl: string,
+  blobPathname: string
+}
+```
+
+**Output (success)**:
+```
+{
+  success: true,
+  data: { id: number },
+  linkedPeriodLabel?: string,
+  linkWarning?: string
+}
+```
+
+**Output (error)**:
+```
+{ success: false, error: string }
+```
+
+**Behavior**:
+1. Fetch existing invoice (including old `blobPathname` and `linkedBilledCostId`)
+2. Update invoice row: `invoiceDate`, `amountCents`, `vendor`, `blobUrl`, `blobPathname`, `updatedAt`
+3. Delete old R2 blob (best-effort)
+4. Handle linked billed cost:
+   - If existing billed cost exists and new date maps to same period → update billed cost in place
+   - If existing billed cost exists and new date maps to different period → delete old billed cost, create new one in correct period
+   - If no existing billed cost → attempt auto-link (same as fresh upload)
+   - If no matching period → save without link, return `linkWarning`
+5. Return updated invoice ID and linking result
+
+---
+
+### cleanupBlob (new — internal helper)
+
+**Purpose**: Delete an R2 object by key. Used when skipping a duplicate (single upload) or cleaning up skipped blobs in bulk upload.
+
+**Input**:
+```
+{ blobPathname: string }
+```
+
+**Behavior**: Best-effort deletion. Failures are logged but do not propagate errors. Not exposed as a public server action — called internally by other actions and the skip handler.
+
+---
+
+## Modified Server Actions
+
+### saveInvoice (existing — modified)
+
+**Changes**:
+- Remove the current soft duplicate check (lines 102-106 and warning on line 171)
+- The duplicate check is now handled separately by `checkInvoiceDuplicate` before `saveInvoice` is called
+- `saveInvoice` becomes a pure insert action (no duplicate awareness)
+- If called with a duplicate invoice number (e.g., race condition), the insert succeeds as before (no DB constraint) — the UI-level check is the primary gate
+
+### saveBulkInvoices (existing — modified)
+
+**Changes**:
+- Accept an additional `skip` boolean per item in the input array
+- Items marked `skip: true` are not saved; their R2 blobs are cleaned up
+- The outcome array includes `skipped: true` and `skipReason` for skipped items
+- Non-skipped items proceed through `saveInvoice` as before
+
+**Updated input type**:
+```
+Array<CreateInvoiceInput & { filename: string; skip?: boolean; skipReason?: string }>
+```
+
+**Updated outcome type**:
+```
+{
+  filename: string,
+  invoiceId?: number,
+  linkedPeriodLabel?: string,
+  linkWarning?: string,
+  error?: string,
+  skipped?: boolean,
+  skipReason?: string
+}
+```
+
+---
+
+## UI Contracts
+
+### Single Upload Form — Duplicate Dialog
+
+**Trigger**: After extraction completes AND after the admin confirms/edits the invoice number, call `checkInvoiceDuplicate`. If duplicate found, show a dialog before allowing form submission.
+
+**Dialog content**:
+- Warning message: "An invoice with this number already exists"
+- Existing invoice details: number, date, amount (formatted as dollars), vendor
+- Two action buttons: "Skip (Cancel Upload)" and "Overwrite Existing"
+
+**Skip action**: Call `cleanupBlob` with the new upload's `blobPathname`, reset form
+**Overwrite action**: Call `overwriteInvoice` with the new data and existing invoice ID
+
+### Single Upload Form — Amount Field
+
+**Current**: `<input type="number">` with label "Amount (cents)", placeholder "e.g. 12500 for $125.00"
+
+**New**: `<input type="number" step="0.01" min="0.01">` with label "Amount ($)", placeholder "0.00"
+
+**Conversion**:
+- After extraction: `setValue("amountDollars", (extractedAmountCents / 100).toFixed(2))`
+- On submit: `amountCents = Math.round(parseFloat(amountDollars) * 100)`
+
+### Bulk Review Screen — Duplicate Flags
+
+**Visual indicator**: Duplicate rows get a warning badge/icon and muted styling. The row is non-editable when flagged as duplicate.
+
+**Skip column**: A "Status" column shows "Duplicate — will be skipped" for flagged rows, or a checkmark for new invoices.
+
+**Amount column**: All amounts displayed in dollars (converted from extracted cents).

--- a/specs/008-invoice-duplicate-handling/data-model.md
+++ b/specs/008-invoice-duplicate-handling/data-model.md
@@ -1,0 +1,121 @@
+# Data Model: Invoice Duplicate Handling & Amount Display
+
+**Feature**: 008-invoice-duplicate-handling
+**Date**: 2026-03-06
+
+## Existing Entities (No Schema Changes)
+
+This feature does not require database schema changes. All modifications are at the application and UI layer. The existing schema supports everything needed.
+
+### invoices (existing — unchanged)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| id | serial | PK | Preserved on overwrite (update-in-place) |
+| invoiceNumber | varchar(255) | NOT NULL, indexed (non-unique) | Duplicate detection key |
+| invoiceDate | date | NOT NULL | Updated on overwrite |
+| amountCents | integer | NOT NULL | Stored as cents; displayed as dollars in UI |
+| vendor | varchar(255) | nullable | Updated on overwrite |
+| linkedBilledCostId | integer | FK → billed_costs.id, ON DELETE SET NULL | Updated/replaced on overwrite |
+| blobUrl | text | NOT NULL | Updated on overwrite; old blob deleted from R2 |
+| blobPathname | text | NOT NULL | Updated on overwrite; old key used for R2 cleanup |
+| uploadedBy | integer | NOT NULL, FK → users.id | Unchanged on overwrite (original uploader preserved) |
+| createdAt | timestamp | NOT NULL, default now() | Unchanged on overwrite |
+| updatedAt | timestamp | NOT NULL, default now() | Set to now() on overwrite |
+
+**Design decision**: `invoiceNumber` remains non-unique at the DB level. Uniqueness is enforced at the application layer with explicit user choice (skip/overwrite). A unique constraint would require `ON CONFLICT` upsert syntax which doesn't support the linked billed cost update logic cleanly.
+
+### billed_costs (existing — unchanged)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| id | serial | PK | May be deleted + re-created if period changes on overwrite |
+| periodId | integer | NOT NULL, FK → budget_periods.id, ON DELETE CASCADE | Determines which budget period the cost belongs to |
+| amountCents | integer | NOT NULL | Updated on overwrite |
+| invoiceDate | date | NOT NULL | Updated on overwrite |
+| description | varchar(500) | NOT NULL | Pattern: "Invoice {number} — {vendor}" or "Invoice {number}" |
+| vendorReference | varchar(255) | nullable | Stores the invoice number |
+| createdAt | timestamp | NOT NULL, default now() | |
+| updatedAt | timestamp | NOT NULL, default now() | Set to now() on update |
+
+## State Transitions
+
+### Single Upload Flow (with duplicate detection)
+
+```
+PDF uploaded to R2
+  → Fields extracted
+    → Invoice number checked against DB
+      → No match → Normal save flow (unchanged)
+      → Match found → Duplicate dialog shown
+        → Admin chooses "Skip"
+          → R2 blob deleted, no DB changes
+        → Admin chooses "Overwrite"
+          → Existing invoice updated (date, amount, vendor, blob refs)
+          → Old R2 blob deleted
+          → Linked billed cost handling:
+            → Same period: update billed cost in place
+            → Different period: delete old billed cost, create new in correct period
+            → No existing billed cost: attempt auto-link to period (same as fresh upload)
+            → No matching period: save invoice without link, show warning
+```
+
+### Bulk Upload Flow (with duplicate detection)
+
+```
+ZIP uploaded, PDFs extracted
+  → Each PDF: uploaded to R2, fields extracted
+    → All invoice numbers checked against DB (batch query)
+    → Within-batch duplicates detected (client-side)
+    → Batch review screen shown:
+      → Duplicates (DB match): flagged, pre-marked "Skip"
+      → Within-batch duplicates: second occurrence flagged
+      → New invoices: normal editable rows
+    → Admin submits batch
+      → Skipped rows: R2 blobs cleaned up
+      → Non-skipped rows: saved via existing saveInvoice flow
+      → Outcome summary: saved / skipped (duplicate) / failed
+```
+
+## Transient Types (Client-Side Only)
+
+### DuplicateCheckResult
+
+Returned by the new `checkInvoiceDuplicate` server action:
+
+- `isDuplicate`: boolean
+- `existingInvoice` (if duplicate): { id, invoiceNumber, invoiceDate, amountCents, vendor, linkedBilledCostId }
+
+### BulkDuplicateCheckResult
+
+Returned by the new `checkBulkDuplicates` server action:
+
+- `duplicates`: Map<invoiceNumber, { id, invoiceDate, amountCents, vendor }>
+
+### BulkSaveOutcome (enhanced)
+
+Extended from existing type to include skip reason:
+
+- `filename`: string
+- `invoiceId?`: number
+- `linkedPeriodLabel?`: string
+- `linkWarning?`: string
+- `error?`: string
+- `skipped?`: boolean
+- `skipReason?`: "duplicate" | "within-batch-duplicate"
+
+## Validation Rules
+
+### Amount Display Conversion
+
+- **UI layer**: Accepts dollar input as `number` with `step="0.01"`
+- **Conversion**: `amountCents = Math.round(dollarValue * 100)`
+- **Reverse**: `dollarValue = (amountCents / 100).toFixed(2)`
+- **Zod schema**: Unchanged — `amountCents` remains `z.number().int().positive()`
+- **Extraction layer**: Unchanged — returns `amountCents` as integer cents
+
+### Duplicate Detection
+
+- **Key**: `invoiceNumber` (case-sensitive, exact match)
+- **Scope**: All invoices in the database (no date/vendor filtering)
+- **Within-batch**: Second occurrence of same `invoiceNumber` in a single zip upload

--- a/specs/008-invoice-duplicate-handling/plan.md
+++ b/specs/008-invoice-duplicate-handling/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: Invoice Duplicate Handling & Amount Display
+
+**Branch**: `008-invoice-duplicate-handling` | **Date**: 2026-03-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/008-invoice-duplicate-handling/spec.md`
+
+## Summary
+
+Improve invoice upload reliability by detecting duplicate invoices (by invoice number), giving admins explicit skip/overwrite control on single uploads, auto-skipping duplicates in bulk uploads, and displaying extracted amounts in dollars instead of cents. No database schema changes required — all modifications are at the application and UI layer.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3 (strict mode)
+**Primary Dependencies**: Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, React Hook Form 7.71.2, Zod 4.3.6, TanStack Table 8.21.3, shadcn/ui, Sonner (toasts), @aws-sdk/client-s3 (R2)
+**Storage**: Neon PostgreSQL (serverless) via Drizzle ORM + Cloudflare R2 (PDF blobs)
+**Testing**: Vitest (unit/integration), Playwright (e2e)
+**Target Platform**: Web application (Next.js, server-rendered)
+**Project Type**: Web application (full-stack)
+**Performance Goals**: Standard web app — duplicate check response < 500ms, overwrite completes < 5s
+**Constraints**: No database schema changes; amounts stored as integer cents; R2 blob cleanup is best-effort
+**Scale/Scope**: Single admin user, typical batch size 10-50 invoices
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Type-Safe Code Quality | PASS | All new actions use typed inputs/outputs; Zod validation unchanged |
+| II. UX Consistency | PASS | Dollar input matches existing billed cost pattern (`step="0.01"`); shadcn/ui dialog for duplicate resolution |
+| III. Performance Budgets | PASS | No new routes; duplicate check is a single indexed DB query; no bundle impact beyond dialog component |
+| IV. Accessibility-First | PASS | Duplicate dialog uses shadcn AlertDialog (keyboard navigable, ARIA); duplicate flags use text + icon (not color alone) |
+| V. Simplicity & Maintainability | PASS | No new abstractions; reuses existing patterns (R2 cleanup, billed cost linking, formatCurrency utility) |
+
+**Post-Phase 1 re-check**: All gates still pass. No new dependencies introduced. Data model unchanged.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-invoice-duplicate-handling/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── api-contracts.md # Phase 1 output
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── actions/
+│   └── invoices.ts              # Modified: add checkInvoiceDuplicate, checkBulkDuplicates,
+│                                #   overwriteInvoice, cleanupBlob; modify saveInvoice, saveBulkInvoices
+├── app/
+│   └── invoices/
+│       ├── new/
+│       │   └── invoice-upload-form.tsx  # Modified: dollar input, duplicate check + dialog
+│       └── bulk/
+│           └── bulk-upload-form.tsx     # Modified: duplicate flags, skip logic, dollar display
+└── lib/
+    └── validators.ts            # No changes (amountCents stays as-is)
+```
+
+**Structure Decision**: No new files or directories needed. All changes fit within the existing structure. The feature modifies 3 existing files (`invoices.ts`, `invoice-upload-form.tsx`, `bulk-upload-form.tsx`).
+
+## Complexity Tracking
+
+No constitution violations to justify. All changes follow existing patterns.

--- a/specs/008-invoice-duplicate-handling/quickstart.md
+++ b/specs/008-invoice-duplicate-handling/quickstart.md
@@ -1,0 +1,82 @@
+# Quickstart: Invoice Duplicate Handling & Amount Display
+
+**Feature**: 008-invoice-duplicate-handling
+**Date**: 2026-03-06
+
+## What This Feature Does
+
+Improves the invoice upload experience in three ways:
+
+1. **Duplicate detection** — Recognizes when an uploaded invoice has the same number as an existing one
+2. **Single upload resolution** — Lets the admin skip or overwrite the existing invoice (and its budget link)
+3. **Bulk upload skip** — Automatically flags duplicates in batch uploads so they're skipped on save
+4. **Dollar display** — Shows extracted amounts in dollars ($125.00) instead of raw cents (12500)
+
+## Files to Modify
+
+### Server Actions (`src/actions/invoices.ts`)
+
+- **Add** `checkInvoiceDuplicate(invoiceNumber)` — returns existing invoice details if found
+- **Add** `checkBulkDuplicates(invoiceNumbers[])` — batch duplicate check for zip uploads
+- **Add** `overwriteInvoice(existingId, newData)` — update-in-place with billed cost handling
+- **Add** `cleanupBlob(blobPathname)` — internal helper for R2 deletion on skip
+- **Modify** `saveInvoice()` — remove soft duplicate check (lines 102-106, 171)
+- **Modify** `saveBulkInvoices()` — accept `skip` flag per item, clean up skipped blobs
+
+### Single Upload Form (`src/app/invoices/new/invoice-upload-form.tsx`)
+
+- **Add** duplicate check call after extraction/field edit
+- **Add** duplicate resolution dialog (Skip / Overwrite)
+- **Change** amount field: label "Amount ($)", input `step="0.01"`, placeholder "0.00"
+- **Add** cents↔dollars conversion: divide by 100 on display, multiply by 100 on submit
+
+### Bulk Upload Form (`src/app/invoices/bulk/bulk-upload-form.tsx`)
+
+- **Add** `checkBulkDuplicates` call after extraction, before review screen
+- **Add** visual duplicate flags on review table rows
+- **Add** within-batch duplicate detection (client-side)
+- **Add** skip logic: flagged rows excluded from save, blobs cleaned up
+- **Change** amount column: display in dollars instead of cents
+- **Modify** outcome summary: show saved / skipped (duplicate) / failed counts
+
+### Validators (`src/lib/validators.ts`)
+
+- No schema changes needed — `amountCents` stays as `z.number().int().positive()`
+- Conversion between dollars and cents is a UI concern
+
+### Database Schema (`src/lib/db/schema.ts`)
+
+- No changes — `invoiceNumber` remains non-unique index
+
+## Implementation Order
+
+1. **Amount display** (P3 from spec, but simplest change — do first to reduce diff noise)
+   - Update single upload form amount field
+   - Update bulk review table amount column
+   - Add cents↔dollars conversion logic
+
+2. **Duplicate check actions** (foundation for P1 and P2)
+   - Implement `checkInvoiceDuplicate`
+   - Implement `checkBulkDuplicates`
+   - Implement `cleanupBlob` helper
+
+3. **Single upload duplicate flow** (P1)
+   - Add duplicate check after extraction
+   - Build duplicate resolution dialog
+   - Implement `overwriteInvoice` action
+   - Handle skip (blob cleanup + form reset)
+
+4. **Bulk upload duplicate flow** (P2)
+   - Integrate `checkBulkDuplicates` into zip upload flow
+   - Add within-batch duplicate detection
+   - Add visual flags to review table
+   - Modify `saveBulkInvoices` to skip flagged items
+   - Update outcome summary display
+
+## Key Patterns to Follow
+
+- **Server action return type**: `{ success: true, data } | { success: false, error }` (existing pattern)
+- **R2 cleanup**: Best-effort `DeleteObjectCommand` in try/catch (see `src/actions/invoices.ts:124-129`)
+- **Dollar input**: `type="number" step="0.01" min="0.01"` with `Math.round(parseFloat(v) * 100)` (see `src/app/budget/[id]/budget-detail-client.tsx:549-562`)
+- **Currency display**: Use `formatCurrency()` from `src/lib/utils.ts`
+- **Audit trail**: Call `recordCreation` for new billed costs (existing pattern)

--- a/specs/008-invoice-duplicate-handling/research.md
+++ b/specs/008-invoice-duplicate-handling/research.md
@@ -1,0 +1,72 @@
+# Research: Invoice Duplicate Handling & Amount Display
+
+**Feature**: 008-invoice-duplicate-handling
+**Date**: 2026-03-06
+
+## R1: Current Duplicate Detection Mechanism
+
+**Decision**: Enhance the existing soft duplicate check into a blocking check with user-driven resolution (skip/overwrite).
+
+**Rationale**: The current implementation (`src/actions/invoices.ts:102-106`) performs a `findFirst` query on `invoiceNumber` but proceeds to insert regardless, returning only a warning string. This means duplicates are silently created with a toast notification the admin can miss. The invoice table has no unique constraint on `invoiceNumber` — only a non-unique index (`src/lib/db/schema.ts:276`). Adding a unique DB constraint would break the overwrite flow (update-in-place), so duplicate enforcement remains application-level but becomes blocking.
+
+**Alternatives considered**:
+- **Add unique DB constraint + upsert**: Rejected because upsert semantics in Drizzle require the unique constraint, but the overwrite flow needs to update the existing row and its linked billed cost atomically, which is more complex than a simple upsert.
+- **Keep soft warning only**: Rejected because it doesn't prevent budget double-counting, which is the core problem.
+
+## R2: Duplicate Check Timing (Client vs Server)
+
+**Decision**: Introduce a dedicated server action `checkInvoiceDuplicate(invoiceNumber)` called client-side after extraction completes, before the form is submitted.
+
+**Rationale**: The duplicate check must happen after the invoice number is known (post-extraction) but before the save. A separate action allows the UI to display the duplicate dialog without submitting the form. For bulk uploads, the check happens server-side in a new `checkBulkDuplicates(invoiceNumbers[])` action called before the batch review screen renders.
+
+**Alternatives considered**:
+- **Check during save only**: Rejected because the admin would fill out the form, submit, and only then learn about the duplicate — poor UX.
+- **Check in the extraction action**: Rejected because the invoice number may be edited by the admin after extraction.
+
+## R3: Overwrite Strategy for Single Uploads
+
+**Decision**: Update-in-place — modify the existing invoice row and its linked billed cost rather than delete + re-create.
+
+**Rationale**: Update-in-place preserves the original invoice ID and any audit history references (`recordCreation` in `src/actions/history.ts`). The existing `linkedBilledCostId` foreign key with `onDelete: "set null"` means we can safely update or replace the billed cost. When the new invoice date maps to a different budget period, the old billed cost is deleted and a new one is created in the correct period.
+
+**Alternatives considered**:
+- **Delete old + insert new**: Rejected because it breaks referential integrity for audit history and changes the invoice ID.
+- **Soft-delete old + insert new**: Rejected as over-engineering — no soft-delete infrastructure exists.
+
+## R4: Bulk Duplicate UX (Skip-Only)
+
+**Decision**: Bulk upload flags duplicates as "skip" on the batch review screen. No per-row overwrite option.
+
+**Rationale**: The batch review screen (`src/app/invoices/bulk/bulk-upload-form.tsx`) uses TanStack Table with editable rows. Adding a per-row skip/overwrite toggle for each duplicate would significantly complicate the UI. The simpler approach — flag duplicates, auto-skip on save — covers the primary use case (monthly reconciliation re-uploads). Admins needing to overwrite can re-upload individual invoices.
+
+**Alternatives considered**:
+- **Per-row overwrite toggle**: Rejected for complexity; would need per-row confirmation dialogs.
+- **Batch-level "overwrite all duplicates" toggle**: Rejected as dangerous — could unintentionally overwrite invoices the admin didn't intend to change.
+
+## R5: Amount Display Conversion (Dollars vs Cents)
+
+**Decision**: Change the invoice upload form to accept dollar input (like the existing billed cost forms) and convert to cents on submission. Use the existing `formatCurrency()` utility for display.
+
+**Rationale**: The billed cost add/edit dialogs in `src/app/budget/[id]/budget-detail-client.tsx` already use dollar input with `step="0.01"` and convert via `Math.round(parseFloat(value) * 100)`. The invoice upload form (`src/app/invoices/new/invoice-upload-form.tsx:248-257`) is the only place that shows "Amount (cents)" — an inconsistency. The extraction layer (`src/lib/invoice-extraction.ts`) returns `amountCents` as an integer; the form will divide by 100 for display and multiply back for storage. The Zod schema `createInvoiceSchema` validates `amountCents` as `z.number().int().positive()` — this stays unchanged; the conversion happens in the form layer.
+
+**Alternatives considered**:
+- **Change the Zod schema to accept dollars**: Rejected because other consumers of `createInvoiceSchema` (e.g., `saveBulkInvoices`) also pass cents. Keeping the schema in cents maintains a single source of truth.
+- **Add a separate `amountDollars` field to the schema**: Rejected as unnecessary — the conversion is a UI concern, not a validation concern.
+
+## R6: Within-Batch Duplicate Detection
+
+**Decision**: After extraction, scan the batch for duplicate invoice numbers within the same zip. Flag the second (and subsequent) occurrences as within-batch duplicates.
+
+**Rationale**: The current `saveBulkInvoices` calls `saveInvoice` per item sequentially. If two PDFs in the same zip share an invoice number, both would be inserted (since there's no unique constraint). The within-batch check runs client-side on the batch review data before submission.
+
+**Alternatives considered**:
+- **Server-side within-batch check**: Rejected — the data is already client-side in the review table; no need for a round-trip.
+
+## R7: R2 Cleanup on Skip
+
+**Decision**: When a single upload is skipped (duplicate rejected), delete the already-uploaded PDF from R2 using the existing `DeleteObjectCommand` pattern.
+
+**Rationale**: The PDF is uploaded to R2 before extraction (`src/app/api/invoices/upload-url/route.ts`), so by the time the duplicate is detected, the blob already exists. The existing cleanup pattern (`src/actions/invoices.ts:124-129`) provides the template. For bulk uploads, skipped duplicates' blobs are cleaned up during the save phase.
+
+**Alternatives considered**:
+- **Defer upload until after duplicate check**: Rejected because extraction requires the PDF to be in R2 (the extraction function fetches from R2 by object key).

--- a/specs/008-invoice-duplicate-handling/spec.md
+++ b/specs/008-invoice-duplicate-handling/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: Invoice Duplicate Handling & Amount Display
+
+**Feature Branch**: `008-invoice-duplicate-handling`
+**Created**: 2026-03-06
+**Status**: Draft
+**Input**: User description: "Invoice uploading should be handled better. Duplicate invoices should be recognized by the invoice number. Duplicate invoices can be marked that they will be skipped when they are part of a bulk upload. For single uploads you should be able to select if you want to skip or overwrite the existing invoice and the referred entry for the budgets. The detected invoice amount should be displayed in dollars and not in cents."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Duplicate Detection on Single Upload (Priority: P1)
+
+An admin uploads a single PDF invoice. After extraction, the system checks whether an invoice with the same invoice number already exists. If a duplicate is found, the admin is presented with a clear choice: skip (cancel the upload) or overwrite (replace the existing invoice record and its linked billed cost entry in the budget). The admin makes an informed decision before anything is saved.
+
+**Why this priority**: Duplicate invoices corrupt budget tracking by double-counting costs. Giving admins explicit control over how duplicates are handled is the most critical improvement to upload reliability.
+
+**Independent Test**: Upload an invoice with an invoice number that already exists in the archive. Verify the system detects the duplicate, presents skip/overwrite options, and correctly executes the chosen action.
+
+**Acceptance Scenarios**:
+
+1. **Given** an invoice with number "INV-100" already exists in the archive, **When** the admin uploads a new PDF and the extracted invoice number is "INV-100", **Then** the system displays a duplicate warning showing the existing invoice details (number, date, amount, vendor) and offers "Skip" and "Overwrite" options.
+2. **Given** a duplicate is detected and the admin chooses "Skip", **When** the action is confirmed, **Then** the uploaded PDF is removed from storage and no changes are made to the existing invoice or its linked billed cost.
+3. **Given** a duplicate is detected and the admin chooses "Overwrite", **When** the action is confirmed, **Then** the existing invoice record is updated with the new PDF, date, amount, and vendor; the previously linked billed cost entry is also updated to reflect the new amount and date; and the old PDF file is removed from storage.
+4. **Given** the existing duplicate invoice has a linked billed cost, **When** the admin chooses "Overwrite", **Then** the linked billed cost amount, date, and description are updated to match the new invoice data.
+5. **Given** the existing duplicate invoice has no linked billed cost (e.g. no matching budget period existed at original upload time), **When** the admin overwrites it, **Then** the system attempts to link to a budget period using the new invoice date, following the same auto-link logic as a fresh upload.
+6. **Given** the extracted invoice number does not match any existing invoice, **When** the admin submits the form, **Then** the invoice is saved normally with no duplicate prompt.
+
+---
+
+### User Story 2 - Duplicate Handling in Bulk Upload (Priority: P2)
+
+An admin uploads a zip file containing multiple PDF invoices. During the batch review screen, any invoice whose extracted invoice number matches an existing record in the archive is flagged as a duplicate. Duplicates are pre-marked to be skipped. The admin can review the flags before submitting. On submission, flagged duplicates are skipped and the remaining invoices are saved normally.
+
+**Why this priority**: Bulk uploads are common during monthly reconciliation. Without duplicate handling, re-uploading a batch that partially overlaps with previous uploads creates duplicate billed cost entries. This story depends on P1's detection logic.
+
+**Independent Test**: Upload a zip containing 5 PDFs, 2 of which have invoice numbers matching existing records. Verify the batch review screen flags the 2 duplicates, that they are skipped on save, and the other 3 are processed normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** a zip file is uploaded and processed, **When** the batch review screen is displayed, **Then** each invoice whose number matches an existing record is visually marked as a duplicate with a "Skip" indicator.
+2. **Given** duplicates are flagged on the batch review screen, **When** the admin submits the batch, **Then** flagged duplicates are not saved to the archive and their uploaded PDFs are cleaned up from storage.
+3. **Given** a batch contains both duplicate and new invoices, **When** the admin submits, **Then** only non-duplicate invoices are saved and linked to budget periods; the outcome summary clearly distinguishes saved, skipped (duplicate), and failed invoices.
+4. **Given** two invoices within the same zip batch share the same invoice number, **When** the batch review screen is shown, **Then** the second occurrence is flagged as a within-batch duplicate so the admin can resolve it.
+5. **Given** all invoices in a batch are duplicates, **When** the admin submits, **Then** none are saved and the summary reports all were skipped due to duplication.
+
+---
+
+### User Story 3 - Display Invoice Amount in Dollars (Priority: P3)
+
+When an admin uploads an invoice (single or bulk), the extracted amount is displayed in the review form as a dollar value (e.g. "$125.00") rather than raw cents (e.g. "12500"). The underlying storage continues to use cents for precision, but the user-facing input and display uses dollars with two decimal places.
+
+**Why this priority**: Displaying amounts in cents is confusing and error-prone for admins. This is a straightforward usability improvement that does not depend on the duplicate handling stories.
+
+**Independent Test**: Upload a PDF invoice. Verify the amount field shows a dollar value (e.g. "125.00") rather than cents. Edit the value, save, and confirm the correct cent value is stored in the database.
+
+**Acceptance Scenarios**:
+
+1. **Given** the extraction returns an amount of 12500 cents, **When** the form is displayed, **Then** the amount field shows "125.00" with a dollar sign label or prefix.
+2. **Given** the admin edits the amount field to "250.50", **When** the invoice is saved, **Then** the database stores 25050 cents.
+3. **Given** the extraction returns a null amount, **When** the form is displayed, **Then** the amount field is empty with an appropriate placeholder (e.g. "0.00") indicating dollars, not cents.
+4. **Given** a bulk upload batch review screen, **When** amounts are displayed per invoice row, **Then** all amounts are shown in dollars, not cents.
+
+---
+
+### Edge Cases
+
+- What happens when the admin edits the invoice number in the form to match an existing record (duplicate not detected at extraction time but present at save time)?
+- How does the system handle an overwrite when the new invoice date falls in a different budget period than the original?
+- What if the admin enters a dollar amount with more than two decimal places (e.g. "125.005")?
+- What happens when overwriting an invoice whose linked billed cost was manually edited after the original auto-link?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST check the invoice number against existing records after extraction and before saving, for both single and bulk uploads.
+- **FR-002**: For single uploads with a detected duplicate, the system MUST present the admin with the existing invoice details and offer explicit "Skip" and "Overwrite" options.
+- **FR-003**: When "Skip" is chosen for a single upload, the system MUST delete the uploaded PDF from storage and make no changes to the existing record.
+- **FR-004**: When "Overwrite" is chosen for a single upload, the system MUST update the existing invoice record (PDF reference, date, amount, vendor) and update or create the linked billed cost entry accordingly.
+- **FR-005**: When overwriting, the system MUST delete the old PDF file from storage after the new record is saved.
+- **FR-006**: For bulk uploads, the system MUST flag duplicate invoices on the batch review screen with a visual indicator.
+- **FR-007**: Duplicate invoices in bulk uploads MUST be pre-marked to be skipped; the admin can review but does not need to take action for duplicates to be excluded.
+- **FR-008**: The batch outcome summary MUST separately report saved, skipped (duplicate), and failed invoices.
+- **FR-009**: The system MUST detect within-batch duplicates (two invoices in the same zip with the same invoice number) and flag the second occurrence.
+- **FR-010**: The invoice amount MUST be displayed to the admin in dollars (with two decimal places) on all upload and review forms, not in raw cents.
+- **FR-011**: The system MUST convert dollar input to integer cents before storing, using standard rounding (round half up) for sub-cent values.
+- **FR-012**: The underlying database storage for amounts MUST remain in integer cents to preserve precision and consistency with existing budget data.
+- **FR-013**: When overwriting an invoice whose date maps to a different budget period than the original, the system MUST move the linked billed cost to the correct new period (or create a new one and delete the old).
+
+### Key Entities
+
+- **Invoice**: Existing entity with invoice number as the duplicate-detection key. No new attributes needed; overwrite updates existing fields (amount, date, vendor, blob references).
+- **Billed Cost**: Existing entity linked from an invoice. On overwrite, the linked billed cost is updated or re-created in the correct budget period.
+- **Duplicate Flag (transient)**: A client-side marker on the batch review screen indicating an invoice is a duplicate. Not persisted; used only during the upload review flow.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero duplicate billed cost entries are created when re-uploading invoices with the same invoice number, whether via single or bulk upload.
+- **SC-002**: Admins can resolve a single-upload duplicate (skip or overwrite) in under 10 seconds from the moment the duplicate warning appears.
+- **SC-003**: In a bulk upload of 20 invoices where 5 are duplicates, the admin completes the review and save in under 2 minutes, with all 5 duplicates correctly skipped.
+- **SC-004**: 100% of invoice amounts displayed on upload and review screens show dollar values with two decimal places, not raw cent integers.
+- **SC-005**: Overwriting an invoice correctly updates both the invoice record and its linked billed cost entry (or creates a new link if the period changed) with no orphaned or stale data.
+
+## Assumptions
+
+- Invoice number is the sole key for duplicate detection. Two invoices with different numbers but identical content are treated as distinct records.
+- The "Overwrite" action for single uploads is an update-in-place: the existing invoice row is modified rather than deleted and re-created. This preserves the original invoice ID and any audit history references.
+- When overwriting causes a period change for the linked billed cost, the old billed cost is deleted and a new one is created in the correct period, since billed costs are scoped to a specific period.
+- Bulk upload does not offer an "Overwrite" option per duplicate — only skip. This keeps the batch flow simple and avoids complex per-row conflict resolution. Admins can re-upload individual invoices with overwrite if needed.
+- The dollar-to-cents conversion rounds to the nearest cent using standard arithmetic rounding. Inputs with more than two decimal places are rounded before storage.
+- All existing invoice list views and detail screens that currently show amounts in cents will also be updated to display dollars for consistency.

--- a/specs/008-invoice-duplicate-handling/tasks.md
+++ b/specs/008-invoice-duplicate-handling/tasks.md
@@ -46,12 +46,12 @@ _Phase skipped — all infrastructure already exists._
 
 ### Implementation for User Story 1
 
-- [ ] T005 [US1] Add `overwriteInvoice` server action in `src/actions/invoices.ts` that: (a) fetches existing invoice with old blobPathname and linkedBilledCostId, (b) updates invoice row (date, amount, vendor, blobUrl, blobPathname, updatedAt), (c) deletes old R2 blob via `cleanupBlob`, (d) handles linked billed cost: update in place if same period, or delete old + create new if period changed, or attempt auto-link if no prior link, (e) returns success with linkedPeriodLabel/linkWarning
-- [ ] T006 [US1] Add duplicate check call in `src/app/invoices/new/invoice-upload-form.tsx` — after extraction completes and form fields are populated, call `checkInvoiceDuplicate` with the extracted invoice number; store the result (isDuplicate + existingInvoice) in component state
-- [ ] T007 [US1] Build duplicate resolution dialog in `src/app/invoices/new/invoice-upload-form.tsx` — use shadcn AlertDialog showing existing invoice details (number, date, amount formatted as dollars via `formatCurrency`, vendor), with "Skip (Cancel Upload)" and "Overwrite Existing" action buttons
-- [ ] T008 [US1] Wire "Skip" action in duplicate dialog in `src/app/invoices/new/invoice-upload-form.tsx` — call `cleanupBlob` with the new upload's blobPathname, reset form state and upload state to idle, show toast confirming skip
-- [ ] T009 [US1] Wire "Overwrite" action in duplicate dialog in `src/app/invoices/new/invoice-upload-form.tsx` — call `overwriteInvoice` with existingInvoice.id and current form data (converting amountDollars to cents if US3 is done, otherwise using amountCents), handle success/error toasts and redirect to /invoices
-- [ ] T010 [US1] Add re-check on invoice number field blur in `src/app/invoices/new/invoice-upload-form.tsx` — when admin manually edits the invoice number field and it loses focus, re-run `checkInvoiceDuplicate` and update the duplicate state so the dialog triggers on submit if a match is found
+- [x] T005 [US1] Add `overwriteInvoice` server action in `src/actions/invoices.ts` that: (a) fetches existing invoice with old blobPathname and linkedBilledCostId, (b) updates invoice row (date, amount, vendor, blobUrl, blobPathname, updatedAt), (c) deletes old R2 blob via `cleanupBlob`, (d) handles linked billed cost: update in place if same period, or delete old + create new if period changed, or attempt auto-link if no prior link, (e) returns success with linkedPeriodLabel/linkWarning
+- [x] T006 [US1] Add duplicate check call in `src/app/invoices/new/invoice-upload-form.tsx` — after extraction completes and form fields are populated, call `checkInvoiceDuplicate` with the extracted invoice number; store the result (isDuplicate + existingInvoice) in component state
+- [x] T007 [US1] Build duplicate resolution dialog in `src/app/invoices/new/invoice-upload-form.tsx` — use shadcn AlertDialog showing existing invoice details (number, date, amount formatted as dollars via `formatCurrency`, vendor), with "Skip (Cancel Upload)" and "Overwrite Existing" action buttons
+- [x] T008 [US1] Wire "Skip" action in duplicate dialog in `src/app/invoices/new/invoice-upload-form.tsx` — call `cleanupBlob` with the new upload's blobPathname, reset form state and upload state to idle, show toast confirming skip
+- [x] T009 [US1] Wire "Overwrite" action in duplicate dialog in `src/app/invoices/new/invoice-upload-form.tsx` — call `overwriteInvoice` with existingInvoice.id and current form data (converting amountDollars to cents if US3 is done, otherwise using amountCents), handle success/error toasts and redirect to /invoices
+- [x] T010 [US1] Add re-check on invoice number field blur in `src/app/invoices/new/invoice-upload-form.tsx` — when admin manually edits the invoice number field and it loses focus, re-run `checkInvoiceDuplicate` and update the duplicate state so the dialog triggers on submit if a match is found
 
 **Checkpoint**: Single upload duplicate detection fully functional — skip and overwrite both work.
 
@@ -65,12 +65,12 @@ _Phase skipped — all infrastructure already exists._
 
 ### Implementation for User Story 2
 
-- [ ] T011 [US2] Integrate `checkBulkDuplicates` into the bulk upload flow in `src/app/invoices/bulk/bulk-upload-form.tsx` — after zip extraction results arrive, collect all extracted invoice numbers, call `checkBulkDuplicates`, and store the duplicates map in component state
-- [ ] T012 [US2] Add within-batch duplicate detection in `src/app/invoices/bulk/bulk-upload-form.tsx` — scan the extraction results client-side for repeated invoice numbers; mark second+ occurrences as within-batch duplicates in row state
-- [ ] T013 [US2] Add visual duplicate flags to the review table in `src/app/invoices/bulk/bulk-upload-form.tsx` — add a "Status" column; show "Duplicate — will be skipped" badge with warning icon for DB-match and within-batch duplicates; make flagged rows visually muted (reduced opacity or strikethrough styling); make flagged rows non-editable
-- [ ] T014 [US2] Modify `saveBulkInvoices` in `src/actions/invoices.ts` to accept an optional `skip` boolean and `skipReason` string per item; skipped items have their R2 blobs cleaned up via `cleanupBlob` and are returned in outcomes with `skipped: true` and `skipReason`
-- [ ] T015 [US2] Update the batch submit handler in `src/app/invoices/bulk/bulk-upload-form.tsx` to pass `skip: true` and `skipReason: "duplicate"` or `"within-batch-duplicate"` for flagged rows when calling `saveBulkInvoices`
-- [ ] T016 [US2] Update the outcome summary (done state) in `src/app/invoices/bulk/bulk-upload-form.tsx` to show three categories: saved (with invoice ID and period), skipped (with reason), and failed (with error); include counts for each category
+- [x] T011 [US2] Integrate `checkBulkDuplicates` into the bulk upload flow in `src/app/invoices/bulk/bulk-upload-form.tsx` — after zip extraction results arrive, collect all extracted invoice numbers, call `checkBulkDuplicates`, and store the duplicates map in component state
+- [x] T012 [US2] Add within-batch duplicate detection in `src/app/invoices/bulk/bulk-upload-form.tsx` — scan the extraction results client-side for repeated invoice numbers; mark second+ occurrences as within-batch duplicates in row state
+- [x] T013 [US2] Add visual duplicate flags to the review table in `src/app/invoices/bulk/bulk-upload-form.tsx` — add a "Status" column; show "Duplicate — will be skipped" badge with warning icon for DB-match and within-batch duplicates; make flagged rows visually muted (reduced opacity or strikethrough styling); make flagged rows non-editable
+- [x] T014 [US2] Modify `saveBulkInvoices` in `src/actions/invoices.ts` to accept an optional `skip` boolean and `skipReason` string per item; skipped items have their R2 blobs cleaned up via `cleanupBlob` and are returned in outcomes with `skipped: true` and `skipReason`
+- [x] T015 [US2] Update the batch submit handler in `src/app/invoices/bulk/bulk-upload-form.tsx` to pass `skip: true` and `skipReason: "duplicate"` or `"within-batch-duplicate"` for flagged rows when calling `saveBulkInvoices`
+- [x] T016 [US2] Update the outcome summary (done state) in `src/app/invoices/bulk/bulk-upload-form.tsx` to show three categories: saved (with invoice ID and period), skipped (with reason), and failed (with error); include counts for each category
 
 **Checkpoint**: Bulk upload duplicate handling complete — duplicates flagged on review, skipped on save, reported in summary.
 
@@ -84,10 +84,10 @@ _Phase skipped — all infrastructure already exists._
 
 ### Implementation for User Story 3
 
-- [ ] T017 [P] [US3] Change the amount field in the single upload form in `src/app/invoices/new/invoice-upload-form.tsx` — change label from "Amount (cents)" to "Amount ($)", change placeholder from "e.g. 12500 for $125.00" to "0.00", add `step="0.01"` and `min="0.01"` to the input, use a local `amountDollars` form field instead of `amountCents`
-- [ ] T018 [P] [US3] Add cents-to-dollars conversion after extraction in `src/app/invoices/new/invoice-upload-form.tsx` — when extraction returns `amountCents`, set form value to `(amountCents / 100).toFixed(2)`; on form submit, convert back with `Math.round(parseFloat(amountDollars) * 100)` before passing to `saveInvoice` or `overwriteInvoice`
-- [ ] T019 [P] [US3] Change the amount column in the bulk review table in `src/app/invoices/bulk/bulk-upload-form.tsx` — display extracted amounts as dollars (divide by 100), change the ARIA label from "Amount in cents" to "Amount in dollars", update the input to use `step="0.01"`, convert back to cents on batch submit
-- [ ] T020 [US3] Update the duplicate dialog in `src/app/invoices/new/invoice-upload-form.tsx` to display the existing invoice's amount using `formatCurrency` (already divides cents by 100) rather than raw cents
+- [x] T017 [P] [US3] Change the amount field in the single upload form in `src/app/invoices/new/invoice-upload-form.tsx` — change label from "Amount (cents)" to "Amount ($)", change placeholder from "e.g. 12500 for $125.00" to "0.00", add `step="0.01"` and `min="0.01"` to the input, use a local `amountDollars` form field instead of `amountCents`
+- [x] T018 [P] [US3] Add cents-to-dollars conversion after extraction in `src/app/invoices/new/invoice-upload-form.tsx` — when extraction returns `amountCents`, set form value to `(amountCents / 100).toFixed(2)`; on form submit, convert back with `Math.round(parseFloat(amountDollars) * 100)` before passing to `saveInvoice` or `overwriteInvoice`
+- [x] T019 [P] [US3] Change the amount column in the bulk review table in `src/app/invoices/bulk/bulk-upload-form.tsx` — display extracted amounts as dollars (divide by 100), change the ARIA label from "Amount in cents" to "Amount in dollars", update the input to use `step="0.01"`, convert back to cents on batch submit
+- [x] T020 [US3] Update the duplicate dialog in `src/app/invoices/new/invoice-upload-form.tsx` to display the existing invoice's amount using `formatCurrency` (already divides cents by 100) rather than raw cents
 
 **Checkpoint**: All amount displays show dollars. Storage unchanged at cents.
 
@@ -97,9 +97,9 @@ _Phase skipped — all infrastructure already exists._
 
 **Purpose**: Final validation across all stories.
 
-- [ ] T021 Verify all amount displays are consistent across single upload form, bulk review table, duplicate dialog, and outcome summary — spot-check with `formatCurrency` from `src/lib/utils.ts`
-- [ ] T022 Run `pnpm typecheck` and `pnpm lint` to confirm zero errors and zero warnings across all modified files
-- [ ] T023 Run `pnpm build` to confirm production build succeeds with no errors
+- [x] T021 Verify all amount displays are consistent across single upload form, bulk review table, duplicate dialog, and outcome summary — spot-check with `formatCurrency` from `src/lib/utils.ts`
+- [x] T022 Run `pnpm typecheck` and `pnpm lint` to confirm zero errors and zero warnings across all modified files
+- [x] T023 Run `pnpm build` to confirm production build succeeds with no errors
 
 ---
 

--- a/specs/008-invoice-duplicate-handling/tasks.md
+++ b/specs/008-invoice-duplicate-handling/tasks.md
@@ -1,0 +1,203 @@
+# Tasks: Invoice Duplicate Handling & Amount Display
+
+**Input**: Design documents from `/specs/008-invoice-duplicate-handling/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/api-contracts.md, quickstart.md
+
+**Tests**: Not explicitly requested — test tasks omitted.
+
+**Organization**: Tasks grouped by user story. No new files or schema changes; all work modifies 3 existing files + 1 action file.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project setup needed — existing codebase, no new dependencies, no schema changes.
+
+_Phase skipped — all infrastructure already exists._
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Server-side actions that US1 and US2 both depend on. Must complete before user story work.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T001 [P] Add `checkInvoiceDuplicate` server action that queries by invoice number and returns existing invoice details (id, invoiceNumber, invoiceDate, amountCents, vendor, linkedBilledCostId) in `src/actions/invoices.ts`
+- [x] T002 [P] Add `checkBulkDuplicates` server action that accepts an array of invoice numbers and returns a map of duplicates (keyed by invoice number) with existing invoice details in `src/actions/invoices.ts`
+- [x] T003 [P] Add `cleanupBlob` internal helper function that deletes an R2 object by blobPathname using the existing DeleteObjectCommand pattern (best-effort, swallow errors) in `src/actions/invoices.ts`
+- [x] T004 Remove the soft duplicate check (lines 102-106) and the duplicate warning return (line 171) from `saveInvoice` in `src/actions/invoices.ts` — duplicate detection is now handled separately before save
+
+**Checkpoint**: Foundation ready — all three user stories can now proceed.
+
+---
+
+## Phase 3: User Story 1 — Duplicate Detection on Single Upload (Priority: P1) MVP
+
+**Goal**: When an admin uploads a single invoice whose number matches an existing record, they see a dialog with the existing invoice details and can choose to skip (cancel) or overwrite (replace the existing invoice and its linked billed cost).
+
+**Independent Test**: Upload an invoice with a number that already exists. Verify the duplicate dialog appears with existing details. Choose "Skip" and confirm nothing changes. Re-upload and choose "Overwrite" — confirm the existing record and billed cost are updated.
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] Add `overwriteInvoice` server action in `src/actions/invoices.ts` that: (a) fetches existing invoice with old blobPathname and linkedBilledCostId, (b) updates invoice row (date, amount, vendor, blobUrl, blobPathname, updatedAt), (c) deletes old R2 blob via `cleanupBlob`, (d) handles linked billed cost: update in place if same period, or delete old + create new if period changed, or attempt auto-link if no prior link, (e) returns success with linkedPeriodLabel/linkWarning
+- [ ] T006 [US1] Add duplicate check call in `src/app/invoices/new/invoice-upload-form.tsx` — after extraction completes and form fields are populated, call `checkInvoiceDuplicate` with the extracted invoice number; store the result (isDuplicate + existingInvoice) in component state
+- [ ] T007 [US1] Build duplicate resolution dialog in `src/app/invoices/new/invoice-upload-form.tsx` — use shadcn AlertDialog showing existing invoice details (number, date, amount formatted as dollars via `formatCurrency`, vendor), with "Skip (Cancel Upload)" and "Overwrite Existing" action buttons
+- [ ] T008 [US1] Wire "Skip" action in duplicate dialog in `src/app/invoices/new/invoice-upload-form.tsx` — call `cleanupBlob` with the new upload's blobPathname, reset form state and upload state to idle, show toast confirming skip
+- [ ] T009 [US1] Wire "Overwrite" action in duplicate dialog in `src/app/invoices/new/invoice-upload-form.tsx` — call `overwriteInvoice` with existingInvoice.id and current form data (converting amountDollars to cents if US3 is done, otherwise using amountCents), handle success/error toasts and redirect to /invoices
+- [ ] T010 [US1] Add re-check on invoice number field blur in `src/app/invoices/new/invoice-upload-form.tsx` — when admin manually edits the invoice number field and it loses focus, re-run `checkInvoiceDuplicate` and update the duplicate state so the dialog triggers on submit if a match is found
+
+**Checkpoint**: Single upload duplicate detection fully functional — skip and overwrite both work.
+
+---
+
+## Phase 4: User Story 2 — Duplicate Handling in Bulk Upload (Priority: P2)
+
+**Goal**: In a bulk zip upload, duplicates (both DB matches and within-batch) are flagged on the review screen and auto-skipped on save. The outcome summary distinguishes saved, skipped, and failed invoices.
+
+**Independent Test**: Upload a zip with 5 PDFs — 2 matching existing invoice numbers, 1 sharing a number with another in the batch. Verify the review screen flags all 3 duplicates. Submit and confirm only 2 new invoices are saved; skipped items show in the summary.
+
+### Implementation for User Story 2
+
+- [ ] T011 [US2] Integrate `checkBulkDuplicates` into the bulk upload flow in `src/app/invoices/bulk/bulk-upload-form.tsx` — after zip extraction results arrive, collect all extracted invoice numbers, call `checkBulkDuplicates`, and store the duplicates map in component state
+- [ ] T012 [US2] Add within-batch duplicate detection in `src/app/invoices/bulk/bulk-upload-form.tsx` — scan the extraction results client-side for repeated invoice numbers; mark second+ occurrences as within-batch duplicates in row state
+- [ ] T013 [US2] Add visual duplicate flags to the review table in `src/app/invoices/bulk/bulk-upload-form.tsx` — add a "Status" column; show "Duplicate — will be skipped" badge with warning icon for DB-match and within-batch duplicates; make flagged rows visually muted (reduced opacity or strikethrough styling); make flagged rows non-editable
+- [ ] T014 [US2] Modify `saveBulkInvoices` in `src/actions/invoices.ts` to accept an optional `skip` boolean and `skipReason` string per item; skipped items have their R2 blobs cleaned up via `cleanupBlob` and are returned in outcomes with `skipped: true` and `skipReason`
+- [ ] T015 [US2] Update the batch submit handler in `src/app/invoices/bulk/bulk-upload-form.tsx` to pass `skip: true` and `skipReason: "duplicate"` or `"within-batch-duplicate"` for flagged rows when calling `saveBulkInvoices`
+- [ ] T016 [US2] Update the outcome summary (done state) in `src/app/invoices/bulk/bulk-upload-form.tsx` to show three categories: saved (with invoice ID and period), skipped (with reason), and failed (with error); include counts for each category
+
+**Checkpoint**: Bulk upload duplicate handling complete — duplicates flagged on review, skipped on save, reported in summary.
+
+---
+
+## Phase 5: User Story 3 — Display Invoice Amount in Dollars (Priority: P3)
+
+**Goal**: All invoice upload and review forms display amounts in dollars ($125.00) instead of raw cents (12500). Storage remains in cents.
+
+**Independent Test**: Upload a PDF invoice. Verify the amount field shows "125.00" (not "12500") with a dollar label. Edit to "250.50", save, and confirm the database stores 25050 cents.
+
+### Implementation for User Story 3
+
+- [ ] T017 [P] [US3] Change the amount field in the single upload form in `src/app/invoices/new/invoice-upload-form.tsx` — change label from "Amount (cents)" to "Amount ($)", change placeholder from "e.g. 12500 for $125.00" to "0.00", add `step="0.01"` and `min="0.01"` to the input, use a local `amountDollars` form field instead of `amountCents`
+- [ ] T018 [P] [US3] Add cents-to-dollars conversion after extraction in `src/app/invoices/new/invoice-upload-form.tsx` — when extraction returns `amountCents`, set form value to `(amountCents / 100).toFixed(2)`; on form submit, convert back with `Math.round(parseFloat(amountDollars) * 100)` before passing to `saveInvoice` or `overwriteInvoice`
+- [ ] T019 [P] [US3] Change the amount column in the bulk review table in `src/app/invoices/bulk/bulk-upload-form.tsx` — display extracted amounts as dollars (divide by 100), change the ARIA label from "Amount in cents" to "Amount in dollars", update the input to use `step="0.01"`, convert back to cents on batch submit
+- [ ] T020 [US3] Update the duplicate dialog in `src/app/invoices/new/invoice-upload-form.tsx` to display the existing invoice's amount using `formatCurrency` (already divides cents by 100) rather than raw cents
+
+**Checkpoint**: All amount displays show dollars. Storage unchanged at cents.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation across all stories.
+
+- [ ] T021 Verify all amount displays are consistent across single upload form, bulk review table, duplicate dialog, and outcome summary — spot-check with `formatCurrency` from `src/lib/utils.ts`
+- [ ] T022 Run `pnpm typecheck` and `pnpm lint` to confirm zero errors and zero warnings across all modified files
+- [ ] T023 Run `pnpm build` to confirm production build succeeds with no errors
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Skipped — no setup required
+- **Foundational (Phase 2)**: No dependencies — can start immediately
+- **User Story 1 (Phase 3)**: Depends on Phase 2 (needs `checkInvoiceDuplicate`, `cleanupBlob`)
+- **User Story 2 (Phase 4)**: Depends on Phase 2 (needs `checkBulkDuplicates`, `cleanupBlob`). Independent of US1.
+- **User Story 3 (Phase 5)**: No dependencies on Phase 2. Can start in parallel with US1/US2. However, T020 depends on T007 (duplicate dialog must exist before updating its amount display).
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Requires T001, T003, T004 from Phase 2. Independent of US2 and US3.
+- **US2 (P2)**: Requires T002, T003, T004 from Phase 2. Independent of US1 and US3.
+- **US3 (P3)**: Mostly independent. T017-T019 can run any time. T020 requires T007 (duplicate dialog from US1).
+
+### Within Each User Story
+
+- US1: T005 (overwrite action) → T006 (duplicate check in form) → T007 (dialog) → T008, T009 (wire actions, parallel) → T010 (blur re-check)
+- US2: T011 (bulk check integration) → T012 (within-batch detection) → T013 (visual flags) → T014 (server skip support) → T015 (submit handler) → T016 (outcome summary)
+- US3: T017, T018, T019 (all parallel, different sections of different files) → T020 (depends on T007)
+
+### Parallel Opportunities
+
+- **Phase 2**: T001, T002, T003 can all run in parallel (independent functions in same file, no conflicts if written as additions)
+- **US1 + US2**: Can proceed in parallel after Phase 2 (different UI files)
+- **US3 T017-T019**: Can run in parallel with each other (T017/T018 touch single form, T019 touches bulk form)
+- **US1 T008 + T009**: Can run in parallel (independent button handlers)
+
+---
+
+## Parallel Example: Phase 2
+
+```text
+# Launch all foundational tasks together (all are additions to src/actions/invoices.ts):
+Task T001: "Add checkInvoiceDuplicate server action in src/actions/invoices.ts"
+Task T002: "Add checkBulkDuplicates server action in src/actions/invoices.ts"
+Task T003: "Add cleanupBlob helper in src/actions/invoices.ts"
+```
+
+## Parallel Example: US1 + US2 After Phase 2
+
+```text
+# These can proceed simultaneously (different files):
+Agent A (US1): T005-T010 in src/app/invoices/new/invoice-upload-form.tsx + src/actions/invoices.ts
+Agent B (US2): T011-T016 in src/app/invoices/bulk/bulk-upload-form.tsx + src/actions/invoices.ts
+```
+
+## Parallel Example: US3 Amount Display
+
+```text
+# All three amount display tasks can run in parallel:
+Task T017: "Change amount field in src/app/invoices/new/invoice-upload-form.tsx"
+Task T018: "Add cents-to-dollars conversion in src/app/invoices/new/invoice-upload-form.tsx"
+Task T019: "Change amount column in src/app/invoices/bulk/bulk-upload-form.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Foundational (T001-T004)
+2. Complete Phase 3: User Story 1 (T005-T010)
+3. **STOP and VALIDATE**: Test single upload duplicate detection independently
+4. Deploy/demo if ready — admins can now skip or overwrite duplicates on single uploads
+
+### Incremental Delivery
+
+1. Phase 2 → Foundation ready
+2. US1 (Phase 3) → Single upload duplicate handling → Deploy (MVP)
+3. US2 (Phase 4) → Bulk upload duplicate handling → Deploy
+4. US3 (Phase 5) → Dollar amount display → Deploy
+5. Polish (Phase 6) → Final validation → Deploy
+
+### Parallel Team Strategy
+
+With multiple developers or agents:
+
+1. Complete Phase 2 together (4 tasks, all in same file)
+2. Once Phase 2 is done:
+   - Agent A: US1 (single upload form + overwrite action)
+   - Agent B: US2 (bulk upload form + skip logic)
+   - Agent C: US3 T017-T019 (amount display, both forms)
+3. Converge for T020 (US3 depends on US1 dialog) and Phase 6 polish
+
+---
+
+## Notes
+
+- No database schema changes — all modifications are application-level
+- `invoiceNumber` stays non-unique at DB level; enforcement is application-level with user choice
+- R2 blob cleanup is always best-effort (swallow errors)
+- Dollar↔cents conversion is UI-only; Zod schema (`createInvoiceSchema`) stays as `amountCents: z.number().int().positive()`
+- Overwrite is update-in-place (preserves invoice ID and audit history)
+- Bulk upload offers skip only (no per-row overwrite) — admins re-upload individually to overwrite

--- a/src/actions/invoices.ts
+++ b/src/actions/invoices.ts
@@ -12,6 +12,7 @@ import { revalidatePath } from "next/cache";
 import { DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { getR2Client, getR2Bucket } from "@/lib/r2-client";
 import { requireAdmin } from "@/lib/auth-helpers";
+import { z } from "zod";
 import { createInvoiceSchema } from "@/lib/validators";
 import type { CreateInvoiceInput, InvoiceExtractionResult } from "@/lib/validators";
 import { extractInvoiceFields as extractFromLib } from "@/lib/invoice-extraction";
@@ -113,8 +114,9 @@ export async function checkBulkDuplicates(invoiceNumbers: string[]): Promise<
   return { success: true, data: { duplicates } };
 }
 
-// T003: Best-effort R2 blob cleanup
-export async function cleanupBlob(blobPathname: string): Promise<void> {
+// T003: Best-effort R2 blob cleanup (internal only)
+async function cleanupBlobInternal(blobPathname: string): Promise<void> {
+  if (!blobPathname.startsWith("invoices/")) return;
   try {
     await getR2Client().send(
       new DeleteObjectCommand({ Bucket: getR2Bucket(), Key: blobPathname })
@@ -122,6 +124,13 @@ export async function cleanupBlob(blobPathname: string): Promise<void> {
   } catch {
     // Best-effort — swallow errors
   }
+}
+
+// Authenticated wrapper for client-callable cleanup
+export async function cleanupBlob(blobPathname: string): Promise<void> {
+  const admin = await requireAdmin();
+  if (!admin) return;
+  await cleanupBlobInternal(blobPathname);
 }
 
 async function findActivePeriodForDate(
@@ -190,13 +199,22 @@ type OverwriteResult =
   | { success: true; data: { id: number }; linkedPeriodLabel?: string; linkWarning?: string }
   | { success: false; error: string };
 
+const overwriteInvoiceSchema = createInvoiceSchema.extend({
+  existingInvoiceId: z.number().int().positive(),
+});
+
 export async function overwriteInvoice(
   input: OverwriteInvoiceInput
 ): Promise<OverwriteResult> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
 
-  const { existingInvoiceId, invoiceNumber, invoiceDate, amountCents, vendor, blobUrl, blobPathname } = input;
+  const parsed = overwriteInvoiceSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: "Validation failed: " + parsed.error.issues.map(i => i.message).join(", ") };
+  }
+
+  const { existingInvoiceId, invoiceNumber, invoiceDate, amountCents, vendor, blobUrl, blobPathname } = parsed.data;
 
   // Fetch existing invoice
   const existing = await db.query.invoices.findFirst({
@@ -209,100 +227,106 @@ export async function overwriteInvoice(
   const oldBlobPathname = existing.blobPathname;
   const oldLinkedBilledCostId = existing.linkedBilledCostId;
 
-  // Update invoice row
-  await db
-    .update(invoices)
-    .set({
-      invoiceNumber,
-      invoiceDate,
-      amountCents,
-      vendor: vendor ?? null,
-      blobUrl,
-      blobPathname,
-      updatedAt: new Date(),
-    })
-    .where(eq(invoices.id, existingInvoiceId));
-
-  // Delete old R2 blob (best-effort)
-  if (oldBlobPathname !== blobPathname) {
-    await cleanupBlob(oldBlobPathname);
-  }
-
-  // Handle linked billed cost
+  // Perform all DB mutations atomically
   let linkedPeriodLabel: string | undefined;
   let linkWarning: string | undefined;
   const period = await findActivePeriodForDate(invoiceDate);
 
-  if (oldLinkedBilledCostId) {
-    // Existing billed cost — check if period changed
-    const oldCost = await db.query.billedCosts.findFirst({
-      where: eq(billedCosts.id, oldLinkedBilledCostId),
-    });
+  await db.transaction(async (tx) => {
+    // Update invoice row
+    await tx
+      .update(invoices)
+      .set({
+        invoiceNumber,
+        invoiceDate,
+        amountCents,
+        vendor: vendor ?? null,
+        blobUrl,
+        blobPathname,
+        updatedAt: new Date(),
+      })
+      .where(eq(invoices.id, existingInvoiceId));
 
-    if (period && oldCost && oldCost.periodId === period.id) {
-      // Same period — update in place
+    // Handle linked billed cost
+    if (oldLinkedBilledCostId) {
+      const oldCost = await tx.query.billedCosts.findFirst({
+        where: eq(billedCosts.id, oldLinkedBilledCostId),
+      });
+
+      if (period && oldCost && oldCost.periodId === period.id) {
+        // Same period — update in place
+        const description = vendor
+          ? `Invoice ${invoiceNumber} — ${vendor}`
+          : `Invoice ${invoiceNumber}`;
+        await tx
+          .update(billedCosts)
+          .set({
+            amountCents,
+            invoiceDate,
+            description,
+            vendorReference: invoiceNumber,
+            updatedAt: new Date(),
+          })
+          .where(eq(billedCosts.id, oldLinkedBilledCostId));
+        linkedPeriodLabel = period.periodLabel;
+      } else if (period) {
+        // Different period — delete old, create new
+        await tx.delete(billedCosts).where(eq(billedCosts.id, oldLinkedBilledCostId));
+        const description = vendor
+          ? `Invoice ${invoiceNumber} — ${vendor}`
+          : `Invoice ${invoiceNumber}`;
+        const [created] = await tx
+          .insert(billedCosts)
+          .values({
+            periodId: period.id,
+            amountCents,
+            invoiceDate,
+            description,
+            vendorReference: invoiceNumber,
+          })
+          .returning({ id: billedCosts.id });
+        await tx
+          .update(invoices)
+          .set({ linkedBilledCostId: created.id })
+          .where(eq(invoices.id, existingInvoiceId));
+        linkedPeriodLabel = period.periodLabel;
+      } else {
+        // No matching period — remove link
+        await tx.delete(billedCosts).where(eq(billedCosts.id, oldLinkedBilledCostId));
+        await tx
+          .update(invoices)
+          .set({ linkedBilledCostId: null })
+          .where(eq(invoices.id, existingInvoiceId));
+        linkWarning = "No active budget period covers this invoice date. Previous budget link was removed.";
+      }
+    } else if (period) {
+      // No existing billed cost — attempt auto-link
       const description = vendor
         ? `Invoice ${invoiceNumber} — ${vendor}`
         : `Invoice ${invoiceNumber}`;
-      await db
-        .update(billedCosts)
-        .set({
+      const [created] = await tx
+        .insert(billedCosts)
+        .values({
+          periodId: period.id,
           amountCents,
           invoiceDate,
           description,
           vendorReference: invoiceNumber,
-          updatedAt: new Date(),
         })
-        .where(eq(billedCosts.id, oldLinkedBilledCostId));
-      linkedPeriodLabel = period.periodLabel;
-    } else if (period) {
-      // Different period — delete old, create new
-      await db.delete(billedCosts).where(eq(billedCosts.id, oldLinkedBilledCostId));
-      const costId = await insertBilledCostDirect({
-        periodId: period.id,
-        amountCents,
-        invoiceDate,
-        invoiceNumber,
-        vendor,
-        uploadedById: Number(admin.id),
-      });
-      await db
+        .returning({ id: billedCosts.id });
+      await tx
         .update(invoices)
-        .set({ linkedBilledCostId: costId })
+        .set({ linkedBilledCostId: created.id })
         .where(eq(invoices.id, existingInvoiceId));
       linkedPeriodLabel = period.periodLabel;
-    } else {
-      // No matching period — remove link
-      await db.delete(billedCosts).where(eq(billedCosts.id, oldLinkedBilledCostId));
-      await db
-        .update(invoices)
-        .set({ linkedBilledCostId: null })
-        .where(eq(invoices.id, existingInvoiceId));
-      linkWarning = "No active budget period covers this invoice date. Previous budget link was removed.";
-    }
-  } else {
-    // No existing billed cost — attempt auto-link
-    if (period) {
-      try {
-        const costId = await insertBilledCostDirect({
-          periodId: period.id,
-          amountCents,
-          invoiceDate,
-          invoiceNumber,
-          vendor,
-          uploadedById: Number(admin.id),
-        });
-        await db
-          .update(invoices)
-          .set({ linkedBilledCostId: costId })
-          .where(eq(invoices.id, existingInvoiceId));
-        linkedPeriodLabel = period.periodLabel;
-      } catch {
-        linkWarning = "Invoice was overwritten, but automatic linking to the budget period failed.";
-      }
     } else {
       linkWarning = "No active budget period covers this invoice date.";
     }
+  });
+
+  // R2 blob cleanup outside transaction (best-effort)
+  if (oldBlobPathname !== blobPathname) {
+    await cleanupBlobInternal(oldBlobPathname);
   }
 
   revalidatePath("/invoices");

--- a/src/actions/invoices.ts
+++ b/src/actions/invoices.ts
@@ -175,6 +175,146 @@ async function insertBilledCostDirect(params: {
   return created.id;
 }
 
+// T005: Overwrite existing invoice (update-in-place)
+type OverwriteInvoiceInput = {
+  existingInvoiceId: number;
+  invoiceNumber: string;
+  invoiceDate: string;
+  amountCents: number;
+  vendor?: string;
+  blobUrl: string;
+  blobPathname: string;
+};
+
+type OverwriteResult =
+  | { success: true; data: { id: number }; linkedPeriodLabel?: string; linkWarning?: string }
+  | { success: false; error: string };
+
+export async function overwriteInvoice(
+  input: OverwriteInvoiceInput
+): Promise<OverwriteResult> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  const { existingInvoiceId, invoiceNumber, invoiceDate, amountCents, vendor, blobUrl, blobPathname } = input;
+
+  // Fetch existing invoice
+  const existing = await db.query.invoices.findFirst({
+    where: eq(invoices.id, existingInvoiceId),
+  });
+  if (!existing) {
+    return { success: false, error: "Existing invoice not found" };
+  }
+
+  const oldBlobPathname = existing.blobPathname;
+  const oldLinkedBilledCostId = existing.linkedBilledCostId;
+
+  // Update invoice row
+  await db
+    .update(invoices)
+    .set({
+      invoiceNumber,
+      invoiceDate,
+      amountCents,
+      vendor: vendor ?? null,
+      blobUrl,
+      blobPathname,
+      updatedAt: new Date(),
+    })
+    .where(eq(invoices.id, existingInvoiceId));
+
+  // Delete old R2 blob (best-effort)
+  if (oldBlobPathname !== blobPathname) {
+    await cleanupBlob(oldBlobPathname);
+  }
+
+  // Handle linked billed cost
+  let linkedPeriodLabel: string | undefined;
+  let linkWarning: string | undefined;
+  const period = await findActivePeriodForDate(invoiceDate);
+
+  if (oldLinkedBilledCostId) {
+    // Existing billed cost — check if period changed
+    const oldCost = await db.query.billedCosts.findFirst({
+      where: eq(billedCosts.id, oldLinkedBilledCostId),
+    });
+
+    if (period && oldCost && oldCost.periodId === period.id) {
+      // Same period — update in place
+      const description = vendor
+        ? `Invoice ${invoiceNumber} — ${vendor}`
+        : `Invoice ${invoiceNumber}`;
+      await db
+        .update(billedCosts)
+        .set({
+          amountCents,
+          invoiceDate,
+          description,
+          vendorReference: invoiceNumber,
+          updatedAt: new Date(),
+        })
+        .where(eq(billedCosts.id, oldLinkedBilledCostId));
+      linkedPeriodLabel = period.periodLabel;
+    } else if (period) {
+      // Different period — delete old, create new
+      await db.delete(billedCosts).where(eq(billedCosts.id, oldLinkedBilledCostId));
+      const costId = await insertBilledCostDirect({
+        periodId: period.id,
+        amountCents,
+        invoiceDate,
+        invoiceNumber,
+        vendor,
+        uploadedById: Number(admin.id),
+      });
+      await db
+        .update(invoices)
+        .set({ linkedBilledCostId: costId })
+        .where(eq(invoices.id, existingInvoiceId));
+      linkedPeriodLabel = period.periodLabel;
+    } else {
+      // No matching period — remove link
+      await db.delete(billedCosts).where(eq(billedCosts.id, oldLinkedBilledCostId));
+      await db
+        .update(invoices)
+        .set({ linkedBilledCostId: null })
+        .where(eq(invoices.id, existingInvoiceId));
+      linkWarning = "No active budget period covers this invoice date. Previous budget link was removed.";
+    }
+  } else {
+    // No existing billed cost — attempt auto-link
+    if (period) {
+      try {
+        const costId = await insertBilledCostDirect({
+          periodId: period.id,
+          amountCents,
+          invoiceDate,
+          invoiceNumber,
+          vendor,
+          uploadedById: Number(admin.id),
+        });
+        await db
+          .update(invoices)
+          .set({ linkedBilledCostId: costId })
+          .where(eq(invoices.id, existingInvoiceId));
+        linkedPeriodLabel = period.periodLabel;
+      } catch {
+        linkWarning = "Invoice was overwritten, but automatic linking to the budget period failed.";
+      }
+    } else {
+      linkWarning = "No active budget period covers this invoice date.";
+    }
+  }
+
+  revalidatePath("/invoices");
+
+  return {
+    success: true,
+    data: { id: existingInvoiceId },
+    linkedPeriodLabel,
+    linkWarning,
+  };
+}
+
 type SaveInvoiceResult =
   | { success: true; data: { id: number }; linkedPeriodLabel?: string; linkWarning?: string }
   | { success: false; error: string; fieldErrors?: Record<string, string[]> };
@@ -268,17 +408,25 @@ export type BulkSaveOutcome = {
   linkedPeriodLabel?: string;
   linkWarning?: string;
   error?: string;
+  skipped?: boolean;
+  skipReason?: string;
 };
 
 export async function saveBulkInvoices(
-  inputs: Array<CreateInvoiceInput & { filename: string }>
+  inputs: Array<CreateInvoiceInput & { filename: string; skip?: boolean; skipReason?: string }>
 ): Promise<ActionResult<BulkSaveOutcome[]>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
 
   const outcomes: BulkSaveOutcome[] = [];
 
-  for (const { filename, ...invoiceInput } of inputs) {
+  for (const { filename, skip, skipReason, ...invoiceInput } of inputs) {
+    if (skip) {
+      await cleanupBlob(invoiceInput.blobPathname);
+      outcomes.push({ filename, skipped: true, skipReason });
+      continue;
+    }
+
     try {
       const result = await saveInvoice(invoiceInput);
       if (result.success) {

--- a/src/actions/invoices.ts
+++ b/src/actions/invoices.ts
@@ -7,7 +7,7 @@ import {
   budgetPeriods,
   annualBudgets,
 } from "@/lib/db/schema";
-import { eq, and, lte, gt, desc } from "drizzle-orm";
+import { eq, and, lte, gt, desc, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { getR2Client, getR2Bucket } from "@/lib/r2-client";
@@ -25,6 +25,103 @@ export async function extractInvoiceFieldsAction(
   if (!admin) return { success: false, error: "Unauthorized" };
 
   return extractFromLib(input);
+}
+
+// T001: Check single invoice duplicate
+export async function checkInvoiceDuplicate(invoiceNumber: string): Promise<
+  ActionResult<{
+    isDuplicate: boolean;
+    existingInvoice?: {
+      id: number;
+      invoiceNumber: string;
+      invoiceDate: string;
+      amountCents: number;
+      vendor: string | null;
+      linkedBilledCostId: number | null;
+    };
+  }>
+> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  const existing = await db.query.invoices.findFirst({
+    where: eq(invoices.invoiceNumber, invoiceNumber),
+  });
+
+  if (!existing) {
+    return { success: true, data: { isDuplicate: false } };
+  }
+
+  return {
+    success: true,
+    data: {
+      isDuplicate: true,
+      existingInvoice: {
+        id: existing.id,
+        invoiceNumber: existing.invoiceNumber,
+        invoiceDate: existing.invoiceDate,
+        amountCents: existing.amountCents,
+        vendor: existing.vendor,
+        linkedBilledCostId: existing.linkedBilledCostId,
+      },
+    },
+  };
+}
+
+// T002: Batch check multiple invoice numbers
+export async function checkBulkDuplicates(invoiceNumbers: string[]): Promise<
+  ActionResult<{
+    duplicates: Record<
+      string,
+      { id: number; invoiceDate: string; amountCents: number; vendor: string | null }
+    >;
+  }>
+> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  if (invoiceNumbers.length === 0) {
+    return { success: true, data: { duplicates: {} } };
+  }
+
+  const existing = await db
+    .select({
+      id: invoices.id,
+      invoiceNumber: invoices.invoiceNumber,
+      invoiceDate: invoices.invoiceDate,
+      amountCents: invoices.amountCents,
+      vendor: invoices.vendor,
+    })
+    .from(invoices)
+    .where(inArray(invoices.invoiceNumber, invoiceNumbers));
+
+  const duplicates: Record<
+    string,
+    { id: number; invoiceDate: string; amountCents: number; vendor: string | null }
+  > = {};
+  for (const row of existing) {
+    if (!duplicates[row.invoiceNumber]) {
+      duplicates[row.invoiceNumber] = {
+        id: row.id,
+        invoiceDate: row.invoiceDate,
+        amountCents: row.amountCents,
+        vendor: row.vendor,
+      };
+    }
+  }
+
+  return { success: true, data: { duplicates } };
+}
+
+// T003: Best-effort R2 blob cleanup
+export async function cleanupBlob(blobPathname: string): Promise<void> {
+  try {
+    await getR2Client().send(
+      new DeleteObjectCommand({ Bucket: getR2Bucket(), Key: blobPathname })
+    );
+  } catch {
+    // Best-effort — swallow errors
+  }
 }
 
 async function findActivePeriodForDate(
@@ -79,7 +176,7 @@ async function insertBilledCostDirect(params: {
 }
 
 type SaveInvoiceResult =
-  | { success: true; data: { id: number }; warning?: string; linkedPeriodLabel?: string; linkWarning?: string }
+  | { success: true; data: { id: number }; linkedPeriodLabel?: string; linkWarning?: string }
   | { success: false; error: string; fieldErrors?: Record<string, string[]> };
 
 export async function saveInvoice(
@@ -98,12 +195,6 @@ export async function saveInvoice(
   }
 
   const { invoiceNumber, invoiceDate, amountCents, vendor, blobUrl, blobPathname } = parsed.data;
-
-  // Soft duplicate check
-  const existing = await db.query.invoices.findFirst({
-    where: eq(invoices.invoiceNumber, invoiceNumber),
-  });
-  const isDuplicate = !!existing;
 
   let newId: number;
   try {
@@ -168,7 +259,6 @@ export async function saveInvoice(
     data: { id: newId },
     linkedPeriodLabel,
     linkWarning,
-    ...(isDuplicate ? { warning: "An invoice with this number already exists." } : {}),
   };
 }
 

--- a/src/app/invoices/bulk/bulk-upload-form.tsx
+++ b/src/app/invoices/bulk/bulk-upload-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useMemo } from "react";
+import { useState, useRef, useMemo, useCallback } from "react";
 import { toast } from "sonner";
 import { Loader2, Upload, ArrowLeft, AlertTriangle } from "lucide-react";
 import {
@@ -123,17 +123,20 @@ export function BulkUploadForm() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // ---- row mutation helper ----
-  function updateRow(
-    index: number,
-    field: "invoiceNumber" | "invoiceDate" | "amountDollars" | "vendor",
-    value: string,
-  ) {
-    setRows((prev) => {
-      const next = [...prev];
-      next[index] = { ...next[index], [field]: value };
-      return next;
-    });
-  }
+  const updateRow = useCallback(
+    (
+      index: number,
+      field: "invoiceNumber" | "invoiceDate" | "amountDollars" | "vendor",
+      value: string,
+    ) => {
+      setRows((prev) => {
+        const next = [...prev];
+        next[index] = { ...next[index], [field]: value };
+        return next;
+      });
+    },
+    [],
+  );
 
   const columns: ColumnDef<EditableRow, unknown>[] = useMemo(
     () => [
@@ -216,6 +219,7 @@ export function BulkUploadForm() {
             <Input
               type="number"
               step="0.01"
+              min="0.01"
               value={row.original.amountDollars}
               onChange={(e) =>
                 updateRow(row.index, "amountDollars", e.target.value)
@@ -254,7 +258,7 @@ export function BulkUploadForm() {
           ) : null,
       },
     ],
-    [],
+    [updateRow],
   );
 
   const table = useReactTable({

--- a/src/app/invoices/bulk/bulk-upload-form.tsx
+++ b/src/app/invoices/bulk/bulk-upload-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useMemo } from "react";
 import { toast } from "sonner";
-import { Loader2, Upload, ArrowLeft } from "lucide-react";
+import { Loader2, Upload, ArrowLeft, AlertTriangle } from "lucide-react";
 import {
   useReactTable,
   getCoreRowModel,
@@ -21,7 +21,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import Link from "next/link";
-import { saveBulkInvoices, type BulkSaveOutcome } from "@/actions/invoices";
+import {
+  saveBulkInvoices,
+  checkBulkDuplicates,
+  type BulkSaveOutcome,
+} from "@/actions/invoices";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -53,7 +57,7 @@ type EditableRow = {
   blobUrl: string;
   invoiceNumber: string;
   invoiceDate: string;
-  amountCents: string;
+  amountDollars: string;
   vendor: string;
   confidence: {
     invoiceNumber: "high" | "medium" | "low";
@@ -62,6 +66,7 @@ type EditableRow = {
     vendor: "high" | "medium" | "low";
   } | null;
   error: string | null;
+  duplicateType?: "db-duplicate" | "within-batch-duplicate";
 };
 
 type State = "idle" | "uploading" | "reviewing" | "saving" | "done" | "error";
@@ -79,7 +84,10 @@ function draftsToRows(drafts: ExtractionDraft[]): EditableRow[] {
     blobUrl: d.blobUrl,
     invoiceNumber: d.extracted?.invoiceNumber ?? "",
     invoiceDate: d.extracted?.invoiceDate ?? "",
-    amountCents: d.extracted?.amountCents != null ? String(d.extracted.amountCents) : "",
+    amountDollars:
+      d.extracted?.amountCents != null
+        ? (d.extracted.amountCents / 100).toFixed(2)
+        : "",
     vendor: d.extracted?.vendor ?? "",
     confidence: d.extracted?.confidence ?? null,
     error: d.error,
@@ -115,7 +123,11 @@ export function BulkUploadForm() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // ---- row mutation helper ----
-  function updateRow(index: number, field: "invoiceNumber" | "invoiceDate" | "amountCents" | "vendor", value: string) {
+  function updateRow(
+    index: number,
+    field: "invoiceNumber" | "invoiceDate" | "amountDollars" | "vendor",
+    value: string,
+  ) {
     setRows((prev) => {
       const next = [...prev];
       next[index] = { ...next[index], [field]: value };
@@ -123,85 +135,127 @@ export function BulkUploadForm() {
     });
   }
 
-  const columns: ColumnDef<EditableRow, unknown>[] = useMemo(() => [
-    {
-      accessorKey: "filename",
-      header: "Filename",
-      cell: ({ row }) => (
-        <span className="font-mono text-sm">{row.original.filename}</span>
-      ),
-    },
-    {
-      accessorKey: "invoiceNumber",
-      header: "Invoice Number",
-      cell: ({ row }) => {
-        const lowConf = row.original.confidence?.invoiceNumber === "low";
-        return (
-          <Input
-            value={row.original.invoiceNumber}
-            onChange={(e) => updateRow(row.index, "invoiceNumber", e.target.value)}
-            className={cn(lowConf && "border-amber-500")}
-            aria-label={`Invoice number for ${row.original.filename}`}
-          />
-        );
+  const columns: ColumnDef<EditableRow, unknown>[] = useMemo(
+    () => [
+      {
+        accessorKey: "filename",
+        header: "Filename",
+        cell: ({ row }) => (
+          <span className="font-mono text-sm">{row.original.filename}</span>
+        ),
       },
-    },
-    {
-      accessorKey: "invoiceDate",
-      header: "Date",
-      cell: ({ row }) => {
-        const lowConf = row.original.confidence?.invoiceDate === "low";
-        return (
-          <Input
-            value={row.original.invoiceDate}
-            onChange={(e) => updateRow(row.index, "invoiceDate", e.target.value)}
-            className={cn(lowConf && "border-amber-500")}
-            aria-label={`Invoice date for ${row.original.filename}`}
-          />
-        );
+      {
+        id: "status",
+        header: "Status",
+        cell: ({ row }) => {
+          const dup = row.original.duplicateType;
+          if (dup === "db-duplicate") {
+            return (
+              <Badge variant="outline" className="text-amber-600">
+                <AlertTriangle className="mr-1 size-3" />
+                Duplicate — will be skipped
+              </Badge>
+            );
+          }
+          if (dup === "within-batch-duplicate") {
+            return (
+              <Badge variant="outline" className="text-amber-600">
+                <AlertTriangle className="mr-1 size-3" />
+                Within-batch duplicate — will be skipped
+              </Badge>
+            );
+          }
+          return null;
+        },
       },
-    },
-    {
-      accessorKey: "amountCents",
-      header: "Amount",
-      cell: ({ row }) => {
-        const lowConf = row.original.confidence?.amountCents === "low";
-        return (
-          <Input
-            type="number"
-            value={row.original.amountCents}
-            onChange={(e) => updateRow(row.index, "amountCents", e.target.value)}
-            className={cn(lowConf && "border-amber-500")}
-            aria-label={`Amount in cents for ${row.original.filename}`}
-          />
-        );
+      {
+        accessorKey: "invoiceNumber",
+        header: "Invoice Number",
+        cell: ({ row }) => {
+          const lowConf = row.original.confidence?.invoiceNumber === "low";
+          const isDuplicate = !!row.original.duplicateType;
+          return (
+            <Input
+              value={row.original.invoiceNumber}
+              onChange={(e) =>
+                updateRow(row.index, "invoiceNumber", e.target.value)
+              }
+              className={cn(lowConf && "border-amber-500")}
+              aria-label={`Invoice number for ${row.original.filename}`}
+              disabled={isDuplicate}
+            />
+          );
+        },
       },
-    },
-    {
-      accessorKey: "vendor",
-      header: "Vendor",
-      cell: ({ row }) => {
-        const conf = row.original.confidence?.vendor;
-        const lowOrNull = conf === "low" || conf == null;
-        return (
-          <Input
-            value={row.original.vendor}
-            onChange={(e) => updateRow(row.index, "vendor", e.target.value)}
-            className={cn(lowOrNull && "border-amber-500")}
-            aria-label={`Vendor for ${row.original.filename}`}
-          />
-        );
+      {
+        accessorKey: "invoiceDate",
+        header: "Date",
+        cell: ({ row }) => {
+          const lowConf = row.original.confidence?.invoiceDate === "low";
+          const isDuplicate = !!row.original.duplicateType;
+          return (
+            <Input
+              value={row.original.invoiceDate}
+              onChange={(e) =>
+                updateRow(row.index, "invoiceDate", e.target.value)
+              }
+              className={cn(lowConf && "border-amber-500")}
+              aria-label={`Invoice date for ${row.original.filename}`}
+              disabled={isDuplicate}
+            />
+          );
+        },
       },
-    },
-    {
-      accessorKey: "error",
-      header: "Error",
-      cell: ({ row }) =>
-        row.original.error ? (
-          <Badge variant="destructive">{row.original.error}</Badge>
-        ) : null,
-    },
-  ], []);
+      {
+        accessorKey: "amountDollars",
+        header: "Amount",
+        cell: ({ row }) => {
+          const lowConf = row.original.confidence?.amountCents === "low";
+          const isDuplicate = !!row.original.duplicateType;
+          return (
+            <Input
+              type="number"
+              step="0.01"
+              value={row.original.amountDollars}
+              onChange={(e) =>
+                updateRow(row.index, "amountDollars", e.target.value)
+              }
+              className={cn(lowConf && "border-amber-500")}
+              aria-label={`Amount in dollars for ${row.original.filename}`}
+              disabled={isDuplicate}
+            />
+          );
+        },
+      },
+      {
+        accessorKey: "vendor",
+        header: "Vendor",
+        cell: ({ row }) => {
+          const conf = row.original.confidence?.vendor;
+          const lowOrNull = conf === "low" || conf == null;
+          const isDuplicate = !!row.original.duplicateType;
+          return (
+            <Input
+              value={row.original.vendor}
+              onChange={(e) => updateRow(row.index, "vendor", e.target.value)}
+              className={cn(lowOrNull && "border-amber-500")}
+              aria-label={`Vendor for ${row.original.filename}`}
+              disabled={isDuplicate}
+            />
+          );
+        },
+      },
+      {
+        accessorKey: "error",
+        header: "Error",
+        cell: ({ row }) =>
+          row.original.error ? (
+            <Badge variant="destructive">{row.original.error}</Badge>
+          ) : null,
+      },
+    ],
+    [],
+  );
 
   const table = useReactTable({
     data: rows,
@@ -235,10 +289,58 @@ export function BulkUploadForm() {
         results: ExtractionDraft[];
         skipped: string[];
       };
-      setRows(draftsToRows(drafts));
+
+      const editableRows = draftsToRows(drafts);
+
+      // --- T011: Check for DB duplicates ---
+      const invoiceNumbers = editableRows
+        .map((r) => r.invoiceNumber)
+        .filter(Boolean);
+
+      let dbDuplicates: Record<string, unknown> = {};
+      if (invoiceNumbers.length > 0) {
+        const dupResult = await checkBulkDuplicates(invoiceNumbers);
+        if (dupResult.success) {
+          dbDuplicates = dupResult.data.duplicates;
+        }
+      }
+
+      // --- T012: Within-batch duplicate detection ---
+      const seen = new Set<string>();
+      const batchDuplicates = new Set<number>();
+      for (let i = 0; i < editableRows.length; i++) {
+        const num = editableRows[i].invoiceNumber;
+        if (!num) continue;
+        if (seen.has(num)) {
+          batchDuplicates.add(i);
+        } else {
+          seen.add(num);
+        }
+      }
+
+      // Apply duplicate flags to rows
+      const flaggedRows = editableRows.map((row, i) => {
+        if (row.invoiceNumber && row.invoiceNumber in dbDuplicates) {
+          return { ...row, duplicateType: "db-duplicate" as const };
+        }
+        if (batchDuplicates.has(i)) {
+          return {
+            ...row,
+            duplicateType: "within-batch-duplicate" as const,
+          };
+        }
+        return row;
+      });
+
+      setRows(flaggedRows);
       setState("reviewing");
-      const skippedMsg = skipped.length > 0 ? ` (${skipped.length} non-PDF files skipped)` : "";
-      toast.success(`Extracted ${drafts.length} invoice(s). Please review.${skippedMsg}`);
+      const skippedMsg =
+        skipped.length > 0
+          ? ` (${skipped.length} non-PDF files skipped)`
+          : "";
+      toast.success(
+        `Extracted ${drafts.length} invoice(s). Please review.${skippedMsg}`,
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : "Upload failed";
       setErrorMessage(message);
@@ -253,9 +355,16 @@ export function BulkUploadForm() {
     setErrorMessage(null);
 
     try {
-      const incomplete = rows.filter((r) => !r.invoiceNumber || !r.invoiceDate || !r.amountCents);
+      // Only validate non-skipped rows for completeness
+      const incomplete = rows.filter(
+        (r) =>
+          !r.duplicateType &&
+          (!r.invoiceNumber || !r.invoiceDate || !r.amountDollars),
+      );
       if (incomplete.length > 0) {
-        toast.error(`${incomplete.length} row(s) have missing required fields.`);
+        toast.error(
+          `${incomplete.length} row(s) have missing required fields.`,
+        );
         setState("reviewing");
         return;
       }
@@ -264,10 +373,13 @@ export function BulkUploadForm() {
         filename: r.filename,
         invoiceNumber: r.invoiceNumber,
         invoiceDate: r.invoiceDate,
-        amountCents: Number(r.amountCents),
+        amountCents: Math.round(parseFloat(r.amountDollars) * 100),
         vendor: r.vendor || undefined,
         blobUrl: r.blobUrl,
         blobPathname: r.objectKey,
+        ...(r.duplicateType
+          ? { skip: true as const, skipReason: r.duplicateType }
+          : {}),
       }));
 
       const result = await saveBulkInvoices(payload);
@@ -287,10 +399,22 @@ export function BulkUploadForm() {
     }
   }
 
+  // ---- outcome summary helpers ----
+  const savedOutcomes = outcomes.filter(
+    (o) => !o.error && !o.skipped,
+  );
+  const skippedOutcomes = outcomes.filter((o) => o.skipped);
+  const failedOutcomes = outcomes.filter((o) => !!o.error);
+
   return (
     <div className="space-y-6">
       {/* ARIA live region for state announcements */}
-      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
         {stateLabel(state)}
       </div>
 
@@ -337,7 +461,10 @@ export function BulkUploadForm() {
                       <TableHead key={header.id}>
                         {header.isPlaceholder
                           ? null
-                          : flexRender(header.column.columnDef.header, header.getContext())}
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
                       </TableHead>
                     ))}
                   </TableRow>
@@ -346,16 +473,27 @@ export function BulkUploadForm() {
               <TableBody>
                 {table.getRowModel().rows.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={columns.length} className="text-center">
+                    <TableCell
+                      colSpan={columns.length}
+                      className="text-center"
+                    >
                       No invoices extracted.
                     </TableCell>
                   </TableRow>
                 ) : (
                   table.getRowModel().rows.map((row) => (
-                    <TableRow key={row.id}>
+                    <TableRow
+                      key={row.id}
+                      className={cn(
+                        row.original.duplicateType && "opacity-50",
+                      )}
+                    >
                       {row.getVisibleCells().map((cell) => (
                         <TableCell key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
                         </TableCell>
                       ))}
                     </TableRow>
@@ -380,6 +518,23 @@ export function BulkUploadForm() {
       {/* ---- DONE ---- */}
       {state === "done" && (
         <div className="space-y-4">
+          {/* Outcome summary counts */}
+          <div className="flex flex-wrap gap-4">
+            <Badge variant="default">
+              {savedOutcomes.length} invoice(s) saved
+            </Badge>
+            {skippedOutcomes.length > 0 && (
+              <Badge variant="outline" className="text-amber-600">
+                {skippedOutcomes.length} invoice(s) skipped (duplicate)
+              </Badge>
+            )}
+            {failedOutcomes.length > 0 && (
+              <Badge variant="destructive">
+                {failedOutcomes.length} invoice(s) failed
+              </Badge>
+            )}
+          </div>
+
           <div className="rounded-md border">
             <Table>
               <TableHeader>
@@ -391,8 +546,9 @@ export function BulkUploadForm() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {outcomes.map((outcome, i) => (
-                  <TableRow key={i}>
+                {/* Saved outcomes */}
+                {savedOutcomes.map((outcome, i) => (
+                  <TableRow key={`saved-${i}`}>
                     <TableCell className="font-mono text-sm">
                       {outcome.filename}
                     </TableCell>
@@ -407,11 +563,38 @@ export function BulkUploadForm() {
                       )}
                     </TableCell>
                     <TableCell>
-                      {outcome.error ? (
-                        <Badge variant="destructive">{outcome.error}</Badge>
-                      ) : (
-                        <Badge variant="default">Saved</Badge>
-                      )}
+                      <Badge variant="default">Saved</Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {/* Skipped outcomes */}
+                {skippedOutcomes.map((outcome, i) => (
+                  <TableRow key={`skipped-${i}`} className="opacity-50">
+                    <TableCell className="font-mono text-sm">
+                      {outcome.filename}
+                    </TableCell>
+                    <TableCell>—</TableCell>
+                    <TableCell>—</TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="text-amber-600">
+                        <AlertTriangle className="mr-1 size-3" />
+                        Skipped — {outcome.skipReason === "within-batch-duplicate"
+                          ? "within-batch duplicate"
+                          : "duplicate"}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {/* Failed outcomes */}
+                {failedOutcomes.map((outcome, i) => (
+                  <TableRow key={`failed-${i}`}>
+                    <TableCell className="font-mono text-sm">
+                      {outcome.filename}
+                    </TableCell>
+                    <TableCell>—</TableCell>
+                    <TableCell>—</TableCell>
+                    <TableCell>
+                      <Badge variant="destructive">{outcome.error}</Badge>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/app/invoices/new/invoice-upload-form.tsx
+++ b/src/app/invoices/new/invoice-upload-form.tsx
@@ -259,7 +259,13 @@ export function InvoiceUploadForm() {
     setIsOverwriting(true);
     try {
       const formValues = watch();
-      const amountCents = Math.round(parseFloat(amountDollars) * 100);
+      const parsedAmount = parseFloat(amountDollars);
+      if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+        toast.error("Please enter a valid positive amount before overwriting.");
+        setIsOverwriting(false);
+        return;
+      }
+      const amountCents = Math.round(parsedAmount * 100);
 
       const result = await overwriteInvoice({
         existingInvoiceId: duplicateInfo.existingInvoice.id,
@@ -441,7 +447,7 @@ export function InvoiceUploadForm() {
             error={errors.vendor?.message}
           />
 
-          <Button type="submit" disabled={isSubmitting || !blobPathname}>
+          <Button type="submit" disabled={isSubmitting || !blobPathname || !!duplicateInfo?.isDuplicate}>
             {isSubmitting ? (
               <>
                 <Loader2 className="mr-2 size-4 animate-spin" />
@@ -455,7 +461,7 @@ export function InvoiceUploadForm() {
       )}
 
       {/* T007: Duplicate resolution dialog */}
-      <AlertDialog open={duplicateDialogOpen} onOpenChange={setDuplicateDialogOpen}>
+      <AlertDialog open={duplicateDialogOpen} onOpenChange={(open) => { if (!open) return; setDuplicateDialogOpen(open); }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Duplicate Invoice Detected</AlertDialogTitle>

--- a/src/app/invoices/new/invoice-upload-form.tsx
+++ b/src/app/invoices/new/invoice-upload-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
@@ -15,20 +15,48 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { createInvoiceSchema } from "@/lib/validators";
 import type { CreateInvoiceInput, InvoiceExtractionResult } from "@/lib/validators";
-import { extractInvoiceFieldsAction, saveInvoice } from "@/actions/invoices";
-import { cn } from "@/lib/utils";
+import {
+  extractInvoiceFieldsAction,
+  saveInvoice,
+  checkInvoiceDuplicate,
+  cleanupBlob,
+  overwriteInvoice,
+} from "@/actions/invoices";
+import { cn, formatCurrency } from "@/lib/utils";
 import type { UseFormRegisterReturn } from "react-hook-form";
 
 type UploadState = "idle" | "uploading" | "extracting" | "extracted" | "error";
 
 type ConfidenceLevel = "high" | "medium" | "low";
 
+type DuplicateInfo = {
+  isDuplicate: boolean;
+  existingInvoice?: {
+    id: number;
+    invoiceNumber: string;
+    invoiceDate: string;
+    amountCents: number;
+    vendor: string | null;
+    linkedBilledCostId: number | null;
+  };
+};
+
 const ARIA_STATUS: Record<UploadState, string> = {
   idle: "",
-  uploading: "Uploading PDF…",
-  extracting: "Extracting invoice fields…",
+  uploading: "Uploading PDF\u2026",
+  extracting: "Extracting invoice fields\u2026",
   extracted: "Extraction complete. Please review the form.",
   error: "Extraction failed. Please enter fields manually.",
 };
@@ -49,6 +77,9 @@ type ConfidenceInputProps = {
   confidence: ConfidenceLevel | undefined;
   watchedValue: string | null | undefined;
   error?: string;
+  step?: string;
+  min?: string;
+  onBlur?: () => void;
 };
 
 function ConfidenceInput({
@@ -60,8 +91,23 @@ function ConfidenceInput({
   confidence,
   watchedValue,
   error,
+  step,
+  min,
+  onBlur,
 }: ConfidenceInputProps) {
   const low = isLowConfidence(confidence, watchedValue);
+
+  // Merge the external onBlur with registerProps.onBlur
+  const mergedRegisterProps = onBlur
+    ? {
+        ...registerProps,
+        onBlur: (e: React.FocusEvent<HTMLInputElement>) => {
+          registerProps.onBlur(e);
+          onBlur();
+        },
+      }
+    : registerProps;
+
   return (
     <div className="space-y-1">
       <Label htmlFor={id}>{label}</Label>
@@ -71,9 +117,11 @@ function ConfidenceInput({
             <Input
               id={id}
               type={type}
-              {...registerProps}
+              {...mergedRegisterProps}
               className={cn(low ? "border-amber-400" : "")}
               placeholder={placeholder}
+              step={step}
+              min={min}
             />
           </TooltipTrigger>
           {low && <TooltipContent>Low confidence — please verify</TooltipContent>}
@@ -90,19 +138,39 @@ export function InvoiceUploadForm() {
   const [uploadState, setUploadState] = useState<UploadState>("idle");
   const [extractionResult, setExtractionResult] =
     useState<InvoiceExtractionResult | null>(null);
+  const [duplicateInfo, setDuplicateInfo] = useState<DuplicateInfo | null>(null);
+  const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
+  const [isOverwriting, setIsOverwriting] = useState(false);
 
   const {
     register,
     handleSubmit,
     setValue,
     watch,
+    reset,
     formState: { errors, isSubmitting },
   } = useForm<CreateInvoiceInput>({
     resolver: zodResolver(createInvoiceSchema),
   });
 
-  const { invoiceNumber, invoiceDate, amountCents, vendor, blobPathname } = watch();
+  const { invoiceNumber, invoiceDate, vendor, blobPathname } = watch();
+  // Separate state for the dollars display value (T017/T018)
+  const [amountDollars, setAmountDollars] = useState("");
   const confidence = extractionResult?.confidence;
+
+  const runDuplicateCheck = useCallback(async (invNumber: string) => {
+    if (!invNumber || invNumber.trim() === "") {
+      setDuplicateInfo(null);
+      return;
+    }
+    const result = await checkInvoiceDuplicate(invNumber.trim());
+    if (result.success) {
+      setDuplicateInfo(result.data);
+      if (result.data.isDuplicate) {
+        setDuplicateDialogOpen(true);
+      }
+    }
+  }, []);
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -115,6 +183,7 @@ export function InvoiceUploadForm() {
 
     setUploadState("uploading");
     setExtractionResult(null);
+    setDuplicateInfo(null);
 
     try {
       const formData = new FormData();
@@ -147,10 +216,20 @@ export function InvoiceUploadForm() {
 
       if (extracted.invoiceNumber) setValue("invoiceNumber", extracted.invoiceNumber);
       if (extracted.invoiceDate) setValue("invoiceDate", extracted.invoiceDate);
-      if (extracted.amountCents) setValue("amountCents", extracted.amountCents);
+      if (extracted.amountCents) {
+        // T018: Convert cents to dollars for display
+        const dollars = (extracted.amountCents / 100).toFixed(2);
+        setAmountDollars(dollars);
+        setValue("amountCents", extracted.amountCents);
+      }
       if (extracted.vendor) setValue("vendor", extracted.vendor);
 
       setUploadState("extracted");
+
+      // T006: Run duplicate check after extraction
+      if (extracted.invoiceNumber) {
+        await runDuplicateCheck(extracted.invoiceNumber);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Upload failed";
       setUploadState("error");
@@ -158,8 +237,75 @@ export function InvoiceUploadForm() {
     }
   };
 
+  // T008: Skip (cancel upload) action
+  const handleSkipDuplicate = async () => {
+    const currentBlobPathname = watch().blobPathname;
+    if (currentBlobPathname) {
+      await cleanupBlob(currentBlobPathname);
+    }
+    reset();
+    setAmountDollars("");
+    setUploadState("idle");
+    setExtractionResult(null);
+    setDuplicateInfo(null);
+    setDuplicateDialogOpen(false);
+    toast.info("Upload skipped — duplicate invoice cancelled.");
+  };
+
+  // T009: Overwrite existing action
+  const handleOverwriteDuplicate = async () => {
+    if (!duplicateInfo?.existingInvoice) return;
+
+    setIsOverwriting(true);
+    try {
+      const formValues = watch();
+      const amountCents = Math.round(parseFloat(amountDollars) * 100);
+
+      const result = await overwriteInvoice({
+        existingInvoiceId: duplicateInfo.existingInvoice.id,
+        invoiceNumber: formValues.invoiceNumber,
+        invoiceDate: formValues.invoiceDate,
+        amountCents,
+        vendor: formValues.vendor || undefined,
+        blobUrl: formValues.blobUrl,
+        blobPathname: formValues.blobPathname,
+      });
+
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+
+      if (result.linkWarning) {
+        toast.warning("Invoice overwritten.", { description: result.linkWarning });
+      } else if (result.linkedPeriodLabel) {
+        toast.success(`Invoice overwritten. Linked to ${result.linkedPeriodLabel}.`);
+      } else {
+        toast.success("Invoice overwritten successfully.");
+      }
+      router.push("/invoices");
+    } catch {
+      toast.error("Failed to overwrite invoice.");
+    } finally {
+      setIsOverwriting(false);
+      setDuplicateDialogOpen(false);
+    }
+  };
+
+  // T010: Re-check on invoice number blur
+  const handleInvoiceNumberBlur = () => {
+    const currentInvoiceNumber = watch().invoiceNumber;
+    if (currentInvoiceNumber) {
+      runDuplicateCheck(currentInvoiceNumber);
+    }
+  };
+
   const onSubmit = async (data: CreateInvoiceInput) => {
-    const result = await saveInvoice(data);
+    // T018: Convert dollars to cents before saving
+    const amountCents = Math.round(parseFloat(amountDollars) * 100);
+    const submitData = { ...data, amountCents };
+
+    const result = await saveInvoice(submitData);
     if (!result.success) {
       toast.error(result.error);
       return;
@@ -196,7 +342,7 @@ export function InvoiceUploadForm() {
             {uploadState === "uploading" || uploadState === "extracting" ? (
               <>
                 <Loader2 className="mr-2 size-4 animate-spin" />
-                {uploadState === "uploading" ? "Uploading…" : "Extracting…"}
+                {uploadState === "uploading" ? "Uploading\u2026" : "Extracting\u2026"}
               </>
             ) : (
               <>
@@ -230,6 +376,7 @@ export function InvoiceUploadForm() {
             confidence={confidence?.invoiceNumber}
             watchedValue={invoiceNumber}
             error={errors.invoiceNumber?.message}
+            onBlur={handleInvoiceNumberBlur}
           />
 
           <ConfidenceInput
@@ -242,16 +389,47 @@ export function InvoiceUploadForm() {
             error={errors.invoiceDate?.message}
           />
 
-          <ConfidenceInput
-            id="amountCents"
-            label="Amount (cents)"
-            placeholder="e.g. 12500 for $125.00"
-            type="number"
-            registerProps={register("amountCents", { valueAsNumber: true })}
-            confidence={confidence?.amountCents}
-            watchedValue={amountCents?.toString()}
-            error={errors.amountCents?.message}
-          />
+          {/* T017: Amount in dollars display */}
+          <div className="space-y-1">
+            <Label htmlFor="amountDollars">Amount ($)</Label>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Input
+                    id="amountDollars"
+                    type="number"
+                    step="0.01"
+                    min="0.01"
+                    placeholder="0.00"
+                    value={amountDollars}
+                    onChange={(e) => {
+                      setAmountDollars(e.target.value);
+                      // Keep the hidden amountCents in sync for validation
+                      const cents = Math.round(parseFloat(e.target.value || "0") * 100);
+                      setValue("amountCents", isNaN(cents) ? 0 : cents);
+                    }}
+                    className={cn(
+                      isLowConfidence(
+                        confidence?.amountCents,
+                        amountDollars || undefined
+                      )
+                        ? "border-amber-400"
+                        : ""
+                    )}
+                  />
+                </TooltipTrigger>
+                {isLowConfidence(
+                  confidence?.amountCents,
+                  amountDollars || undefined
+                ) && <TooltipContent>Low confidence — please verify</TooltipContent>}
+              </Tooltip>
+            </TooltipProvider>
+            {errors.amountCents?.message && (
+              <p className="text-sm text-destructive">{errors.amountCents.message}</p>
+            )}
+            {/* Hidden field to keep react-hook-form validation working */}
+            <input type="hidden" {...register("amountCents", { valueAsNumber: true })} />
+          </div>
 
           <ConfidenceInput
             id="vendor"
@@ -275,6 +453,57 @@ export function InvoiceUploadForm() {
           </Button>
         </form>
       )}
+
+      {/* T007: Duplicate resolution dialog */}
+      <AlertDialog open={duplicateDialogOpen} onOpenChange={setDuplicateDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Duplicate Invoice Detected</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2">
+                <p>
+                  An invoice with this number already exists in the archive:
+                </p>
+                {duplicateInfo?.existingInvoice && (
+                  <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
+                    <dt className="font-medium">Number:</dt>
+                    <dd>{duplicateInfo.existingInvoice.invoiceNumber}</dd>
+                    <dt className="font-medium">Date:</dt>
+                    <dd>{duplicateInfo.existingInvoice.invoiceDate}</dd>
+                    <dt className="font-medium">Amount:</dt>
+                    {/* T020: Display amount using formatCurrency */}
+                    <dd>{formatCurrency(duplicateInfo.existingInvoice.amountCents)}</dd>
+                    <dt className="font-medium">Vendor:</dt>
+                    <dd>{duplicateInfo.existingInvoice.vendor ?? "—"}</dd>
+                  </dl>
+                )}
+                <p>
+                  Would you like to skip this upload or overwrite the existing invoice?
+                </p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleSkipDuplicate} disabled={isOverwriting}>
+              Skip (Cancel Upload)
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={handleOverwriteDuplicate}
+              disabled={isOverwriting}
+            >
+              {isOverwriting ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  Overwriting…
+                </>
+              ) : (
+                "Overwrite Existing"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/app/invoices/new/invoice-upload-form.tsx
+++ b/src/app/invoices/new/invoice-upload-form.tsx
@@ -171,9 +171,6 @@ export function InvoiceUploadForm() {
     } else {
       toast.success("Invoice saved to archive.");
     }
-    if (result.warning) {
-      toast.warning(result.warning);
-    }
     router.push("/invoices");
   };
 


### PR DESCRIPTION
## Summary

- **Duplicate detection on single upload**: After extraction (or invoice number edit), checks for existing invoices by number. Shows AlertDialog with existing invoice details — admin can skip (cleans up R2 blob) or overwrite (updates invoice + billed cost in place)
- **Duplicate handling in bulk upload**: Flags both DB-match and within-batch duplicates on the review screen with warning badges. Flagged rows are muted/non-editable and auto-skipped on save. Outcome summary shows saved/skipped/failed counts
- **Dollar amount display**: All invoice upload forms now show amounts in dollars ($125.00) instead of raw cents (12500). Storage remains in integer cents — conversion is UI-only

## Changes

| File | What changed |
|------|-------------|
| `src/actions/invoices.ts` | Added `checkInvoiceDuplicate`, `checkBulkDuplicates`, `cleanupBlob`, `overwriteInvoice`. Extended `saveBulkInvoices` with skip support. Removed soft duplicate warning from `saveInvoice` |
| `src/app/invoices/new/invoice-upload-form.tsx` | Duplicate check + AlertDialog (skip/overwrite), blur re-check, dollar amount input with cents conversion |
| `src/app/invoices/bulk/bulk-upload-form.tsx` | DB + within-batch duplicate detection, visual flags, skip logic, dollar display, enhanced outcome summary |

## Test plan

- [ ] Upload a single PDF whose invoice number matches an existing record — verify duplicate dialog appears with correct details
- [ ] Choose "Skip" — verify R2 blob is cleaned up and form resets
- [ ] Re-upload and choose "Overwrite" — verify existing invoice and billed cost are updated
- [ ] Edit invoice number to a duplicate and blur — verify dialog re-triggers
- [ ] Upload a ZIP with duplicates (DB matches + within-batch) — verify flags on review screen
- [ ] Submit bulk — verify duplicates are skipped, others saved, summary shows all three categories
- [ ] Verify amount fields show dollars (e.g., "125.00") not cents (e.g., "12500") in both forms
- [ ] Verify saved amounts are stored as integer cents in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)