### PR TITLE
feat: standardize all data tables with sorting, filters, tooltips, and overflow menus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-02
 - Neon PostgreSQL via Drizzle ORM (minor schema default change for UserPreferences) (010-pro-dashboard-theme)
 - TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, shadcn/ui (new-york), Sonner (toasts), Lucide React, bcryptjs, Zod 4.3.6 (011-user-import)
 - Neon PostgreSQL (serverless) via `@neondatabase/serverless` + Drizzle ORM (011-user-import)
+- TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, TanStack Table 8.21.3, shadcn/ui (new-york style), Lucide React, Sonner (toasts) (012-better-tables)
+- Neon PostgreSQL via Drizzle ORM (no schema changes — this is a UI-only feature) (012-better-tables)
 
 - **Language**: TypeScript 5.x (strict mode), Node.js LTS
 - **Framework**: Next.js 15 (App Router, Server Components, Server Actions)
@@ -83,9 +85,9 @@ pnpm lighthouse        # Lighthouse CI
 - Server Components by default — `"use client"` only when client interactivity needed
 
 ## Recent Changes
+- 012-better-tables: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, TanStack Table 8.21.3, shadcn/ui (new-york style), Lucide React, Sonner (toasts)
 - 011-user-import: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, shadcn/ui (new-york), Sonner (toasts), Lucide React, bcryptjs, Zod 4.3.6
 - 010-pro-dashboard-theme: Added TypeScript 5.9.3 (strict mode), React 19.2.4, Next.js 15.5.12 (App Router) + Tailwind CSS 4.2.1, shadcn/ui (new-york), next-themes 0.4.6, Recharts 2.15.4, class-variance-authority
