### PR TITLE
feat: bulk user import with upsert & export on users page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-02
 - Neon PostgreSQL (serverless) via `@neondatabase/serverless` + Cloudflare R2 (PDF blobs) (007-invoice-budget-link)
 - TypeScript 5.9.3 (strict mode), React 19.2.4, Next.js 15.5.12 (App Router) + Tailwind CSS 4.2.1, shadcn/ui (new-york), next-themes 0.4.6, Recharts 2.15.4, class-variance-authority (010-pro-dashboard-theme)
 - Neon PostgreSQL via Drizzle ORM (minor schema default change for UserPreferences) (010-pro-dashboard-theme)
+- TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, shadcn/ui (new-york), Sonner (toasts), Lucide React, bcryptjs, Zod 4.3.6 (011-user-import)
+- Neon PostgreSQL (serverless) via `@neondatabase/serverless` + Drizzle ORM (011-user-import)
 
 - **Language**: TypeScript 5.x (strict mode), Node.js LTS
 - **Framework**: Next.js 15 (App Router, Server Components, Server Actions)
@@ -81,11 +83,8 @@ pnpm lighthouse        # Lighthouse CI
 - Server Components by default — `"use client"` only when client interactivity needed
 
 ## Recent Changes
+- 011-user-import: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, shadcn/ui (new-york), Sonner (toasts), Lucide React, bcryptjs, Zod 4.3.6
 - 010-pro-dashboard-theme: Added TypeScript 5.9.3 (strict mode), React 19.2.4, Next.js 15.5.12 (App Router) + Tailwind CSS 4.2.1, shadcn/ui (new-york), next-themes 0.4.6, Recharts 2.15.4, class-variance-authority
-- 007-invoice-budget-link: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6, React Hook Form 7.71.2, TanStack Table 8.21.3, shadcn/ui (new-york), Sonner (toasts), `unzipper` (NEW — zip extraction)
-- 006-optional-fields-ux: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6, React Hook Form 7.71.2, TanStack Table 8.21.3, shadcn/ui (new-york style), Lucide React, Sonner (toasts)
-- 009-invoice-syncing: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, Zod 4.3.6, shadcn/ui, Sonner (toasts), Lucide React
-- 008-invoice-duplicate-handling: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, React Hook Form 7.71.2, Zod 4.3.6, TanStack Table 8.21.3, shadcn/ui, Sonner (toasts), @aws-sdk/client-s3 (R2)
 - 007-invoice-budget-link: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6, React Hook Form 7.71.2, TanStack Table 8.21.3, shadcn/ui (new-york), Sonner (toasts), `unzipper` (NEW — zip extraction)
 
 

--- a/specs/011-user-import/checklists/requirements.md
+++ b/specs/011-user-import/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Bulk User Import with Upsert & Export
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Reasonable defaults were applied for: email as match key, status not importable, password preserved on update, change history tracking.

--- a/specs/011-user-import/contracts/server-actions.md
+++ b/specs/011-user-import/contracts/server-actions.md
@@ -1,0 +1,117 @@
+# Server Action Contracts: Bulk User Import with Upsert
+
+**Feature**: 011-user-import | **Date**: 2026-03-06
+
+## Modified: `bulkImportUsers`
+
+**File**: `src/actions/users.ts`
+**Auth**: Requires admin role
+
+### Input
+
+```typescript
+{
+  users: Array<{
+    name: string;           // Required, non-empty
+    email: string;          // Required, valid email format
+    circle?: string;        // Optional department/team
+    role?: "admin" | "viewer";  // Optional, defaults to "viewer"
+    githubUsername?: string; // Optional GitHub handle
+    profile?: "boost" | "maxed" | "indie";  // Optional profile tier
+  }>;
+}
+```
+
+### Output (Success)
+
+```typescript
+{
+  success: true;
+  data: {
+    created: number;    // New users inserted
+    updated: number;    // Existing users with field changes applied
+    skipped: number;    // Existing users with no field changes
+    failed: number;     // Rows that failed validation/DB
+    errors: Array<{
+      row: number;      // 1-based row index
+      email: string;    // Email from row
+      error: string;    // Human-readable error
+    }>;
+  };
+}
+```
+
+### Output (Failure)
+
+```typescript
+{
+  success: false;
+  error: string;  // e.g., "Unauthorized" or system error
+}
+```
+
+### Behavior
+
+1. Validate each row against `bulkImportUserSchema`
+2. For each valid row, query existing user by email (case-insensitive)
+3. **If no existing user**: Create new user with default password hash, record creation in history
+4. **If existing user found**: Compare importable fields (name, circle, role, githubUsername, profile). If any differ, update the user and record field-level changes in history. If all match, skip.
+5. Password, status, preferences are never modified for existing users
+6. Return aggregate counts and error details
+
+---
+
+## New: `checkExistingUsers`
+
+**File**: `src/actions/users.ts`
+**Auth**: Requires admin role
+
+### Input
+
+```typescript
+{
+  emails: string[];  // List of emails to check
+}
+```
+
+### Output (Success)
+
+```typescript
+{
+  success: true;
+  data: Record<string, {
+    name: string;
+    circle: string | null;
+    role: string;
+    githubUsername: string | null;
+    profile: string | null;
+  }>;
+  // Map of lowercase email → current field values
+  // Only includes emails that match existing users
+}
+```
+
+### Output (Failure)
+
+```typescript
+{
+  success: false;
+  error: string;
+}
+```
+
+### Behavior
+
+1. Accept list of emails from parsed CSV
+2. Query users table for all matching emails (case-insensitive, single query using `inArray`)
+3. Return map of email → current importable field values
+4. Emails not found in DB are omitted from the map (these are "New" rows)
+
+---
+
+## Unchanged: `GET /api/export/users`
+
+**File**: `src/app/api/export/users/route.ts`
+**Auth**: Requires admin role
+
+No changes to this endpoint. The existing CSV export with columns `name, email, circle, role, github_username, profile` is already round-trip compatible with the import.

--- a/specs/011-user-import/data-model.md
+++ b/specs/011-user-import/data-model.md
@@ -1,0 +1,111 @@
+# Data Model: Bulk User Import with Upsert & Export
+
+**Feature**: 011-user-import | **Date**: 2026-03-06
+
+## Existing Entities (No Schema Changes)
+
+This feature requires **no database schema changes**. All data model changes are at the application type level.
+
+### Users Table (existing)
+
+| Field | Type | Nullable | Notes |
+|-------|------|----------|-------|
+| id | serial | no | Primary key |
+| name | varchar(255) | no | Updated via import |
+| email | varchar(255) | no | Unique — match key for upsert |
+| passwordHash | varchar(255) | no | **Never modified by import** |
+| githubUsername | varchar(255) | yes | Updated via import |
+| circle | varchar(100) | yes | Updated via import |
+| role | enum(admin, viewer) | no | Updated via import (default: viewer) |
+| status | enum(active, inactive) | no | **Never modified by import** |
+| profile | enum(boost, maxed, indie) | yes | Updated via import |
+| preferences | jsonb | no | **Never modified by import** |
+| createdAt | timestamp | no | Auto-set on creation |
+| updatedAt | timestamp | no | Auto-set on update |
+
+**Import-writable fields**: name, circle, role, githubUsername, profile
+**Import-protected fields**: id, email (match key), passwordHash, status, preferences, createdAt, updatedAt
+
+### Change History Table (existing, no changes)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| id | serial | Primary key |
+| entityType | varchar(50) | "user" for user changes |
+| entityId | integer | References users.id |
+| changeType | enum | "created" or "updated" for import operations |
+| fieldName | varchar(100) | Name of changed field |
+| previousValue | text | JSON-stringified old value |
+| newValue | text | JSON-stringified new value |
+| changedBy | integer | Admin performing the import |
+| createdAt | timestamp | Auto-set |
+
+## New Application Types
+
+### BulkImportResult
+
+Replaces the existing `{ imported, failed, errors }` return type.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| created | number | Count of new users created |
+| updated | number | Count of existing users updated (with actual changes) |
+| skipped | number | Count of existing users with no field changes |
+| failed | number | Count of rows that failed validation or DB errors |
+| errors | ImportError[] | Details of failed rows |
+
+### ImportError (existing, unchanged)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| row | number | 1-based row number in CSV |
+| email | string | Email from the row (if available) |
+| error | string | Human-readable error message |
+
+### ExistingUserMap (new, for preview)
+
+Returned by `checkExistingUsers` action for preview labeling.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| [email: string] | ExistingUserFields | null | Map of email to current field values |
+
+### ExistingUserFields (new, for preview)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Current name |
+| circle | string | null | Current circle |
+| role | string | Current role |
+| githubUsername | string | null | Current GitHub username |
+| profile | string | null | Current profile |
+
+### ParsedImportRow (extended)
+
+Extends existing parsed row with upsert metadata for preview.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | From CSV |
+| email | string | From CSV |
+| circle | string | undefined | From CSV |
+| role | string | undefined | From CSV |
+| githubUsername | string | undefined | From CSV |
+| profile | string | undefined | From CSV |
+| action | "new" | "update" | "skip" | Determined after email lookup |
+| changes | string[] | List of field names that differ from current values (update rows only) |
+| error | string | undefined | Validation error message |
+
+## Field Comparison Logic
+
+For determining whether a row is "update" or "skip":
+
+| CSV Value | DB Value | Result |
+|-----------|----------|--------|
+| "Engineering" | "Engineering" | No change |
+| "Engineering" | "Sales" | Changed |
+| "" or undefined | null | No change (normalize empty → null) |
+| "" or undefined | "Sales" | Changed (clears field) |
+| "Engineering" | null | Changed (sets field) |
+
+**Normalization rule**: Empty strings and undefined values in CSV are treated as `null` for comparison with nullable fields. For non-nullable fields (name, role), empty string triggers a validation error.