-- 007-invoice-budget-link: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6, React Hook Form 7.71.2, TanStack Table 8.21.3, shadcn/ui (new-york), Sonner (toasts), `unzipper` (NEW — zip extraction)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/012-better-tables/checklists/requirements.md
+++ b/specs/012-better-tables/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Better Tables
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- One minor note: The Assumptions section references "DataTable component" and "basic table components" which are light implementation references, but they serve to clarify scope boundaries (what's being migrated vs. enhanced) and are acceptable in the Assumptions section.

--- a/specs/012-better-tables/contracts/ui-contracts.md
+++ b/specs/012-better-tables/contracts/ui-contracts.md
@@ -1,0 +1,146 @@
+# UI Contracts: Better Tables
+
+**Feature**: 012-better-tables
+**Date**: 2026-03-06
+
+## Component Contracts
+
+### DataTableColumnHeader
+
+**Location**: `src/components/data-table-column-header.tsx`
+
+**Props**:
+```typescript
+interface DataTableColumnHeaderProps<TData, TValue> {
+  column: Column<TData, TValue>
+  title: string
+  className?: string
+}
+```
+
+**Rendering Rules**:
+- If `column.getCanSort()` is false → render plain `<div>` with title text
+- If `column.getCanSort()` is true → render `<Button variant="ghost">` with:
+  - Title text
+  - Sort icon: `ArrowDown` if sorted desc, `ArrowUp` if sorted asc, `ArrowUpDown` if unsorted
+  - Click handler: `column.toggleSorting()`
+
+---
+
+### DataTableFacetedFilter
+
+**Location**: `src/components/data-table-faceted-filter.tsx`
+
+**Props**:
+```typescript
+interface DataTableFacetedFilterProps<TData, TValue> {
+  column?: Column<TData, TValue>
+  title: string
+  options: { label: string; value: string; icon?: ComponentType<{ className?: string }> }[]
+}
+```
+
+**Rendering Rules**:
+- Renders a `<Button variant="outline" size="sm">` that opens a `<Popover>`
+- Button displays: `<PlusCircle />` icon + title + optional badge with count of selected values
+- Popover content: scrollable list of `<CommandItem>` checkboxes for each option
+- Selecting/deselecting an option updates `column.setFilterValue()`
+- "Clear filters" separator + button at bottom when any filter active
+- If selected count > 2, show `"{count} selected"` badge instead of individual value badges
+
+---
+
+### Row Action Buttons
+
+**Pattern** (not a standalone component — applied inline in each table's column definitions):
+
+**Standard Action Button Contract**:
+```typescript
+// Every action button MUST be wrapped in Tooltip
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button
+      variant="ghost"
+      size="sm"
+      aria-label={`${actionVerb} ${itemName}`}  // REQUIRED
+    >
+      <IconComponent className="size-4" />
+    </Button>
+  </TooltipTrigger>
+  <TooltipContent>{actionVerb}</TooltipContent>
+</Tooltip>
+```
+
+**Overflow Menu Contract**:
+```typescript
+// Only renders when user has permission for >= 1 destructive action
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button
+      variant="ghost"
+      size="sm"
+      aria-label={`More actions for ${itemName}`}
+    >
+      <MoreHorizontal className="size-4" />
+    </Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent align="end">
+    <DropdownMenuItem
+      variant="destructive"
+      onSelect={() => setDialogOpen(true)}
+    >
+      <IconComponent className="size-4" />
+      {actionLabel}
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+// AlertDialog rendered separately, controlled by state
+<AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+  {/* existing confirmation content */}
+</AlertDialog>
+```
+
+---
+
+## Icon Registry
+
+Canonical icon assignments for row actions. These MUST NOT vary across tables.
+
+| Action | Icon | Tooltip Text | aria-label Format |
+|--------|------|-------------|-------------------|
+| View | `Eye` | "View" | "View {name}" |
+| Edit | `Pencil` | "Edit" | "Edit {name}" |
+| Download | `Download` | "Download" | "Download {name}" |
+| More Actions | `MoreHorizontal` | "More actions" | "More actions for {name}" |
+| Archive | `Archive` | — (in menu) | — (menu item, no separate aria-label) |
+| Deactivate | `UserX` | — (in menu) | — |
+| Revoke | `Ban` | — (in menu) | — |
+| Delete | `Trash2` | — (in menu) | — |
+
+---
+
+## DataTable Enhancement Contract
+
+**Location**: `src/components/data-table.tsx`
+
+**Change**: Wrap the entire DataTable output in `<TooltipProvider>` to enable tooltips for all action buttons without requiring each page to add its own provider.
+
+**Enhanced Props** (additive, backward-compatible):
+```typescript
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  searchPlaceholder?: string
+  searchKey?: string
+  facetedFilters?: {                    // NEW
+    columnId: string
+    title: string
+    options: { label: string; value: string }[]
+  }[]
+}
+```
+
+**Rendering Rules for Faceted Filters**:
+- If `facetedFilters` is provided, render filter buttons in a toolbar row between the search input and the table
+- Each filter button renders a `DataTableFacetedFilter` for the specified column
+- Filters work alongside global search (intersection)

--- a/specs/012-better-tables/data-model.md
+++ b/specs/012-better-tables/data-model.md
@@ -1,0 +1,156 @@
+# Data Model: Better Tables
+
+**Feature**: 012-better-tables
+**Date**: 2026-03-06
+
+> This feature is UI-only — no database schema changes required. This document describes the **component model** (shared UI component interfaces and their relationships).
+
+## Component Entities
+
+### DataTableColumnHeader
+
+Reusable sortable column header component that replaces the inline sort button pattern currently duplicated across tables.
+
+**Props**:
+- `column`: TanStack Table `Column` instance (provides sort state and toggle methods)
+- `title`: Display text for the column header
+
+**Behavior**:
+- Renders a ghost button with the column title and sort indicator icon
+- Click cycles through: unsorted → ascending → descending → unsorted
+- Icon states: `ArrowUpDown` (unsorted), `ArrowUp` (ascending), `ArrowDown` (descending)
+- Non-sortable columns render plain text (no button wrapper)
+
+**Relationships**: Used by every column definition across all 5 tables
+
+---
+
+### DataTableFacetedFilter
+
+Reusable faceted filter component for categorical columns with multi-select capability.
+
+**Props**:
+- `column`: TanStack Table `Column` instance (provides filter state)
+- `title`: Display label for the filter
+- `options`: Array of `{ label: string, value: string, icon?: LucideIcon }` describing available filter values
+
+**Behavior**:
+- Renders a button that opens a popover with a list of checkbox options
+- Multiple selections allowed (union within the same filter)
+- Active filter count shown as badge on the button
+- "Clear filters" action resets the column filter
+- Integrates with DataTable's `columnFilters` state
+
+**Relationships**: Used by categorical columns (Status, Role, Vendor) in the DataTable toolbar area
+
+---
+
+### DataTableRowActions
+
+Not a single shared component, but a **standardized pattern** for row action columns across all tables.
+
+**Standard Actions** (direct buttons, always visible per permissions):
+
+| Action | Icon | Tooltip | aria-label pattern | Visibility |
+|--------|------|---------|-------------------|------------|
+| View | `Eye` | "View" | "View {itemName}" | All users |
+| Edit | `Pencil` | "Edit" | "Edit {itemName}" | Admin only |
+| Download | `Download` | "Download" | "Download {itemName}" | All users (invoices only) |
+
+**Overflow Menu Actions** (inside DropdownMenu, destructive):
+
+| Action | Icon | Label | Variant | Visibility |
+|--------|------|-------|---------|------------|
+| Archive | `Archive` | "Archive" | destructive | Admin, non-archived items |
+| Deactivate | `UserX` | "Deactivate" | destructive | Admin, active users |
+| Revoke | `Ban` | "Revoke" | destructive | Admin, active assignments |
+| Delete | `Trash2` | "Delete" | destructive | Admin, non-archived budgets |
+
+**Overflow Menu Trigger**:
+- Icon: `MoreHorizontal`
+- Tooltip: "More actions"
+- aria-label: "More actions for {itemName}"
+- Only renders when user has permission for at least one destructive action on that row
+
+**Relationships**: Each table's action column follows this pattern. The overflow menu trigger opens a DropdownMenu; selecting a destructive item sets component state to open the corresponding AlertDialog.
+
+---
+
+### Per-Table Column Configurations
+
+#### Tools Table Columns
+
+| Column | Sortable | Filterable | Filter Type |
+|--------|----------|------------|-------------|
+| Name | Yes | No (covered by global search) | — |
+| Vendor | Yes | No (covered by global search) | — |
+| Active Licenses | Yes | No | — |
+| Status | Yes | Yes | Faceted: Active, Archived |
+| Actions | No | No | — |
+
+#### Users Table Columns
+
+| Column | Sortable | Filterable | Filter Type |
+|--------|----------|------------|-------------|
+| Name | Yes | No (covered by global search) | — |
+| Email | Yes | No (covered by global search) | — |
+| Circle | Yes | No (keep existing "No Circle" toggle) | — |
+| Role | Yes | Yes | Faceted: Admin, Viewer |
+| Profile | Yes | No | — |
+| Status | Yes | Yes | Faceted: Active, Inactive |
+| Actions | No | No | — |
+
+#### Assignments Table Columns
+
+| Column | Sortable | Filterable | Filter Type |
+|--------|----------|------------|-------------|
+| User | Yes | No (covered by global search) | — |
+| Tool | Yes | No (covered by global search) | — |
+| Tier | Yes | No | — |
+| Monthly Cost | Yes | No | — |
+| Status | Yes | Yes | Faceted: Active, Revoked |
+| Workspace | Yes | No (keep existing "No Workspace" toggle) | — |
+| Assigned | Yes | No | — |
+| Actions | No | No | — |
+
+#### Invoices Table Columns (NEW — migrating to DataTable)
+
+| Column | Sortable | Filterable | Filter Type |
+|--------|----------|------------|-------------|
+| Invoice Number | Yes | No | — |
+| Date | Yes | No | — |
+| Amount | Yes | No | — |
+| Vendor | Yes | No (covered by global search) | — |
+| Budget Period | Yes | No | — |
+| Uploaded By | Yes | No | — |
+| Actions (Download) | No | No | — |
+
+#### Budget List Table Columns (NEW — migrating to DataTable)
+
+| Column | Sortable | Filterable | Filter Type |
+|--------|----------|------------|-------------|
+| Fiscal Year | Yes | No | — |
+| Planned Amount | Yes | No | — |
+| Status | Yes | Yes | Faceted: Active, Archived |
+| Actions | No | No | — |
+
+## State Transitions
+
+### Column Sort State
+
+```
+Unsorted → [click] → Ascending → [click] → Descending → [click] → Unsorted
+```
+
+### Overflow Menu → AlertDialog Flow
+
+```
+Row Actions visible
+  → User clicks MoreHorizontal button
+  → DropdownMenu opens
+  → User clicks destructive item (e.g., "Archive")
+  → DropdownMenu closes
+  → AlertDialog opens with confirmation
+  → User confirms → Action executes → Toast notification
+  → User cancels → AlertDialog closes → No action
+```

--- a/specs/012-better-tables/plan.md
+++ b/specs/012-better-tables/plan.md
@@ -55,7 +55,6 @@ src/
 │   ├── data-table.tsx              # Shared DataTable (enhanced with TooltipProvider)
 │   ├── data-table-column-header.tsx # NEW: Reusable sortable column header
 │   ├── data-table-faceted-filter.tsx # NEW: Reusable faceted filter component
-│   ├── data-table-row-actions.tsx   # NEW: Shared row action patterns (view, edit, overflow)
 │   └── ui/
 │       ├── dropdown-menu.tsx        # Existing (no changes)
 │       ├── tooltip.tsx              # Existing (no changes)
@@ -75,14 +74,6 @@ src/
 │       ├── page.tsx                 # Refactored to delegate to client table
 │       ├── budget-table.tsx         # NEW: Client component with DataTable
 │       └── budget-list-actions.tsx  # Updated to use overflow menu
-
-tests/
-├── unit/
-│   ├── data-table-column-header.test.tsx  # NEW
-│   ├── data-table-faceted-filter.test.tsx # NEW
-│   └── data-table-row-actions.test.tsx    # NEW
-└── e2e/
-    └── table-consistency.spec.ts          # NEW: Cross-table consistency checks
 ```
 
 **Structure Decision**: Follows the existing Next.js App Router convention. Shared table components live in `src/components/` alongside the existing `data-table.tsx`. Page-specific table client components live alongside their pages. No new directories needed.

--- a/specs/012-better-tables/plan.md
+++ b/specs/012-better-tables/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Better Tables
+
+**Branch**: `012-better-tables` | **Date**: 2026-03-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/012-better-tables/spec.md`
+
+## Summary
+
+Standardize all data tables across the application with universal column sorting, faceted column filtering on categorical columns, unified quick-action icons with tooltips and accessible labels, and a three-dot overflow menu for destructive actions. Migrate the two remaining plain HTML tables (Invoices, Budget list) to the shared DataTable component.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3 (strict mode)
+**Primary Dependencies**: Next.js 15.5.12 (App Router), React 19.2.4, TanStack Table 8.21.3, shadcn/ui (new-york style), Lucide React, Sonner (toasts)
+**Storage**: Neon PostgreSQL via Drizzle ORM (no schema changes — this is a UI-only feature)
+**Testing**: Vitest (unit), Playwright (e2e + a11y)
+**Target Platform**: Web (desktop + mobile responsive)
+**Project Type**: Web application (Next.js App Router)
+**Performance Goals**: Sorting and filtering interactions complete within 100ms (client-side only, no network). Meets existing Core Web Vitals budgets (LCP < 2.5s, INP < 200ms, CLS < 0.1).
+**Constraints**: No new dependencies. All required UI components (DropdownMenu, Tooltip, AlertDialog) already exist in the shadcn/ui component library.
+**Scale/Scope**: 5 data tables (Tools, Users, Assignments, Invoices, Budget list). Approximately 15-20 column definitions to update, 5 action columns to refactor.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Type-Safe Code Quality | PASS | All column definitions and action components will be fully typed via TanStack Table's `ColumnDef<TData>` generics. No `any` types needed. |
+| II. UX Consistency | PASS | This feature's primary goal is UX consistency — standardizing icons, tooltips, labels, and interaction patterns across all tables. Uses shadcn/ui design system exclusively. |
+| III. Performance Budgets | PASS | All sorting/filtering is client-side via TanStack Table (no network requests). No new JS bundles — TanStack Table, DropdownMenu, and Tooltip are already in the bundle. |
+| IV. Accessibility-First | PASS | Adding tooltips and `aria-label` attributes to all action buttons. DropdownMenu and Tooltip from Radix UI provide built-in keyboard navigation and ARIA compliance. |
+| V. Simplicity & Maintainability | PASS | Extracting shared patterns (sortable header, row actions) reduces duplication. No new abstractions beyond what's needed — reuses existing DataTable component. |
+
+**Post-Phase 1 Re-check**: No violations detected. All design decisions align with constitution principles.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-better-tables/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (component model)
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (UI contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── components/
+│   ├── data-table.tsx              # Shared DataTable (enhanced with TooltipProvider)
+│   ├── data-table-column-header.tsx # NEW: Reusable sortable column header
+│   ├── data-table-faceted-filter.tsx # NEW: Reusable faceted filter component
+│   ├── data-table-row-actions.tsx   # NEW: Shared row action patterns (view, edit, overflow)
+│   └── ui/
+│       ├── dropdown-menu.tsx        # Existing (no changes)
+│       ├── tooltip.tsx              # Existing (no changes)
+│       ├── alert-dialog.tsx         # Existing (no changes)
+│       └── table.tsx                # Existing (no changes)
+├── app/
+│   ├── tools/
+│   │   └── tools-table.tsx          # Updated columns + overflow menu
+│   ├── users/
+│   │   └── users-table.tsx          # Updated columns + overflow menu
+│   ├── assignments/
+│   │   └── assignments-client.tsx   # Updated columns + overflow menu
+│   ├── invoices/
+│   │   ├── page.tsx                 # Refactored to delegate to client table
+│   │   └── invoices-table.tsx       # NEW: Client component with DataTable
+│   └── budget/
+│       ├── page.tsx                 # Refactored to delegate to client table
+│       ├── budget-table.tsx         # NEW: Client component with DataTable
+│       └── budget-list-actions.tsx  # Updated to use overflow menu
+
+tests/
+├── unit/
+│   ├── data-table-column-header.test.tsx  # NEW
+│   ├── data-table-faceted-filter.test.tsx # NEW
+│   └── data-table-row-actions.test.tsx    # NEW
+└── e2e/
+    └── table-consistency.spec.ts          # NEW: Cross-table consistency checks
+```
+
+**Structure Decision**: Follows the existing Next.js App Router convention. Shared table components live in `src/components/` alongside the existing `data-table.tsx`. Page-specific table client components live alongside their pages. No new directories needed.
+
+## Complexity Tracking
+
+No constitution violations — table is not needed.

--- a/specs/012-better-tables/quickstart.md
+++ b/specs/012-better-tables/quickstart.md
@@ -1,0 +1,105 @@
+# Quickstart: Better Tables
+
+**Feature**: 012-better-tables
+**Date**: 2026-03-06
+
+## Overview
+
+This feature standardizes all data tables with sorting, filtering, tooltips, accessible labels, and a three-dot overflow menu for destructive actions. No database changes — purely a UI refactor.
+
+## Prerequisites
+
+- Node.js LTS + pnpm installed
+- Local dev server runs: `pnpm dev`
+- No new dependencies to install — all required packages already present
+
+## Key Files to Understand
+
+1. **`src/components/data-table.tsx`** — Shared DataTable wrapper around TanStack Table. All tables use this (or will after migration).
+2. **`src/components/ui/dropdown-menu.tsx`** — shadcn/ui DropdownMenu with `variant="destructive"` support. Used for the new overflow menu.
+3. **`src/components/ui/tooltip.tsx`** — shadcn/ui Tooltip with zero-delay. Used for action button tooltips.
+
+## Implementation Order
+
+### Phase 1: Shared Components
+Create reusable `DataTableColumnHeader` and `DataTableFacetedFilter` components in `src/components/`. These are used by all tables.
+
+### Phase 2: Update Existing Tables (Tools → Users → Assignments)
+For each table:
+1. Replace inline sort button headers with `DataTableColumnHeader`
+2. Enable sorting on all data columns
+3. Add tooltips to all action buttons
+4. Add `aria-label` attributes to all action buttons
+5. Move destructive actions into DropdownMenu overflow
+6. Wire DropdownMenu items to existing AlertDialog confirmations
+7. Add faceted filters for categorical columns
+
+### Phase 3: Migrate Plain Tables (Invoices, Budget List)
+1. Create client components (`invoices-table.tsx`, `budget-table.tsx`)
+2. Move table rendering from server page to client component
+3. Define column definitions with sorting enabled
+4. Apply the same action patterns (tooltips, overflow menu)
+
+### Phase 4: Testing
+1. Unit tests for shared components
+2. E2E tests for cross-table consistency
+
+## Verification
+
+```bash
+pnpm typecheck     # No TypeScript errors
+pnpm lint          # No ESLint warnings
+pnpm test          # Unit tests pass
+pnpm dev           # Manual verification: visit /tools, /users, /assignments, /invoices, /budget
+```
+
+## Key Patterns
+
+### Sortable Column Header
+```tsx
+// Before (inline, duplicated):
+header: ({ column }) => (
+  <Button variant="ghost" onClick={() => column.toggleSorting(...)}>
+    Name <ArrowUpDown className="ml-2 size-4" />
+  </Button>
+)
+
+// After (shared component):
+header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />
+```
+
+### Overflow Menu for Destructive Actions
+```tsx
+// Before (direct button):
+<AlertDialog>
+  <AlertDialogTrigger asChild>
+    <Button size="sm" variant="ghost"><Archive /></Button>
+  </AlertDialogTrigger>
+  ...
+</AlertDialog>
+
+// After (menu item → state → dialog):
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="ghost" size="sm"><MoreHorizontal /></Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuItem variant="destructive" onSelect={() => setShowArchiveDialog(true)}>
+      <Archive /> Archive
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+<AlertDialog open={showArchiveDialog} onOpenChange={setShowArchiveDialog}>...</AlertDialog>
+```
+
+### Tooltip on Action Button
+```tsx
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button variant="ghost" size="sm" aria-label={`View ${itemName}`} asChild>
+      <Link href={`/resource/${id}`}><Eye className="size-4" /></Link>
+    </Button>
+  </TooltipTrigger>
+  <TooltipContent>View</TooltipContent>
+</Tooltip>
+```

--- a/specs/012-better-tables/research.md
+++ b/specs/012-better-tables/research.md
@@ -1,0 +1,129 @@
+# Research: Better Tables
+
+**Feature**: 012-better-tables
+**Date**: 2026-03-06
+
+## R1: Existing Table Infrastructure
+
+### Decision: Extend Existing DataTable Component
+
+**Rationale**: The shared `DataTable` component at `src/components/data-table.tsx` already integrates TanStack Table v8 with sorting (`getSortedRowModel`), filtering (`getFilteredRowModel`), and pagination. Rather than building new components, extend this shared component and migrate the remaining plain HTML tables to use it.
+
+**Alternatives Considered**:
+- Build separate enhanced table components per page — rejected due to code duplication and inconsistency
+- Replace TanStack Table with a different library — rejected since TanStack Table v8 is already installed, well-integrated, and meets all requirements
+
+### Current State
+
+| Table | Component | Uses DataTable | Sorting | Filtering | Pagination |
+|-------|-----------|---------------|---------|-----------|------------|
+| Tools | `tools-table.tsx` | Yes | Name, Vendor only | Global search | Yes |
+| Users | `users-table.tsx` | Yes | Name, Circle only | Global search + "No Circle" toggle | Yes |
+| Assignments | `assignments-client.tsx` | Yes | None | Global search + "No Workspace" toggle | Yes |
+| Invoices | `invoices/page.tsx` | No (plain Table) | None | None | None |
+| Budget List | `budget/page.tsx` | No (plain Table) | None | None | None |
+
+### Tables Excluded from Scope
+
+- **Budget Detail (periods/billed costs)**: Hierarchical expandable table with inline editing — too specialized for the shared DataTable pattern. Sorting/filtering not applicable (small, fixed dataset per budget).
+- **Bulk Upload Review**: Editable review table with confidence scoring — specialized workflow, not a standard data browsing table.
+- **Bulk Upload Results**: Simple outcome summary — no need for sorting/filtering.
+
+## R2: Sorting Implementation Pattern
+
+### Decision: Use TanStack Table Column-Level Sorting with Three-State Cycle
+
+**Rationale**: TanStack Table v8 natively supports `enableSorting` per column and the `toggleSorting()` API. The existing pattern in tools-table.tsx and users-table.tsx uses `ArrowUpDown` icon with `column.toggleSorting()` — extend this to all data columns.
+
+**Implementation Pattern** (already established in codebase):
+```tsx
+header: ({ column }) => (
+  <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+    Column Name
+    <ArrowUpDown className="ml-2 size-4" />
+  </Button>
+)
+```
+
+**Enhancement**: Replace `ArrowUpDown` with directional indicators (`ArrowUp`, `ArrowDown`) when actively sorted, keeping `ArrowUpDown` for the unsorted state. Use TanStack's built-in `enableSortingRemoval: true` for three-state cycling (asc → desc → none).
+
+**Alternatives Considered**:
+- Server-side sorting via query params — rejected; dataset sizes are small enough for client-side sorting
+- Custom sort comparators — not needed for standard text, number, and date columns; TanStack handles these natively
+
+## R3: Column Filtering Pattern
+
+### Decision: Use Faceted Filters for Categorical Columns
+
+**Rationale**: The shadcn/ui DataTable examples demonstrate a "faceted filter" pattern using `DropdownMenuCheckboxItem` or a popover with checkbox list for categorical columns. This allows multi-select filtering (e.g., show both "active" and "suspended" statuses simultaneously).
+
+**Columns to Add Filters**:
+| Table | Column | Filter Type | Values |
+|-------|--------|-------------|--------|
+| Tools | Status | Faceted (multi-select) | Active, Archived |
+| Users | Role | Faceted (multi-select) | Admin, Viewer |
+| Users | Status | Faceted (multi-select) | Active, Inactive |
+| Assignments | Status | Faceted (multi-select) | Active, Revoked |
+
+**Existing Custom Filters**: The "No Circle" and "No Workspace" toggle buttons will remain as-is — they serve a specific workflow need and are already well-understood by users.
+
+**Alternatives Considered**:
+- Replace custom toggles with column filters — rejected; the toggles serve a different UX purpose (quick-access boolean filter vs. multi-select categorical)
+- Add text-based column search for all columns — rejected; global search already covers text matching
+
+## R4: Overflow Menu for Destructive Actions
+
+### Decision: Use shadcn/ui DropdownMenu with MoreHorizontal Trigger
+
+**Rationale**: The `DropdownMenu` component already exists at `src/components/ui/dropdown-menu.tsx` with full Radix UI accessibility support and a `variant="destructive"` option on `DropdownMenuItem`. The `MoreHorizontal` icon from Lucide React is the standard three-dot menu trigger.
+
+**Pattern**:
+- Direct action buttons: View (Eye), Edit (Pencil) — always visible based on permissions
+- Overflow menu (MoreHorizontal): Contains Archive, Deactivate, Revoke, Delete — only renders when user has permission for at least one item
+- Each destructive menu item opens the existing AlertDialog for confirmation
+- Menu items use `variant="destructive"` for visual distinction
+
+**Challenge**: AlertDialog currently uses `AlertDialogTrigger` as the direct button. Moving destructive actions into a DropdownMenu requires changing the trigger mechanism — the DropdownMenuItem will set state to open the AlertDialog rather than wrapping the trigger.
+
+**Alternatives Considered**:
+- Nested AlertDialog inside DropdownMenuItem — problematic due to Radix UI portal conflicts
+- Custom confirmation modal instead of AlertDialog — rejected; AlertDialog is already well-tested and consistent
+
+## R5: Tooltip and Accessibility Pattern
+
+### Decision: Wrap All Action Buttons with Tooltip Component
+
+**Rationale**: The `Tooltip` component exists at `src/components/ui/tooltip.tsx` with zero-delay configuration. Currently, action buttons use `<span className="sr-only">` for screen reader labels but have no visual tooltips on hover. Adding tooltips improves discoverability for sighted users while maintaining screen reader accessibility.
+
+**Pattern**:
+```tsx
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button variant="ghost" size="sm" aria-label="View Cursor Pro">
+      <Eye className="size-4" />
+    </Button>
+  </TooltipTrigger>
+  <TooltipContent>View</TooltipContent>
+</Tooltip>
+```
+
+**Accessibility Labels**: Format as `"[Action] [item name]"` for `aria-label` attributes, e.g., "View Cursor Pro", "Edit Alice Smith", "More actions for Budget FY2026".
+
+**Alternatives Considered**:
+- HTML `title` attribute instead of Tooltip component — rejected; `title` has inconsistent behavior across browsers and is not reliably accessible
+
+## R6: Invoices and Budget Table Migration
+
+### Decision: Convert to Client Components Using DataTable
+
+**Rationale**: Both the Invoices list (`invoices/page.tsx`) and Budget list (`budget/page.tsx`) currently render as server components with plain HTML tables. To gain sorting, filtering, and pagination, they need to be split into a server component (data fetching) and a client component (DataTable rendering), following the established pattern in tools and users.
+
+**Migration Pattern**:
+1. Keep the page.tsx as a server component for data fetching
+2. Extract table rendering into a new client component (e.g., `invoices-table.tsx`, `budget-table.tsx`)
+3. Pass fetched data as props to the client component
+4. Define column definitions with sorting enabled on all data columns
+
+**Alternatives Considered**:
+- Add sorting/filtering to server components via URL query params — rejected; would require full page reloads and is inconsistent with the client-side pattern used elsewhere
+- Keep as plain tables — rejected; contradicts the feature requirement of universal sorting

--- a/specs/012-better-tables/spec.md
+++ b/specs/012-better-tables/spec.md
@@ -108,7 +108,7 @@ Currently, tables have a global search input and a couple of custom toggle filte
 - **FR-009**: Destructive menu items MUST be visually distinguished from non-destructive items (e.g., using a warning/destructive color)
 - **FR-010**: Selecting a destructive action from the overflow menu MUST still trigger the existing confirmation dialog before executing
 - **FR-011**: The three-dot overflow menu MUST only appear for users with permission to perform at least one destructive action on that row
-- **FR-012**: System MUST provide column-level filters on categorical columns: Status columns on all tables, Role on Users, Vendor on Tools
+- **FR-012**: System MUST provide column-level filters on categorical columns: Status columns on all tables, Role on Users, and Vendor on Tools
 - **FR-013**: Column filters and global search MUST work together, with results showing the intersection of all active filters
 - **FR-014**: Each active column filter MUST have a visible indicator and a way to clear it
 - **FR-015**: The Download action on the Invoices table MUST remain a direct action button (not moved to overflow menu) since it is non-destructive

--- a/specs/012-better-tables/spec.md
+++ b/specs/012-better-tables/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Better Tables
+
+**Feature Branch**: `012-better-tables`
+**Created**: 2026-03-06
+**Status**: Draft
+**Input**: User description: "Tables across the application should have sorting and potentially filtering available on most columns. Quick actions in table rows should be unified across the application, both in selection of icons and or tooltips or labels. Destructive actions for quick actions can be hidden behind a dot dot dot menu."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Column Sorting Across All Tables (Priority: P1)
+
+As a user viewing any data table in the application, I want to click on column headers to sort data ascending or descending, so I can quickly find the information I need without scrolling through unsorted rows.
+
+Currently, only a few columns on a few tables support sorting (e.g., Name and Vendor on the Tools table, Name and Circle on the Users table). Most columns across all tables lack sorting, making it difficult to organize data by cost, date, status, or other relevant fields.
+
+**Why this priority**: Sorting is the most fundamental table interaction. Without it, users cannot efficiently locate data in growing lists. This delivers immediate value across every table in the application.
+
+**Independent Test**: Can be fully tested by clicking any column header on any table and verifying the data reorders correctly. Delivers the value of instant data organization.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is viewing the Tools table, **When** they click the "Active Licenses" column header, **Then** the table sorts by that column in ascending order, and clicking again reverses to descending order
+2. **Given** a user is viewing the Users table, **When** they click the "Email" column header, **Then** the table sorts alphabetically by email
+3. **Given** a user is viewing the Assignments table, **When** they click the "Monthly Cost" column header, **Then** the table sorts numerically by cost amount
+4. **Given** a user is viewing any table with a "Status" column, **When** they click the Status header, **Then** the table sorts by status values in a logical order
+5. **Given** a user has sorted a column, **When** they click the same column header a third time, **Then** the sort is cleared and the table returns to its default order
+
+---
+
+### User Story 2 - Unified Quick Actions with Consistent Icons, Tooltips, and Labels (Priority: P1)
+
+As a user performing row-level actions across different tables, I want the same type of action to always use the same icon, tooltip, and label, so the interface feels predictable and I don't have to re-learn interaction patterns on each page.
+
+Currently, quick actions vary in presentation: some use icon-only buttons, some use text buttons (e.g., "View" text on Assignments vs. Eye icon on Tools), and tooltips or accessible labels are inconsistently applied. This creates confusion and reduces usability.
+
+**Why this priority**: Consistency is essential for usability and accessibility. Users should not need to guess what an icon does or notice that the same action looks different on different pages. This is equal priority with sorting because it directly improves every table interaction.
+
+**Independent Test**: Can be tested by navigating to each table page and verifying that the same action type (view, edit) uses the same icon, tooltip text, and accessible label everywhere.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user hovers over a "View" action button on any table row, **When** the tooltip appears, **Then** it displays "View" consistently across all tables
+2. **Given** a user hovers over an "Edit" action button on any table row, **When** the tooltip appears, **Then** it displays "Edit" consistently across all tables
+3. **Given** a user uses a screen reader on any table, **When** the screen reader encounters an action button, **Then** it announces a clear, consistent accessible label (e.g., "View [item name]", "Edit [item name]")
+4. **Given** a user views the Assignments table, **When** they look at the View action, **Then** it uses the Eye icon (not a text-only button) matching all other tables
+
+---
+
+### User Story 3 - Destructive Actions Hidden Behind Overflow Menu (Priority: P2)
+
+As an administrator performing destructive actions (archive, deactivate, revoke, delete), I want these actions tucked behind a "more options" menu (three-dot / ellipsis menu) rather than displayed as direct icon buttons, so I am less likely to accidentally trigger a destructive action and the row actions area stays clean.
+
+Currently, destructive actions like Archive, Deactivate, and Revoke are displayed as direct icon buttons alongside non-destructive actions like View and Edit. This increases the risk of accidental clicks and clutters the actions column.
+
+**Why this priority**: Hiding destructive actions behind a menu reduces accidental destructive operations and simplifies the visible row actions. This is a meaningful UX improvement but slightly less critical than sorting and consistency since confirmation dialogs already protect against accidental execution.
+
+**Independent Test**: Can be tested by verifying that destructive actions on every table are only accessible via the three-dot menu, not as direct icon buttons, and that they still trigger confirmation dialogs.
+
+**Acceptance Scenarios**:
+
+1. **Given** an admin views the Tools table, **When** they look at the row actions, **Then** they see View and Edit as direct icon buttons, and a three-dot menu containing "Archive"
+2. **Given** an admin clicks the three-dot menu on a user row, **When** the menu opens, **Then** "Deactivate" appears as a menu item styled with a destructive/warning appearance
+3. **Given** an admin selects "Revoke" from the three-dot menu on an assignment row, **When** they click it, **Then** the existing confirmation dialog still appears before the action executes
+4. **Given** a non-admin user views any table, **When** they look at the row actions, **Then** they see only the View action as a direct button and no three-dot menu (since Edit and destructive actions are admin-only)
+
+---
+
+### User Story 4 - Column Filtering on Key Columns (Priority: P3)
+
+As a user managing a large number of records, I want to filter table data by specific column values (e.g., status, role, vendor), so I can narrow down the displayed rows to only those relevant to my current task without relying solely on the global search.
+
+Currently, tables have a global search input and a couple of custom toggle filters (e.g., "No Circle" on Users, "No Workspace" on Assignments). There is no standardized column-level filtering for categorical data like status, role, or vendor.
+
+**Why this priority**: Column filtering enhances data exploration for power users but is additive — global search already provides basic filtering capability. This is a quality-of-life improvement that builds on the sorting foundation.
+
+**Independent Test**: Can be tested by selecting a filter value on a categorical column and verifying only matching rows are displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user views the Users table, **When** they open a filter on the "Role" column and select "Admin", **Then** only users with the Admin role are displayed
+2. **Given** a user views the Tools table, **When** they open a filter on the "Status" column and select "Active", **Then** only active tools are shown
+3. **Given** a user views the Assignments table, **When** they filter by "Status" and select "Active", **Then** only active assignments are displayed
+4. **Given** a user has applied a column filter, **When** they clear the filter, **Then** all rows are displayed again
+5. **Given** a user has applied a column filter, **When** they also use the global search, **Then** both filters are applied together (intersection)
+
+---
+
+### Edge Cases
+
+- What happens when a table has zero rows after filtering? The existing "No results" message should display.
+- What happens when sorting a column that contains null or empty values? Null/empty values should sort to the end regardless of sort direction.
+- What happens when the three-dot menu has only one destructive action? The menu should still render with that single item for consistency.
+- What happens on a table with only one row? Sorting controls should still be visible and functional, even if sorting has no visible effect.
+- What happens when a non-admin user views the actions column? They should see only the View button with no three-dot menu, and the actions column should not show empty space or orphaned menus where admin-only actions would be.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST enable sorting on all data columns across the Tools, Users, Assignments, Invoices, and Budget tables (excluding the actions column)
+- **FR-002**: Column sorting MUST cycle through three states: ascending, descending, and unsorted (default)
+- **FR-003**: Each sortable column header MUST display a visual indicator showing the current sort direction
+- **FR-004**: System MUST display a tooltip on every quick-action button that describes the action (e.g., "View", "Edit")
+- **FR-005**: Every quick-action button MUST have an accessible label that includes the action type and the item identifier (e.g., "View Cursor Pro", "Edit Alice Smith")
+- **FR-006**: The "View" action MUST use the Eye icon consistently across all tables
+- **FR-007**: The "Edit" action MUST use the Pencil icon consistently across all tables
+- **FR-008**: All destructive actions (Archive, Deactivate, Revoke, Delete) MUST be placed inside a three-dot overflow menu, not as direct action buttons
+- **FR-009**: Destructive menu items MUST be visually distinguished from non-destructive items (e.g., using a warning/destructive color)
+- **FR-010**: Selecting a destructive action from the overflow menu MUST still trigger the existing confirmation dialog before executing
+- **FR-011**: The three-dot overflow menu MUST only appear for users with permission to perform at least one destructive action on that row
+- **FR-012**: System MUST provide column-level filters on categorical columns: Status columns on all tables, Role on Users, Vendor on Tools
+- **FR-013**: Column filters and global search MUST work together, with results showing the intersection of all active filters
+- **FR-014**: Each active column filter MUST have a visible indicator and a way to clear it
+- **FR-015**: The Download action on the Invoices table MUST remain a direct action button (not moved to overflow menu) since it is non-destructive
+
+### Key Entities
+
+- **Table Column Configuration**: Defines per-column settings including whether sorting is enabled, whether a filter is available, and the filter type (text search, categorical dropdown)
+- **Quick Action**: A row-level action with a standardized icon, tooltip, accessible label, and visibility rules based on user role and item state
+- **Overflow Menu**: A three-dot menu component that groups destructive actions for a table row, appearing only when the user has permissions for at least one contained action
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every data column across all five tables supports ascending/descending sorting with a single click
+- **SC-002**: 100% of quick-action buttons display a tooltip on hover and have screen-reader-accessible labels
+- **SC-003**: The same action type uses the same icon and tooltip text across all tables with zero variations
+- **SC-004**: All destructive actions are accessible only through the overflow menu, reducing accidental destructive action attempts
+- **SC-005**: Users can filter categorical columns and see results narrow to matching rows within 1 second
+- **SC-006**: Applying column filters in combination with global search returns the correct intersection of results
+- **SC-007**: Non-admin users see a clean actions column with no empty space or orphaned menus where admin-only actions would appear
+
+## Assumptions
+
+- The existing shared `DataTable` component already supports sorting and filtering capabilities — this feature enables and standardizes them rather than building from scratch.
+- The Invoices list table and Budget list table, which currently use basic table components rather than the shared DataTable, will be migrated to use the shared component to gain sorting/filtering capabilities.
+- Existing confirmation dialogs for destructive actions are adequate and do not need redesign — only the trigger mechanism changes (from direct button to menu item).
+- The "Download" action on invoices is non-destructive and remains a direct button, not placed in the overflow menu.
+- Tooltip and accessible label patterns follow the format: "[Action]" for tooltip, "[Action] [item name]" for aria-label (e.g., tooltip: "View", aria-label: "View Cursor Pro").

--- a/specs/012-better-tables/tasks.md
+++ b/specs/012-better-tables/tasks.md
@@ -17,8 +17,8 @@
 
 **Purpose**: Create the reusable shared components that multiple user stories depend on
 
-- [ ] T001 [P] Create DataTableColumnHeader component with three-state sort cycling (unsorted/asc/desc) and directional icons (ArrowUpDown/ArrowUp/ArrowDown) per contracts in `src/components/data-table-column-header.tsx`
-- [ ] T002 [P] Enhance DataTable component: wrap output in TooltipProvider, add `facetedFilters` prop support to render filter toolbar between search and table in `src/components/data-table.tsx`
+- [x] T001 [P] Create DataTableColumnHeader component with three-state sort cycling (unsorted/asc/desc) and directional icons (ArrowUpDown/ArrowUp/ArrowDown) per contracts in `src/components/data-table-column-header.tsx`
+- [x] T002 [P] Enhance DataTable component: wrap output in TooltipProvider, add `facetedFilters` prop support to render filter toolbar between search and table in `src/components/data-table.tsx`
 
 ---
 
@@ -28,10 +28,10 @@
 
 **CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T003 Create Invoices client table component: extract table rendering from server page into new client component with TanStack Table column definitions (Invoice Number, Date, Amount, Vendor, Budget Period, Uploaded By, Download action) in `src/app/invoices/invoices-table.tsx`
-- [ ] T004 Refactor Invoices page to delegate table rendering to the new InvoicesTable client component, keeping data fetching in the server component in `src/app/invoices/page.tsx`
-- [ ] T005 Create Budget list client table component: extract table rendering from server page into new client component with TanStack Table column definitions (Fiscal Year, Planned Amount, Status, Actions) in `src/app/budget/budget-table.tsx`
-- [ ] T006 Refactor Budget list page to delegate table rendering to the new BudgetTable client component, keeping data fetching and summary cards in the server component in `src/app/budget/page.tsx`
+- [x] T003 Create Invoices client table component: extract table rendering from server page into new client component with TanStack Table column definitions (Invoice Number, Date, Amount, Vendor, Budget Period, Uploaded By, Download action) in `src/app/invoices/invoices-table.tsx`
+- [x] T004 Refactor Invoices page to delegate table rendering to the new InvoicesTable client component, keeping data fetching in the server component in `src/app/invoices/page.tsx`
+- [x] T005 Create Budget list client table component: extract table rendering from server page into new client component with TanStack Table column definitions (Fiscal Year, Planned Amount, Status, Actions) in `src/app/budget/budget-table.tsx`
+- [x] T006 Refactor Budget list page to delegate table rendering to the new BudgetTable client component, keeping data fetching and summary cards in the server component in `src/app/budget/page.tsx`
 
 **Checkpoint**: All 5 tables now use the shared DataTable component. Sorting, tooltips, and overflow menus can be applied uniformly.
 
@@ -45,11 +45,11 @@
 
 ### Implementation for User Story 1
 
-- [ ] T007 [P] [US1] Update Tools table columns: replace inline sort buttons on Name and Vendor with DataTableColumnHeader, add DataTableColumnHeader to Active Licenses and Status columns in `src/app/tools/tools-table.tsx`
-- [ ] T008 [P] [US1] Update Users table columns: replace inline sort buttons on Name and Circle with DataTableColumnHeader, add DataTableColumnHeader to Email, Role, Profile, and Status columns in `src/app/users/users-table.tsx`
-- [ ] T009 [P] [US1] Update Assignments table columns: add DataTableColumnHeader to all data columns (User, Tool, Tier, Monthly Cost, Status, Workspace, Assigned) in `src/app/assignments/assignments-client.tsx`
-- [ ] T010 [P] [US1] Add DataTableColumnHeader to all Invoices table column definitions (Invoice Number, Date, Amount, Vendor, Budget Period, Uploaded By) in `src/app/invoices/invoices-table.tsx`
-- [ ] T011 [P] [US1] Add DataTableColumnHeader to all Budget list table column definitions (Fiscal Year, Planned Amount, Status) in `src/app/budget/budget-table.tsx`
+- [x] T007 [P] [US1] Update Tools table columns: replace inline sort buttons on Name and Vendor with DataTableColumnHeader, add DataTableColumnHeader to Active Licenses and Status columns in `src/app/tools/tools-table.tsx`
+- [x] T008 [P] [US1] Update Users table columns: replace inline sort buttons on Name and Circle with DataTableColumnHeader, add DataTableColumnHeader to Email, Role, Profile, and Status columns in `src/app/users/users-table.tsx`
+- [x] T009 [P] [US1] Update Assignments table columns: add DataTableColumnHeader to all data columns (User, Tool, Tier, Monthly Cost, Status, Workspace, Assigned) in `src/app/assignments/assignments-client.tsx`
+- [x] T010 [P] [US1] Add DataTableColumnHeader to all Invoices table column definitions (Invoice Number, Date, Amount, Vendor, Budget Period, Uploaded By) in `src/app/invoices/invoices-table.tsx`
+- [x] T011 [P] [US1] Add DataTableColumnHeader to all Budget list table column definitions (Fiscal Year, Planned Amount, Status) in `src/app/budget/budget-table.tsx`
 
 **Checkpoint**: All 5 tables have sortable columns. US1 is fully functional and testable independently.
 
@@ -63,11 +63,11 @@
 
 ### Implementation for User Story 2
 
-- [ ] T012 [P] [US2] Update Tools table actions column: wrap View (Eye) and Edit (Pencil) buttons in Tooltip, add aria-label="View {toolName}" / "Edit {toolName}" in `src/app/tools/tools-table.tsx`
-- [ ] T013 [P] [US2] Update Users table actions column: wrap View (Eye) and Edit (Pencil) buttons in Tooltip, add aria-label="View {userName}" / "Edit {userName}" in `src/app/users/users-table.tsx`
-- [ ] T014 [P] [US2] Update Assignments table actions column: replace text-based View link with Eye icon button wrapped in Tooltip, wrap Edit (Pencil) button in Tooltip, add aria-labels in `src/app/assignments/assignments-client.tsx`
-- [ ] T015 [P] [US2] Add Tooltip with aria-label to Download (Download icon) action button in Invoices table in `src/app/invoices/invoices-table.tsx`
-- [ ] T016 [P] [US2] Add Tooltip with aria-label to View (Eye) action button in Budget list table in `src/app/budget/budget-table.tsx`
+- [x] T012 [P] [US2] Update Tools table actions column: wrap View (Eye) and Edit (Pencil) buttons in Tooltip, add aria-label="View {toolName}" / "Edit {toolName}" in `src/app/tools/tools-table.tsx`
+- [x] T013 [P] [US2] Update Users table actions column: wrap View (Eye) and Edit (Pencil) buttons in Tooltip, add aria-label="View {userName}" / "Edit {userName}" in `src/app/users/users-table.tsx`
+- [x] T014 [P] [US2] Update Assignments table actions column: replace text-based View link with Eye icon button wrapped in Tooltip, wrap Edit (Pencil) button in Tooltip, add aria-labels in `src/app/assignments/assignments-client.tsx`
+- [x] T015 [P] [US2] Add Tooltip with aria-label to Download (Download icon) action button in Invoices table in `src/app/invoices/invoices-table.tsx`
+- [x] T016 [P] [US2] Add Tooltip with aria-label to View (Eye) action button in Budget list table in `src/app/budget/budget-table.tsx`
 
 **Checkpoint**: All action buttons have tooltips and accessible labels. US2 is fully functional and testable independently.
 
@@ -81,10 +81,10 @@
 
 ### Implementation for User Story 3
 
-- [ ] T017 [P] [US3] Refactor Tools table actions: move Archive action from AlertDialogTrigger button into DropdownMenu with MoreHorizontal trigger, use state to control AlertDialog open/close, add Tooltip to overflow menu trigger, only render menu when isAdmin and status is active in `src/app/tools/tools-table.tsx`
-- [ ] T018 [P] [US3] Refactor Users table actions: move Deactivate action from AlertDialogTrigger button into DropdownMenu with MoreHorizontal trigger, use state to control AlertDialog, add Tooltip to overflow trigger, only render when isAdmin and user is active in `src/app/users/users-table.tsx`
-- [ ] T019 [P] [US3] Refactor Assignments table actions: move Revoke action from AlertDialogTrigger button into DropdownMenu with MoreHorizontal trigger, use state to control AlertDialog, add Tooltip to overflow trigger, only render when isAdmin and assignment is active in `src/app/assignments/assignments-client.tsx`
-- [ ] T020 [US3] Refactor Budget list actions: move Archive action into DropdownMenu with MoreHorizontal trigger inside the BudgetTable actions column, use state to control AlertDialog, add Tooltip to overflow trigger, only render when budget is not archived in `src/app/budget/budget-table.tsx` and `src/app/budget/budget-list-actions.tsx`
+- [x] T017 [P] [US3] Refactor Tools table actions: move Archive action from AlertDialogTrigger button into DropdownMenu with MoreHorizontal trigger, use state to control AlertDialog open/close, add Tooltip to overflow menu trigger, only render menu when isAdmin and status is active in `src/app/tools/tools-table.tsx`
+- [x] T018 [P] [US3] Refactor Users table actions: move Deactivate action from AlertDialogTrigger button into DropdownMenu with MoreHorizontal trigger, use state to control AlertDialog, add Tooltip to overflow trigger, only render when isAdmin and user is active in `src/app/users/users-table.tsx`
+- [x] T019 [P] [US3] Refactor Assignments table actions: move Revoke action from AlertDialogTrigger button into DropdownMenu with MoreHorizontal trigger, use state to control AlertDialog, add Tooltip to overflow trigger, only render when isAdmin and assignment is active in `src/app/assignments/assignments-client.tsx`
+- [x] T020 [US3] Refactor Budget list actions: move Archive action into DropdownMenu with MoreHorizontal trigger inside the BudgetTable actions column, use state to control AlertDialog, add Tooltip to overflow trigger, only render when budget is not archived in `src/app/budget/budget-table.tsx` and `src/app/budget/budget-list-actions.tsx`
 
 **Checkpoint**: All destructive actions are behind overflow menus. US3 is fully functional and testable independently.
 
@@ -98,11 +98,11 @@
 
 ### Implementation for User Story 4
 
-- [ ] T021 Create DataTableFacetedFilter component: popover with checkbox list, multi-select, badge count display, clear action, per contracts in `src/components/data-table-faceted-filter.tsx`
-- [ ] T022 [P] [US4] Add facetedFilters prop to Tools table DataTable: Status column with options Active, Archived in `src/app/tools/tools-table.tsx`
-- [ ] T023 [P] [US4] Add facetedFilters prop to Users table DataTable: Role column (Admin, Viewer) and Status column (Active, Inactive) in `src/app/users/users-table.tsx`
-- [ ] T024 [P] [US4] Add facetedFilters prop to Assignments table DataTable: Status column with options Active, Revoked in `src/app/assignments/assignments-client.tsx`
-- [ ] T025 [P] [US4] Add facetedFilters prop to Budget list table DataTable: Status column with options Active, Archived in `src/app/budget/budget-table.tsx`
+- [x] T021 Create DataTableFacetedFilter component: popover with checkbox list, multi-select, badge count display, clear action, per contracts in `src/components/data-table-faceted-filter.tsx`
+- [x] T022 [P] [US4] Add facetedFilters prop to Tools table DataTable: Status column with options Active, Archived in `src/app/tools/tools-table.tsx`
+- [x] T023 [P] [US4] Add facetedFilters prop to Users table DataTable: Role column (Admin, Viewer) and Status column (Active, Inactive) in `src/app/users/users-table.tsx`
+- [x] T024 [P] [US4] Add facetedFilters prop to Assignments table DataTable: Status column with options Active, Revoked in `src/app/assignments/assignments-client.tsx`
+- [x] T025 [P] [US4] Add facetedFilters prop to Budget list table DataTable: Status column with options Active, Archived in `src/app/budget/budget-table.tsx`
 
 **Checkpoint**: All categorical columns have faceted filters. US4 is fully functional and testable independently.
 
@@ -112,11 +112,11 @@
 
 **Purpose**: Final verification, edge case handling, and cleanup
 
-- [ ] T026 Verify edge case: null/empty values sort to end regardless of sort direction across all tables — add custom sort comparators if needed in `src/components/data-table-column-header.tsx`
-- [ ] T027 Verify edge case: non-admin users see clean actions column with no empty space where admin actions would be — adjust conditional rendering if needed across all table files
-- [ ] T028 Run `pnpm typecheck` and `pnpm lint` — fix any TypeScript or ESLint issues introduced
-- [ ] T029 Run `pnpm build` — verify production build succeeds with no errors
-- [ ] T030 Manual smoke test: verify all 5 tables on /tools, /users, /assignments, /invoices, /budget for sorting, tooltips, overflow menus, and filters
+- [x] T026 Verify edge case: null/empty values sort to end regardless of sort direction across all tables — add custom sort comparators if needed in `src/components/data-table-column-header.tsx`
+- [x] T027 Verify edge case: non-admin users see clean actions column with no empty space where admin actions would be — adjust conditional rendering if needed across all table files
+- [x] T028 Run `pnpm typecheck` and `pnpm lint` — fix any TypeScript or ESLint issues introduced
+- [x] T029 Run `pnpm build` — verify production build succeeds with no errors
+- [x] T030 Manual smoke test: verify all 5 tables on /tools, /users, /assignments, /invoices, /budget for sorting, tooltips, overflow menus, and filters
 
 ---
 

--- a/specs/012-better-tables/tasks.md
+++ b/specs/012-better-tables/tasks.md
@@ -1,0 +1,213 @@
+# Tasks: Better Tables
+
+**Input**: Design documents from `/specs/012-better-tables/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Not explicitly requested in spec. Test tasks omitted.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the reusable shared components that multiple user stories depend on
+
+- [ ] T001 [P] Create DataTableColumnHeader component with three-state sort cycling (unsorted/asc/desc) and directional icons (ArrowUpDown/ArrowUp/ArrowDown) per contracts in `src/components/data-table-column-header.tsx`
+- [ ] T002 [P] Enhance DataTable component: wrap output in TooltipProvider, add `facetedFilters` prop support to render filter toolbar between search and table in `src/components/data-table.tsx`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Migrate the two plain HTML tables to the shared DataTable component so all 5 tables can receive sorting, tooltips, and overflow menus uniformly
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Create Invoices client table component: extract table rendering from server page into new client component with TanStack Table column definitions (Invoice Number, Date, Amount, Vendor, Budget Period, Uploaded By, Download action) in `src/app/invoices/invoices-table.tsx`
+- [ ] T004 Refactor Invoices page to delegate table rendering to the new InvoicesTable client component, keeping data fetching in the server component in `src/app/invoices/page.tsx`
+- [ ] T005 Create Budget list client table component: extract table rendering from server page into new client component with TanStack Table column definitions (Fiscal Year, Planned Amount, Status, Actions) in `src/app/budget/budget-table.tsx`
+- [ ] T006 Refactor Budget list page to delegate table rendering to the new BudgetTable client component, keeping data fetching and summary cards in the server component in `src/app/budget/page.tsx`
+
+**Checkpoint**: All 5 tables now use the shared DataTable component. Sorting, tooltips, and overflow menus can be applied uniformly.
+
+---
+
+## Phase 3: User Story 1 - Column Sorting Across All Tables (Priority: P1) MVP
+
+**Goal**: Every data column on every table supports click-to-sort with ascending/descending/unsorted cycling and visual direction indicators.
+
+**Independent Test**: Click any column header on any table page (/tools, /users, /assignments, /invoices, /budget) and verify data reorders. Click again to reverse. Click a third time to clear sort.
+
+### Implementation for User Story 1
+
+- [ ] T007 [P] [US1] Update Tools table columns: replace inline sort buttons on Name and Vendor with DataTableColumnHeader, add DataTableColumnHeader to Active Licenses and Status columns in `src/app/tools/tools-table.tsx`
+- [ ] T008 [P] [US1] Update Users table columns: replace inline sort buttons on Name and Circle with DataTableColumnHeader, add DataTableColumnHeader to Email, Role, Profile, and Status columns in `src/app/users/users-table.tsx`
+- [ ] T009 [P] [US1] Update Assignments table columns: add DataTableColumnHeader to all data columns (User, Tool, Tier, Monthly Cost, Status, Workspace, Assigned) in `src/app/assignments/assignments-client.tsx`
+- [ ] T010 [P] [US1] Add DataTableColumnHeader to all Invoices table column definitions (Invoice Number, Date, Amount, Vendor, Budget Period, Uploaded By) in `src/app/invoices/invoices-table.tsx`
+- [ ] T011 [P] [US1] Add DataTableColumnHeader to all Budget list table column definitions (Fiscal Year, Planned Amount, Status) in `src/app/budget/budget-table.tsx`
+
+**Checkpoint**: All 5 tables have sortable columns. US1 is fully functional and testable independently.
+
+---
+
+## Phase 4: User Story 2 - Unified Quick Actions with Consistent Icons, Tooltips, and Labels (Priority: P1)
+
+**Goal**: Every row action button across all tables uses the same icon for the same action type, displays a tooltip on hover, and has an accessible aria-label in the format "Action ItemName".
+
+**Independent Test**: Navigate to each table page, hover over View/Edit buttons to verify tooltip appears with correct text. Use browser accessibility inspector to verify aria-label on each button. Confirm Assignments View action uses Eye icon (not text button).
+
+### Implementation for User Story 2
+
+- [ ] T012 [P] [US2] Update Tools table actions column: wrap View (Eye) and Edit (Pencil) buttons in Tooltip, add aria-label="View {toolName}" / "Edit {toolName}" in `src/app/tools/tools-table.tsx`
+- [ ] T013 [P] [US2] Update Users table actions column: wrap View (Eye) and Edit (Pencil) buttons in Tooltip, add aria-label="View {userName}" / "Edit {userName}" in `src/app/users/users-table.tsx`
+- [ ] T014 [P] [US2] Update Assignments table actions column: replace text-based View link with Eye icon button wrapped in Tooltip, wrap Edit (Pencil) button in Tooltip, add aria-labels in `src/app/assignments/assignments-client.tsx`
+- [ ] T015 [P] [US2] Add Tooltip with aria-label to Download (Download icon) action button in Invoices table in `src/app/invoices/invoices-table.tsx`
+- [ ] T016 [P] [US2] Add Tooltip with aria-label to View (Eye) action button in Budget list table in `src/app/budget/budget-table.tsx`
+
+**Checkpoint**: All action buttons have tooltips and accessible labels. US2 is fully functional and testable independently.
+
+---
+
+## Phase 5: User Story 3 - Destructive Actions Hidden Behind Overflow Menu (Priority: P2)
+
+**Goal**: All destructive actions (Archive, Deactivate, Revoke, Delete) are moved from direct icon buttons into a three-dot DropdownMenu. Menu items use `variant="destructive"`. Selecting a menu item opens the existing AlertDialog confirmation. The overflow menu only renders for users with permission for at least one destructive action on that row.
+
+**Independent Test**: On each table, verify destructive actions are no longer visible as direct buttons. Click the three-dot menu to see destructive options. Confirm selecting a destructive option still shows the AlertDialog. As a non-admin, verify no three-dot menu appears.
+
+### Implementation for User Story 3
+
+- [ ] T017 [P] [US3] Refactor Tools table actions: move Archive action from AlertDialogTrigger button into DropdownMenu with MoreHorizontal trigger, use state to control AlertDialog open/close, add Tooltip to overflow menu trigger, only render menu when isAdmin and status is active in `src/app/tools/tools-table.tsx`
+- [ ] T018 [P] [US3] Refactor Users table actions: move Deactivate action from AlertDialogTrigger button into DropdownMenu with MoreHorizontal trigger, use state to control AlertDialog, add Tooltip to overflow trigger, only render when isAdmin and user is active in `src/app/users/users-table.tsx`
+- [ ] T019 [P] [US3] Refactor Assignments table actions: move Revoke action from AlertDialogTrigger button into DropdownMenu with MoreHorizontal trigger, use state to control AlertDialog, add Tooltip to overflow trigger, only render when isAdmin and assignment is active in `src/app/assignments/assignments-client.tsx`
+- [ ] T020 [US3] Refactor Budget list actions: move Archive action into DropdownMenu with MoreHorizontal trigger inside the BudgetTable actions column, use state to control AlertDialog, add Tooltip to overflow trigger, only render when budget is not archived in `src/app/budget/budget-table.tsx` and `src/app/budget/budget-list-actions.tsx`
+
+**Checkpoint**: All destructive actions are behind overflow menus. US3 is fully functional and testable independently.
+
+---
+
+## Phase 6: User Story 4 - Column Filtering on Key Columns (Priority: P3)
+
+**Goal**: Categorical columns display faceted filter buttons in the DataTable toolbar. Users can multi-select filter values to narrow displayed rows. Filters work alongside global search.
+
+**Independent Test**: On the Tools table, use the Status filter to select "Active" — only active tools shown. On Users, filter by Role "Admin" — only admins shown. Apply a filter and use global search simultaneously — both apply (intersection). Clear filter — all rows return.
+
+### Implementation for User Story 4
+
+- [ ] T021 Create DataTableFacetedFilter component: popover with checkbox list, multi-select, badge count display, clear action, per contracts in `src/components/data-table-faceted-filter.tsx`
+- [ ] T022 [P] [US4] Add facetedFilters prop to Tools table DataTable: Status column with options Active, Archived in `src/app/tools/tools-table.tsx`
+- [ ] T023 [P] [US4] Add facetedFilters prop to Users table DataTable: Role column (Admin, Viewer) and Status column (Active, Inactive) in `src/app/users/users-table.tsx`
+- [ ] T024 [P] [US4] Add facetedFilters prop to Assignments table DataTable: Status column with options Active, Revoked in `src/app/assignments/assignments-client.tsx`
+- [ ] T025 [P] [US4] Add facetedFilters prop to Budget list table DataTable: Status column with options Active, Archived in `src/app/budget/budget-table.tsx`
+
+**Checkpoint**: All categorical columns have faceted filters. US4 is fully functional and testable independently.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, edge case handling, and cleanup
+
+- [ ] T026 Verify edge case: null/empty values sort to end regardless of sort direction across all tables — add custom sort comparators if needed in `src/components/data-table-column-header.tsx`
+- [ ] T027 Verify edge case: non-admin users see clean actions column with no empty space where admin actions would be — adjust conditional rendering if needed across all table files
+- [ ] T028 Run `pnpm typecheck` and `pnpm lint` — fix any TypeScript or ESLint issues introduced
+- [ ] T029 Run `pnpm build` — verify production build succeeds with no errors
+- [ ] T030 Manual smoke test: verify all 5 tables on /tools, /users, /assignments, /invoices, /budget for sorting, tooltips, overflow menus, and filters
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on T002 (DataTable enhancement) for TooltipProvider — BLOCKS all user stories
+- **US1 Sorting (Phase 3)**: Depends on T001 (DataTableColumnHeader) and Phase 2 (table migrations)
+- **US2 Quick Actions (Phase 4)**: Depends on T002 (TooltipProvider in DataTable) and Phase 2 (table migrations)
+- **US3 Overflow Menu (Phase 5)**: Depends on Phase 2 (table migrations). Can run in parallel with US1 and US2.
+- **US4 Filtering (Phase 6)**: Depends on T021 (DataTableFacetedFilter) and T002 (DataTable facetedFilters prop)
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 1 + Phase 2. No dependencies on other stories.
+- **US2 (P1)**: Depends on Phase 1 + Phase 2. No dependencies on other stories. Can run in parallel with US1.
+- **US3 (P2)**: Depends on Phase 2. No dependencies on US1 or US2. Can run in parallel.
+- **US4 (P3)**: Depends on Phase 1 + Phase 2 + T021. No dependencies on US1-US3. Can run in parallel.
+
+### Within Each User Story
+
+All tasks within US1, US2, US3, and US4 are marked [P] (parallelizable) since they modify different files with no cross-dependencies.
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel (different files)
+- T003+T004 and T005+T006 can run in parallel (different page migrations)
+- All US1 tasks (T007-T011) can run in parallel
+- All US2 tasks (T012-T016) can run in parallel
+- All US3 tasks (T017-T020) can run in parallel
+- T022-T025 can run in parallel (after T021 completes)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After Phase 1 + Phase 2 complete, launch all US1 tasks in parallel:
+Task T007: "Update Tools table columns with DataTableColumnHeader in src/app/tools/tools-table.tsx"
+Task T008: "Update Users table columns with DataTableColumnHeader in src/app/users/users-table.tsx"
+Task T009: "Update Assignments table columns with DataTableColumnHeader in src/app/assignments/assignments-client.tsx"
+Task T010: "Add DataTableColumnHeader to Invoices table in src/app/invoices/invoices-table.tsx"
+Task T011: "Add DataTableColumnHeader to Budget table in src/app/budget/budget-table.tsx"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# After Phase 1 + Phase 2 complete, launch all US2 tasks in parallel:
+Task T012: "Add tooltips and aria-labels to Tools table actions in src/app/tools/tools-table.tsx"
+Task T013: "Add tooltips and aria-labels to Users table actions in src/app/users/users-table.tsx"
+Task T014: "Add tooltips and aria-labels to Assignments table actions in src/app/assignments/assignments-client.tsx"
+Task T015: "Add tooltips and aria-labels to Invoices table actions in src/app/invoices/invoices-table.tsx"
+Task T016: "Add tooltips and aria-labels to Budget table actions in src/app/budget/budget-table.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001, T002)
+2. Complete Phase 2: Foundational (T003-T006)
+3. Complete Phase 3: User Story 1 — Sorting (T007-T011)
+4. **STOP and VALIDATE**: Click column headers on all 5 tables, verify sorting works
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → Foundation ready (all tables on DataTable)
+2. Add US1 (Sorting) → Test → Deploy/Demo (MVP!)
+3. Add US2 (Tooltips + Consistent Icons) → Test → Deploy/Demo
+4. Add US3 (Overflow Menus) → Test → Deploy/Demo
+5. Add US4 (Faceted Filters) → Test → Deploy/Demo
+6. Polish → Final validation → Deploy
+
+### Parallel Strategy
+
+Since US1-US4 modify the same files (each table's component), the safest approach is sequential by user story. However, within each story, all 5 table modifications can run in parallel. US1 and US2 can also be combined into a single pass per table file if preferred.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- Commit after each task or logical group (e.g., after each phase, or after each table file update)
+- No database migrations needed — this is a UI-only feature
+- No new npm dependencies needed — all components already available

--- a/src/app/assignments/assignments-client.tsx
+++ b/src/app/assignments/assignments-client.tsx
@@ -62,6 +62,7 @@ import {
   CalendarIcon,
   AlertTriangle,
   Ban,
+  MoreHorizontal,
 } from "lucide-react";
 import {
   AlertDialog,
@@ -72,8 +73,19 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { DataTableColumnHeader } from "@/components/data-table-column-header";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface AssignmentRow {
   id: number;
@@ -409,6 +421,91 @@ function EditAssignmentDialog({
   );
 }
 
+// ---- Assignment Row Actions ----
+
+function AssignmentRowActions({
+  assignment,
+  isAdmin,
+  onRevoke,
+  onSaved,
+}: {
+  assignment: AssignmentRow;
+  isAdmin: boolean;
+  onRevoke: (id: number) => void;
+  onSaved: () => void;
+}) {
+  const [showRevokeDialog, setShowRevokeDialog] = useState(false);
+  return (
+    <div className="flex items-center gap-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="sm"
+            variant="ghost"
+            aria-label={`View ${assignment.user.name}'s assignment`}
+            asChild
+          >
+            <Link href={`/assignments/${assignment.id}`}>
+              <Eye className="size-4" />
+            </Link>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>View</TooltipContent>
+      </Tooltip>
+      {isAdmin && assignment.status === "active" && (
+        <>
+          <EditAssignmentDialog assignment={assignment} onSaved={onSaved} />
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`More actions for ${assignment.user.name}'s assignment`}
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>More actions</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => setShowRevokeDialog(true)}
+              >
+                <Ban className="size-4" />
+                Revoke
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <AlertDialog
+            open={showRevokeDialog}
+            onOpenChange={setShowRevokeDialog}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Revoke this assignment?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will revoke {assignment.user.name}&apos;s license for{" "}
+                  {assignment.tool.name}.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={() => onRevoke(assignment.id)}>
+                  Revoke
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </>
+      )}
+    </div>
+  );
+}
+
 // ---- Main Component ----
 
 interface Props {
@@ -486,26 +583,37 @@ export function AssignmentsClient({
     {
       accessorFn: (row) => row.user.name,
       id: "userName",
-      header: "User",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="User" />
+      ),
     },
     {
       accessorFn: (row) => row.tool.name,
       id: "toolName",
-      header: "Tool",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Tool" />
+      ),
     },
     {
       accessorFn: (row) => row.tier.name,
       id: "tierName",
-      header: "Tier",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Tier" />
+      ),
     },
     {
       accessorKey: "costAtAssignmentCents",
-      header: "Monthly Cost",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Monthly Cost" />
+      ),
       cell: ({ row }) => formatCurrency(row.original.costAtAssignmentCents),
     },
     {
       accessorKey: "status",
-      header: "Status",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Status" />
+      ),
+      filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
       cell: ({ row }) => (
         <Badge
           variant={
@@ -518,52 +626,27 @@ export function AssignmentsClient({
     },
     {
       accessorKey: "workspace",
-      header: "Workspace",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Workspace" />
+      ),
       cell: ({ row }) => row.original.workspace || "\u2014",
     },
     {
       accessorKey: "assignedAt",
-      header: "Assigned",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Assigned" />
+      ),
       cell: ({ row }) => formatDate(row.original.assignedAt),
     },
     {
       id: "actions" as const,
       cell: ({ row }: { row: { original: AssignmentRow } }) => (
-        <div className="flex items-center gap-1">
-          <Button size="sm" variant="ghost" asChild>
-            <Link href={`/assignments/${row.original.id}`}>View</Link>
-          </Button>
-          {isAdmin && row.original.status === "active" && (
-            <>
-              <EditAssignmentDialog
-                assignment={row.original}
-                onSaved={() => router.refresh()}
-              />
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button size="sm" variant="ghost">
-                    <Ban className="size-4" />
-                    <span className="sr-only">Revoke</span>
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Revoke this assignment?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This will revoke {row.original.user.name}&apos;s license for {row.original.tool.name}.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction onClick={() => handleRevoke(row.original.id)}>
-                      Revoke
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            </>
-          )}
-        </div>
+        <AssignmentRowActions
+          assignment={row.original}
+          isAdmin={isAdmin}
+          onRevoke={handleRevoke}
+          onSaved={() => router.refresh()}
+        />
       ),
     },
   ];
@@ -680,6 +763,16 @@ export function AssignmentsClient({
         columns={columns}
         data={filteredAssignments}
         searchPlaceholder="Search assignments..."
+        facetedFilters={[
+          {
+            columnId: "status",
+            title: "Status",
+            options: [
+              { label: "Active", value: "active" },
+              { label: "Revoked", value: "revoked" },
+            ],
+          },
+        ]}
       />
     </div>
   );

--- a/src/app/assignments/assignments-client.tsx
+++ b/src/app/assignments/assignments-client.tsx
@@ -16,7 +16,7 @@ import {
 import { getToolWithTiers } from "@/actions/tools";
 import { updateAssignmentSchema } from "@/lib/validators";
 import type { UpdateAssignmentInput } from "@/lib/validators";
-import { DataTable } from "@/components/data-table";
+import { DataTable, arrayIncludesFilterFn } from "@/components/data-table";
 import { formatCurrency, formatDate, cn } from "@/lib/utils";
 import type { AiTool, User, AccessTier } from "@/types";
 import { Button } from "@/components/ui/button";
@@ -506,6 +506,97 @@ function AssignmentRowActions({
   );
 }
 
+// ---- Column Definitions ----
+
+function getColumns(
+  isAdmin: boolean,
+  onRevoke: (id: number) => void,
+  onSaved: () => void
+): ColumnDef<AssignmentRow>[] {
+  return [
+    {
+      accessorFn: (row) => row.user.name,
+      id: "userName",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="User" />
+      ),
+    },
+    {
+      accessorFn: (row) => row.tool.name,
+      id: "toolName",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Tool" />
+      ),
+    },
+    {
+      accessorFn: (row) => row.tier.name,
+      id: "tierName",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Tier" />
+      ),
+    },
+    {
+      accessorKey: "costAtAssignmentCents",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Monthly Cost" />
+      ),
+      cell: ({ row }) => formatCurrency(row.original.costAtAssignmentCents),
+    },
+    {
+      accessorKey: "status",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Status" />
+      ),
+      filterFn: arrayIncludesFilterFn,
+      cell: ({ row }) => (
+        <Badge
+          variant={
+            row.original.status === "active" ? "default" : "secondary"
+          }
+        >
+          {row.original.status}
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: "workspace",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Workspace" />
+      ),
+      cell: ({ row }) => row.original.workspace || "\u2014",
+    },
+    {
+      accessorKey: "assignedAt",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Assigned" />
+      ),
+      cell: ({ row }) => formatDate(row.original.assignedAt),
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <AssignmentRowActions
+          assignment={row.original}
+          isAdmin={isAdmin}
+          onRevoke={onRevoke}
+          onSaved={onSaved}
+        />
+      ),
+    },
+  ];
+}
+
+const ASSIGNMENT_FACETED_FILTERS = [
+  {
+    columnId: "status",
+    title: "Status",
+    options: [
+      { label: "Active", value: "active" },
+      { label: "Revoked", value: "revoked" },
+    ],
+  },
+];
+
 // ---- Main Component ----
 
 interface Props {
@@ -534,6 +625,21 @@ export function AssignmentsClient({
   const [selectedTierId, setSelectedTierId] = useState<string>("");
   const [availableTiers, setAvailableTiers] = useState<AccessTier[]>([]);
   const [assigning, setAssigning] = useState(false);
+
+  const handleRefresh = useCallback(() => router.refresh(), [router]);
+  const handleRevoke = useCallback(async (id: number) => {
+    const result = await revokeLicense({ id });
+    if (result.success) {
+      toast.success("License revoked");
+      router.refresh();
+    } else {
+      toast.error(result.error);
+    }
+  }, [router]);
+  const columns = useMemo(
+    () => getColumns(isAdmin, handleRevoke, handleRefresh),
+    [isAdmin, handleRevoke, handleRefresh]
+  );
 
   async function handleToolChange(toolId: string) {
     setSelectedToolId(toolId);
@@ -568,88 +674,6 @@ export function AssignmentsClient({
       toast.error(result.error);
     }
   }
-
-  async function handleRevoke(id: number) {
-    const result = await revokeLicense({ id });
-    if (result.success) {
-      toast.success("License revoked");
-      router.refresh();
-    } else {
-      toast.error(result.error);
-    }
-  }
-
-  const columns: ColumnDef<AssignmentRow>[] = [
-    {
-      accessorFn: (row) => row.user.name,
-      id: "userName",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="User" />
-      ),
-    },
-    {
-      accessorFn: (row) => row.tool.name,
-      id: "toolName",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Tool" />
-      ),
-    },
-    {
-      accessorFn: (row) => row.tier.name,
-      id: "tierName",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Tier" />
-      ),
-    },
-    {
-      accessorKey: "costAtAssignmentCents",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Monthly Cost" />
-      ),
-      cell: ({ row }) => formatCurrency(row.original.costAtAssignmentCents),
-    },
-    {
-      accessorKey: "status",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Status" />
-      ),
-      filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
-      cell: ({ row }) => (
-        <Badge
-          variant={
-            row.original.status === "active" ? "default" : "secondary"
-          }
-        >
-          {row.original.status}
-        </Badge>
-      ),
-    },
-    {
-      accessorKey: "workspace",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Workspace" />
-      ),
-      cell: ({ row }) => row.original.workspace || "\u2014",
-    },
-    {
-      accessorKey: "assignedAt",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Assigned" />
-      ),
-      cell: ({ row }) => formatDate(row.original.assignedAt),
-    },
-    {
-      id: "actions" as const,
-      cell: ({ row }: { row: { original: AssignmentRow } }) => (
-        <AssignmentRowActions
-          assignment={row.original}
-          isAdmin={isAdmin}
-          onRevoke={handleRevoke}
-          onSaved={() => router.refresh()}
-        />
-      ),
-    },
-  ];
 
   return (
     <div className="space-y-6">
@@ -763,16 +787,7 @@ export function AssignmentsClient({
         columns={columns}
         data={filteredAssignments}
         searchPlaceholder="Search assignments..."
-        facetedFilters={[
-          {
-            columnId: "status",
-            title: "Status",
-            options: [
-              { label: "Active", value: "active" },
-              { label: "Revoked", value: "revoked" },
-            ],
-          },
-        ]}
+        facetedFilters={ASSIGNMENT_FACETED_FILTERS}
       />
     </div>
   );

--- a/src/app/budget/budget-list-actions.tsx
+++ b/src/app/budget/budget-list-actions.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -13,9 +14,19 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { Eye, Archive } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { Eye, Archive, MoreHorizontal } from "lucide-react";
 import { archiveBudget } from "@/actions/budget";
 
 interface BudgetListActionsProps {
@@ -26,52 +37,71 @@ interface BudgetListActionsProps {
 
 export function BudgetListActions({ id, fiscalYear, status }: BudgetListActionsProps) {
   const router = useRouter();
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
 
   return (
     <div className="flex items-center justify-end gap-1">
-      <Button size="sm" variant="ghost" asChild>
-        <Link href={`/budget/${id}`}>
-          <Eye className="size-4" />
-          <span className="sr-only">View</span>
-        </Link>
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="sm" variant="ghost" aria-label={`View FY ${fiscalYear}`} asChild>
+            <Link href={`/budget/${id}`}>
+              <Eye className="size-4" />
+            </Link>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>View</TooltipContent>
+      </Tooltip>
       {status !== "archived" && (
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button size="sm" variant="ghost">
-              <Archive className="size-4" />
-              <span className="sr-only">Archive</span>
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Archive FY {fiscalYear}?</AlertDialogTitle>
-              <AlertDialogDescription>
-                This will archive the budget for fiscal year {fiscalYear}.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={async () => {
-                  try {
-                    const result = await archiveBudget({ id });
-                    if (result.success) {
-                      toast.success("Budget archived");
-                      router.refresh();
-                    } else {
-                      toast.error(result.error);
-                    }
-                  } catch {
-                    toast.error("An unexpected error occurred");
-                  }
-                }}
-              >
+        <>
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm" aria-label={`More actions for FY ${fiscalYear}`}>
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>More actions</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem variant="destructive" onSelect={() => setShowArchiveDialog(true)}>
+                <Archive className="size-4" />
                 Archive
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <AlertDialog open={showArchiveDialog} onOpenChange={setShowArchiveDialog}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Archive FY {fiscalYear}?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will archive the budget for fiscal year {fiscalYear}.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={async () => {
+                    try {
+                      const result = await archiveBudget({ id });
+                      if (result.success) {
+                        toast.success("Budget archived");
+                        router.refresh();
+                      } else {
+                        toast.error(result.error);
+                      }
+                    } catch {
+                      toast.error("An unexpected error occurred");
+                    }
+                  }}
+                >
+                  Archive
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </>
       )}
     </div>
   );

--- a/src/app/budget/budget-table.tsx
+++ b/src/app/budget/budget-table.tsx
@@ -4,6 +4,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { formatCurrency } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { DataTable } from "@/components/data-table";
+import { DataTableColumnHeader } from "@/components/data-table-column-header";
 import { BudgetListActions } from "./budget-list-actions";
 
 interface BudgetRow {
@@ -16,19 +17,19 @@ interface BudgetRow {
 const columns: ColumnDef<BudgetRow>[] = [
   {
     accessorKey: "fiscalYear",
-    header: "Fiscal Year",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Fiscal Year" />,
     cell: ({ row }) => (
       <span className="font-medium">FY {row.getValue("fiscalYear")}</span>
     ),
   },
   {
     accessorKey: "totalAmountCents",
-    header: "Planned Amount",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Planned Amount" />,
     cell: ({ row }) => formatCurrency(row.getValue("totalAmountCents")),
   },
   {
     accessorKey: "status",
-    header: "Status",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
     cell: ({ row }) => {
       const status = row.getValue("status") as string;
       return (
@@ -37,6 +38,7 @@ const columns: ColumnDef<BudgetRow>[] = [
         </Badge>
       );
     },
+    filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
   },
   {
     id: "actions",
@@ -63,6 +65,16 @@ export function BudgetTable({ data }: BudgetTableProps) {
       columns={columns}
       data={data}
       searchPlaceholder="Search budgets..."
+      facetedFilters={[
+        {
+          columnId: "status",
+          title: "Status",
+          options: [
+            { label: "Active", value: "active" },
+            { label: "Archived", value: "archived" },
+          ],
+        },
+      ]}
     />
   );
 }

--- a/src/app/budget/budget-table.tsx
+++ b/src/app/budget/budget-table.tsx
@@ -3,7 +3,7 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { formatCurrency } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { DataTable } from "@/components/data-table";
+import { DataTable, arrayIncludesFilterFn } from "@/components/data-table";
 import { DataTableColumnHeader } from "@/components/data-table-column-header";
 import { BudgetListActions } from "./budget-list-actions";
 
@@ -38,7 +38,7 @@ const columns: ColumnDef<BudgetRow>[] = [
         </Badge>
       );
     },
-    filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
+    filterFn: arrayIncludesFilterFn,
   },
   {
     id: "actions",
@@ -54,27 +54,24 @@ const columns: ColumnDef<BudgetRow>[] = [
   },
 ];
 
-interface BudgetTableProps {
-  data: BudgetRow[];
-  isAdmin: boolean;
-}
+const BUDGET_FACETED_FILTERS = [
+  {
+    columnId: "status",
+    title: "Status",
+    options: [
+      { label: "Active", value: "active" },
+      { label: "Archived", value: "archived" },
+    ],
+  },
+];
 
-export function BudgetTable({ data }: BudgetTableProps) {
+export function BudgetTable({ data }: { data: BudgetRow[] }) {
   return (
     <DataTable
       columns={columns}
       data={data}
       searchPlaceholder="Search budgets..."
-      facetedFilters={[
-        {
-          columnId: "status",
-          title: "Status",
-          options: [
-            { label: "Active", value: "active" },
-            { label: "Archived", value: "archived" },
-          ],
-        },
-      ]}
+      facetedFilters={BUDGET_FACETED_FILTERS}
     />
   );
 }

--- a/src/app/budget/budget-table.tsx
+++ b/src/app/budget/budget-table.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { formatCurrency } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { DataTable } from "@/components/data-table";
+import { BudgetListActions } from "./budget-list-actions";
+
+interface BudgetRow {
+  id: number;
+  fiscalYear: number;
+  totalAmountCents: number;
+  status: string;
+}
+
+const columns: ColumnDef<BudgetRow>[] = [
+  {
+    accessorKey: "fiscalYear",
+    header: "Fiscal Year",
+    cell: ({ row }) => (
+      <span className="font-medium">FY {row.getValue("fiscalYear")}</span>
+    ),
+  },
+  {
+    accessorKey: "totalAmountCents",
+    header: "Planned Amount",
+    cell: ({ row }) => formatCurrency(row.getValue("totalAmountCents")),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => {
+      const status = row.getValue("status") as string;
+      return (
+        <Badge variant={status === "active" ? "default" : "secondary"}>
+          {status}
+        </Badge>
+      );
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => (
+      <div className="text-right">
+        <BudgetListActions
+          id={row.original.id}
+          fiscalYear={row.original.fiscalYear}
+          status={row.original.status}
+        />
+      </div>
+    ),
+  },
+];
+
+interface BudgetTableProps {
+  data: BudgetRow[];
+  isAdmin: boolean;
+}
+
+export function BudgetTable({ data }: BudgetTableProps) {
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      searchPlaceholder="Search budgets..."
+    />
+  );
+}

--- a/src/app/budget/page.tsx
+++ b/src/app/budget/page.tsx
@@ -15,17 +15,9 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { Plus } from "lucide-react";
 import { AuthGuard } from "@/components/auth-guard";
-import { BudgetListActions } from "./budget-list-actions";
+import { BudgetTable } from "./budget-table";
 
 export default async function BudgetPage() {
   const session = await auth();
@@ -164,42 +156,7 @@ export default async function BudgetPage() {
               <CardTitle>All Budgets</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="rounded-md border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Fiscal Year</TableHead>
-                      <TableHead>Planned</TableHead>
-                      <TableHead>Status</TableHead>
-                      <TableHead />
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {allBudgets.map((b) => (
-                      <TableRow key={b.id}>
-                        <TableCell className="font-medium">
-                          FY {b.fiscalYear}
-                        </TableCell>
-                        <TableCell>
-                          {formatCurrency(b.totalAmountCents)}
-                        </TableCell>
-                        <TableCell>
-                          <Badge
-                            variant={
-                              b.status === "active" ? "default" : "secondary"
-                            }
-                          >
-                            {b.status}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <BudgetListActions id={b.id} fiscalYear={b.fiscalYear} status={b.status} />
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+              <BudgetTable data={allBudgets} isAdmin={isAdmin} />
             </CardContent>
           </Card>
         )}

--- a/src/app/budget/page.tsx
+++ b/src/app/budget/page.tsx
@@ -156,7 +156,7 @@ export default async function BudgetPage() {
               <CardTitle>All Budgets</CardTitle>
             </CardHeader>
             <CardContent>
-              <BudgetTable data={allBudgets} isAdmin={isAdmin} />
+              <BudgetTable data={allBudgets} />
             </CardContent>
           </Card>
         )}

--- a/src/app/invoices/invoices-table.tsx
+++ b/src/app/invoices/invoices-table.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
 import { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "@/components/data-table";
+import { DataTableColumnHeader } from "@/components/data-table-column-header";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import { Download } from "lucide-react";
 import { formatCurrency, formatDate } from "@/lib/utils";
 
@@ -20,58 +25,74 @@ interface InvoiceRow {
 const columns: ColumnDef<InvoiceRow>[] = [
   {
     accessorKey: "invoiceNumber",
-    header: "Invoice Number",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Invoice Number" />
+    ),
     cell: ({ row }) => (
       <span className="font-medium">{row.getValue("invoiceNumber")}</span>
     ),
   },
   {
     accessorKey: "invoiceDate",
-    header: "Date",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Date" />
+    ),
     cell: ({ row }) => formatDate(row.getValue("invoiceDate")),
   },
   {
     accessorKey: "amountCents",
-    header: "Amount",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Amount" />
+    ),
     cell: ({ row }) => formatCurrency(row.getValue("amountCents")),
   },
   {
     accessorKey: "vendor",
-    header: "Vendor",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Vendor" />
+    ),
     cell: ({ row }) => (row.getValue("vendor") as string) ?? "—",
   },
   {
     accessorKey: "periodLabel",
-    header: "Budget Period",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Budget Period" />
+    ),
     cell: ({ row }) => (row.getValue("periodLabel") as string) ?? "—",
   },
   {
     accessorKey: "uploaderName",
-    header: "Uploaded By",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Uploaded By" />
+    ),
     cell: ({ row }) => (row.getValue("uploaderName") as string) ?? "—",
   },
   {
     id: "actions",
-    header: "Download",
     cell: ({ row }) => (
-      <Button variant="ghost" size="icon" asChild>
-        <a
-          href={`/api/invoices/${row.original.id}/pdf`}
-          aria-label={`Download PDF for invoice ${row.original.invoiceNumber}`}
-        >
-          <Download className="size-4" />
-        </a>
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={`Download invoice ${row.original.invoiceNumber}`}
+            asChild
+          >
+            <a href={`/api/invoices/${row.original.id}/pdf`}>
+              <Download className="size-4" />
+            </a>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Download</TooltipContent>
+      </Tooltip>
     ),
   },
 ];
 
 export function InvoicesTable({ data }: { data: InvoiceRow[] }) {
-  const memoizedColumns = useMemo(() => columns, []);
-
   return (
     <DataTable
-      columns={memoizedColumns}
+      columns={columns}
       data={data}
       searchPlaceholder="Search invoices..."
     />

--- a/src/app/invoices/invoices-table.tsx
+++ b/src/app/invoices/invoices-table.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useMemo } from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/components/data-table";
+import { Button } from "@/components/ui/button";
+import { Download } from "lucide-react";
+import { formatCurrency, formatDate } from "@/lib/utils";
+
+interface InvoiceRow {
+  id: number;
+  invoiceNumber: string;
+  invoiceDate: Date | string | null;
+  amountCents: number;
+  vendor: string | null;
+  uploaderName: string | null;
+  periodLabel: string | null;
+}
+
+const columns: ColumnDef<InvoiceRow>[] = [
+  {
+    accessorKey: "invoiceNumber",
+    header: "Invoice Number",
+    cell: ({ row }) => (
+      <span className="font-medium">{row.getValue("invoiceNumber")}</span>
+    ),
+  },
+  {
+    accessorKey: "invoiceDate",
+    header: "Date",
+    cell: ({ row }) => formatDate(row.getValue("invoiceDate")),
+  },
+  {
+    accessorKey: "amountCents",
+    header: "Amount",
+    cell: ({ row }) => formatCurrency(row.getValue("amountCents")),
+  },
+  {
+    accessorKey: "vendor",
+    header: "Vendor",
+    cell: ({ row }) => (row.getValue("vendor") as string) ?? "—",
+  },
+  {
+    accessorKey: "periodLabel",
+    header: "Budget Period",
+    cell: ({ row }) => (row.getValue("periodLabel") as string) ?? "—",
+  },
+  {
+    accessorKey: "uploaderName",
+    header: "Uploaded By",
+    cell: ({ row }) => (row.getValue("uploaderName") as string) ?? "—",
+  },
+  {
+    id: "actions",
+    header: "Download",
+    cell: ({ row }) => (
+      <Button variant="ghost" size="icon" asChild>
+        <a
+          href={`/api/invoices/${row.original.id}/pdf`}
+          aria-label={`Download PDF for invoice ${row.original.invoiceNumber}`}
+        >
+          <Download className="size-4" />
+        </a>
+      </Button>
+    ),
+  },
+];
+
+export function InvoicesTable({ data }: { data: InvoiceRow[] }) {
+  const memoizedColumns = useMemo(() => columns, []);
+
+  return (
+    <DataTable
+      columns={memoizedColumns}
+      data={data}
+      searchPlaceholder="Search invoices..."
+    />
+  );
+}

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -3,19 +3,10 @@ import { redirect } from "next/navigation";
 import { db } from "@/lib/db";
 import { invoices, users, billedCosts, budgetPeriods } from "@/lib/db/schema";
 import { desc, eq } from "drizzle-orm";
-import { formatCurrency, formatDate } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Download } from "lucide-react";
 import Link from "next/link";
 import { SyncInvoicesButton } from "./sync-invoices-button";
+import { InvoicesTable } from "./invoices-table";
 
 export default async function InvoicesPage() {
   const admin = await requireAdmin();
@@ -60,41 +51,7 @@ export default async function InvoicesPage() {
           </Button>
         </div>
       ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Invoice Number</TableHead>
-              <TableHead>Date</TableHead>
-              <TableHead>Amount</TableHead>
-              <TableHead>Vendor</TableHead>
-              <TableHead>Budget Period</TableHead>
-              <TableHead>Uploaded By</TableHead>
-              <TableHead className="w-16">Download</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {invoiceList.map((invoice) => (
-              <TableRow key={invoice.id}>
-                <TableCell className="font-medium">{invoice.invoiceNumber}</TableCell>
-                <TableCell>{formatDate(invoice.invoiceDate)}</TableCell>
-                <TableCell>{formatCurrency(invoice.amountCents)}</TableCell>
-                <TableCell>{invoice.vendor ?? "—"}</TableCell>
-                <TableCell>{invoice.periodLabel ?? "—"}</TableCell>
-                <TableCell>{invoice.uploaderName ?? "—"}</TableCell>
-                <TableCell>
-                  <Button variant="ghost" size="icon" asChild>
-                    <a
-                      href={`/api/invoices/${invoice.id}/pdf`}
-                      aria-label={`Download PDF for invoice ${invoice.invoiceNumber}`}
-                    >
-                      <Download className="size-4" />
-                    </a>
-                  </Button>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <InvoicesTable data={invoiceList} />
       )}
     </div>
   );

--- a/src/app/tools/tools-table.tsx
+++ b/src/app/tools/tools-table.tsx
@@ -150,6 +150,7 @@ function getColumns(isAdmin: boolean, onArchived: () => void): ColumnDef<ToolRow
     {
       accessorKey: "vendor",
       header: ({ column }) => <DataTableColumnHeader column={column} title="Vendor" />,
+      filterFn: arrayIncludesFilterFn,
     },
     {
       accessorKey: "activeLicenses",
@@ -186,17 +187,6 @@ function getColumns(isAdmin: boolean, onArchived: () => void): ColumnDef<ToolRow
   return columns;
 }
 
-const TOOLS_FACETED_FILTERS = [
-  {
-    columnId: "status",
-    title: "Status",
-    options: [
-      { label: "Active", value: "active" },
-      { label: "Archived", value: "archived" },
-    ],
-  },
-];
-
 export function ToolsTable({
   data,
   isAdmin,
@@ -208,12 +198,32 @@ export function ToolsTable({
   const handleRefresh = useCallback(() => router.refresh(), [router]);
   const columns = useMemo(() => getColumns(isAdmin, handleRefresh), [isAdmin, handleRefresh]);
 
+  const facetedFilters = useMemo(() => {
+    const uniqueVendors = [...new Set(data.map((t) => t.vendor).filter(Boolean))]
+      .sort()
+      .map((v) => ({ label: v!, value: v! }));
+
+    return [
+      {
+        columnId: "status",
+        title: "Status",
+        options: [
+          { label: "Active", value: "active" },
+          { label: "Archived", value: "archived" },
+        ],
+      },
+      ...(uniqueVendors.length > 0
+        ? [{ columnId: "vendor", title: "Vendor", options: uniqueVendors }]
+        : []),
+    ];
+  }, [data]);
+
   return (
     <DataTable
       columns={columns}
       data={data}
       searchPlaceholder="Search tools..."
-      facetedFilters={TOOLS_FACETED_FILTERS}
+      facetedFilters={facetedFilters}
     />
   );
 }

--- a/src/app/tools/tools-table.tsx
+++ b/src/app/tools/tools-table.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ColumnDef } from "@tanstack/react-table";
 import { toast } from "sonner";
-import { DataTable } from "@/components/data-table";
+import { DataTable, arrayIncludesFilterFn } from "@/components/data-table";
 import { DataTableColumnHeader } from "@/components/data-table-column-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -160,7 +160,7 @@ function getColumns(isAdmin: boolean, onArchived: () => void): ColumnDef<ToolRow
     {
       accessorKey: "status",
       header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
-      filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
+      filterFn: arrayIncludesFilterFn,
       cell: ({ row }) => (
         <Badge
           variant={
@@ -186,6 +186,17 @@ function getColumns(isAdmin: boolean, onArchived: () => void): ColumnDef<ToolRow
   return columns;
 }
 
+const TOOLS_FACETED_FILTERS = [
+  {
+    columnId: "status",
+    title: "Status",
+    options: [
+      { label: "Active", value: "active" },
+      { label: "Archived", value: "archived" },
+    ],
+  },
+];
+
 export function ToolsTable({
   data,
   isAdmin,
@@ -202,16 +213,7 @@ export function ToolsTable({
       columns={columns}
       data={data}
       searchPlaceholder="Search tools..."
-      facetedFilters={[
-        {
-          columnId: "status",
-          title: "Status",
-          options: [
-            { label: "Active", value: "active" },
-            { label: "Archived", value: "archived" },
-          ],
-        },
-      ]}
+      facetedFilters={TOOLS_FACETED_FILTERS}
     />
   );
 }

--- a/src/app/tools/tools-table.tsx
+++ b/src/app/tools/tools-table.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ColumnDef } from "@tanstack/react-table";
 import { toast } from "sonner";
 import { DataTable } from "@/components/data-table";
+import { DataTableColumnHeader } from "@/components/data-table-column-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,27 +18,126 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { ArrowUpDown, Archive, Eye, Pencil } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Archive, Eye, MoreHorizontal, Pencil } from "lucide-react";
 import { archiveTool } from "@/actions/tools";
 import type { AiTool } from "@/types";
 
 type ToolRow = AiTool & { activeLicenses: number };
 
+function ToolRowActions({
+  row,
+  isAdmin,
+  onArchived,
+}: {
+  row: ToolRow;
+  isAdmin: boolean;
+  onArchived: () => void;
+}) {
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
+
+  return (
+    <div className="flex items-center gap-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="sm" variant="ghost" aria-label={`View ${row.name}`} asChild>
+            <Link href={`/tools/${row.id}`}>
+              <Eye className="size-4" />
+            </Link>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>View</TooltipContent>
+      </Tooltip>
+      {isAdmin && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button size="sm" variant="ghost" aria-label={`Edit ${row.name}`} asChild>
+              <Link href={`/tools/${row.id}`}>
+                <Pencil className="size-4" />
+              </Link>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Edit</TooltipContent>
+        </Tooltip>
+      )}
+      {isAdmin && row.status === "active" && (
+        <>
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm" aria-label={`More actions for ${row.name}`}>
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>More actions</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => setShowArchiveDialog(true)}
+              >
+                <Archive className="size-4" />
+                Archive
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <AlertDialog open={showArchiveDialog} onOpenChange={setShowArchiveDialog}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Archive {row.name}?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {row.activeLicenses > 0
+                    ? `This tool has ${row.activeLicenses} active license(s). Revoke them before archiving.`
+                    : "This will archive the tool and make it unavailable for new assignments."}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  disabled={row.activeLicenses > 0}
+                  onClick={async () => {
+                    try {
+                      const result = await archiveTool({ id: row.id });
+                      if (result.success) {
+                        toast.success("Tool archived");
+                        onArchived();
+                      } else {
+                        toast.error(result.error);
+                      }
+                    } catch {
+                      toast.error("An unexpected error occurred");
+                    }
+                  }}
+                >
+                  Archive
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </>
+      )}
+    </div>
+  );
+}
+
 function getColumns(isAdmin: boolean, onArchived: () => void): ColumnDef<ToolRow>[] {
   const columns: ColumnDef<ToolRow>[] = [
     {
       accessorKey: "name",
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Name
-          <ArrowUpDown className="ml-2 size-4" />
-        </Button>
-      ),
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
       cell: ({ row }) => (
         <Link
           href={`/tools/${row.original.id}`}
@@ -49,23 +149,18 @@ function getColumns(isAdmin: boolean, onArchived: () => void): ColumnDef<ToolRow
     },
     {
       accessorKey: "vendor",
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Vendor
-          <ArrowUpDown className="ml-2 size-4" />
-        </Button>
-      ),
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Vendor" />,
     },
     {
       accessorKey: "activeLicenses",
-      header: "Active Licenses",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Active Licenses" />
+      ),
     },
     {
       accessorKey: "status",
-      header: "Status",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
+      filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
       cell: ({ row }) => (
         <Badge
           variant={
@@ -79,67 +174,11 @@ function getColumns(isAdmin: boolean, onArchived: () => void): ColumnDef<ToolRow
     {
       id: "actions",
       cell: ({ row }) => (
-        <div className="flex items-center gap-1">
-          <Button size="sm" variant="ghost" asChild>
-            <Link href={`/tools/${row.original.id}`}>
-              <Eye className="size-4" />
-              <span className="sr-only">View</span>
-            </Link>
-          </Button>
-          {isAdmin && (
-            <Button size="sm" variant="ghost" asChild>
-              <Link href={`/tools/${row.original.id}`}>
-                <Pencil className="size-4" />
-                <span className="sr-only">Edit</span>
-              </Link>
-            </Button>
-          )}
-          {isAdmin && (
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  disabled={row.original.status !== "active"}
-                >
-                  <Archive className="size-4" />
-                  <span className="sr-only">Archive</span>
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Archive {row.original.name}?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    {row.original.activeLicenses > 0
-                      ? `This tool has ${row.original.activeLicenses} active license(s). Revoke them before archiving.`
-                      : "This will archive the tool and make it unavailable for new assignments."}
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    disabled={row.original.activeLicenses > 0}
-                    onClick={async () => {
-                      try {
-                        const result = await archiveTool({ id: row.original.id });
-                        if (result.success) {
-                          toast.success("Tool archived");
-                          onArchived();
-                        } else {
-                          toast.error(result.error);
-                        }
-                      } catch {
-                        toast.error("An unexpected error occurred");
-                      }
-                    }}
-                  >
-                    Archive
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          )}
-        </div>
+        <ToolRowActions
+          row={row.original}
+          isAdmin={isAdmin}
+          onArchived={onArchived}
+        />
       ),
     },
   ];
@@ -163,6 +202,16 @@ export function ToolsTable({
       columns={columns}
       data={data}
       searchPlaceholder="Search tools..."
+      facetedFilters={[
+        {
+          columnId: "status",
+          title: "Status",
+          options: [
+            { label: "Active", value: "active" },
+            { label: "Archived", value: "archived" },
+          ],
+        },
+      ]}
     />
   );
 }

--- a/src/app/users/users-table.tsx
+++ b/src/app/users/users-table.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "@/components/data-table";
+import { DataTableColumnHeader } from "@/components/data-table-column-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,25 +18,103 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { ArrowUpDown, Eye, Pencil, UserX } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Eye, MoreHorizontal, Pencil, UserX } from "lucide-react";
 import { deactivateUser } from "@/actions/users";
 import type { User } from "@/types";
+
+function UserRowActions({ row, isAdmin, onDeactivated }: { row: User; isAdmin: boolean; onDeactivated: () => void }) {
+  const [showDeactivateDialog, setShowDeactivateDialog] = useState(false);
+  return (
+    <div className="flex items-center gap-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="sm" variant="ghost" aria-label={`View ${row.name}`} asChild>
+            <Link href={`/users/${row.id}`}><Eye className="size-4" /></Link>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>View</TooltipContent>
+      </Tooltip>
+      {isAdmin && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button size="sm" variant="ghost" aria-label={`Edit ${row.name}`} asChild>
+              <Link href={`/users/${row.id}`}><Pencil className="size-4" /></Link>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Edit</TooltipContent>
+        </Tooltip>
+      )}
+      {isAdmin && row.status === "active" && (
+        <>
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm" aria-label={`More actions for ${row.name}`}>
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>More actions</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem variant="destructive" onSelect={() => setShowDeactivateDialog(true)}>
+                <UserX className="size-4" />
+                Deactivate
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <AlertDialog open={showDeactivateDialog} onOpenChange={setShowDeactivateDialog}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Deactivate {row.name}?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will deactivate the user and revoke all their active license assignments.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={async () => {
+                  try {
+                    const result = await deactivateUser({ id: row.id });
+                    if (result.success) {
+                      toast.success(`User deactivated. ${result.data.revokedCount} license(s) revoked.`);
+                      onDeactivated();
+                    } else {
+                      toast.error(result.error);
+                    }
+                  } catch {
+                    toast.error("An unexpected error occurred");
+                  }
+                }}>
+                  Deactivate
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </>
+      )}
+    </div>
+  );
+}
 
 function getColumns(isAdmin: boolean, onDeactivated: () => void): ColumnDef<User>[] {
   const columns: ColumnDef<User>[] = [
     {
       accessorKey: "name",
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Name
-          <ArrowUpDown className="ml-2 size-4" />
-        </Button>
-      ),
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
       cell: ({ row }) => (
         <Link
           href={`/users/${row.original.id}`}
@@ -47,24 +126,17 @@ function getColumns(isAdmin: boolean, onDeactivated: () => void): ColumnDef<User
     },
     {
       accessorKey: "email",
-      header: "Email",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Email" />,
     },
     {
       accessorKey: "circle",
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Circle
-          <ArrowUpDown className="ml-2 size-4" />
-        </Button>
-      ),
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Circle" />,
       cell: ({ row }) => row.getValue("circle") || "\u2014",
     },
     {
       accessorKey: "role",
-      header: "Role",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Role" />,
+      filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
       cell: ({ row }) => (
         <Badge variant="outline" className="capitalize">
           {row.getValue("role") as string}
@@ -73,7 +145,7 @@ function getColumns(isAdmin: boolean, onDeactivated: () => void): ColumnDef<User
     },
     {
       accessorKey: "profile",
-      header: "Profile",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Profile" />,
       cell: ({ row }) => {
         const profile = row.getValue("profile") as string | null;
         return profile ? (
@@ -87,7 +159,8 @@ function getColumns(isAdmin: boolean, onDeactivated: () => void): ColumnDef<User
     },
     {
       accessorKey: "status",
-      header: "Status",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
+      filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
       cell: ({ row }) => (
         <Badge
           variant={
@@ -101,60 +174,11 @@ function getColumns(isAdmin: boolean, onDeactivated: () => void): ColumnDef<User
     {
       id: "actions",
       cell: ({ row }) => (
-        <div className="flex items-center gap-1">
-          <Button size="sm" variant="ghost" asChild>
-            <Link href={`/users/${row.original.id}`}>
-              <Eye className="size-4" />
-              <span className="sr-only">View</span>
-            </Link>
-          </Button>
-          {isAdmin && (
-            <Button size="sm" variant="ghost" asChild>
-              <Link href={`/users/${row.original.id}`}>
-                <Pencil className="size-4" />
-                <span className="sr-only">Edit</span>
-              </Link>
-            </Button>
-          )}
-          {isAdmin && row.original.status === "active" && (
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button size="sm" variant="ghost">
-                  <UserX className="size-4" />
-                  <span className="sr-only">Deactivate</span>
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Deactivate {row.original.name}?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will deactivate the user and revoke all their active license assignments.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={async () => {
-                      try {
-                        const result = await deactivateUser({ id: row.original.id });
-                        if (result.success) {
-                          toast.success(`User deactivated. ${result.data.revokedCount} license(s) revoked.`);
-                          onDeactivated();
-                        } else {
-                          toast.error(result.error);
-                        }
-                      } catch {
-                        toast.error("An unexpected error occurred");
-                      }
-                    }}
-                  >
-                    Deactivate
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          )}
-        </div>
+        <UserRowActions
+          row={row.original}
+          isAdmin={isAdmin}
+          onDeactivated={onDeactivated}
+        />
       ),
     },
   ];
@@ -194,6 +218,16 @@ export function UsersTable({
         columns={columns}
         data={filteredData}
         searchPlaceholder="Search users..."
+        facetedFilters={[
+          { columnId: "role", title: "Role", options: [
+            { label: "Admin", value: "admin" },
+            { label: "Viewer", value: "viewer" },
+          ]},
+          { columnId: "status", title: "Status", options: [
+            { label: "Active", value: "active" },
+            { label: "Inactive", value: "inactive" },
+          ]},
+        ]}
       />
     </div>
   );

--- a/src/app/users/users-table.tsx
+++ b/src/app/users/users-table.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { ColumnDef } from "@tanstack/react-table";
-import { DataTable } from "@/components/data-table";
+import { DataTable, arrayIncludesFilterFn } from "@/components/data-table";
 import { DataTableColumnHeader } from "@/components/data-table-column-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -136,7 +136,7 @@ function getColumns(isAdmin: boolean, onDeactivated: () => void): ColumnDef<User
     {
       accessorKey: "role",
       header: ({ column }) => <DataTableColumnHeader column={column} title="Role" />,
-      filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
+      filterFn: arrayIncludesFilterFn,
       cell: ({ row }) => (
         <Badge variant="outline" className="capitalize">
           {row.getValue("role") as string}
@@ -160,7 +160,7 @@ function getColumns(isAdmin: boolean, onDeactivated: () => void): ColumnDef<User
     {
       accessorKey: "status",
       header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
-      filterFn: (row, id, value: string[]) => value.includes(row.getValue(id)),
+      filterFn: arrayIncludesFilterFn,
       cell: ({ row }) => (
         <Badge
           variant={
@@ -185,6 +185,25 @@ function getColumns(isAdmin: boolean, onDeactivated: () => void): ColumnDef<User
 
   return columns;
 }
+
+const USERS_FACETED_FILTERS = [
+  {
+    columnId: "role",
+    title: "Role",
+    options: [
+      { label: "Admin", value: "admin" },
+      { label: "Viewer", value: "viewer" },
+    ],
+  },
+  {
+    columnId: "status",
+    title: "Status",
+    options: [
+      { label: "Active", value: "active" },
+      { label: "Inactive", value: "inactive" },
+    ],
+  },
+];
 
 export function UsersTable({
   data,
@@ -218,16 +237,7 @@ export function UsersTable({
         columns={columns}
         data={filteredData}
         searchPlaceholder="Search users..."
-        facetedFilters={[
-          { columnId: "role", title: "Role", options: [
-            { label: "Admin", value: "admin" },
-            { label: "Viewer", value: "viewer" },
-          ]},
-          { columnId: "status", title: "Status", options: [
-            { label: "Active", value: "active" },
-            { label: "Inactive", value: "inactive" },
-          ]},
-        ]}
+        facetedFilters={USERS_FACETED_FILTERS}
       />
     </div>
   );

--- a/src/components/data-table-column-header.tsx
+++ b/src/components/data-table-column-header.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Column } from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DataTableColumnHeaderProps<TData, TValue> {
+  column: Column<TData, TValue>;
+  title: string;
+  className?: string;
+}
+
+export function DataTableColumnHeader<TData, TValue>({
+  column,
+  title,
+  className,
+}: DataTableColumnHeaderProps<TData, TValue>) {
+  if (!column.getCanSort()) {
+    return <div className={cn(className)}>{title}</div>;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      className={cn("-ml-3 h-8", className)}
+    >
+      {title}
+      {column.getIsSorted() === "desc" ? (
+        <ArrowDown className="ml-2 size-4" />
+      ) : column.getIsSorted() === "asc" ? (
+        <ArrowUp className="ml-2 size-4" />
+      ) : (
+        <ArrowUpDown className="ml-2 size-4" />
+      )}
+    </Button>
+  );
+}

--- a/src/components/data-table-column-header.tsx
+++ b/src/components/data-table-column-header.tsx
@@ -23,7 +23,13 @@ export function DataTableColumnHeader<TData, TValue>({
   return (
     <Button
       variant="ghost"
-      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      onClick={() => {
+        if (column.getIsSorted() === "desc") {
+          column.clearSorting();
+        } else {
+          column.toggleSorting(column.getIsSorted() === "asc");
+        }
+      }}
       className={cn("-ml-3 h-8", className)}
     >
       {title}

--- a/src/components/data-table-faceted-filter.tsx
+++ b/src/components/data-table-faceted-filter.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { type ComponentType } from "react";
+import { Column } from "@tanstack/react-table";
+import { CheckIcon, PlusCircle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+interface DataTableFacetedFilterProps<TData, TValue> {
+  column?: Column<TData, TValue>;
+  title: string;
+  options: {
+    label: string;
+    value: string;
+    icon?: ComponentType<{ className?: string }>;
+  }[];
+}
+
+export function DataTableFacetedFilter<TData, TValue>({
+  column,
+  title,
+  options,
+}: DataTableFacetedFilterProps<TData, TValue>) {
+  const facets = column?.getFacetedUniqueValues();
+  const selectedValues = new Set(column?.getFilterValue() as string[]);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 border-dashed">
+          <PlusCircle className="mr-2 size-4" />
+          {title}
+          {selectedValues.size > 0 && (
+            <>
+              <Separator orientation="vertical" className="mx-2 h-4" />
+              <Badge
+                variant="secondary"
+                className="rounded-sm px-1 font-normal lg:hidden"
+              >
+                {selectedValues.size}
+              </Badge>
+              <div className="hidden space-x-1 lg:flex">
+                {selectedValues.size > 2 ? (
+                  <Badge
+                    variant="secondary"
+                    className="rounded-sm px-1 font-normal"
+                  >
+                    {selectedValues.size} selected
+                  </Badge>
+                ) : (
+                  options
+                    .filter((option) => selectedValues.has(option.value))
+                    .map((option) => (
+                      <Badge
+                        variant="secondary"
+                        key={option.value}
+                        className="rounded-sm px-1 font-normal"
+                      >
+                        {option.label}
+                      </Badge>
+                    ))
+                )}
+              </div>
+            </>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder={title} />
+          <CommandList>
+            <CommandEmpty>No results found.</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => {
+                const isSelected = selectedValues.has(option.value);
+                return (
+                  <CommandItem
+                    key={option.value}
+                    onSelect={() => {
+                      if (isSelected) {
+                        selectedValues.delete(option.value);
+                      } else {
+                        selectedValues.add(option.value);
+                      }
+                      const filterValues = Array.from(selectedValues);
+                      column?.setFilterValue(
+                        filterValues.length ? filterValues : undefined
+                      );
+                    }}
+                  >
+                    <div
+                      className={cn(
+                        "mr-2 flex size-4 items-center justify-center rounded-sm border border-primary",
+                        isSelected
+                          ? "bg-primary text-primary-foreground"
+                          : "opacity-50 [&_svg]:invisible"
+                      )}
+                    >
+                      <CheckIcon className="size-4" />
+                    </div>
+                    {option.icon && (
+                      <option.icon className="mr-2 size-4 text-muted-foreground" />
+                    )}
+                    <span>{option.label}</span>
+                    {facets?.get(option.value) != null && (
+                      <span className="ml-auto flex size-4 items-center justify-center font-mono text-xs">
+                        {facets.get(option.value)}
+                      </span>
+                    )}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            {selectedValues.size > 0 && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    onSelect={() => column?.setFilterValue(undefined)}
+                    className="justify-center text-center"
+                  >
+                    Clear filters
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -7,6 +7,8 @@ import {
   SortingState,
   flexRender,
   getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
@@ -29,12 +31,23 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  TooltipProvider,
+} from "@/components/ui/tooltip";
+import { DataTableFacetedFilter } from "@/components/data-table-faceted-filter";
+
+interface FacetedFilterConfig {
+  columnId: string;
+  title: string;
+  options: { label: string; value: string }[];
+}
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   searchPlaceholder?: string;
   searchKey?: string;
+  facetedFilters?: FacetedFilterConfig[];
 }
 
 export function DataTable<TData, TValue>({
@@ -42,6 +55,7 @@ export function DataTable<TData, TValue>({
   data,
   searchPlaceholder = "Search...",
   searchKey,
+  facetedFilters,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -59,27 +73,44 @@ export function DataTable<TData, TValue>({
     onColumnFiltersChange: setColumnFilters,
     onGlobalFilterChange: setGlobalFilter,
     onPaginationChange: setPagination,
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
     state: { sorting, columnFilters, globalFilter, pagination },
   });
 
   return (
+    <TooltipProvider>
     <div className="space-y-4">
-      <Input
-        placeholder={searchPlaceholder}
-        value={
-          searchKey
-            ? (table.getColumn(searchKey)?.getFilterValue() as string) ?? ""
-            : globalFilter
-        }
-        onChange={(e) => {
-          if (searchKey) {
-            table.getColumn(searchKey)?.setFilterValue(e.target.value);
-          } else {
-            setGlobalFilter(e.target.value);
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          placeholder={searchPlaceholder}
+          value={
+            searchKey
+              ? (table.getColumn(searchKey)?.getFilterValue() as string) ?? ""
+              : globalFilter
           }
-        }}
-        className="max-w-sm"
-      />
+          onChange={(e) => {
+            if (searchKey) {
+              table.getColumn(searchKey)?.setFilterValue(e.target.value);
+            } else {
+              setGlobalFilter(e.target.value);
+            }
+          }}
+          className="max-w-sm"
+        />
+        {facetedFilters?.map((filter) => {
+          const column = table.getColumn(filter.columnId);
+          if (!column) return null;
+          return (
+            <DataTableFacetedFilter
+              key={filter.columnId}
+              column={column}
+              title={filter.title}
+              options={filter.options}
+            />
+          );
+        })}
+      </div>
       <div className="overflow-x-auto rounded-md border">
         <Table>
           <TableHeader>
@@ -161,5 +192,6 @@ export function DataTable<TData, TValue>({
         </Button>
       </div>
     </div>
+    </TooltipProvider>
   );
 }

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import {
   ColumnDef,
   ColumnFiltersState,
+  FilterFn,
   SortingState,
   flexRender,
   getCoreRowModel,
@@ -14,6 +15,12 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+
+// Shared filter function for faceted (multi-select) column filters.
+// Use as `filterFn: arrayIncludesFilterFn` in column definitions.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const arrayIncludesFilterFn: FilterFn<any> = (row, id, value: string[]) =>
+  value.includes(row.getValue(id));
 import {
   Table,
   TableBody,

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -87,6 +87,7 @@ export function DataTable<TData, TValue>({
     onPaginationChange: setPagination,
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
+    defaultColumn: { sortUndefined: "last" },
     state: { sorting, columnFilters, globalFilter, pagination },
   });
 

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -18,9 +18,14 @@ import {
 
 // Shared filter function for faceted (multi-select) column filters.
 // Use as `filterFn: arrayIncludesFilterFn` in column definitions.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const arrayIncludesFilterFn: FilterFn<any> = (row, id, value: string[]) =>
-  value.includes(row.getValue(id));
+export function arrayIncludesFilterFn<TData>(
+  row: { getValue: (columnId: string) => unknown },
+  columnId: string,
+  value: string[]
+): boolean {
+  return value.includes(row.getValue(columnId) as string);
+}
+arrayIncludesFilterFn.autoRemove = (val: unknown) => !val || (Array.isArray(val) && val.length === 0);
 import {
   Table,
   TableBody,


### PR DESCRIPTION
## Summary

- **Migrate** Invoices and Budget list tables from plain HTML to the shared DataTable component
- **Add sortable columns** across all 5 tables (Tools, Users, Assignments, Invoices, Budget) via reusable `DataTableColumnHeader`
- **Add tooltips and aria-labels** to all action buttons for accessibility
- **Move destructive actions** (Archive, Deactivate, Revoke) into three-dot overflow menus with confirmation dialogs
- **Add faceted filters** on categorical columns (Status, Role) via reusable `DataTableFacetedFilter`
- **Extract shared utilities**: `arrayIncludesFilterFn`, hoisted filter configs, memoized column definitions

## Files changed

**New components (3)**:
- `src/components/data-table-column-header.tsx` — Reusable sortable column header
- `src/components/data-table-faceted-filter.tsx` — Multi-select faceted filter popover
- `src/app/invoices/invoices-table.tsx` — Client table component for invoices
- `src/app/budget/budget-table.tsx` — Client table component for budget list

**Modified (7)**:
- `src/components/data-table.tsx` — TooltipProvider wrapper, faceted filter support, shared filterFn
- `src/app/tools/tools-table.tsx` — Sorting, tooltips, overflow menu, status filter
- `src/app/users/users-table.tsx` — Sorting, tooltips, overflow menu, role/status filters
- `src/app/assignments/assignments-client.tsx` — Sorting, tooltips, overflow menu, status filter
- `src/app/invoices/page.tsx` — Delegate to InvoicesTable
- `src/app/budget/page.tsx` — Delegate to BudgetTable
- `src/app/budget/budget-list-actions.tsx` — Tooltips, overflow menu

## Test plan

- [ ] Visit `/tools` — verify column sorting (click headers), Status filter, tooltips on View/Edit, Archive in overflow menu
- [ ] Visit `/users` — verify sorting, Role + Status filters, tooltips, Deactivate in overflow menu
- [ ] Visit `/assignments` — verify sorting, Status filter, Eye icon for View, Revoke in overflow menu
- [ ] Visit `/invoices` — verify sorting on all columns, Download tooltip
- [ ] Visit `/budget` — verify sorting, Status filter, Archive in overflow menu
- [ ] Verify non-admin users see no overflow menus
- [ ] Run `pnpm typecheck && pnpm lint && pnpm build` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)