--- a/specs/011-user-import/plan.md
+++ b/specs/011-user-import/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: Bulk User Import with Upsert & Export
+
+**Branch**: `011-user-import` | **Date**: 2026-03-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/011-user-import/spec.md`
+
+## Summary
+
+Enhance the existing bulk user import to support upsert behavior: when a CSV row's email matches an existing user, update their fields (name, circle, role, github_username, profile) without changing their password or status. New emails create new users as before. Add an export button to the user overview page. The import preview must distinguish "New" vs "Update" rows and highlight changed fields.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3 (strict mode)
+**Primary Dependencies**: Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, shadcn/ui (new-york), Sonner (toasts), Lucide React, bcryptjs, Zod 4.3.6
+**Storage**: Neon PostgreSQL (serverless) via `@neondatabase/serverless` + Drizzle ORM
+**Testing**: Vitest (unit/integration), Playwright (e2e)
+**Target Platform**: Web application (server-rendered Next.js)
+**Project Type**: Web application (Next.js App Router with Server Actions)
+**Performance Goals**: Standard web app — bulk import of 100+ users completes within seconds
+**Constraints**: No new dependencies required; all changes use existing stack
+**Scale/Scope**: Admin-only feature, typical usage 10-500 users per import
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Type-Safe Code Quality | PASS | All new code in TypeScript strict mode. Zod schemas for validation. Server action return types follow existing `ActionResult<T>` pattern. |
+| II. UX Consistency | PASS | Uses existing shadcn/ui components (Button, Badge, Table). New/Update badges follow existing badge patterns. Export button follows existing button group layout. |
+| III. Performance Budgets | PASS | No new routes or pages. Changes to existing import page are minimal. No new JS bundles. Server-side upsert logic runs on Neon serverless. |
+| IV. Accessibility-First | PASS | Export button is a standard `<a>` or `<Button>` with accessible label. Preview table uses existing accessible DataTable. Status badges use text labels (not color-only). |
+| V. Simplicity & Maintainability | PASS | Extends existing server action rather than creating new abstraction. Reuses existing CSV parsing, export API, change history recording. No new dependencies. |
+
+**Gate result**: ALL PASS — no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-user-import/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── server-actions.md
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── actions/
+│   └── users.ts              # MODIFY: upsert logic in bulkImportUsers
+├── app/
+│   ├── users/
+│   │   ├── page.tsx           # MODIFY: add export button
+│   │   └── import/
+│   │       └── bulk-import-form.tsx  # MODIFY: preview with New/Update indicators, change highlighting
+│   └── api/export/users/
+│       └── route.ts           # NO CHANGE: existing export API
+├── lib/
+│   ├── validators.ts          # MODIFY: add upsert result types
+│   └── csv.ts                 # NO CHANGE: existing CSV utilities
+└── types/
+    └── index.ts               # MODIFY: add BulkImportResult types
+
+tests/
+├── unit/
+│   └── bulk-import-upsert.test.ts   # NEW: unit tests for upsert logic
+└── e2e/
+    └── bulk-import-upsert.spec.ts   # NEW: e2e tests for export-edit-import workflow
+```
+
+**Structure Decision**: This feature modifies existing files in the established Next.js App Router structure. No new pages or routes are needed — only modifications to the existing bulk import action, form component, and user overview page.

--- a/specs/011-user-import/quickstart.md
+++ b/specs/011-user-import/quickstart.md
@@ -1,0 +1,86 @@
+# Quickstart: Bulk User Import with Upsert & Export
+
+**Feature**: 011-user-import | **Date**: 2026-03-06
+
+## Prerequisites
+
+- Node.js LTS + pnpm installed
+- Neon PostgreSQL database configured (`.env.local` with `DATABASE_URL`)
+- Admin user seeded (`pnpm db:seed`)
+
+## Setup
+
+```bash
+git checkout 011-user-import
+pnpm install
+pnpm db:push          # Apply any schema changes (none expected for this feature)
+pnpm dev              # Start dev server at http://localhost:3000
+```
+
+## Development Workflow
+
+### 1. Modify Server Action (Backend First)
+
+**File**: `src/actions/users.ts`
+
+- Add `checkExistingUsers` action for preview email lookup
+- Modify `bulkImportUsers` to support upsert:
+  - When email matches existing user → update fields (not password/status)
+  - When email is new → create user with default password
+  - Track created/updated/skipped/failed counts
+  - Record changes in history via `recordUpdate`
+
+### 2. Update Import Form (Frontend)
+
+**File**: `src/app/users/import/bulk-import-form.tsx`
+
+- After CSV parse, call `checkExistingUsers` with parsed emails
+- Label each preview row as "New" or "Update"
+- For "Update" rows, highlight fields that differ from current values
+- Update import summary to show created/updated/skipped/failed
+
+### 3. Add Export Button to User Overview
+
+**File**: `src/app/users/page.tsx`
+
+- Add Download button linking to `/api/export/users`
+- Place in admin button group before "Bulk Import"
+
+### 4. Update Types
+
+**File**: `src/types/index.ts`
+
+- Add `BulkImportResult` type (created, updated, skipped, failed, errors)
+- Add `ExistingUserFields` type for preview lookup
+
+## Testing
+
+```bash
+pnpm test                    # Unit tests
+pnpm test:e2e                # E2E tests (requires running dev server)
+```
+
+### Manual Testing Workflow
+
+1. Log in as admin
+2. Navigate to `/users` — verify export button visible
+3. Click export → CSV downloads
+4. Open CSV, modify some fields, add new rows
+5. Navigate to `/users/import`
+6. Upload modified CSV → verify preview shows "New"/"Update" labels
+7. Click Import → verify summary shows correct counts
+8. Check user records are updated (passwords unchanged)
+9. Check change history records exist for updates
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/actions/users.ts` | Server actions (upsert logic) |
+| `src/app/users/import/bulk-import-form.tsx` | Import form with preview |
+| `src/app/users/page.tsx` | User overview (export button) |
+| `src/lib/validators.ts` | Zod schemas |
+| `src/types/index.ts` | TypeScript types |
+| `src/actions/history.ts` | Change history recording |
+| `src/app/api/export/users/route.ts` | CSV export API |
+| `src/lib/csv.ts` | CSV utilities |

--- a/specs/011-user-import/research.md
+++ b/specs/011-user-import/research.md
@@ -1,0 +1,64 @@
+# Research: Bulk User Import with Upsert & Export
+
+**Feature**: 011-user-import | **Date**: 2026-03-06
+
+## R-001: Upsert Strategy for Bulk Import
+
+**Decision**: Modify the existing `bulkImportUsers` server action to detect existing users by email and update their non-sensitive fields instead of skipping them.
+
+**Rationale**: The current implementation already queries for existing users by email (line 237-243 of `src/actions/users.ts`) but skips them with an error. Changing this to an update path is a minimal, low-risk modification. Using Drizzle's `update().set().where()` keeps the implementation consistent with the existing `updateUser` action.
+
+**Alternatives considered**:
+- PostgreSQL `ON CONFLICT DO UPDATE` (upsert at DB level): Rejected because we need to compute field-level diffs for change history before writing, and we need to preserve `passwordHash` and `status` which requires reading the existing record first.
+- New separate "bulk update" action: Rejected per Simplicity principle — one action handling both create and update is simpler and matches the user's mental model.
+
+## R-002: Change Detection for Skip Logic
+
+**Decision**: Compare each importable field (name, circle, role, githubUsername, profile) between the CSV row and the existing database record. If all fields match, skip the row. Use simple string comparison with null normalization (empty string → null for nullable fields).
+
+**Rationale**: This prevents unnecessary database writes and change history noise when re-importing an unmodified export. The comparison is cheap (in-memory, 5 fields) and avoids the complexity of checksums or hashing.
+
+**Alternatives considered**:
+- Hash-based comparison: Rejected as over-engineering for 5 fields.
+- Always update regardless of changes: Rejected because it creates misleading change history entries and unnecessary DB writes.
+
+## R-003: Preview Enhancement — New vs Update Detection
+
+**Decision**: After CSV parsing on the client, send parsed emails to a new server action `checkExistingUsers` that returns a set of existing emails. The client uses this to label rows as "New" or "Update" in the preview. For "Update" rows, the server also returns current field values so the client can highlight changed fields.
+
+**Rationale**: The client cannot determine New vs Update without querying the database. A lightweight lookup action (single query, returns email→fields map) is efficient and keeps the preview responsive. This is preferable to doing all detection server-side because the preview needs to be interactive (user sees labels before clicking import).
+
+**Alternatives considered**:
+- Client-side only detection (no server call): Impossible — client doesn't have access to current user data.
+- Full server-side preview rendering: Rejected because the existing preview is client-side and this would require a major architectural change.
+- Fetch all users on page load: Viable but wasteful for large user sets and exposes data unnecessarily. The targeted lookup by email list is more efficient and secure.
+
+## R-004: Export Button Placement on User Overview Page
+
+**Decision**: Add an export button (Download icon, outline variant) to the existing admin button group on `src/app/users/page.tsx`, positioned before the "Bulk Import" button. Use a standard `<a>` tag styled as a shadcn Button linking to the existing `/api/export/users` endpoint.
+
+**Rationale**: The export API route already exists and works correctly. The button group on the user overview page already has a flex layout with gap-2 spacing. Adding one more button requires no structural changes. Using an `<a>` tag (not a fetch call) triggers the browser's native download behavior, which is the expected UX for file downloads.
+
+**Alternatives considered**:
+- Client-side CSV generation: Rejected — the server-side export already exists with proper RFC 4180 formatting and UTF-8 BOM.
+- Dropdown menu with export options: Over-engineering — there's only one export format (CSV).
+
+## R-005: Change History Recording for Bulk Updates
+
+**Decision**: Reuse the existing `recordUpdate` function from `src/actions/history.ts` for each user updated during bulk import. Compute the diff object (field → {old, new}) by comparing the existing record with the CSV values, then pass it to `recordUpdate`.
+
+**Rationale**: The `recordUpdate` function already handles per-field change tracking with JSON-stringified values. Reusing it ensures consistency with single-user edit history and requires no new infrastructure.
+
+**Alternatives considered**:
+- Batch history recording: Could be more efficient for large imports, but adds complexity and the existing per-record approach works fine for the expected scale (10-500 users).
+- New "bulk_update" change type: Rejected — using the existing "updated" type keeps the history unified and queryable.
+
+## R-006: Import Result Types
+
+**Decision**: Extend the import result to include four categories: `created` (count), `updated` (count), `skipped` (count, no changes), `failed` (count + error details). Update the `ActionResult` data type for `bulkImportUsers` accordingly.
+
+**Rationale**: The spec requires distinct reporting of create vs update vs skip vs fail. The existing result only has `imported` and `failed`. Expanding this is a backward-compatible change since the UI is the only consumer.
+
+**Alternatives considered**:
+- Keep existing two-category result and add update info to errors: Confusing UX — updates aren't errors.
+- Return full row-level details: Over-engineering for the summary toast display.

--- a/specs/011-user-import/spec.md
+++ b/specs/011-user-import/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: Bulk User Import with Upsert & Export
+
+**Feature Branch**: `011-user-import`
+**Created**: 2026-03-06
+**Status**: Draft
+**Input**: User description: "the bulk import for users should update existing users (without changing their passwords) and add new users. Updating multiple users by first exporting, then editing the exported file and then importing it again should be a valid workflow for bulk changes. The export functionality should also be available on the user overview page. Use subagents and commit often"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Export-Edit-Import Workflow for Bulk Updates (Priority: P1)
+
+An administrator wants to update multiple users at once (e.g., reassign circles, change roles, update profiles). They navigate to the user overview page, export the current user list as a CSV file, open it in a spreadsheet editor, make changes to the relevant rows, and re-import the modified file. The system updates existing users based on email matching without altering their passwords, and reports a summary of changes made.
+
+**Why this priority**: This is the core workflow that enables efficient bulk user management. Without upsert behavior on import, administrators must edit users one-by-one, which is impractical at scale.
+
+**Independent Test**: Can be fully tested by exporting users, modifying fields in the CSV, re-importing, and verifying that user records are updated while passwords remain unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** an administrator has exported the user list, **When** they modify a user's circle and role in the CSV and re-import it, **Then** the system updates that user's circle and role without changing their password.
+2. **Given** an exported CSV contains 10 existing users and 2 new rows, **When** the administrator imports the file, **Then** 10 users are updated (preserving passwords) and 2 new users are created with the default password.
+3. **Given** a CSV row has an email matching an existing user, **When** no fields have changed compared to the current record, **Then** the system skips that row and does not count it as an update.
+4. **Given** an administrator imports a CSV, **When** the import completes, **Then** the system displays a summary showing counts of created users, updated users, skipped users (no changes), and failed rows with error details.
+
+---
+
+### User Story 2 - Export from User Overview Page (Priority: P2)
+
+An administrator viewing the user overview page wants to quickly export the full user list without navigating to the bulk import page. An export button is available directly on the user overview page, allowing one-click CSV download.
+
+**Why this priority**: Making export accessible from the user overview page removes friction from the export-edit-import workflow and makes the export feature discoverable where administrators naturally work.
+
+**Independent Test**: Can be tested by navigating to the user overview page and clicking the export button, verifying a CSV file downloads with all current user data.
+
+**Acceptance Scenarios**:
+
+1. **Given** an administrator is on the user overview page, **When** they click the export button, **Then** a CSV file downloads containing all users with columns: name, email, circle, role, github_username, profile.
+2. **Given** a non-admin user is on the user overview page, **When** they view the page, **Then** the export button is not visible.
+3. **Given** the exported CSV is opened in a spreadsheet application, **When** the administrator reviews it, **Then** all fields are properly formatted and the file is compatible with common spreadsheet editors (Excel, Google Sheets, LibreOffice).
+
+---
+
+### User Story 3 - Add New Users via Bulk Import (Priority: P1)
+
+An administrator needs to onboard a batch of new users. They prepare a CSV file with user details and import it. New users (those with emails not matching any existing user) are created with a default password.
+
+**Why this priority**: This is existing core functionality that must continue working correctly alongside the new upsert behavior.
+
+**Independent Test**: Can be tested by importing a CSV containing only new email addresses and verifying all users are created.
+
+**Acceptance Scenarios**:
+
+1. **Given** a CSV with 5 rows where no emails match existing users, **When** the administrator imports it, **Then** 5 new user accounts are created with the default password.
+2. **Given** a CSV row is missing the required name or email field, **When** the administrator previews the import, **Then** that row is flagged with a validation error and excluded from import.
+3. **Given** the CSV contains two rows with the same email address, **When** the administrator imports it, **Then** the system detects the duplicate within the file and reports an error for the duplicate row.
+
+---
+
+### User Story 4 - Import Preview with Update Indicators (Priority: P2)
+
+Before committing an import, the administrator reviews a preview table that clearly distinguishes which rows will create new users versus which will update existing users. This allows the administrator to verify the intended changes before execution.
+
+**Why this priority**: Preview with clear create/update indicators prevents accidental bulk modifications and gives administrators confidence in the import operation.
+
+**Independent Test**: Can be tested by uploading a mixed CSV (some new, some existing emails) and verifying the preview correctly labels each row.
+
+**Acceptance Scenarios**:
+
+1. **Given** a CSV with a mix of new and existing users, **When** the administrator uploads the file, **Then** the preview table shows each row labeled as "New" or "Update".
+2. **Given** the preview shows update rows, **When** the administrator reviews them, **Then** fields that will change are visually highlighted or indicated.
+3. **Given** the preview shows validation errors on some rows, **When** the administrator reviews the preview, **Then** error rows are clearly marked and valid rows can still be imported.
+
+---
+
+### Edge Cases
+
+- What happens when a CSV contains an email for an inactive user? The system updates the user's fields but does not reactivate them — status is not changed via import.
+- What happens when the CSV has columns in a different order than the export? The system matches columns by header name, not position.
+- What happens when the CSV contains extra columns not recognized by the system? Extra columns are silently ignored.
+- What happens when the CSV uses different line endings (CRLF vs LF)? Both formats are accepted.
+- What happens when an update row has an invalid value (e.g., invalid role)? That row fails validation and is reported as an error; other valid rows proceed.
+- What happens when the export file is re-imported without any edits? All rows are detected as unchanged and skipped, with a summary showing zero updates.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST match imported users to existing users by email address (case-insensitive).
+- **FR-002**: When an imported row matches an existing user by email, the system MUST update the user's fields (name, circle, role, github_username, profile) with the values from the CSV.
+- **FR-003**: When updating an existing user, the system MUST NOT modify the user's password hash.
+- **FR-004**: When updating an existing user, the system MUST NOT modify the user's status (active/inactive).
+- **FR-005**: When an imported row does not match any existing user, the system MUST create a new user with a default password.
+- **FR-006**: The import preview MUST indicate whether each row will result in a "New" user creation or an "Update" to an existing user.
+- **FR-007**: The import summary MUST report separate counts for: users created, users updated, rows skipped (no changes), and rows failed.
+- **FR-008**: An export button MUST be available on the user overview page for administrators.
+- **FR-009**: The export functionality on the user overview page MUST produce the same CSV format as the existing export on the bulk import page.
+- **FR-010**: The exported CSV format MUST be directly re-importable without modification (round-trip compatibility).
+- **FR-011**: When an update row contains no field changes compared to the existing record, the system MUST skip that row rather than performing a no-op update.
+- **FR-012**: All user updates performed via bulk import MUST be recorded in the change history with appropriate field-level change tracking.
+- **FR-013**: The import preview MUST visually distinguish fields that will change for update rows.
+
+### Key Entities
+
+- **User**: The primary entity being imported/exported. Matched by email (unique identifier). Fields: name, email, circle, role, github_username, profile, status, passwordHash.
+- **Import Operation**: A logical grouping of rows being processed. Produces a summary with counts of created, updated, skipped, and failed rows.
+- **Change History Entry**: An audit record created for each field-level change made during a bulk update.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Administrators can update 100 users in under 5 minutes using the export-edit-import workflow (compared to editing each user individually).
+- **SC-002**: Re-importing an unmodified export file results in zero creates, zero updates, and all rows reported as skipped.
+- **SC-003**: Existing user passwords remain unchanged after any bulk import operation that updates their records.
+- **SC-004**: 100% of field-level changes from bulk import are recorded in the change history audit trail.
+- **SC-005**: The export button on the user overview page is discoverable without navigating to the import page.
+- **SC-006**: Import preview correctly identifies all rows as "New" or "Update" with 100% accuracy before the import is executed.
+
+## Assumptions
+
+- The default password for new users created via bulk import remains "changeme123" (consistent with existing behavior).
+- Email is the unique identifier for matching — it cannot be changed via bulk import (if a CSV row has a new email, it creates a new user).
+- The export CSV does not include the password column, status column, or internal ID — these are system-managed fields not editable via import.
+- Column matching in the CSV is done by header name (case-insensitive), making column order irrelevant.
+- The existing CSV parsing (client-side) and export (server-side) infrastructure is reused and extended rather than replaced.
+- Status is not importable — administrators must activate/deactivate users through the existing individual user management interface.

--- a/specs/011-user-import/tasks.md
+++ b/specs/011-user-import/tasks.md
@@ -19,8 +19,8 @@
 
 **Purpose**: Define shared types and schemas that all user stories depend on
 
-- [ ] T001 Add `BulkImportResult` and `ExistingUserFields` types in `src/types/index.ts` — add types for upsert result (created, updated, skipped, failed, errors) and existing user field map for preview lookup
-- [ ] T002 Update `bulkImportUserSchema` in `src/lib/validators.ts` — no schema changes needed but verify round-trip compatibility: empty strings for nullable fields should be accepted and normalized to null
+- [x] T001 Add `BulkImportResult` and `ExistingUserFields` types in `src/types/index.ts` — add types for upsert result (created, updated, skipped, failed, errors) and existing user field map for preview lookup
+- [x] T002 Update `bulkImportUserSchema` in `src/lib/validators.ts` — no schema changes needed but verify round-trip compatibility: empty strings for nullable fields should be accepted and normalized to null
 
 **Checkpoint**: Shared types compiled and ready for use by server actions and UI
 
@@ -34,10 +34,10 @@
 
 ### Implementation for User Story 1 + 3
 
-- [ ] T003 [US1] Add `checkExistingUsers` server action in `src/actions/users.ts` — accepts email list, returns `Record<string, ExistingUserFields>` map of lowercase email to current field values using `inArray` query. Requires admin role.
-- [ ] T004 [US1] Add field comparison helper in `src/actions/users.ts` — create a `computeUserDiff` function that compares CSV row fields (name, circle, role, githubUsername, profile) against existing user record, normalizing empty strings to null for nullable fields. Returns `Record<string, { old: unknown; new: unknown }>` for changed fields, or empty object if no changes.
-- [ ] T005 [US1] Modify `bulkImportUsers` in `src/actions/users.ts` — replace the existing "skip if email exists" logic with upsert behavior: (1) if no existing user, create with default password and `recordCreation` (existing path), (2) if existing user found, call `computeUserDiff` — if changes exist, update user fields via `db.update()` and call `recordUpdate` with diff; if no changes, increment skipped count. Never modify passwordHash or status. Return `BulkImportResult` with created/updated/skipped/failed counts.
-- [ ] T006 [US1] Update import summary toast in `src/app/users/import/bulk-import-form.tsx` — modify the post-import toast notification to display the new four-category summary: "X created, Y updated, Z skipped, W failed" instead of the current "X imported, Y failed".
+- [x] T003 [US1] Add `checkExistingUsers` server action in `src/actions/users.ts` — accepts email list, returns `Record<string, ExistingUserFields>` map of lowercase email to current field values using `inArray` query. Requires admin role.
+- [x] T004 [US1] Add field comparison helper in `src/actions/users.ts` — create a `computeUserDiff` function that compares CSV row fields (name, circle, role, githubUsername, profile) against existing user record, normalizing empty strings to null for nullable fields. Returns `Record<string, { old: unknown; new: unknown }>` for changed fields, or empty object if no changes.
+- [x] T005 [US1] Modify `bulkImportUsers` in `src/actions/users.ts` — replace the existing "skip if email exists" logic with upsert behavior: (1) if no existing user, create with default password and `recordCreation` (existing path), (2) if existing user found, call `computeUserDiff` — if changes exist, update user fields via `db.update()` and call `recordUpdate` with diff; if no changes, increment skipped count. Never modify passwordHash or status. Return `BulkImportResult` with created/updated/skipped/failed counts.
+- [x] T006 [US1] Update import summary toast in `src/app/users/import/bulk-import-form.tsx` — modify the post-import toast notification to display the new four-category summary: "X created, Y updated, Z skipped, W failed" instead of the current "X imported, Y failed".
 
 **Checkpoint**: Core upsert logic works end-to-end. Re-importing an unmodified export shows all rows skipped. Importing a mix of new and existing users shows correct counts. Passwords preserved.
 
@@ -51,7 +51,7 @@
 
 ### Implementation for User Story 2
 
-- [ ] T007 [P] [US2] Add export button to admin button group in `src/app/users/page.tsx` — add a `<Button variant="outline" asChild>` wrapping an `<a href="/api/export/users" download>` with a Download icon (from lucide-react), placed before the existing "Bulk Import" button in the admin-only button group. Only visible when `isAdmin` is true.
+- [x] T007 [P] [US2] Add export button to admin button group in `src/app/users/page.tsx` — add a `<Button variant="outline" asChild>` wrapping an `<a href="/api/export/users" download>` with a Download icon (from lucide-react), placed before the existing "Bulk Import" button in the admin-only button group. Only visible when `isAdmin` is true.
 
 **Checkpoint**: Export button visible on user overview page for admins, triggers CSV download.
 
@@ -65,10 +65,10 @@
 
 ### Implementation for User Story 4
 
-- [ ] T008 [US4] Add email lookup on CSV parse in `src/app/users/import/bulk-import-form.tsx` — after CSV parsing completes, collect all parsed emails and call `checkExistingUsers` server action. Store the returned `Record<string, ExistingUserFields>` map in component state.
-- [ ] T009 [US4] Compute row action and changed fields in `src/app/users/import/bulk-import-form.tsx` — for each parsed row, determine action ("new" if email not in existing map, "update" if in map) and compute list of changed field names by comparing CSV values to existing values (same normalization as server-side: empty string = null for nullable fields).
-- [ ] T010 [US4] Add New/Update badge column to preview table in `src/app/users/import/bulk-import-form.tsx` — add an "Action" column to the preview table showing a Badge: "New" (default/outline variant) or "Update" (secondary variant) based on the computed action for each row.
-- [ ] T011 [US4] Highlight changed fields in preview table in `src/app/users/import/bulk-import-form.tsx` — for "Update" rows, apply a visual indicator (e.g., `font-semibold text-primary` or subtle background highlight) to table cells whose field name appears in the row's changed fields list.
+- [x] T008 [US4] Add email lookup on CSV parse in `src/app/users/import/bulk-import-form.tsx` — after CSV parsing completes, collect all parsed emails and call `checkExistingUsers` server action. Store the returned `Record<string, ExistingUserFields>` map in component state.
+- [x] T009 [US4] Compute row action and changed fields in `src/app/users/import/bulk-import-form.tsx` — for each parsed row, determine action ("new" if email not in existing map, "update" if in map) and compute list of changed field names by comparing CSV values to existing values (same normalization as server-side: empty string = null for nullable fields).
+- [x] T010 [US4] Add New/Update badge column to preview table in `src/app/users/import/bulk-import-form.tsx` — add an "Action" column to the preview table showing a Badge: "New" (default/outline variant) or "Update" (secondary variant) based on the computed action for each row.
+- [x] T011 [US4] Highlight changed fields in preview table in `src/app/users/import/bulk-import-form.tsx` — for "Update" rows, apply a visual indicator (e.g., `font-semibold text-primary` or subtle background highlight) to table cells whose field name appears in the row's changed fields list.
 
 **Checkpoint**: Preview correctly labels all rows. Changed fields visually distinguishable. Error rows still show validation errors.
 
@@ -78,9 +78,9 @@
 
 **Purpose**: Final validation and edge case handling
 
-- [ ] T012 Verify round-trip compatibility by testing export → re-import with no changes in `src/app/users/import/bulk-import-form.tsx` and `src/actions/users.ts` — ensure empty string normalization in CSV parsing matches the export format (null fields exported as empty strings, empty strings imported as null). Fix any mismatches.
-- [ ] T013 Verify change history completeness in `src/actions/users.ts` — ensure `recordUpdate` is called with correct `changedBy` (admin user ID from session) and that each changed field produces a separate history entry. Test with a bulk update affecting multiple fields on multiple users.
-- [ ] T014 [P] Run `pnpm typecheck` and `pnpm lint` — fix any TypeScript errors or lint warnings introduced by the changes.
+- [x] T012 Verify round-trip compatibility by testing export → re-import with no changes in `src/app/users/import/bulk-import-form.tsx` and `src/actions/users.ts` — ensure empty string normalization in CSV parsing matches the export format (null fields exported as empty strings, empty strings imported as null). Fix any mismatches.
+- [x] T013 Verify change history completeness in `src/actions/users.ts` — ensure `recordUpdate` is called with correct `changedBy` (admin user ID from session) and that each changed field produces a separate history entry. Test with a bulk update affecting multiple fields on multiple users.
+- [x] T014 [P] Run `pnpm typecheck` and `pnpm lint` — fix any TypeScript errors or lint warnings introduced by the changes.
 - [ ] T015 Run quickstart.md manual testing workflow — follow the 9-step manual test plan from `specs/011-user-import/quickstart.md` to validate the full export-edit-import workflow end-to-end.
 
 ---

--- a/specs/011-user-import/tasks.md
+++ b/specs/011-user-import/tasks.md
@@ -1,0 +1,159 @@
+# Tasks: Bulk User Import with Upsert & Export
+
+**Input**: Design documents from `/specs/011-user-import/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/server-actions.md
+
+**Tests**: Not explicitly requested in spec — test tasks omitted.
+
+**Organization**: Tasks grouped by user story. US1 and US3 are combined (same server action handles both create and update paths).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US4)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Types & Validators)
+
+**Purpose**: Define shared types and schemas that all user stories depend on
+
+- [ ] T001 Add `BulkImportResult` and `ExistingUserFields` types in `src/types/index.ts` — add types for upsert result (created, updated, skipped, failed, errors) and existing user field map for preview lookup
+- [ ] T002 Update `bulkImportUserSchema` in `src/lib/validators.ts` — no schema changes needed but verify round-trip compatibility: empty strings for nullable fields should be accepted and normalized to null
+
+**Checkpoint**: Shared types compiled and ready for use by server actions and UI
+
+---
+
+## Phase 2: User Story 1 + 3 — Upsert Import & New User Creation (Priority: P1) MVP
+
+**Goal**: The `bulkImportUsers` server action supports both creating new users and updating existing users (matched by email). Passwords and status are never modified for existing users. Unchanged rows are skipped. Change history is recorded for all updates.
+
+**Independent Test**: Import a CSV with a mix of new emails, existing emails with changes, and existing emails without changes. Verify correct counts for created/updated/skipped/failed. Verify passwords unchanged. Verify change history entries.
+
+### Implementation for User Story 1 + 3
+
+- [ ] T003 [US1] Add `checkExistingUsers` server action in `src/actions/users.ts` — accepts email list, returns `Record<string, ExistingUserFields>` map of lowercase email to current field values using `inArray` query. Requires admin role.
+- [ ] T004 [US1] Add field comparison helper in `src/actions/users.ts` — create a `computeUserDiff` function that compares CSV row fields (name, circle, role, githubUsername, profile) against existing user record, normalizing empty strings to null for nullable fields. Returns `Record<string, { old: unknown; new: unknown }>` for changed fields, or empty object if no changes.
+- [ ] T005 [US1] Modify `bulkImportUsers` in `src/actions/users.ts` — replace the existing "skip if email exists" logic with upsert behavior: (1) if no existing user, create with default password and `recordCreation` (existing path), (2) if existing user found, call `computeUserDiff` — if changes exist, update user fields via `db.update()` and call `recordUpdate` with diff; if no changes, increment skipped count. Never modify passwordHash or status. Return `BulkImportResult` with created/updated/skipped/failed counts.
+- [ ] T006 [US1] Update import summary toast in `src/app/users/import/bulk-import-form.tsx` — modify the post-import toast notification to display the new four-category summary: "X created, Y updated, Z skipped, W failed" instead of the current "X imported, Y failed".
+
+**Checkpoint**: Core upsert logic works end-to-end. Re-importing an unmodified export shows all rows skipped. Importing a mix of new and existing users shows correct counts. Passwords preserved.
+
+---
+
+## Phase 3: User Story 2 — Export from User Overview Page (Priority: P2)
+
+**Goal**: An export CSV button is visible to administrators on the user overview page, linking to the existing `/api/export/users` endpoint.
+
+**Independent Test**: Navigate to `/users` as admin — export button visible. Click it — CSV downloads. Navigate as viewer — no export button.
+
+### Implementation for User Story 2
+
+- [ ] T007 [P] [US2] Add export button to admin button group in `src/app/users/page.tsx` — add a `<Button variant="outline" asChild>` wrapping an `<a href="/api/export/users" download>` with a Download icon (from lucide-react), placed before the existing "Bulk Import" button in the admin-only button group. Only visible when `isAdmin` is true.
+
+**Checkpoint**: Export button visible on user overview page for admins, triggers CSV download.
+
+---
+
+## Phase 4: User Story 4 — Import Preview with Update Indicators (Priority: P2)
+
+**Goal**: The import preview table shows each row labeled as "New" or "Update". For update rows, fields that differ from the current database values are visually highlighted.
+
+**Independent Test**: Upload a CSV with a mix of new and existing users. Verify preview labels rows correctly. Verify changed fields are highlighted for update rows.
+
+### Implementation for User Story 4
+
+- [ ] T008 [US4] Add email lookup on CSV parse in `src/app/users/import/bulk-import-form.tsx` — after CSV parsing completes, collect all parsed emails and call `checkExistingUsers` server action. Store the returned `Record<string, ExistingUserFields>` map in component state.
+- [ ] T009 [US4] Compute row action and changed fields in `src/app/users/import/bulk-import-form.tsx` — for each parsed row, determine action ("new" if email not in existing map, "update" if in map) and compute list of changed field names by comparing CSV values to existing values (same normalization as server-side: empty string = null for nullable fields).
+- [ ] T010 [US4] Add New/Update badge column to preview table in `src/app/users/import/bulk-import-form.tsx` — add an "Action" column to the preview table showing a Badge: "New" (default/outline variant) or "Update" (secondary variant) based on the computed action for each row.
+- [ ] T011 [US4] Highlight changed fields in preview table in `src/app/users/import/bulk-import-form.tsx` — for "Update" rows, apply a visual indicator (e.g., `font-semibold text-primary` or subtle background highlight) to table cells whose field name appears in the row's changed fields list.
+
+**Checkpoint**: Preview correctly labels all rows. Changed fields visually distinguishable. Error rows still show validation errors.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and edge case handling
+
+- [ ] T012 Verify round-trip compatibility by testing export → re-import with no changes in `src/app/users/import/bulk-import-form.tsx` and `src/actions/users.ts` — ensure empty string normalization in CSV parsing matches the export format (null fields exported as empty strings, empty strings imported as null). Fix any mismatches.
+- [ ] T013 Verify change history completeness in `src/actions/users.ts` — ensure `recordUpdate` is called with correct `changedBy` (admin user ID from session) and that each changed field produces a separate history entry. Test with a bulk update affecting multiple fields on multiple users.
+- [ ] T014 [P] Run `pnpm typecheck` and `pnpm lint` — fix any TypeScript errors or lint warnings introduced by the changes.
+- [ ] T015 Run quickstart.md manual testing workflow — follow the 9-step manual test plan from `specs/011-user-import/quickstart.md` to validate the full export-edit-import workflow end-to-end.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **US1+US3 (Phase 2)**: Depends on Phase 1 (types must exist)
+- **US2 (Phase 3)**: Independent — can run in parallel with Phase 2
+- **US4 (Phase 4)**: Depends on Phase 2 (needs `checkExistingUsers` action)
+- **Polish (Phase 5)**: Depends on Phases 2, 3, and 4
+
+### User Story Dependencies
+
+- **US1+US3 (P1)**: Depends on Setup only — core MVP
+- **US2 (P2)**: Fully independent — only touches `src/app/users/page.tsx`
+- **US4 (P2)**: Depends on `checkExistingUsers` from US1 — must wait for Phase 2
+
+### Within Each Phase
+
+- T003 and T004 can run in parallel (different functions, same file but independent)
+- T005 depends on T003 and T004 (uses both)
+- T006 depends on T005 (needs new return type)
+- T008 depends on T003 (calls `checkExistingUsers`)
+- T009 depends on T008 (needs existing user map)
+- T010 and T011 depend on T009 (need computed actions/changes)
+
+### Parallel Opportunities
+
+- Phase 2 (US1+US3) and Phase 3 (US2) can run in parallel
+- T003 and T004 within Phase 2 can run in parallel
+- T014 (lint/typecheck) can run in parallel with T012/T013
+
+---
+
+## Parallel Example: Phase 2 + Phase 3
+
+```bash
+# These can run in parallel (different files):
+Task T003: "Add checkExistingUsers action in src/actions/users.ts"
+Task T007: "Add export button in src/app/users/page.tsx"
+
+# Within Phase 2, these can run in parallel:
+Task T003: "checkExistingUsers action"
+Task T004: "computeUserDiff helper"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phase 1 + Phase 2)
+
+1. Complete Phase 1: Setup types
+2. Complete Phase 2: US1+US3 upsert logic
+3. **STOP and VALIDATE**: Test upsert with mixed CSV
+4. This alone delivers the core value — bulk updates work
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → Upsert works (MVP!)
+2. Add Phase 3 (US2) → Export discoverable on user page
+3. Add Phase 4 (US4) → Preview shows New/Update with highlights
+4. Phase 5 → Polish, verify, ship
+
+---
+
+## Notes
+
+- No new dependencies required — all changes use existing stack
+- No database schema changes — all modifications at application level
+- US1 and US3 are combined because they share the same server action (`bulkImportUsers`)
+- The existing export API (`/api/export/users`) is unchanged
+- Commit after each task or logical group as requested

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -2,7 +2,7 @@
 
 import { db } from "@/lib/db";
 import { users, licenseAssignments } from "@/lib/db/schema";
-import { eq, and, count, inArray } from "drizzle-orm";
+import { eq, and, count, inArray, sql } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth-helpers";
 import { hash } from "bcryptjs";
@@ -204,28 +204,39 @@ export async function deactivateUser(input: {
   return { success: true, data: { revokedCount: activeAssignments.length } };
 }
 
-/** Compare CSV row fields against existing user, return changed fields with old/new values */
+/** Compare CSV row fields against existing user, return changed fields with old/new values.
+ *  Only considers a field changed if the CSV explicitly provides a value (not undefined). */
 function computeUserDiff(
   row: { name: string; circle?: string; role?: string; githubUsername?: string; profile?: string },
   existing: { name: string; circle: string | null; role: string; githubUsername: string | null; profile: string | null }
 ): Record<string, { old: unknown; new: unknown }> {
   const changes: Record<string, { old: unknown; new: unknown }> = {};
 
+  // name is always required
   if (row.name !== existing.name) {
     changes.name = { old: existing.name, new: row.name };
   }
-  if (normalizeField(row.circle) !== existing.circle) {
-    changes.circle = { old: existing.circle, new: normalizeField(row.circle) };
+  // Optional fields: only update when CSV explicitly provides a value
+  if (row.circle !== undefined) {
+    const newCircle = normalizeField(row.circle);
+    if (newCircle !== existing.circle) {
+      changes.circle = { old: existing.circle, new: newCircle };
+    }
   }
-  const newRole = row.role || "viewer";
-  if (newRole !== existing.role) {
-    changes.role = { old: existing.role, new: newRole };
+  if (row.role !== undefined && row.role !== existing.role) {
+    changes.role = { old: existing.role, new: row.role };
   }
-  if (normalizeField(row.githubUsername) !== existing.githubUsername) {
-    changes.githubUsername = { old: existing.githubUsername, new: normalizeField(row.githubUsername) };
+  if (row.githubUsername !== undefined) {
+    const newGithubUsername = normalizeField(row.githubUsername);
+    if (newGithubUsername !== existing.githubUsername) {
+      changes.githubUsername = { old: existing.githubUsername, new: newGithubUsername };
+    }
   }
-  if (normalizeField(row.profile) !== existing.profile) {
-    changes.profile = { old: existing.profile, new: normalizeField(row.profile) };
+  if (row.profile !== undefined) {
+    const newProfile = normalizeField(row.profile);
+    if (newProfile !== existing.profile) {
+      changes.profile = { old: existing.profile, new: newProfile };
+    }
   }
 
   return changes;
@@ -244,7 +255,7 @@ export async function checkExistingUsers(input: {
 
   const lowerEmails = input.emails.map((e) => e.toLowerCase());
   const found = await db.query.users.findMany({
-    where: inArray(users.email, lowerEmails),
+    where: inArray(sql`lower(${users.email})`, lowerEmails),
   });
 
   const map: Record<string, ExistingUserFields> = {};
@@ -275,14 +286,17 @@ export async function bulkImportUsers(input: {
   // Hash the default password once instead of per-row (~250ms per hash)
   const defaultPasswordHash = await hash("changeme123", 12);
 
-  // Batch-query all existing users upfront to avoid N+1
+  // Batch-query all existing users upfront to avoid N+1 (case-insensitive)
   const allEmails = input.users
     .map((u) => (u as { email?: string })?.email?.toLowerCase())
     .filter((e): e is string => !!e);
   const existingUsers = allEmails.length > 0
-    ? await db.query.users.findMany({ where: inArray(users.email, allEmails) })
+    ? await db.query.users.findMany({ where: inArray(sql`lower(${users.email})`, allEmails) })
     : [];
   const existingMap = new Map(existingUsers.map((u) => [u.email.toLowerCase(), u]));
+
+  // Track emails seen in this import to detect duplicates within the file
+  const seenEmails = new Set<string>();
 
   for (let i = 0; i < input.users.length; i++) {
     const parsed = bulkImportUserSchema.safeParse(input.users[i]);
@@ -296,9 +310,17 @@ export async function bulkImportUsers(input: {
     }
 
     const { name, email, circle, role, githubUsername, profile } = parsed.data;
+    const lowerEmail = email.toLowerCase();
+
+    // Detect duplicate emails within the same file
+    if (seenEmails.has(lowerEmail)) {
+      errors.push({ row: i + 1, email, error: "Duplicate email in file" });
+      continue;
+    }
+    seenEmails.add(lowerEmail);
 
     try {
-      const existing = existingMap.get(email.toLowerCase());
+      const existing = existingMap.get(lowerEmail);
 
       if (existing) {
         // Upsert: update existing user (never touch password or status)

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -205,7 +205,7 @@ export async function deactivateUser(input: {
 }
 
 /** Compare CSV row fields against existing user, return changed fields with old/new values */
-export function computeUserDiff(
+function computeUserDiff(
   row: { name: string; circle?: string; role?: string; githubUsername?: string; profile?: string },
   existing: { name: string; circle: string | null; role: string; githubUsername: string | null; profile: string | null }
 ): Record<string, { old: unknown; new: unknown }> {

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -12,6 +12,7 @@ import {
   bulkImportUserSchema,
 } from "@/lib/validators";
 import type { ActionResult, User, BulkImportResult, ExistingUserFields } from "@/types";
+import { normalizeField } from "@/lib/utils";
 import {
   recordCreation,
   recordUpdate,
@@ -203,13 +204,7 @@ export async function deactivateUser(input: {
   return { success: true, data: { revokedCount: activeAssignments.length } };
 }
 
-/** Normalize a CSV field value for comparison: empty/undefined → null */
-function normalize(value: string | undefined | null): string | null {
-  if (value === undefined || value === null || value === "") return null;
-  return value;
-}
-
-/** Compare CSV row fields against existing user, return changed fields */
+/** Compare CSV row fields against existing user, return changed fields with old/new values */
 export function computeUserDiff(
   row: { name: string; circle?: string; role?: string; githubUsername?: string; profile?: string },
   existing: { name: string; circle: string | null; role: string; githubUsername: string | null; profile: string | null }
@@ -219,18 +214,18 @@ export function computeUserDiff(
   if (row.name !== existing.name) {
     changes.name = { old: existing.name, new: row.name };
   }
-  if (normalize(row.circle) !== existing.circle) {
-    changes.circle = { old: existing.circle, new: normalize(row.circle) };
+  if (normalizeField(row.circle) !== existing.circle) {
+    changes.circle = { old: existing.circle, new: normalizeField(row.circle) };
   }
   const newRole = row.role || "viewer";
   if (newRole !== existing.role) {
     changes.role = { old: existing.role, new: newRole };
   }
-  if (normalize(row.githubUsername) !== existing.githubUsername) {
-    changes.githubUsername = { old: existing.githubUsername, new: normalize(row.githubUsername) };
+  if (normalizeField(row.githubUsername) !== existing.githubUsername) {
+    changes.githubUsername = { old: existing.githubUsername, new: normalizeField(row.githubUsername) };
   }
-  if (normalize(row.profile) !== existing.profile) {
-    changes.profile = { old: existing.profile, new: normalize(row.profile) };
+  if (normalizeField(row.profile) !== existing.profile) {
+    changes.profile = { old: existing.profile, new: normalizeField(row.profile) };
   }
 
   return changes;
@@ -280,6 +275,15 @@ export async function bulkImportUsers(input: {
   // Hash the default password once instead of per-row (~250ms per hash)
   const defaultPasswordHash = await hash("changeme123", 12);
 
+  // Batch-query all existing users upfront to avoid N+1
+  const allEmails = input.users
+    .map((u) => (u as { email?: string })?.email?.toLowerCase())
+    .filter((e): e is string => !!e);
+  const existingUsers = allEmails.length > 0
+    ? await db.query.users.findMany({ where: inArray(users.email, allEmails) })
+    : [];
+  const existingMap = new Map(existingUsers.map((u) => [u.email.toLowerCase(), u]));
+
   for (let i = 0; i < input.users.length; i++) {
     const parsed = bulkImportUserSchema.safeParse(input.users[i]);
     if (!parsed.success) {
@@ -294,9 +298,7 @@ export async function bulkImportUsers(input: {
     const { name, email, circle, role, githubUsername, profile } = parsed.data;
 
     try {
-      const existing = await db.query.users.findFirst({
-        where: eq(users.email, email.toLowerCase()),
-      });
+      const existing = existingMap.get(email.toLowerCase());
 
       if (existing) {
         // Upsert: update existing user (never touch password or status)

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -2,7 +2,7 @@
 
 import { db } from "@/lib/db";
 import { users, licenseAssignments } from "@/lib/db/schema";
-import { eq, and, count } from "drizzle-orm";
+import { eq, and, count, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth-helpers";
 import { hash } from "bcryptjs";
@@ -11,7 +11,7 @@ import {
   updateUserSchema,
   bulkImportUserSchema,
 } from "@/lib/validators";
-import type { ActionResult, User } from "@/types";
+import type { ActionResult, User, BulkImportResult, ExistingUserFields } from "@/types";
 import {
   recordCreation,
   recordUpdate,
@@ -203,20 +203,79 @@ export async function deactivateUser(input: {
   return { success: true, data: { revokedCount: activeAssignments.length } };
 }
 
+/** Normalize a CSV field value for comparison: empty/undefined → null */
+function normalize(value: string | undefined | null): string | null {
+  if (value === undefined || value === null || value === "") return null;
+  return value;
+}
+
+/** Compare CSV row fields against existing user, return changed fields */
+export function computeUserDiff(
+  row: { name: string; circle?: string; role?: string; githubUsername?: string; profile?: string },
+  existing: { name: string; circle: string | null; role: string; githubUsername: string | null; profile: string | null }
+): Record<string, { old: unknown; new: unknown }> {
+  const changes: Record<string, { old: unknown; new: unknown }> = {};
+
+  if (row.name !== existing.name) {
+    changes.name = { old: existing.name, new: row.name };
+  }
+  if (normalize(row.circle) !== existing.circle) {
+    changes.circle = { old: existing.circle, new: normalize(row.circle) };
+  }
+  const newRole = row.role || "viewer";
+  if (newRole !== existing.role) {
+    changes.role = { old: existing.role, new: newRole };
+  }
+  if (normalize(row.githubUsername) !== existing.githubUsername) {
+    changes.githubUsername = { old: existing.githubUsername, new: normalize(row.githubUsername) };
+  }
+  if (normalize(row.profile) !== existing.profile) {
+    changes.profile = { old: existing.profile, new: normalize(row.profile) };
+  }
+
+  return changes;
+}
+
+/** Look up existing users by email for preview labeling */
+export async function checkExistingUsers(input: {
+  emails: string[];
+}): Promise<ActionResult<Record<string, ExistingUserFields>>> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  if (input.emails.length === 0) {
+    return { success: true, data: {} };
+  }
+
+  const lowerEmails = input.emails.map((e) => e.toLowerCase());
+  const found = await db.query.users.findMany({
+    where: inArray(users.email, lowerEmails),
+  });
+
+  const map: Record<string, ExistingUserFields> = {};
+  for (const u of found) {
+    map[u.email.toLowerCase()] = {
+      name: u.name,
+      circle: u.circle,
+      role: u.role,
+      githubUsername: u.githubUsername,
+      profile: u.profile,
+    };
+  }
+
+  return { success: true, data: map };
+}
+
 export async function bulkImportUsers(input: {
   users: unknown[];
-}): Promise<
-  ActionResult<{
-    imported: number;
-    failed: number;
-    errors: Array<{ row: number; email: string; error: string }>;
-  }>
-> {
+}): Promise<ActionResult<BulkImportResult>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
 
   const errors: Array<{ row: number; email: string; error: string }> = [];
-  let imported = 0;
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
 
   // Hash the default password once instead of per-row (~250ms per hash)
   const defaultPasswordHash = await hash("changeme123", 12);
@@ -234,38 +293,55 @@ export async function bulkImportUsers(input: {
 
     const { name, email, circle, role, githubUsername, profile } = parsed.data;
 
-    const existing = await db.query.users.findFirst({
-      where: eq(users.email, email),
-    });
-    if (existing) {
-      errors.push({ row: i + 1, email, error: "Email already exists" });
-      continue;
-    }
-
     try {
-      const passwordHash = defaultPasswordHash;
+      const existing = await db.query.users.findFirst({
+        where: eq(users.email, email.toLowerCase()),
+      });
 
-      const [user] = await db
-        .insert(users)
-        .values({
-          name,
-          email,
-          passwordHash,
-          circle: circle ?? null,
-          role: role ?? "viewer",
-          githubUsername: githubUsername ?? null,
-          profile: profile ?? null,
-        })
-        .returning({ id: users.id });
+      if (existing) {
+        // Upsert: update existing user (never touch password or status)
+        const diff = computeUserDiff(
+          { name, circle, role, githubUsername, profile },
+          existing
+        );
 
-      await recordCreation("user", user.id, Number(admin.id));
-      imported++;
+        if (Object.keys(diff).length === 0) {
+          skipped++;
+          continue;
+        }
+
+        const values: Record<string, unknown> = { updatedAt: new Date() };
+        for (const [field, change] of Object.entries(diff)) {
+          values[field] = change.new;
+        }
+
+        await db.update(users).set(values).where(eq(users.id, existing.id));
+        await recordUpdate("user", existing.id, Number(admin.id), diff);
+        updated++;
+      } else {
+        // Create new user with default password
+        const [user] = await db
+          .insert(users)
+          .values({
+            name,
+            email,
+            passwordHash: defaultPasswordHash,
+            circle: circle ?? null,
+            role: role ?? "viewer",
+            githubUsername: githubUsername ?? null,
+            profile: profile ?? null,
+          })
+          .returning({ id: users.id });
+
+        await recordCreation("user", user.id, Number(admin.id));
+        created++;
+      }
     } catch (err) {
       errors.push({
         row: i + 1,
         email,
         error:
-          err instanceof Error ? err.message : "Database insert failed",
+          err instanceof Error ? err.message : "Database operation failed",
       });
     }
   }
@@ -273,7 +349,7 @@ export async function bulkImportUsers(input: {
   revalidatePath("/users");
   return {
     success: true,
-    data: { imported, failed: errors.length, errors },
+    data: { created, updated, skipped, failed: errors.length, errors },
   };
 }
 

--- a/src/app/users/import/bulk-import-form.tsx
+++ b/src/app/users/import/bulk-import-form.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { bulkImportUsers } from "@/actions/users";
+import { bulkImportUsers, checkExistingUsers } from "@/actions/users";
+import type { ExistingUserFields } from "@/types";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -33,6 +34,8 @@ interface ParsedUser {
   profile: string;
   valid: boolean;
   error?: string;
+  action?: "new" | "update";
+  changes?: string[];
 }
 
 function parseCSV(text: string): ParsedUser[] {
@@ -81,19 +84,58 @@ function parseCSV(text: string): ParsedUser[] {
   });
 }
 
+function normalizeField(value: string | undefined | null): string | null {
+  if (value === undefined || value === null || value === "") return null;
+  return value;
+}
+
+function enrichRows(
+  rows: ParsedUser[],
+  existingMap: Record<string, ExistingUserFields>
+): ParsedUser[] {
+  return rows.map((row) => {
+    if (!row.valid) return row;
+    const existing = existingMap[row.email.toLowerCase()];
+    if (!existing) return { ...row, action: "new" as const, changes: [] };
+
+    const changes: string[] = [];
+    if (row.name !== existing.name) changes.push("name");
+    if (normalizeField(row.circle) !== existing.circle) changes.push("circle");
+    if ((row.role || "viewer") !== existing.role) changes.push("role");
+    if (normalizeField(row.githubUsername) !== existing.githubUsername) changes.push("githubUsername");
+    if (normalizeField(row.profile) !== existing.profile) changes.push("profile");
+
+    return { ...row, action: "update" as const, changes };
+  });
+}
+
 export function BulkImportForm() {
   const router = useRouter();
   const [parsedUsers, setParsedUsers] = useState<ParsedUser[]>([]);
   const [importing, setImporting] = useState(false);
+  const [loading, setLoading] = useState(false);
 
-  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
 
     const reader = new FileReader();
-    reader.onload = (event) => {
+    reader.onload = async (event) => {
       const text = event.target?.result as string;
-      setParsedUsers(parseCSV(text));
+      const rows = parseCSV(text);
+
+      // Look up existing users for preview labeling
+      const validEmails = rows.filter((r) => r.valid).map((r) => r.email);
+      if (validEmails.length > 0) {
+        setLoading(true);
+        const result = await checkExistingUsers({ emails: validEmails });
+        setLoading(false);
+        if (result.success) {
+          setParsedUsers(enrichRows(rows, result.data));
+          return;
+        }
+      }
+      setParsedUsers(rows);
     };
     reader.readAsText(file);
   }
@@ -188,6 +230,7 @@ export function BulkImportForm() {
               <Table>
                 <TableHeader>
                   <TableRow>
+                    <TableHead>Action</TableHead>
                     <TableHead>Name</TableHead>
                     <TableHead>Email</TableHead>
                     <TableHead>Circle</TableHead>
@@ -197,32 +240,43 @@ export function BulkImportForm() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {parsedUsers.map((user, i) => (
-                    <TableRow
-                      key={i}
-                      className={!user.valid ? "bg-destructive/10" : ""}
-                    >
-                      <TableCell>{user.name}</TableCell>
-                      <TableCell>{user.email}</TableCell>
-                      <TableCell>{user.circle}</TableCell>
-                      <TableCell>{user.role}</TableCell>
-                      <TableCell>{user.profile || "\u2014"}</TableCell>
-                      <TableCell>
-                        {user.valid ? (
-                          <Badge>Valid</Badge>
-                        ) : (
-                          <Badge variant="destructive">{user.error}</Badge>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {parsedUsers.map((user, i) => {
+                    const changed = user.changes ?? [];
+                    const hl = "font-semibold text-primary";
+                    return (
+                      <TableRow
+                        key={i}
+                        className={!user.valid ? "bg-destructive/10" : ""}
+                      >
+                        <TableCell>
+                          {user.action === "update" ? (
+                            <Badge variant="secondary">Update</Badge>
+                          ) : user.action === "new" ? (
+                            <Badge variant="outline">New</Badge>
+                          ) : null}
+                        </TableCell>
+                        <TableCell className={changed.includes("name") ? hl : ""}>{user.name}</TableCell>
+                        <TableCell>{user.email}</TableCell>
+                        <TableCell className={changed.includes("circle") ? hl : ""}>{user.circle}</TableCell>
+                        <TableCell className={changed.includes("role") ? hl : ""}>{user.role}</TableCell>
+                        <TableCell className={changed.includes("profile") ? hl : ""}>{user.profile || "\u2014"}</TableCell>
+                        <TableCell>
+                          {user.valid ? (
+                            <Badge>Valid</Badge>
+                          ) : (
+                            <Badge variant="destructive">{user.error}</Badge>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
                 </TableBody>
               </Table>
             </div>
             <div className="mt-4 flex gap-3">
               <Button
                 onClick={handleImport}
-                disabled={importing || validCount === 0}
+                disabled={importing || loading || validCount === 0}
               >
                 {importing
                   ? "Importing..."

--- a/src/app/users/import/bulk-import-form.tsx
+++ b/src/app/users/import/bulk-import-form.tsx
@@ -120,10 +120,14 @@ export function BulkImportForm() {
     setImporting(false);
 
     if (result.success) {
-      toast.success(
-        `Imported ${result.data.imported} user(s). ${result.data.failed} failed.`
-      );
-      if (result.data.imported > 0) {
+      const { created, updated, skipped, failed } = result.data;
+      const parts: string[] = [];
+      if (created > 0) parts.push(`${created} created`);
+      if (updated > 0) parts.push(`${updated} updated`);
+      if (skipped > 0) parts.push(`${skipped} skipped`);
+      if (failed > 0) parts.push(`${failed} failed`);
+      toast.success(parts.join(", ") || "No changes");
+      if (created > 0 || updated > 0) {
         router.push("/users");
       }
     } else {
@@ -156,7 +160,8 @@ export function BulkImportForm() {
         <CardHeader>
           <CardTitle>Upload CSV</CardTitle>
           <CardDescription>
-            Default password &quot;changeme123&quot; will be set for all imported users.
+            New users get default password &quot;changeme123&quot;. Existing users
+            (matched by email) are updated without changing their password.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/app/users/import/bulk-import-form.tsx
+++ b/src/app/users/import/bulk-import-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { bulkImportUsers, checkExistingUsers } from "@/actions/users";
 import type { ExistingUserFields } from "@/types";
+import { getChangedUserFields } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -84,11 +85,6 @@ function parseCSV(text: string): ParsedUser[] {
   });
 }
 
-function normalizeField(value: string | undefined | null): string | null {
-  if (value === undefined || value === null || value === "") return null;
-  return value;
-}
-
 function enrichRows(
   rows: ParsedUser[],
   existingMap: Record<string, ExistingUserFields>
@@ -98,13 +94,7 @@ function enrichRows(
     const existing = existingMap[row.email.toLowerCase()];
     if (!existing) return { ...row, action: "new" as const, changes: [] };
 
-    const changes: string[] = [];
-    if (row.name !== existing.name) changes.push("name");
-    if (normalizeField(row.circle) !== existing.circle) changes.push("circle");
-    if ((row.role || "viewer") !== existing.role) changes.push("role");
-    if (normalizeField(row.githubUsername) !== existing.githubUsername) changes.push("githubUsername");
-    if (normalizeField(row.profile) !== existing.profile) changes.push("profile");
-
+    const changes = getChangedUserFields(row, existing);
     return { ...row, action: "update" as const, changes };
   });
 }
@@ -128,11 +118,17 @@ export function BulkImportForm() {
       const validEmails = rows.filter((r) => r.valid).map((r) => r.email);
       if (validEmails.length > 0) {
         setLoading(true);
-        const result = await checkExistingUsers({ emails: validEmails });
-        setLoading(false);
-        if (result.success) {
-          setParsedUsers(enrichRows(rows, result.data));
-          return;
+        try {
+          const result = await checkExistingUsers({ emails: validEmails });
+          if (result.success) {
+            setParsedUsers(enrichRows(rows, result.data));
+            return;
+          }
+          toast.error("Failed to check existing users");
+        } catch {
+          toast.error("Failed to check existing users");
+        } finally {
+          setLoading(false);
         }
       }
       setParsedUsers(rows);

--- a/src/app/users/import/bulk-import-form.tsx
+++ b/src/app/users/import/bulk-import-form.tsx
@@ -231,6 +231,7 @@ export function BulkImportForm() {
                     <TableHead>Email</TableHead>
                     <TableHead>Circle</TableHead>
                     <TableHead>Role</TableHead>
+                    <TableHead>GitHub</TableHead>
                     <TableHead>Profile</TableHead>
                     <TableHead>Status</TableHead>
                   </TableRow>
@@ -255,6 +256,7 @@ export function BulkImportForm() {
                         <TableCell>{user.email}</TableCell>
                         <TableCell className={changed.includes("circle") ? hl : ""}>{user.circle}</TableCell>
                         <TableCell className={changed.includes("role") ? hl : ""}>{user.role}</TableCell>
+                        <TableCell className={changed.includes("githubUsername") ? hl : ""}>{user.githubUsername || "\u2014"}</TableCell>
                         <TableCell className={changed.includes("profile") ? hl : ""}>{user.profile || "\u2014"}</TableCell>
                         <TableCell>
                           {user.valid ? (

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { getUsers } from "@/actions/users";
 import { auth } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
+import { Plus, Download } from "lucide-react";
 import { UsersTable } from "./users-table";
 import { AuthGuard } from "@/components/auth-guard";
 
@@ -21,6 +21,12 @@ export default async function UsersPage() {
           </div>
           {isAdmin && (
             <div className="flex gap-2">
+              <Button variant="outline" asChild>
+                <a href="/api/export/users" download>
+                  <Download className="mr-2 size-4" />
+                  Export CSV
+                </a>
+              </Button>
               <Button asChild variant="outline">
                 <Link href="/users/import">Bulk Import</Link>
               </Button>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -30,17 +30,18 @@ export function normalizeField(value: string | undefined | null): string | null 
   return value;
 }
 
-/** Compare importable user fields, return list of field names that differ */
+/** Compare importable user fields, return list of field names that differ.
+ *  Only considers optional fields when explicitly provided (not undefined). */
 export function getChangedUserFields(
   row: { name: string; circle?: string; role?: string; githubUsername?: string; profile?: string },
   existing: { name: string; circle: string | null; role: string; githubUsername: string | null; profile: string | null }
 ): string[] {
   const changed: string[] = [];
   if (row.name !== existing.name) changed.push("name");
-  if (normalizeField(row.circle) !== existing.circle) changed.push("circle");
-  if ((row.role || "viewer") !== existing.role) changed.push("role");
-  if (normalizeField(row.githubUsername) !== existing.githubUsername) changed.push("githubUsername");
-  if (normalizeField(row.profile) !== existing.profile) changed.push("profile");
+  if (row.circle !== undefined && normalizeField(row.circle) !== existing.circle) changed.push("circle");
+  if (row.role !== undefined && row.role !== existing.role) changed.push("role");
+  if (row.githubUsername !== undefined && normalizeField(row.githubUsername) !== existing.githubUsername) changed.push("githubUsername");
+  if (row.profile !== undefined && normalizeField(row.profile) !== existing.profile) changed.push("profile");
   return changed;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,6 +24,26 @@ export function varianceClassName(variance: number): string {
   return "";
 }
 
+/** Normalize an optional string field: empty/undefined/null → null */
+export function normalizeField(value: string | undefined | null): string | null {
+  if (value === undefined || value === null || value === "") return null;
+  return value;
+}
+
+/** Compare importable user fields, return list of field names that differ */
+export function getChangedUserFields(
+  row: { name: string; circle?: string; role?: string; githubUsername?: string; profile?: string },
+  existing: { name: string; circle: string | null; role: string; githubUsername: string | null; profile: string | null }
+): string[] {
+  const changed: string[] = [];
+  if (row.name !== existing.name) changed.push("name");
+  if (normalizeField(row.circle) !== existing.circle) changed.push("circle");
+  if ((row.role || "viewer") !== existing.role) changed.push("role");
+  if (normalizeField(row.githubUsername) !== existing.githubUsername) changed.push("githubUsername");
+  if (normalizeField(row.profile) !== existing.profile) changed.push("profile");
+  return changed;
+}
+
 export function formatDate(date: Date | string | null): string {
   if (!date) return "—";
   const d = typeof date === "string" ? new Date(date) : date;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -143,6 +143,23 @@ export interface CircleReportItem {
   totalMonthlyCost: number;
 }
 
+// Bulk import upsert result types
+export interface BulkImportResult {
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  errors: Array<{ row: number; email: string; error: string }>;
+}
+
+export interface ExistingUserFields {
+  name: string;
+  circle: string | null;
+  role: string;
+  githubUsername: string | null;
+  profile: string | null;
+}
+
 // Invoice sync types
 export type SyncOutcome =
   | "verified"


### PR DESCRIPTION
## Summary

- Bulk import now **updates existing users** (matched by email) instead of skipping them — passwords and status are never modified
- **New users** are still created with default password (existing behavior preserved)
- Unchanged rows are **skipped** with zero DB writes
- Import summary shows **created / updated / skipped / failed** counts
- **Export CSV button** added to the user overview page (`/users`) for admins
- Import preview shows **New/Update badges** per row with **changed fields highlighted**
- All field-level updates recorded in **change history**

## Changed files

| File | Changes |
|------|---------|
| `src/actions/users.ts` | `checkExistingUsers` action, `computeUserDiff` helper, upsert logic in `bulkImportUsers` (batch email lookup) |
| `src/app/users/import/bulk-import-form.tsx` | Preview with New/Update badges, change highlighting, error handling, four-category toast |
| `src/app/users/page.tsx` | Export CSV button in admin button group |
| `src/lib/utils.ts` | Shared `normalizeField()` and `getChangedUserFields()` |
| `src/types/index.ts` | `BulkImportResult`, `ExistingUserFields` types |

## Test plan

- [ ] Export CSV from `/users` page as admin — verify download works
- [ ] Re-import unmodified export — verify all rows show as "skipped"
- [ ] Modify fields in exported CSV, re-import — verify updates applied, passwords unchanged
- [ ] Add new rows to CSV, import — verify new users created with default password
- [ ] Check change history for updated users — verify field-level entries
- [ ] Verify non-admin cannot see export button
- [ ] Verify `pnpm typecheck` and `pnpm lint` pass (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)