### PR TITLE
feat(016): Claude API cost tracking with profile page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Auto-generated from all feature plans. Last updated: 2026-03-02
 - Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 2 new tables, 3 table modifications, 1 new enum (013-github-copilot-integration)
 - TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30 (014-decouple-copilot-billing)
 - TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, NextAuth 5.0.0-beta.30, Recharts 2.15.4, shadcn/ui (new-york), Zod 4.3.6, Sonner (toasts), Lucide React (016-claude-api-costs)
-- Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 1 new table, 1 table modification (016-claude-api-costs)
+- Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 2 new tables (`anthropic_usage_metrics`, `anthropic_sync_status`), no modifications to existing tables (016-claude-api-costs)
 
 - **Language**: TypeScript 5.x (strict mode), Node.js LTS
 - **Framework**: Next.js 15 (App Router, Server Components, Server Actions)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-02
 - TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui (new-york), Recharts 2.15.4, TanStack Table 8.21.3, Zod 4.3.6, Sonner (toasts), Lucide React (013-github-copilot-integration)
 - Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 2 new tables, 3 table modifications, 1 new enum (013-github-copilot-integration)
 - TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30 (014-decouple-copilot-billing)
+- TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, NextAuth 5.0.0-beta.30, Recharts 2.15.4, shadcn/ui (new-york), Zod 4.3.6, Sonner (toasts), Lucide React (016-claude-api-costs)
+- Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 1 new table, 1 table modification (016-claude-api-costs)
 
 - **Language**: TypeScript 5.x (strict mode), Node.js LTS
 - **Framework**: Next.js 15 (App Router, Server Components, Server Actions)
@@ -88,9 +90,9 @@ pnpm lighthouse        # Lighthouse CI
 - Server Components by default — `"use client"` only when client interactivity needed
 
 ## Recent Changes
+- 016-claude-api-costs: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, NextAuth 5.0.0-beta.30, Recharts 2.15.4, shadcn/ui (new-york), Zod 4.3.6, Sonner (toasts), Lucide React
 - 014-decouple-copilot-billing: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30
 - 013-github-copilot-integration: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, shadcn/ui (new-york), Recharts 2.15.4, TanStack Table 8.21.3, Zod 4.3.6, Sonner (toasts), Lucide React
-- 012-better-tables: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, TanStack Table 8.21.3, shadcn/ui (new-york style), Lucide React, Sonner (toasts)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/016-claude-api-costs/checklists/requirements.md
+++ b/specs/016-claude-api-costs/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Claude API Cost Tracking
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-16
+**Updated**: 2026-03-16 (post-clarification)
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass after clarification session (4 questions resolved).
+- Clarification expanded scope to include: profile page, assigned tools display, admin cost visibility, and navigation via user menu dropdown.
+- Spec is ready for `/speckit.plan`.

--- a/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
+++ b/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
@@ -132,7 +132,9 @@ Incrementally syncs usage data from the Anthropic API into `anthropic_usage_metr
 **Constraints**:
 - Requires user to have a valid `anthropicApiKeyId` in their license assignment
 - Uses `ANTHROPIC_ADMIN_API_KEY` environment variable for authentication
-- Rate limit: avoid calling more than once per minute per user
+- **Concurrency guard**: Checks `anthropic_sync_status` before calling the API. If a sync is already in progress (started < 60s ago, not completed), returns existing data immediately. If last sync completed < 60s ago, skips API call and returns existing data.
+- On start: sets `lastSyncStartedAt = now()`. On success: sets `lastSyncCompletedAt = now()`. On failure: sets `lastSyncError`.
+- Stale lock recovery: if `lastSyncStartedAt` is > 5 minutes old with no completion, the lock is considered stale and a new sync is allowed.
 
 ### getUserCostData(userId, month?)
 

--- a/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
+++ b/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
@@ -109,28 +109,37 @@ type ProfileData = {
       }>;
       totalCents: number;
     }>;
-    lastFetchedAt: Date | null;
+    latestDataDate: string | null;  // Latest date with stored data
   };
 };
 ```
 
-### refreshCostData(userId)
+### syncAnthropicUsage(userId)
 
-Fetches fresh data from Anthropic API and updates cache.
+Incrementally syncs usage data from the Anthropic API into `anthropic_usage_metrics`. Follows the `copilot_usage_metrics` incremental sync pattern.
 
-**Input**: `userId: number` (from session)
+**Input**: `userId: number` (from session or admin context)
 
-**Output**: `ActionResult<{ lastFetchedAt: Date }>`
+**Output**: `ActionResult<{ syncedDays: number; latestDate: string }>`
+
+**Behavior**:
+- Detects latest stored date for the user in `anthropic_usage_metrics`
+- Fetches from (latest date + 1 day) to today via the Anthropic Admin API
+- On first sync (no history): backfills up to 31 days (API max per query)
+- Upserts all rows using `onConflictDoUpdate` on (userId, date, model)
+- Today's data is always re-fetched (still accumulating)
 
 **Constraints**:
-- Minimum 5 minutes between refreshes per user
 - Requires user to have a valid `anthropicApiKeyId` in their license assignment
 - Uses `ANTHROPIC_ADMIN_API_KEY` environment variable for authentication
+- Rate limit: avoid calling more than once per minute per user
 
-### getUserCostData(userId) — Admin variant
+### getUserCostData(userId, month?)
 
-Same as cost section of `getProfileData` but callable by admins for any user.
+Returns cost data for a user for a given month (defaults to current month). Reads from persistent `anthropic_usage_metrics` table, computes costs at query time.
 
-**Input**: `userId: number` (from admin context)
+**Input**: `userId: number`, `month?: string` (format "YYYY-MM", defaults to current)
 
 **Output**: Same `costData` shape as above
+
+**Callable by**: The user themselves (profile page) or admins (user detail page)

--- a/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
+++ b/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
@@ -118,9 +118,13 @@ type ProfileData = {
 
 Incrementally syncs usage data from the Anthropic API into `anthropic_usage_metrics`. Follows the `copilot_usage_metrics` incremental sync pattern.
 
-**Input**: `userId: number` (from session or admin context)
+**Input**: `userId: number`
 
 **Output**: `ActionResult<{ syncedDays: number; latestDate: string }>`
+
+**Trigger modes**:
+- **Automatic (server-side)**: Called during `getProfileData` or `getUserCostData` if the user's last sync is older than the sync interval. Runs transparently — the user sees stored data while sync happens in the background. No user-facing refresh button.
+- **Admin manual**: Admin triggers sync from the user detail page. Admin-only access enforced via `requireAdmin()`.
 
 **Behavior**:
 - Detects latest stored date for the user in `anthropic_usage_metrics`

--- a/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
+++ b/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
@@ -115,6 +115,47 @@ limit=31                              # Max days in a month
 
 If `has_more` is true, pass `page=<next_page>` to fetch additional buckets. For monthly queries with daily buckets this should not exceed 1 page (max 31 buckets).
 
+## Cron Route: POST /api/anthropic/sync
+
+Triggers usage sync for all users with valid Anthropic API keys. Called by an external cron service. Follows the same pattern as `POST /api/copilot/sync`.
+
+### Request
+
+```
+POST /api/anthropic/sync
+Authorization: Bearer {CRON_SECRET}
+```
+
+### Behavior
+
+1. Validate `CRON_SECRET` header (reject with 401 if invalid)
+2. Query all users with an active `license_assignment` that has `apiKeyEncrypted` set for an Anthropic tool
+3. For each user (sequentially to respect rate limits):
+   a. Check `anthropic_sync_status` — skip if sync already in progress or recently completed
+   b. Resolve `api_key_id` from cached `resolvedApiKeyId` or by listing org API keys
+   c. Run incremental sync (`syncAnthropicUsage`)
+4. Return JSON summary
+
+### Response
+
+```json
+{
+  "success": true,
+  "syncedUsers": 42,
+  "skippedUsers": 3,
+  "errors": [
+    { "userId": 7, "error": "API key not found in org" }
+  ]
+}
+```
+
+### Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| 401 | Missing or invalid `CRON_SECRET` |
+| 500 | Unexpected error during sync orchestration |
+
 ## Internal Server Actions
 
 ### getProfileData(userId)
@@ -169,8 +210,8 @@ Incrementally syncs usage data from the Anthropic API into `anthropic_usage_metr
 **Output**: `ActionResult<{ syncedDays: number; latestDate: string }>`
 
 **Trigger modes**:
-- **Automatic (server-side)**: Called during `getProfileData` or `getUserCostData` if the user's last sync is older than the sync interval. Runs transparently — the user sees stored data while sync happens in the background. No user-facing refresh button.
-- **Admin manual**: Admin triggers sync from the user detail page. Admin-only access enforced via `requireAdmin()`.
+- **Cron job**: Called by the `POST /api/anthropic/sync` route for each user with a valid API key. Runs sequentially across users to respect rate limits.
+- **Admin manual**: Admin triggers sync for a specific user from the user detail page. Admin-only access enforced via `requireAdmin()`.
 
 **Behavior**:
 - **Resolve API key ID** (first sync or when cached ID is missing): Decrypts user's `apiKeyEncrypted` from `license_assignments`, calls `GET /v1/organizations/api_keys?status=active`, matches `partial_key_hint` to resolve `api_key_id`, caches it in `anthropic_sync_status.resolvedApiKeyId`

--- a/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
+++ b/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
@@ -3,6 +3,52 @@
 **Feature**: 016-claude-api-costs
 **Date**: 2026-03-16
 
+## External API: Anthropic API Key Listing
+
+Used to resolve a stored API key string to its internal `api_key_id` for usage filtering.
+
+### Request
+
+```
+GET https://api.anthropic.com/v1/organizations/api_keys?status=active&limit=100
+```
+
+**Headers**: Same as usage report (Admin API key + anthropic-version).
+
+### Response
+
+```json
+{
+  "data": [
+    {
+      "id": "apikey_01ABC...",
+      "name": "Production Key",
+      "partial_key_hint": "sk-ant-...xyzw",
+      "status": "active",
+      "workspace_id": null,
+      "created_at": "2026-01-15T10:00:00Z",
+      "created_by": { "id": "user_01...", "type": "user" },
+      "type": "api_key"
+    }
+  ],
+  "has_more": false
+}
+```
+
+### Key Resolution Logic
+
+```typescript
+function resolveApiKeyId(decryptedKey: string, orgKeys: OrgApiKey[]): string | null {
+  // Match by checking if the decrypted key ends with the hint's suffix
+  const match = orgKeys.find(k => {
+    const hint = k.partial_key_hint;
+    const suffix = hint.replace(/^\.+/, ''); // Strip leading dots
+    return decryptedKey.endsWith(suffix);
+  });
+  return match?.id ?? null;
+}
+```
+
 ## External API: Anthropic Usage Report
 
 ### Request
@@ -127,14 +173,15 @@ Incrementally syncs usage data from the Anthropic API into `anthropic_usage_metr
 - **Admin manual**: Admin triggers sync from the user detail page. Admin-only access enforced via `requireAdmin()`.
 
 **Behavior**:
+- **Resolve API key ID** (first sync or when cached ID is missing): Decrypts user's `apiKeyEncrypted` from `license_assignments`, calls `GET /v1/organizations/api_keys?status=active`, matches `partial_key_hint` to resolve `api_key_id`, caches it in `anthropic_sync_status.resolvedApiKeyId`
 - Detects latest stored date for the user in `anthropic_usage_metrics`
-- Fetches from (latest date + 1 day) to today via the Anthropic Admin API
+- Fetches from (latest date + 1 day) to today via the Anthropic Admin API, filtered by `api_key_ids[]=<resolvedApiKeyId>`
 - On first sync (no history): backfills up to 31 days (API max per query)
 - Upserts all rows using `onConflictDoUpdate` on (userId, date, model)
 - Today's data is always re-fetched (still accumulating)
 
 **Constraints**:
-- Requires user to have a valid `anthropicApiKeyId` in their license assignment
+- Requires user to have a stored API key (`apiKeyEncrypted`) in their license assignment for an Anthropic tool
 - Uses `ANTHROPIC_ADMIN_API_KEY` environment variable for authentication
 - **Concurrency guard**: Checks `anthropic_sync_status` before calling the API. If a sync is already in progress (started < 60s ago, not completed), returns existing data immediately. If last sync completed < 60s ago, skips API call and returns existing data.
 - On start: sets `lastSyncStartedAt = now()`. On success: sets `lastSyncCompletedAt = now()`. On failure: sets `lastSyncError`.

--- a/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
+++ b/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
@@ -138,10 +138,26 @@ Incrementally syncs usage data from the Anthropic API into `anthropic_usage_metr
 
 ### getUserCostData(userId, month?)
 
-Returns cost data for a user for a given month (defaults to current month). Reads from persistent `anthropic_usage_metrics` table, computes costs at query time.
+Returns cost data for a user for a given month (defaults to current month). Reads `computedCostCents` directly from `anthropic_usage_metrics` — no recomputation needed.
 
 **Input**: `userId: number`, `month?: string` (format "YYYY-MM", defaults to current)
 
-**Output**: Same `costData` shape as above
+**Output**: Same `costData` shape as above, plus:
+```typescript
+{
+  // ...existing costData fields...
+  hasUnresolvedPricing: boolean; // True if any rows in the period have pricingResolved = false
+}
+```
 
 **Callable by**: The user themselves (profile page) or admins (user detail page)
+
+### recalculateUnresolvedCosts()
+
+Admin-only action. Recalculates `computedCostCents` for all rows where `pricingResolved = false`, using the current pricing table. Sets `pricingResolved = true` for rows that now resolve.
+
+**Input**: None (operates on all unresolved rows)
+
+**Output**: `ActionResult<{ updatedRows: number; stillUnresolved: number }>`
+
+**Callable by**: Admins only. Triggered after updating the pricing lookup table in code.

--- a/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
+++ b/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
@@ -69,8 +69,7 @@ starting_at=2026-03-01T00:00:00Z    # First day of current month (RFC 3339)
 ending_at=2026-03-17T00:00:00Z      # Current date + 1 day
 bucket_width=1d                       # Daily granularity
 group_by[]=model                      # Group by model
-group_by[]=api_key_id                 # Group by API key (per-user filtering)
-api_key_ids[]=<user_api_key_id>       # Filter to specific user's key
+group_by[]=api_key_id                 # Group by API key (to attribute usage per user)
 limit=31                              # Max days in a month
 ```
 
@@ -129,12 +128,12 @@ Authorization: Bearer {CRON_SECRET}
 ### Behavior
 
 1. Validate `CRON_SECRET` header (reject with 401 if invalid)
-2. Query all users with an active `license_assignment` that has `apiKeyEncrypted` set for an Anthropic tool
-3. For each user (sequentially to respect rate limits):
-   a. Check `anthropic_sync_status` — skip if sync already in progress or recently completed
-   b. Resolve `api_key_id` from cached `resolvedApiKeyId` or by listing org API keys
-   c. Run incremental sync (`syncAnthropicUsage`)
-4. Return JSON summary
+2. Check global sync lock (skip if sync already in progress)
+3. Resolve all `api_key_id` → `userId` mappings from `anthropic_sync_status` (resolve any missing via org API keys listing)
+4. Fetch ALL org usage in one API call: `group_by[]=model&group_by[]=api_key_id&bucket_width=1d` (paginate if needed)
+5. Map each result to a `userId` via the `api_key_id` mapping
+6. Upsert into `anthropic_usage_metrics` per user
+7. Return JSON summary
 
 ### Response
 
@@ -201,16 +200,38 @@ type ProfileData = {
 };
 ```
 
+### syncAllAnthropicUsage()
+
+Global sync entry point called by the cron route. Fetches all org usage in a single API call and distributes to per-user records.
+
+**Input**: None (syncs all users)
+
+**Output**: `ActionResult<{ syncedUsers: number; skippedUsers: number; errors: Array<{ userId: number; error: string }> }>`
+
+**Behavior**:
+- Resolve all `api_key_id` → `userId` mappings from `anthropic_sync_status` (resolve any missing via org API keys listing)
+- Fetch ALL org usage in one API call: `group_by[]=model&group_by[]=api_key_id&bucket_width=1d`, starting from the earliest unsynced date across all users (paginate if `has_more` is true)
+- For each result row, map `api_key_id` to a `userId` via the resolved mapping; skip rows with unknown keys
+- Upsert into `anthropic_usage_metrics` per user using `onConflictDoUpdate` on (userId, date, model)
+- Today's data is always re-fetched (still accumulating)
+- On first sync for a user (no history): backfills up to 31 days (API max per query)
+- Return summary of synced users, skipped users (no mapping or no data), and errors
+
+**Constraints**:
+- Uses `ANTHROPIC_ADMIN_API_KEY` environment variable for authentication
+- **Global concurrency guard**: Uses a global sync lock (not per-user). If a sync is already in progress (started < 60s ago, not completed), returns immediately. If last sync completed < 60s ago, skips API call.
+- On start: sets global `lastSyncStartedAt = now()`. On success: sets `lastSyncCompletedAt = now()`. On failure: sets `lastSyncError`.
+- Stale lock recovery: if `lastSyncStartedAt` is > 5 minutes old with no completion, the lock is considered stale and a new sync is allowed.
+
 ### syncAnthropicUsage(userId)
 
-Incrementally syncs usage data from the Anthropic API into `anthropic_usage_metrics`. Follows the `copilot_usage_metrics` incremental sync pattern.
+Syncs usage data from the Anthropic API for a single user. Used only for admin manual sync of a specific user.
 
 **Input**: `userId: number`
 
 **Output**: `ActionResult<{ syncedDays: number; latestDate: string }>`
 
 **Trigger modes**:
-- **Cron job**: Called by the `POST /api/anthropic/sync` route for each user with a valid API key. Runs sequentially across users to respect rate limits.
 - **Admin manual**: Admin triggers sync for a specific user from the user detail page. Admin-only access enforced via `requireAdmin()`.
 
 **Behavior**:
@@ -224,7 +245,7 @@ Incrementally syncs usage data from the Anthropic API into `anthropic_usage_metr
 **Constraints**:
 - Requires user to have a stored API key (`apiKeyEncrypted`) in their license assignment for an Anthropic tool
 - Uses `ANTHROPIC_ADMIN_API_KEY` environment variable for authentication
-- **Concurrency guard**: Checks `anthropic_sync_status` before calling the API. If a sync is already in progress (started < 60s ago, not completed), returns existing data immediately. If last sync completed < 60s ago, skips API call and returns existing data.
+- **Per-user concurrency guard**: Checks `anthropic_sync_status` before calling the API. If a sync is already in progress (started < 60s ago, not completed), returns existing data immediately. If last sync completed < 60s ago, skips API call and returns existing data.
 - On start: sets `lastSyncStartedAt = now()`. On success: sets `lastSyncCompletedAt = now()`. On failure: sets `lastSyncError`.
 - Stale lock recovery: if `lastSyncStartedAt` is > 5 minutes old with no completion, the lock is considered stale and a new sync is allowed.
 

--- a/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
+++ b/specs/016-claude-api-costs/contracts/anthropic-usage-api.md
@@ -1,0 +1,136 @@
+# Contract: Anthropic Admin API Integration
+
+**Feature**: 016-claude-api-costs
+**Date**: 2026-03-16
+
+## External API: Anthropic Usage Report
+
+### Request
+
+```
+GET https://api.anthropic.com/v1/organizations/usage_report/messages
+```
+
+**Headers**:
+```
+x-api-key: {ANTHROPIC_ADMIN_API_KEY}
+anthropic-version: 2023-06-01
+```
+
+**Query Parameters** (for our use case):
+```
+starting_at=2026-03-01T00:00:00Z    # First day of current month (RFC 3339)
+ending_at=2026-03-17T00:00:00Z      # Current date + 1 day
+bucket_width=1d                       # Daily granularity
+group_by[]=model                      # Group by model
+group_by[]=api_key_id                 # Group by API key (per-user filtering)
+api_key_ids[]=<user_api_key_id>       # Filter to specific user's key
+limit=31                              # Max days in a month
+```
+
+### Response
+
+```json
+{
+  "data": [
+    {
+      "starting_at": "2026-03-01T00:00:00Z",
+      "ending_at": "2026-03-02T00:00:00Z",
+      "results": [
+        {
+          "model": "claude-opus-4-6",
+          "api_key_id": "apikey_01ABC...",
+          "uncached_input_tokens": 150000,
+          "cache_read_input_tokens": 50000,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 10000,
+            "ephemeral_1h_input_tokens": 5000
+          },
+          "output_tokens": 75000
+        }
+      ]
+    }
+  ],
+  "has_more": false,
+  "next_page": null
+}
+```
+
+### Error Responses
+
+| Status | Meaning | Handling |
+|--------|---------|----------|
+| 401 | Invalid admin API key | Show "API configuration error — contact administrator" |
+| 403 | Insufficient permissions | Show "API key lacks required permissions — contact administrator" |
+| 429 | Rate limited | Retry after `retry-after` header value; serve cached data |
+| 500 | Server error | Serve cached data with stale notice |
+
+### Pagination
+
+If `has_more` is true, pass `page=<next_page>` to fetch additional buckets. For monthly queries with daily buckets this should not exceed 1 page (max 31 buckets).
+
+## Internal Server Actions
+
+### getProfileData(userId)
+
+Returns all data needed for the profile page.
+
+**Input**: `userId: number` (from session)
+
+**Output**:
+```typescript
+type ProfileData = {
+  user: {
+    id: number;
+    name: string;
+    email: string;
+    role: "admin" | "viewer";
+    circle: string | null;
+    profile: "boost" | "maxed" | "indie" | null;
+  };
+  assignments: Array<{
+    id: number;
+    toolName: string;
+    tierName: string;
+    assignedAt: Date;
+    status: "active" | "inactive";
+  }>;
+  costData: {
+    available: boolean;
+    error?: string;
+    monthlyTotalCents: number;
+    dailyBreakdown: Array<{
+      date: string;        // "2026-03-01"
+      models: Array<{
+        model: string;     // "claude-opus-4-6"
+        costCents: number; // Computed from tokens × pricing
+        inputTokens: number;
+        outputTokens: number;
+      }>;
+      totalCents: number;
+    }>;
+    lastFetchedAt: Date | null;
+  };
+};
+```
+
+### refreshCostData(userId)
+
+Fetches fresh data from Anthropic API and updates cache.
+
+**Input**: `userId: number` (from session)
+
+**Output**: `ActionResult<{ lastFetchedAt: Date }>`
+
+**Constraints**:
+- Minimum 5 minutes between refreshes per user
+- Requires user to have a valid `anthropicApiKeyId` in their license assignment
+- Uses `ANTHROPIC_ADMIN_API_KEY` environment variable for authentication
+
+### getUserCostData(userId) — Admin variant
+
+Same as cost section of `getProfileData` but callable by admins for any user.
+
+**Input**: `userId: number` (from admin context)
+
+**Output**: Same `costData` shape as above

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -53,7 +53,7 @@ Follows the incremental sync pattern established by `copilot_usage_metrics`:
 
 **Backfill**: On first sync for a user, fetch up to 31 days back (max per Anthropic API query). For longer backfill, chain multiple 31-day queries paginating backwards.
 
-**Manual sync**: Available to admins only (from the admin user detail page or a bulk sync action). Users see whatever data the last automatic sync produced — no user-facing refresh button.
+**Sync trigger**: Automated via a cron job calling `POST /api/anthropic/sync` (same pattern as Copilot sync at `POST /api/copilot/sync`). Admin can also trigger manually from the UI. Users have no sync controls — they see whatever data the last cron run produced.
 
 ### Pricing Lookup (Application Code)
 
@@ -164,9 +164,8 @@ anthropic_sync_status (NEW)
 
 ### Sync Triggers
 
-- **Automatic**: Sync runs automatically on profile page load if last sync is older than the sync interval (server-side, transparent to users)
-- **Admin manual sync**: Admin can trigger a sync for a user from the admin user detail page
-- **Future**: Scheduled sync via cron (out of scope for this feature, but the incremental pattern supports it)
+- **Cron job**: External cron service calls `POST /api/anthropic/sync` (protected by `CRON_SECRET`). Syncs all users with a valid API key. Same pattern as `POST /api/copilot/sync`.
+- **Admin manual sync**: Admin can trigger a sync for a specific user from the admin user detail page via a server action.
 
 ## Data Volume Estimates
 

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -68,11 +68,21 @@ type ModelPricing = {
   cacheWritePerMToken: number; // USD per million cache-creation tokens
 };
 
-// Ordered by prefix length (longest first) for greedy matching
+// Ordered by prefix length (longest first) for greedy matching.
+// Pricing source: https://docs.anthropic.com/en/docs/about-claude/pricing
 const MODEL_PRICING: ModelPricing[] = [
-  { prefix: "claude-opus-4", inputPerMToken: 15, outputPerMToken: 75, cacheReadPerMToken: 1.5, cacheWritePerMToken: 18.75 },
+  // Opus 4.0/4.1 — highest priced, used as fallback for unknown models
+  { prefix: "claude-opus-4-0", inputPerMToken: 15, outputPerMToken: 75, cacheReadPerMToken: 1.5, cacheWritePerMToken: 18.75 },
+  { prefix: "claude-opus-4-1", inputPerMToken: 15, outputPerMToken: 75, cacheReadPerMToken: 1.5, cacheWritePerMToken: 18.75 },
+  // Opus 4.5/4.6
+  { prefix: "claude-opus-4-5", inputPerMToken: 5, outputPerMToken: 25, cacheReadPerMToken: 0.5, cacheWritePerMToken: 6.25 },
+  { prefix: "claude-opus-4-6", inputPerMToken: 5, outputPerMToken: 25, cacheReadPerMToken: 0.5, cacheWritePerMToken: 6.25 },
+  // Sonnet 4.x — all same pricing
   { prefix: "claude-sonnet-4", inputPerMToken: 3, outputPerMToken: 15, cacheReadPerMToken: 0.3, cacheWritePerMToken: 3.75 },
-  { prefix: "claude-haiku-4", inputPerMToken: 0.80, outputPerMToken: 4, cacheReadPerMToken: 0.08, cacheWritePerMToken: 1 },
+  // Haiku 4.5
+  { prefix: "claude-haiku-4-5", inputPerMToken: 1, outputPerMToken: 5, cacheReadPerMToken: 0.1, cacheWritePerMToken: 1.25 },
+  // Haiku 3.5
+  { prefix: "claude-haiku-3-5", inputPerMToken: 0.80, outputPerMToken: 4, cacheReadPerMToken: 0.08, cacheWritePerMToken: 1 },
 ];
 
 function resolveModelPricing(model: string): { pricing: ModelPricing; resolved: boolean } {
@@ -83,7 +93,7 @@ function resolveModelPricing(model: string): { pricing: ModelPricing; resolved: 
 }
 ```
 
-**Prefix matching rationale**: Anthropic model identifiers include version suffixes and date stamps (e.g., `claude-opus-4-6`, `claude-opus-4-6-20260301`). Prefix matching handles minor version bumps without requiring code changes. The pricing table is ordered by prefix length (longest first) to ensure the most specific match wins.
+**Prefix matching rationale**: Anthropic model identifiers include version suffixes and date stamps (e.g., `claude-opus-4-6`, `claude-opus-4-6-20260301`). Prefix matching handles date stamp variations without requiring code changes. The pricing table uses version-specific prefixes (e.g., `claude-opus-4-6` vs `claude-opus-4-0`) because different model generations have different pricing (Opus 4.0/4.1 at $15/$75 vs Opus 4.5/4.6 at $5/$25).
 
 **Cost storage at sync time**: `computedCostCents` is calculated and stored during sync. This provides:
 - Stable historical costs (users see the same number consistently)

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -51,9 +51,9 @@ Follows the incremental sync pattern established by `copilot_usage_metrics`:
 4. **Today's data**: Always re-fetched and upserted (still accumulating)
 5. **Past days**: Immutable after the day is complete — upsert is a no-op for unchanged data
 
-**Manual refresh**: User can trigger a refresh which re-fetches the current day. Past days are not re-fetched unless a backfill is explicitly triggered.
-
 **Backfill**: On first sync for a user, fetch up to 31 days back (max per Anthropic API query). For longer backfill, chain multiple 31-day queries paginating backwards.
+
+**Manual sync**: Available to admins only (from the admin user detail page or a bulk sync action). Users see whatever data the last automatic sync produced — no user-facing refresh button.
 
 ### Pricing Lookup (Application Code)
 
@@ -168,10 +168,10 @@ anthropic_sync_status (NEW)
 - **Daily Incremental Sync**: Each sync detects the latest stored date and fetches only new days. Today's row is upserted (still accumulating).
 - **Immutable History**: Past days are never modified after the day is complete. Data persists indefinitely for long-term trend analysis.
 
-### Refresh Triggers
+### Sync Triggers
 
-- **Manual**: User clicks "Refresh" on profile page → re-syncs current day only
-- **Admin sync**: Admin can trigger a full sync for a user from the admin detail page
+- **Automatic**: Sync runs automatically on profile page load if last sync is older than the sync interval (server-side, transparent to users)
+- **Admin manual sync**: Admin can trigger a sync for a user from the admin user detail page
 - **Future**: Scheduled sync via cron (out of scope for this feature, but the incremental pattern supports it)
 
 ## Data Volume Estimates

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -16,10 +16,10 @@ Stores daily token usage data fetched from the Anthropic Admin API as a permanen
 | userId | integer | FK → users.id, NOT NULL | The user whose usage this represents |
 | date | date | NOT NULL | The calendar date of usage |
 | model | varchar(100) | NOT NULL | Anthropic model identifier (e.g., "claude-opus-4-6") |
-| uncachedInputTokens | integer | NOT NULL, DEFAULT 0 | Non-cached input tokens consumed |
-| cacheReadInputTokens | integer | NOT NULL, DEFAULT 0 | Cache-read input tokens consumed |
-| cacheCreationInputTokens | integer | NOT NULL, DEFAULT 0 | Cache creation input tokens (all durations combined) |
-| outputTokens | integer | NOT NULL, DEFAULT 0 | Output tokens generated |
+| uncachedInputTokens | bigint | NOT NULL, DEFAULT 0 | Non-cached input tokens consumed |
+| cacheReadInputTokens | bigint | NOT NULL, DEFAULT 0 | Cache-read input tokens consumed |
+| cacheCreationInputTokens | bigint | NOT NULL, DEFAULT 0 | Cache creation input tokens (all durations combined) |
+| outputTokens | bigint | NOT NULL, DEFAULT 0 | Output tokens generated |
 | createdAt | timestamp | NOT NULL, DEFAULT now() | Row creation time |
 | updatedAt | timestamp | NOT NULL, DEFAULT now() | Row last update time |
 
@@ -35,7 +35,7 @@ Stores daily token usage data fetched from the Anthropic Admin API as a permanen
 **Notes**:
 - This is **permanent storage**, not a cache. Historical days are immutable; today's data is upserted (accumulating throughout the day).
 - Costs are NOT stored — they are computed at read time from token counts using a pricing lookup. This ensures pricing updates apply retroactively.
-- Token counts are integers (no fractional tokens).
+- Token counts use `bigint` (not `integer`) to safely handle heavy API users. A single day of aggressive long-context usage can produce hundreds of millions of tokens, exceeding 32-bit integer limits. In Drizzle, use `bigint('column', { mode: 'number' })` since values stay within JS safe integer range for daily per-model granularity.
 - The `model` field stores the exact model identifier returned by the Anthropic API (e.g., "claude-opus-4-6", "claude-sonnet-4-6").
 
 ### Sync Behavior

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -108,11 +108,19 @@ Tracks the last sync time per user to prevent concurrent syncs and enforce rate 
 | lastSyncCompletedAt | timestamp | NULLABLE | When the last sync completed successfully |
 | lastSyncError | varchar(500) | NULLABLE | Error message from last failed sync, if any |
 | syncedDays | integer | NOT NULL, DEFAULT 0 | Number of days synced in last run |
+| resolvedApiKeyId | varchar(100) | NULLABLE | The Anthropic-internal `api_key_id` resolved from the user's stored API key via the Admin API. Cached to avoid re-resolving on every sync. |
 
 **Unique constraint**: (userId)
 
 **Relationships**:
 - `userId` → `users.id` (one-to-one, CASCADE on delete)
+
+**API Key ID Resolution**: The Anthropic Admin API filters usage by `api_key_id` (an internal identifier), not by the API key string. To map a stored API key to its `api_key_id`:
+1. Decrypt the user's `apiKeyEncrypted` from their `license_assignment`
+2. Call `GET /v1/organizations/api_keys?status=active` to list all org API keys
+3. Match the decrypted key against each entry's `partial_key_hint` field (suffix match)
+4. Store the resolved `id` as `resolvedApiKeyId` in this table
+5. On subsequent syncs, reuse `resolvedApiKeyId` without re-resolving (unless the key changes)
 
 **Concurrency guard behavior**:
 1. Before starting a sync, check `lastSyncStartedAt`:
@@ -124,29 +132,15 @@ Tracks the last sync time per user to prevent concurrent syncs and enforce rate 
 
 ## Modified Entities
 
-### license_assignments (existing)
-
-Add one new field to store the Anthropic API key ID used for usage filtering.
-
-| Field | Type | Constraints | Description |
-|-------|------|-------------|-------------|
-| anthropicApiKeyId | varchar(100) | NULLABLE | The Anthropic-internal API key ID, used to filter usage_report queries. Set by admin when configuring the assignment. |
-
-**Migration notes**:
-- Add column with `ALTER TABLE license_assignments ADD COLUMN anthropic_api_key_id varchar(100)` (nullable, no default)
-- Only relevant for assignments where the tool is Claude/Anthropic
-- Populated by admin when configuring a user's API key assignment
+No modifications to existing tables. The existing `license_assignments.apiKeyEncrypted` field is used as-is — the Anthropic `api_key_id` is resolved automatically at sync time and cached in `anthropic_sync_status.resolvedApiKeyId`.
 
 ## Entity Relationship Summary
 
 ```
 users (existing)
-  ├── 1:N → license_assignments (existing, +anthropicApiKeyId)
+  ├── 1:N → license_assignments (existing, unchanged — apiKeyEncrypted used for key resolution)
   ├── 1:N → anthropic_usage_metrics (NEW)
-  └── 1:1 → anthropic_sync_status (NEW)
-
-license_assignments (existing)
-  └── anthropicApiKeyId: used to query Anthropic API for this user's usage
+  └── 1:1 → anthropic_sync_status (NEW, includes cached resolvedApiKeyId)
 
 anthropic_usage_metrics (NEW)
   └── userId → users.id

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -1,0 +1,109 @@
+# Data Model: Claude API Cost Tracking
+
+**Feature**: 016-claude-api-costs
+**Date**: 2026-03-16
+
+## New Entities
+
+### anthropic_usage_cache
+
+Caches daily token usage data fetched from the Anthropic Admin API. One row per user per day per model.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| id | serial | PK, auto-increment | Row identifier |
+| userId | integer | FK → users.id, NOT NULL | The user whose usage this represents |
+| date | date | NOT NULL | The calendar date of usage |
+| model | varchar(100) | NOT NULL | Anthropic model identifier (e.g., "claude-opus-4-6") |
+| uncachedInputTokens | integer | NOT NULL, DEFAULT 0 | Non-cached input tokens consumed |
+| cacheReadInputTokens | integer | NOT NULL, DEFAULT 0 | Cache-read input tokens consumed |
+| cacheCreationInputTokens | integer | NOT NULL, DEFAULT 0 | Cache creation input tokens (all durations combined) |
+| outputTokens | integer | NOT NULL, DEFAULT 0 | Output tokens generated |
+| fetchedAt | timestamp | NOT NULL | When this data was last fetched from API |
+| createdAt | timestamp | NOT NULL, DEFAULT now() | Row creation time |
+| updatedAt | timestamp | NOT NULL, DEFAULT now() | Row last update time |
+
+**Unique constraint**: (userId, date, model)
+
+**Indexes**:
+- `idx_usage_cache_user_date` on (userId, date) — primary query pattern for profile page
+- `idx_usage_cache_fetched` on (fetchedAt) — cache invalidation queries
+
+**Relationships**:
+- `userId` → `users.id` (many-to-one, CASCADE on delete)
+
+**Notes**:
+- Costs are NOT stored — they are computed at read time from token counts using a pricing lookup. This ensures pricing updates apply retroactively.
+- Token counts are integers (no fractional tokens).
+- The `model` field stores the exact model identifier returned by the Anthropic API (e.g., "claude-opus-4-6", "claude-sonnet-4-6").
+
+### Pricing Lookup (Application Code)
+
+Not a database table — defined as a TypeScript constant map. Maps model identifiers to per-token pricing in USD.
+
+```typescript
+type ModelPricing = {
+  inputPerMToken: number;      // USD per million input tokens
+  outputPerMToken: number;     // USD per million output tokens
+  cacheReadPerMToken: number;  // USD per million cache-read tokens
+  cacheWritePerMToken: number; // USD per million cache-creation tokens
+};
+
+const MODEL_PRICING: Record<string, ModelPricing> = {
+  "claude-opus-4-6": { inputPerMToken: 15, outputPerMToken: 75, cacheReadPerMToken: 1.5, cacheWritePerMToken: 18.75 },
+  "claude-sonnet-4-6": { inputPerMToken: 3, outputPerMToken: 15, cacheReadPerMToken: 0.3, cacheWritePerMToken: 3.75 },
+  "claude-haiku-4-5": { inputPerMToken: 0.80, outputPerMToken: 4, cacheReadPerMToken: 0.08, cacheWritePerMToken: 1 },
+  // Fallback for unknown models: use highest pricing (conservative)
+};
+```
+
+## Modified Entities
+
+### license_assignments (existing)
+
+Add one new field to store the Anthropic API key ID used for usage filtering.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| anthropicApiKeyId | varchar(100) | NULLABLE | The Anthropic-internal API key ID, used to filter usage_report queries. Set by admin when configuring the assignment. |
+
+**Migration notes**:
+- Add column with `ALTER TABLE license_assignments ADD COLUMN anthropic_api_key_id varchar(100)` (nullable, no default)
+- Only relevant for assignments where the tool is Claude/Anthropic
+- Populated by admin when configuring a user's API key assignment
+
+## Entity Relationship Summary
+
+```
+users (existing)
+  ├── 1:N → license_assignments (existing, +anthropicApiKeyId)
+  └── 1:N → anthropic_usage_cache (NEW)
+
+license_assignments (existing)
+  └── anthropicApiKeyId: used to query Anthropic API for this user's usage
+
+anthropic_usage_cache (NEW)
+  └── userId → users.id
+```
+
+## State Transitions
+
+### Cache Entry Lifecycle
+
+```
+[Empty] → [Fresh] → [Stale] → [Refreshed/Fresh]
+```
+
+- **Empty**: No cache entry exists for this user/date/model
+- **Fresh**: `fetchedAt` is within the last 5 minutes
+- **Stale**: `fetchedAt` is older than 5 minutes
+- **Refreshed**: User triggered manual refresh, cache updated with new data
+
+Cache entries are upserted (insert or update on conflict of unique constraint).
+
+## Data Volume Estimates
+
+- Per user per month: ~31 days × ~3 models = ~93 rows in anthropic_usage_cache
+- For 100 users: ~9,300 rows/month
+- Annual: ~112,000 rows — well within PostgreSQL comfort zone without partitioning
+- Query pattern: Filter by userId + date range → always hits the composite index

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -20,6 +20,8 @@ Stores daily token usage data fetched from the Anthropic Admin API as a permanen
 | cacheReadInputTokens | bigint | NOT NULL, DEFAULT 0 | Cache-read input tokens consumed |
 | cacheCreationInputTokens | bigint | NOT NULL, DEFAULT 0 | Cache creation input tokens (all durations combined) |
 | outputTokens | bigint | NOT NULL, DEFAULT 0 | Output tokens generated |
+| computedCostCents | integer | NOT NULL, DEFAULT 0 | Cost in USD cents computed at sync time from tokens × pricing. Provides stable historical costs. |
+| pricingResolved | boolean | NOT NULL, DEFAULT true | False if the model was not found in the pricing table at sync time (fallback pricing used). |
 | createdAt | timestamp | NOT NULL, DEFAULT now() | Row creation time |
 | updatedAt | timestamp | NOT NULL, DEFAULT now() | Row last update time |
 
@@ -28,13 +30,14 @@ Stores daily token usage data fetched from the Anthropic Admin API as a permanen
 **Indexes**:
 - `idx_usage_metrics_user_date` on (userId, date) — primary query pattern for profile page and historical reports
 - `idx_usage_metrics_date` on (date) — enables date-range queries across all users (admin reporting)
+- `idx_usage_metrics_unresolved` on (pricingResolved) WHERE pricingResolved = false — fast lookup of rows needing pricing updates
 
 **Relationships**:
 - `userId` → `users.id` (many-to-one, CASCADE on delete)
 
 **Notes**:
 - This is **permanent storage**, not a cache. Historical days are immutable; today's data is upserted (accumulating throughout the day).
-- Costs are NOT stored — they are computed at read time from token counts using a pricing lookup. This ensures pricing updates apply retroactively.
+- Costs are computed at sync time and stored in `computedCostCents`. This provides stable historical values. Token counts are also stored for transparency and potential recalculation.
 - Token counts use `bigint` (not `integer`) to safely handle heavy API users. A single day of aggressive long-context usage can produce hundreds of millions of tokens, exceeding 32-bit integer limits. In Drizzle, use `bigint('column', { mode: 'number' })` since values stay within JS safe integer range for daily per-model granularity.
 - The `model` field stores the exact model identifier returned by the Anthropic API (e.g., "claude-opus-4-6", "claude-sonnet-4-6").
 
@@ -54,23 +57,44 @@ Follows the incremental sync pattern established by `copilot_usage_metrics`:
 
 ### Pricing Lookup (Application Code)
 
-Not a database table — defined as a TypeScript constant map. Maps model identifiers to per-token pricing in USD.
+Not a database table — defined as a TypeScript constant map. Maps model prefixes to per-token pricing in USD.
 
 ```typescript
 type ModelPricing = {
+  prefix: string;              // Model identifier prefix for matching
   inputPerMToken: number;      // USD per million input tokens
   outputPerMToken: number;     // USD per million output tokens
   cacheReadPerMToken: number;  // USD per million cache-read tokens
   cacheWritePerMToken: number; // USD per million cache-creation tokens
 };
 
-const MODEL_PRICING: Record<string, ModelPricing> = {
-  "claude-opus-4-6": { inputPerMToken: 15, outputPerMToken: 75, cacheReadPerMToken: 1.5, cacheWritePerMToken: 18.75 },
-  "claude-sonnet-4-6": { inputPerMToken: 3, outputPerMToken: 15, cacheReadPerMToken: 0.3, cacheWritePerMToken: 3.75 },
-  "claude-haiku-4-5": { inputPerMToken: 0.80, outputPerMToken: 4, cacheReadPerMToken: 0.08, cacheWritePerMToken: 1 },
-  // Fallback for unknown models: use highest pricing (conservative)
-};
+// Ordered by prefix length (longest first) for greedy matching
+const MODEL_PRICING: ModelPricing[] = [
+  { prefix: "claude-opus-4", inputPerMToken: 15, outputPerMToken: 75, cacheReadPerMToken: 1.5, cacheWritePerMToken: 18.75 },
+  { prefix: "claude-sonnet-4", inputPerMToken: 3, outputPerMToken: 15, cacheReadPerMToken: 0.3, cacheWritePerMToken: 3.75 },
+  { prefix: "claude-haiku-4", inputPerMToken: 0.80, outputPerMToken: 4, cacheReadPerMToken: 0.08, cacheWritePerMToken: 1 },
+];
+
+function resolveModelPricing(model: string): { pricing: ModelPricing; resolved: boolean } {
+  const match = MODEL_PRICING.find(p => model.startsWith(p.prefix));
+  if (match) return { pricing: match, resolved: true };
+  // Fallback: use highest pricing (conservative) and flag as unresolved
+  return { pricing: MODEL_PRICING[0], resolved: false };
+}
 ```
+
+**Prefix matching rationale**: Anthropic model identifiers include version suffixes and date stamps (e.g., `claude-opus-4-6`, `claude-opus-4-6-20260301`). Prefix matching handles minor version bumps without requiring code changes. The pricing table is ordered by prefix length (longest first) to ensure the most specific match wins.
+
+**Cost storage at sync time**: `computedCostCents` is calculated and stored during sync. This provides:
+- Stable historical costs (users see the same number consistently)
+- Fast queries (no recomputation on every page load)
+- Clear audit trail of what cost was shown
+
+**Unresolved pricing detection**: When a model is not found in the pricing table:
+1. `pricingResolved` is set to `false` on the row
+2. Fallback pricing (highest tier) is used for `computedCostCents`
+3. An admin-visible indicator surfaces the count of unresolved rows
+4. After updating the pricing table, an admin action (`recalculateUnresolvedCosts`) recomputes `computedCostCents` for all `pricingResolved = false` rows and sets them to `true`
 
 ### anthropic_sync_status
 

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -72,6 +72,32 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
 };
 ```
 
+### anthropic_sync_status
+
+Tracks the last sync time per user to prevent concurrent syncs and enforce rate limiting. One row per user.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| id | serial | PK, auto-increment | Row identifier |
+| userId | integer | FK → users.id, NOT NULL, UNIQUE | The user being synced |
+| lastSyncStartedAt | timestamp | NULLABLE | When the last sync started (used as a lock signal) |
+| lastSyncCompletedAt | timestamp | NULLABLE | When the last sync completed successfully |
+| lastSyncError | varchar(500) | NULLABLE | Error message from last failed sync, if any |
+| syncedDays | integer | NOT NULL, DEFAULT 0 | Number of days synced in last run |
+
+**Unique constraint**: (userId)
+
+**Relationships**:
+- `userId` → `users.id` (one-to-one, CASCADE on delete)
+
+**Concurrency guard behavior**:
+1. Before starting a sync, check `lastSyncStartedAt`:
+   - If `lastSyncStartedAt` is within the last 60 seconds AND `lastSyncCompletedAt` is older than `lastSyncStartedAt` → sync is in progress, skip
+   - If `lastSyncStartedAt` is older than 5 minutes with no completion → treat as stale/failed, allow new sync
+2. Set `lastSyncStartedAt = now()` before calling the API
+3. Set `lastSyncCompletedAt = now()` after success, or `lastSyncError` after failure
+4. This prevents: concurrent syncs per user, redundant API calls on rapid page load + refresh, and rate limit exhaustion across the org
+
 ## Modified Entities
 
 ### license_assignments (existing)
@@ -92,13 +118,17 @@ Add one new field to store the Anthropic API key ID used for usage filtering.
 ```
 users (existing)
   ├── 1:N → license_assignments (existing, +anthropicApiKeyId)
-  └── 1:N → anthropic_usage_metrics (NEW)
+  ├── 1:N → anthropic_usage_metrics (NEW)
+  └── 1:1 → anthropic_sync_status (NEW)
 
 license_assignments (existing)
   └── anthropicApiKeyId: used to query Anthropic API for this user's usage
 
 anthropic_usage_metrics (NEW)
   └── userId → users.id
+
+anthropic_sync_status (NEW)
+  └── userId → users.id (unique, one-to-one)
 ```
 
 ## Data Lifecycle

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -45,15 +45,15 @@ Stores daily token usage data fetched from the Anthropic Admin API as a permanen
 
 Follows the incremental sync pattern established by `copilot_usage_metrics`:
 
-1. **Detect latest stored date**: Query `MAX(date)` for the user from `anthropic_usage_metrics`
-2. **Fetch only new data**: Set `starting_at` to latest date + 1 day (or first of current month if no history)
-3. **Upsert rows**: Use `onConflictDoUpdate` on the unique (userId, date, model) constraint
-4. **Today's data**: Always re-fetched and upserted (still accumulating)
-5. **Past days**: Immutable after the day is complete — upsert is a no-op for unchanged data
+1. **Fetch all org usage**: Single API call with `group_by[]=model&group_by[]=api_key_id&bucket_width=1d` — no per-user filtering
+2. **Resolve api_key_id mappings**: Build a map of api_key_id → userId from `anthropic_sync_status.resolvedApiKeyId` (resolve any unmapped keys first via the org API keys listing)
+3. **Map and upsert**: For each result row, look up the userId from the api_key_id map and upsert into `anthropic_usage_metrics`
+4. **Unmatched keys**: Usage from api_key_ids that don't map to any user is silently skipped (could be API keys not managed in this system)
+5. **Incremental range**: Use the oldest `MAX(date)` across all users as the starting point, or 31 days back if no data exists
 
-**Backfill**: On first sync for a user, fetch up to 31 days back (max per Anthropic API query). For longer backfill, chain multiple 31-day queries paginating backwards.
+**Backfill**: On first sync (no data for any user), fetch up to 31 days back (max per Anthropic API query). For longer backfill, chain multiple 31-day queries paginating backwards.
 
-**Sync trigger**: Automated via a cron job calling `POST /api/anthropic/sync` (same pattern as Copilot sync at `POST /api/copilot/sync`). Admin can also trigger manually from the UI. Users have no sync controls — they see whatever data the last cron run produced.
+**Sync trigger**: Automated via a cron job calling `POST /api/anthropic/sync` (same pattern as Copilot sync at `POST /api/copilot/sync`). This is a single-pass global sync — one API call retrieves usage for the entire org, then results are mapped to individual users. Admin can also trigger manually from the UI. Users have no sync controls — they see whatever data the last cron run produced.
 
 ### Pricing Lookup (Application Code)
 
@@ -98,14 +98,14 @@ function resolveModelPricing(model: string): { pricing: ModelPricing; resolved: 
 
 ### anthropic_sync_status
 
-Tracks the last sync time per user to prevent concurrent syncs and enforce rate limiting. One row per user.
+Tracks per-user sync metadata and cached API key mappings. One row per user. Also used for route-level concurrency guards on the global sync.
 
 | Field | Type | Constraints | Description |
 |-------|------|-------------|-------------|
 | id | serial | PK, auto-increment | Row identifier |
 | userId | integer | FK → users.id, NOT NULL, UNIQUE | The user being synced |
-| lastSyncStartedAt | timestamp | NULLABLE | When the last sync started (used as a lock signal) |
-| lastSyncCompletedAt | timestamp | NULLABLE | When the last sync completed successfully |
+| lastSyncStartedAt | timestamp | NULLABLE | When the last global sync started (written to all rows atomically as a lock signal) |
+| lastSyncCompletedAt | timestamp | NULLABLE | When the last global sync completed successfully for this user |
 | lastSyncError | varchar(500) | NULLABLE | Error message from last failed sync, if any |
 | syncedDays | integer | NOT NULL, DEFAULT 0 | Number of days synced in last run |
 | resolvedApiKeyId | varchar(100) | NULLABLE | The Anthropic-internal `api_key_id` resolved from the user's stored API key via the Admin API. Cached to avoid re-resolving on every sync. |
@@ -122,13 +122,17 @@ Tracks the last sync time per user to prevent concurrent syncs and enforce rate 
 4. Store the resolved `id` as `resolvedApiKeyId` in this table
 5. On subsequent syncs, reuse `resolvedApiKeyId` without re-resolving (unless the key changes)
 
-**Concurrency guard behavior**:
-1. Before starting a sync, check `lastSyncStartedAt`:
-   - If `lastSyncStartedAt` is within the last 60 seconds AND `lastSyncCompletedAt` is older than `lastSyncStartedAt` → sync is in progress, skip
-   - If `lastSyncStartedAt` is older than 5 minutes with no completion → treat as stale/failed, allow new sync
-2. Set `lastSyncStartedAt = now()` before calling the API
-3. Set `lastSyncCompletedAt = now()` after success, or `lastSyncError` after failure
-4. This prevents: concurrent syncs per user, redundant API calls on rapid page load + refresh, and rate limit exhaustion across the org
+**Concurrency guard behavior** (global sync level):
+
+Since the sync is now a single-pass global operation (not per-user), the concurrency guard operates at the route level:
+
+1. Before starting the global sync, check if ANY `anthropic_sync_status` row has `lastSyncStartedAt` within the last 60 seconds AND `lastSyncCompletedAt` older than `lastSyncStartedAt` → a sync is already in progress, return early
+2. If the most recent `lastSyncStartedAt` across all rows is older than 5 minutes with no corresponding completion → treat as stale/failed, allow a new sync
+3. Set `lastSyncStartedAt = now()` on all user rows before calling the API (atomic update acts as a global lock)
+4. After the sync completes, set `lastSyncCompletedAt = now()` on each user row that received data, or `lastSyncError` on rows where mapping/upsert failed
+5. This prevents: overlapping global syncs from concurrent cron invocations, redundant API calls, and rate limit exhaustion
+
+Per-user rows are retained for: `resolvedApiKeyId` caching, per-user `lastSyncCompletedAt` tracking (useful for admin visibility into which users have fresh data), and per-user error reporting.
 
 ## Modified Entities
 
@@ -164,7 +168,7 @@ anthropic_sync_status (NEW)
 
 ### Sync Triggers
 
-- **Cron job**: External cron service calls `POST /api/anthropic/sync` (protected by `CRON_SECRET`). Syncs all users with a valid API key. Same pattern as `POST /api/copilot/sync`.
+- **Cron job**: External cron service calls `POST /api/anthropic/sync` (protected by `CRON_SECRET`). Fetches all org usage in one pass (1–2 API calls) regardless of user count, then maps results to users via cached api_key_id mappings. Same pattern as `POST /api/copilot/sync`.
 - **Admin manual sync**: Admin can trigger a sync for a specific user from the admin user detail page via a server action.
 
 ## Data Volume Estimates

--- a/specs/016-claude-api-costs/data-model.md
+++ b/specs/016-claude-api-costs/data-model.md
@@ -2,12 +2,13 @@
 
 **Feature**: 016-claude-api-costs
 **Date**: 2026-03-16
+**Updated**: 2026-03-16 (revised: persistent history instead of cache)
 
 ## New Entities
 
-### anthropic_usage_cache
+### anthropic_usage_metrics
 
-Caches daily token usage data fetched from the Anthropic Admin API. One row per user per day per model.
+Stores daily token usage data fetched from the Anthropic Admin API as a permanent historical record. One row per user per day per model. Follows the same pattern as `copilot_usage_metrics` — data is persisted indefinitely for long-term cost monitoring and trend analysis.
 
 | Field | Type | Constraints | Description |
 |-------|------|-------------|-------------|
@@ -19,23 +20,37 @@ Caches daily token usage data fetched from the Anthropic Admin API. One row per 
 | cacheReadInputTokens | integer | NOT NULL, DEFAULT 0 | Cache-read input tokens consumed |
 | cacheCreationInputTokens | integer | NOT NULL, DEFAULT 0 | Cache creation input tokens (all durations combined) |
 | outputTokens | integer | NOT NULL, DEFAULT 0 | Output tokens generated |
-| fetchedAt | timestamp | NOT NULL | When this data was last fetched from API |
 | createdAt | timestamp | NOT NULL, DEFAULT now() | Row creation time |
 | updatedAt | timestamp | NOT NULL, DEFAULT now() | Row last update time |
 
 **Unique constraint**: (userId, date, model)
 
 **Indexes**:
-- `idx_usage_cache_user_date` on (userId, date) — primary query pattern for profile page
-- `idx_usage_cache_fetched` on (fetchedAt) — cache invalidation queries
+- `idx_usage_metrics_user_date` on (userId, date) — primary query pattern for profile page and historical reports
+- `idx_usage_metrics_date` on (date) — enables date-range queries across all users (admin reporting)
 
 **Relationships**:
 - `userId` → `users.id` (many-to-one, CASCADE on delete)
 
 **Notes**:
+- This is **permanent storage**, not a cache. Historical days are immutable; today's data is upserted (accumulating throughout the day).
 - Costs are NOT stored — they are computed at read time from token counts using a pricing lookup. This ensures pricing updates apply retroactively.
 - Token counts are integers (no fractional tokens).
 - The `model` field stores the exact model identifier returned by the Anthropic API (e.g., "claude-opus-4-6", "claude-sonnet-4-6").
+
+### Sync Behavior
+
+Follows the incremental sync pattern established by `copilot_usage_metrics`:
+
+1. **Detect latest stored date**: Query `MAX(date)` for the user from `anthropic_usage_metrics`
+2. **Fetch only new data**: Set `starting_at` to latest date + 1 day (or first of current month if no history)
+3. **Upsert rows**: Use `onConflictDoUpdate` on the unique (userId, date, model) constraint
+4. **Today's data**: Always re-fetched and upserted (still accumulating)
+5. **Past days**: Immutable after the day is complete — upsert is a no-op for unchanged data
+
+**Manual refresh**: User can trigger a refresh which re-fetches the current day. Past days are not re-fetched unless a backfill is explicitly triggered.
+
+**Backfill**: On first sync for a user, fetch up to 31 days back (max per Anthropic API query). For longer backfill, chain multiple 31-day queries paginating backwards.
 
 ### Pricing Lookup (Application Code)
 
@@ -77,33 +92,39 @@ Add one new field to store the Anthropic API key ID used for usage filtering.
 ```
 users (existing)
   ├── 1:N → license_assignments (existing, +anthropicApiKeyId)
-  └── 1:N → anthropic_usage_cache (NEW)
+  └── 1:N → anthropic_usage_metrics (NEW)
 
 license_assignments (existing)
   └── anthropicApiKeyId: used to query Anthropic API for this user's usage
 
-anthropic_usage_cache (NEW)
+anthropic_usage_metrics (NEW)
   └── userId → users.id
 ```
 
-## State Transitions
+## Data Lifecycle
 
-### Cache Entry Lifecycle
+### Usage Metric Lifecycle
 
 ```
-[Empty] → [Fresh] → [Stale] → [Refreshed/Fresh]
+[Empty] → [Initial Backfill] → [Daily Incremental Sync] → [Immutable History]
 ```
 
-- **Empty**: No cache entry exists for this user/date/model
-- **Fresh**: `fetchedAt` is within the last 5 minutes
-- **Stale**: `fetchedAt` is older than 5 minutes
-- **Refreshed**: User triggered manual refresh, cache updated with new data
+- **Empty**: No data exists for this user. First sync triggers a backfill (up to 31 days back).
+- **Initial Backfill**: Historical data fetched in 31-day chunks via the Anthropic API.
+- **Daily Incremental Sync**: Each sync detects the latest stored date and fetches only new days. Today's row is upserted (still accumulating).
+- **Immutable History**: Past days are never modified after the day is complete. Data persists indefinitely for long-term trend analysis.
 
-Cache entries are upserted (insert or update on conflict of unique constraint).
+### Refresh Triggers
+
+- **Manual**: User clicks "Refresh" on profile page → re-syncs current day only
+- **Admin sync**: Admin can trigger a full sync for a user from the admin detail page
+- **Future**: Scheduled sync via cron (out of scope for this feature, but the incremental pattern supports it)
 
 ## Data Volume Estimates
 
-- Per user per month: ~31 days × ~3 models = ~93 rows in anthropic_usage_cache
+- Per user per month: ~31 days × ~3 models = ~93 rows
 - For 100 users: ~9,300 rows/month
-- Annual: ~112,000 rows — well within PostgreSQL comfort zone without partitioning
+- Annual (100 users): ~112,000 rows
+- 5-year projection (100 users): ~560,000 rows — well within PostgreSQL comfort zone without partitioning
 - Query pattern: Filter by userId + date range → always hits the composite index
+- Historical queries (e.g., "last 12 months"): ~1,116 rows per user — trivial

--- a/specs/016-claude-api-costs/plan.md
+++ b/specs/016-claude-api-costs/plan.md
@@ -69,7 +69,7 @@ src/
 ├── app/api/anthropic/sync/
 │   └── route.ts                          # Cron endpoint: POST /api/anthropic/sync (CRON_SECRET auth)
 ├── actions/
-│   └── anthropic-usage.ts               # Server actions: getProfileData, syncAnthropicUsage (admin), getUserCostData
+│   └── anthropic-usage.ts               # Server actions: getProfileData, syncAllAnthropicUsage, syncAnthropicUsage (admin single-user), getUserCostData
 ├── components/
 │   ├── profile/
 │   │   ├── profile-header.tsx            # Read-only user info card

--- a/specs/016-claude-api-costs/plan.md
+++ b/specs/016-claude-api-costs/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add a self-service profile page (`/profile`) where authenticated users can view their personal info, assigned AI tools/licenses, and Claude API cost tracking (monthly total + daily breakdown by model with visual chart). Admins can also view user cost data on the admin user detail page. Usage data is fetched from the Anthropic Admin API (`usage_report/messages` endpoint) via incremental sync and stored permanently in PostgreSQL (following the `copilot_usage_metrics` pattern) for long-term cost monitoring. Costs are computed at read time from token counts using a pricing lookup table.
+Add a self-service profile page (`/profile`) where authenticated users can view their personal info, assigned AI tools/licenses, and Claude API cost tracking (monthly total + daily breakdown by model with visual chart). Admins can also view user cost data on the admin user detail page. Usage data is fetched from the Anthropic Admin API (`usage_report/messages` endpoint) via incremental sync and stored permanently in PostgreSQL (following the `copilot_usage_metrics` pattern) for long-term cost monitoring. Costs are computed at sync time from token counts using a pricing lookup table and stored as `computedCostCents` for consistent historical reporting.
 
 ## Technical Context
 

--- a/specs/016-claude-api-costs/plan.md
+++ b/specs/016-claude-api-costs/plan.md
@@ -66,6 +66,8 @@ src/
 │   └── profile/
 │       ├── page.tsx                      # Profile page (server component)
 │       └── profile-client.tsx            # Profile page client component
+├── app/api/anthropic/sync/
+│   └── route.ts                          # Cron endpoint: POST /api/anthropic/sync (CRON_SECRET auth)
 ├── actions/
 │   └── anthropic-usage.ts               # Server actions: getProfileData, syncAnthropicUsage (admin), getUserCostData
 ├── components/
@@ -78,6 +80,7 @@ src/
 │   ├── db/
 │   │   ├── schema.ts                     # MODIFIED: + anthropic_usage_metrics + anthropic_sync_status tables
 │   │   └── migrations/                   # New migration for schema changes
+│   ├── anthropic-sync.ts                 # Sync orchestrator (mirrors copilot-sync.ts pattern)
 │   ├── anthropic-pricing.ts              # Model pricing lookup table + cost computation
 │   └── anthropic-keys.ts                 # API key ID resolution (decrypt → list org keys → match partial_key_hint)
 ├── components/

--- a/specs/016-claude-api-costs/plan.md
+++ b/specs/016-claude-api-costs/plan.md
@@ -11,7 +11,7 @@ Add a self-service profile page (`/profile`) where authenticated users can view 
 
 **Language/Version**: TypeScript 5.9.3 (strict mode)
 **Primary Dependencies**: Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, NextAuth 5.0.0-beta.30, Recharts 2.15.4, shadcn/ui (new-york), Zod 4.3.6, Sonner (toasts), Lucide React
-**Storage**: Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 2 new tables (`anthropic_usage_metrics`, `anthropic_sync_status`), 1 table modification
+**Storage**: Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 2 new tables (`anthropic_usage_metrics`, `anthropic_sync_status`), no modifications to existing tables
 **Testing**: Vitest (unit/integration), Playwright (e2e)
 **Target Platform**: Web application (Node.js server + browser client)
 **Project Type**: Web service (Next.js full-stack)
@@ -76,10 +76,10 @@ src/
 │   └── cost-chart.tsx                    # Recharts stacked bar chart (daily costs by model)
 ├── lib/
 │   ├── db/
-│   │   ├── schema.ts                     # MODIFIED: + anthropic_usage_cache table, + anthropicApiKeyId field
+│   │   ├── schema.ts                     # MODIFIED: + anthropic_usage_metrics + anthropic_sync_status tables
 │   │   └── migrations/                   # New migration for schema changes
 │   ├── anthropic-pricing.ts              # Model pricing lookup table + cost computation
-│   └── validators.ts                     # MODIFIED: + anthropicApiKeyId in assignment schema
+│   └── anthropic-keys.ts                 # API key ID resolution (decrypt → list org keys → match partial_key_hint)
 ├── components/
 │   └── app-sidebar.tsx                   # MODIFIED: + user dropdown with "My Profile" link
 └── app/users/[id]/

--- a/specs/016-claude-api-costs/plan.md
+++ b/specs/016-claude-api-costs/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Claude API Cost Tracking
+
+**Branch**: `016-claude-api-costs` | **Date**: 2026-03-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/016-claude-api-costs/spec.md`
+
+## Summary
+
+Add a self-service profile page (`/profile`) where authenticated users can view their personal info, assigned AI tools/licenses, and Claude API cost tracking (monthly total + daily breakdown by model with visual chart). Admins can also view user cost data on the admin user detail page. Cost data is fetched from the Anthropic Admin API (`usage_report/messages` endpoint), cached in PostgreSQL, and costs are computed from token counts using a pricing lookup table.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3 (strict mode)
+**Primary Dependencies**: Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, NextAuth 5.0.0-beta.30, Recharts 2.15.4, shadcn/ui (new-york), Zod 4.3.6, Sonner (toasts), Lucide React
+**Storage**: Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 1 new table, 1 table modification
+**Testing**: Vitest (unit/integration), Playwright (e2e)
+**Target Platform**: Web application (Node.js server + browser client)
+**Project Type**: Web service (Next.js full-stack)
+**Performance Goals**: Profile page loads in < 3 seconds; cost data from cache in < 500ms; LCP < 2.5s per constitution
+**Constraints**: Anthropic API rate limit ~1 req/min sustained; 5-minute data freshness; < 150 KB gzipped JS per route
+**Scale/Scope**: ~100 users, ~31 days × 3 models = ~93 cache rows per user/month; 3 new pages/components, 1 new server action file
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Research Gate
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Type-Safe Code Quality | PASS | All new code in TypeScript strict mode. Zod schemas for API response validation. Exported types for all public interfaces. |
+| II. UX Consistency | PASS | Using shadcn/ui components exclusively. ChartContainer for Recharts (existing pattern). Design tokens only. |
+| III. Performance Budgets | PASS | Profile page is lightweight (read-only data + 1 chart). Cache avoids blocking API calls on page load. |
+| IV. Accessibility-First | PASS | Chart uses `accessibilityLayer` (existing Recharts pattern). Read-only content is inherently accessible. Keyboard nav via shadcn. |
+| V. Simplicity & Maintainability | PASS | No new dependencies. Reuses existing patterns (server actions, Drizzle, Recharts). Pricing as code constant (no over-engineering). |
+
+### Post-Design Gate
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Type-Safe Code Quality | PASS | Zod schema validates Anthropic API response shape. `ModelPricing` type exported. `ProfileData` type covers all profile data. |
+| II. UX Consistency | PASS | Profile page follows existing card-based layout. Chart matches copilot chart patterns. Empty/error/loading states defined. |
+| III. Performance Budgets | PASS | Cached data served from DB (no API call on render). Chart lazy-loaded via client component. No new dependencies added. |
+| IV. Accessibility-First | PASS | Recharts `accessibilityLayer` provides screen reader support. Tooltips accessible via keyboard. Color not sole indicator (legend labels). |
+| V. Simplicity & Maintainability | PASS | Single cache table. Pricing in code. No abstraction layers. Direct Drizzle queries. Follows existing server action pattern exactly. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-claude-api-costs/
+├── plan.md              # This file
+├── research.md          # Phase 0: API research, architecture decisions
+├── data-model.md        # Phase 1: anthropic_usage_cache table, pricing model
+├── quickstart.md        # Phase 1: Setup guide
+├── contracts/
+│   └── anthropic-usage-api.md  # Phase 1: Anthropic API contract + internal actions
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   └── profile/
+│       ├── page.tsx                      # Profile page (server component)
+│       └── profile-client.tsx            # Profile page client component
+├── actions/
+│   └── anthropic-usage.ts               # Server actions: getProfileData, refreshCostData, getUserCostData
+├── components/
+│   ├── profile/
+│   │   ├── profile-header.tsx            # Read-only user info card
+│   │   ├── profile-assignments.tsx       # Read-only tool assignments list
+│   │   └── cost-tracking-section.tsx     # Monthly total + daily chart + refresh + empty/error states
+│   └── cost-chart.tsx                    # Recharts stacked bar chart (daily costs by model)
+├── lib/
+│   ├── db/
+│   │   ├── schema.ts                     # MODIFIED: + anthropic_usage_cache table, + anthropicApiKeyId field
+│   │   └── migrations/                   # New migration for schema changes
+│   ├── anthropic-pricing.ts              # Model pricing lookup table + cost computation
+│   └── validators.ts                     # MODIFIED: + anthropicApiKeyId in assignment schema
+├── components/
+│   └── app-sidebar.tsx                   # MODIFIED: + user dropdown with "My Profile" link
+└── app/users/[id]/
+    ├── page.tsx                          # MODIFIED: + fetch cost data for admin view
+    └── user-detail-client.tsx            # MODIFIED: + read-only cost section
+
+tests/
+├── unit/
+│   ├── anthropic-pricing.test.ts         # Pricing computation tests
+│   └── anthropic-usage.test.ts           # Server action logic tests
+└── integration/
+    └── profile.test.ts                   # Profile page data flow tests
+```
+
+**Structure Decision**: Extends the existing Next.js App Router structure. New `/profile` route follows the same pattern as existing routes. New server action file follows existing `src/actions/` convention. Shared components in `src/components/profile/` for reuse between profile page and admin detail page.
+
+## Complexity Tracking
+
+No constitution violations. No complexity tracking needed.

--- a/specs/016-claude-api-costs/plan.md
+++ b/specs/016-claude-api-costs/plan.md
@@ -11,7 +11,7 @@ Add a self-service profile page (`/profile`) where authenticated users can view 
 
 **Language/Version**: TypeScript 5.9.3 (strict mode)
 **Primary Dependencies**: Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, NextAuth 5.0.0-beta.30, Recharts 2.15.4, shadcn/ui (new-york), Zod 4.3.6, Sonner (toasts), Lucide React
-**Storage**: Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 1 new table, 1 table modification
+**Storage**: Neon PostgreSQL (serverless) via `@neondatabase/serverless` — 2 new tables (`anthropic_usage_metrics`, `anthropic_sync_status`), 1 table modification
 **Testing**: Vitest (unit/integration), Playwright (e2e)
 **Target Platform**: Web application (Node.js server + browser client)
 **Project Type**: Web service (Next.js full-stack)

--- a/specs/016-claude-api-costs/plan.md
+++ b/specs/016-claude-api-costs/plan.md
@@ -67,12 +67,12 @@ src/
 │       ├── page.tsx                      # Profile page (server component)
 │       └── profile-client.tsx            # Profile page client component
 ├── actions/
-│   └── anthropic-usage.ts               # Server actions: getProfileData, refreshCostData, getUserCostData
+│   └── anthropic-usage.ts               # Server actions: getProfileData, syncAnthropicUsage (admin), getUserCostData
 ├── components/
 │   ├── profile/
 │   │   ├── profile-header.tsx            # Read-only user info card
 │   │   ├── profile-assignments.tsx       # Read-only tool assignments list
-│   │   └── cost-tracking-section.tsx     # Monthly total + daily chart + refresh + empty/error states
+│   │   └── cost-tracking-section.tsx     # Monthly total + daily chart + empty/error states (no refresh button)
 │   └── cost-chart.tsx                    # Recharts stacked bar chart (daily costs by model)
 ├── lib/
 │   ├── db/
@@ -84,7 +84,7 @@ src/
 │   └── app-sidebar.tsx                   # MODIFIED: + user dropdown with "My Profile" link
 └── app/users/[id]/
     ├── page.tsx                          # MODIFIED: + fetch cost data for admin view
-    └── user-detail-client.tsx            # MODIFIED: + read-only cost section
+    └── user-detail-client.tsx            # MODIFIED: + read-only cost section + admin sync button
 
 tests/
 ├── unit/

--- a/specs/016-claude-api-costs/plan.md
+++ b/specs/016-claude-api-costs/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add a self-service profile page (`/profile`) where authenticated users can view their personal info, assigned AI tools/licenses, and Claude API cost tracking (monthly total + daily breakdown by model with visual chart). Admins can also view user cost data on the admin user detail page. Cost data is fetched from the Anthropic Admin API (`usage_report/messages` endpoint), cached in PostgreSQL, and costs are computed from token counts using a pricing lookup table.
+Add a self-service profile page (`/profile`) where authenticated users can view their personal info, assigned AI tools/licenses, and Claude API cost tracking (monthly total + daily breakdown by model with visual chart). Admins can also view user cost data on the admin user detail page. Usage data is fetched from the Anthropic Admin API (`usage_report/messages` endpoint) via incremental sync and stored permanently in PostgreSQL (following the `copilot_usage_metrics` pattern) for long-term cost monitoring. Costs are computed at read time from token counts using a pricing lookup table.
 
 ## Technical Context
 
@@ -31,7 +31,7 @@ Add a self-service profile page (`/profile`) where authenticated users can view 
 | II. UX Consistency | PASS | Using shadcn/ui components exclusively. ChartContainer for Recharts (existing pattern). Design tokens only. |
 | III. Performance Budgets | PASS | Profile page is lightweight (read-only data + 1 chart). Cache avoids blocking API calls on page load. |
 | IV. Accessibility-First | PASS | Chart uses `accessibilityLayer` (existing Recharts pattern). Read-only content is inherently accessible. Keyboard nav via shadcn. |
-| V. Simplicity & Maintainability | PASS | No new dependencies. Reuses existing patterns (server actions, Drizzle, Recharts). Pricing as code constant (no over-engineering). |
+| V. Simplicity & Maintainability | PASS | No new dependencies. Reuses existing patterns (server actions, Drizzle, Recharts, incremental sync from copilot). Pricing as code constant (no over-engineering). |
 
 ### Post-Design Gate
 
@@ -39,9 +39,9 @@ Add a self-service profile page (`/profile`) where authenticated users can view 
 |-----------|--------|-------|
 | I. Type-Safe Code Quality | PASS | Zod schema validates Anthropic API response shape. `ModelPricing` type exported. `ProfileData` type covers all profile data. |
 | II. UX Consistency | PASS | Profile page follows existing card-based layout. Chart matches copilot chart patterns. Empty/error/loading states defined. |
-| III. Performance Budgets | PASS | Cached data served from DB (no API call on render). Chart lazy-loaded via client component. No new dependencies added. |
+| III. Performance Budgets | PASS | Historical data served from DB (no API call on render). Chart lazy-loaded via client component. No new dependencies added. |
 | IV. Accessibility-First | PASS | Recharts `accessibilityLayer` provides screen reader support. Tooltips accessible via keyboard. Color not sole indicator (legend labels). |
-| V. Simplicity & Maintainability | PASS | Single cache table. Pricing in code. No abstraction layers. Direct Drizzle queries. Follows existing server action pattern exactly. |
+| V. Simplicity & Maintainability | PASS | Single metrics table (mirrors copilot pattern). Incremental sync reuses proven pattern. Pricing in code. Direct Drizzle queries. |
 
 ## Project Structure
 

--- a/specs/016-claude-api-costs/quickstart.md
+++ b/specs/016-claude-api-costs/quickstart.md
@@ -70,19 +70,19 @@ specs/016-claude-api-costs/          # (already exists)
 
 ```
 src/
-├── lib/db/schema.ts                  # Add anthropic_usage_metrics table + license_assignments field
+├── lib/db/schema.ts                  # Add anthropic_usage_metrics + anthropic_sync_status tables, + license_assignments field
 ├── lib/validators.ts                 # Add anthropicApiKeyId to assignment schema
 ├── components/app-sidebar.tsx        # Add user dropdown with "My Profile" link
 ├── app/users/[id]/
 │   ├── page.tsx                      # Fetch cost data for admin view
-│   └── user-detail-client.tsx        # Add read-only cost section for admins
+│   └── user-detail-client.tsx        # Add read-only cost section + manual sync button for admins
 └── actions/assignments.ts            # Support anthropicApiKeyId in assignment updates
 ```
 
 ## Key Architecture Decisions
 
 - **Persistent usage history** (not a cache) — follows the `copilot_usage_metrics` pattern. Data stored permanently for long-term cost monitoring.
-- **Incremental sync** — detects latest stored date, fetches only new days. Today's data is upserted.
-- **Costs computed at read time** from stored token counts × pricing table. Pricing updates apply retroactively.
+- **Incremental sync** — detects latest stored date, fetches only new days. Today's data is upserted. Sync runs automatically server-side on stale data; manual trigger is admin-only.
+- **Costs computed at sync time** and stored in `computedCostCents`. Prefix-based pricing lookup handles model version suffixes.
 - **Admin API key in env var** — single org key, not per-user.
-- **Profile at `/profile`** — separate from admin `/users/[id]` route.
+- **Profile at `/profile`** — separate from admin `/users/[id]` route. No user-facing refresh button; data is always served from stored metrics.

--- a/specs/016-claude-api-costs/quickstart.md
+++ b/specs/016-claude-api-costs/quickstart.md
@@ -33,7 +33,15 @@
    - Enter their API key (the system already supports this via the existing assignment edit UI)
    - The Anthropic `api_key_id` is resolved automatically at first sync — no manual ID entry needed
 
-4. **Verify**:
+4. **Configure cron job**:
+   Configure an external cron service to call the sync endpoint on the desired schedule (e.g., daily):
+   ```bash
+   POST https://<your-domain>/api/anthropic/sync
+   Authorization: Bearer <CRON_SECRET>
+   ```
+   Uses the same `CRON_SECRET` as the existing Copilot sync.
+
+5. **Verify**:
    - Log in as a user with a configured API Key ID
    - Navigate to Profile (sidebar footer → user dropdown → "My Profile")
    - Verify cost data loads for the current month
@@ -45,8 +53,12 @@ src/
 ├── app/profile/
 │   ├── page.tsx                      # Profile page (server component)
 │   └── profile-client.tsx            # Profile client component
+├── app/api/anthropic/sync/
+│   └── route.ts                      # Cron endpoint: POST /api/anthropic/sync
+├── lib/
+│   └── anthropic-sync.ts             # Sync orchestrator (mirrors copilot-sync.ts)
 ├── actions/
-│   └── anthropic-usage.ts            # Server actions for cost data
+│   └── anthropic-usage.ts            # Server actions for cost data + admin manual sync
 ├── components/
 │   ├── profile/
 │   │   ├── profile-header.tsx        # Read-only user info display

--- a/specs/016-claude-api-costs/quickstart.md
+++ b/specs/016-claude-api-costs/quickstart.md
@@ -20,7 +20,7 @@
    pnpm db:generate
    pnpm db:migrate
    ```
-   This adds the `anthropic_usage_metrics` table and `anthropic_api_key_id` column to `license_assignments`.
+   This adds the `anthropic_usage_metrics` and `anthropic_sync_status` tables.
 
 2. **Configure environment**:
    ```bash
@@ -28,10 +28,10 @@
    ANTHROPIC_ADMIN_API_KEY=sk-ant-admin01-your-key-here
    ```
 
-3. **Assign API Key IDs**:
-   - Navigate to a user's license assignment for Claude/Anthropic tool
-   - Enter their Anthropic API Key ID (found in Claude Console → API Keys)
-   - Save the assignment
+3. **Assign API Keys** (if not already done):
+   - Navigate to a user's license assignment for the Claude/Anthropic tool
+   - Enter their API key (the system already supports this via the existing assignment edit UI)
+   - The Anthropic `api_key_id` is resolved automatically at first sync — no manual ID entry needed
 
 4. **Verify**:
    - Log in as a user with a configured API Key ID
@@ -54,7 +54,8 @@ src/
 │   │   └── cost-tracking-section.tsx # Monthly total + daily chart
 │   └── cost-chart.tsx                # Recharts daily cost chart
 └── lib/
-    └── anthropic-pricing.ts          # Model pricing lookup table
+    ├── anthropic-pricing.ts          # Model pricing lookup table
+    └── anthropic-keys.ts             # API key ID resolution (decrypt → list → match)
 
 specs/016-claude-api-costs/          # (already exists)
 ├── spec.md
@@ -70,13 +71,11 @@ specs/016-claude-api-costs/          # (already exists)
 
 ```
 src/
-├── lib/db/schema.ts                  # Add anthropic_usage_metrics + anthropic_sync_status tables, + license_assignments field
-├── lib/validators.ts                 # Add anthropicApiKeyId to assignment schema
+├── lib/db/schema.ts                  # Add anthropic_usage_metrics + anthropic_sync_status tables
 ├── components/app-sidebar.tsx        # Add user dropdown with "My Profile" link
-├── app/users/[id]/
-│   ├── page.tsx                      # Fetch cost data for admin view
-│   └── user-detail-client.tsx        # Add read-only cost section + manual sync button for admins
-└── actions/assignments.ts            # Support anthropicApiKeyId in assignment updates
+└── app/users/[id]/
+    ├── page.tsx                      # Fetch cost data for admin view
+    └── user-detail-client.tsx        # Add read-only cost section + manual sync button for admins
 ```
 
 ## Key Architecture Decisions

--- a/specs/016-claude-api-costs/quickstart.md
+++ b/specs/016-claude-api-costs/quickstart.md
@@ -1,0 +1,88 @@
+# Quickstart: Claude API Cost Tracking
+
+**Feature**: 016-claude-api-costs
+**Date**: 2026-03-16
+
+## Prerequisites
+
+1. **Anthropic Admin API Key**: Obtain an Admin API key from Claude Console (`/settings/admin-keys`). Requires organization admin access.
+2. **Environment Setup**: Add to `.env.local`:
+   ```
+   ANTHROPIC_ADMIN_API_KEY=sk-ant-admin01-...
+   ```
+3. **Database**: Neon PostgreSQL instance (existing project database).
+4. **User API Key IDs**: Each user whose costs you want to track needs their Anthropic `api_key_id` stored in their license assignment. This can be found in Claude Console under API Keys.
+
+## Setup Steps
+
+1. **Apply database migration**:
+   ```bash
+   pnpm db:generate
+   pnpm db:migrate
+   ```
+   This adds the `anthropic_usage_cache` table and `anthropic_api_key_id` column to `license_assignments`.
+
+2. **Configure environment**:
+   ```bash
+   # Add to .env.local
+   ANTHROPIC_ADMIN_API_KEY=sk-ant-admin01-your-key-here
+   ```
+
+3. **Assign API Key IDs**:
+   - Navigate to a user's license assignment for Claude/Anthropic tool
+   - Enter their Anthropic API Key ID (found in Claude Console → API Keys)
+   - Save the assignment
+
+4. **Verify**:
+   - Log in as a user with a configured API Key ID
+   - Navigate to Profile (sidebar footer → user dropdown → "My Profile")
+   - Verify cost data loads for the current month
+
+## New Files
+
+```
+src/
+├── app/profile/
+│   ├── page.tsx                      # Profile page (server component)
+│   └── profile-client.tsx            # Profile client component
+├── actions/
+│   └── anthropic-usage.ts            # Server actions for cost data
+├── components/
+│   ├── profile/
+│   │   ├── profile-header.tsx        # Read-only user info display
+│   │   ├── profile-assignments.tsx   # Read-only tool assignments
+│   │   └── cost-tracking-section.tsx # Monthly total + daily chart
+│   └── cost-chart.tsx                # Recharts daily cost chart
+└── lib/
+    └── anthropic-pricing.ts          # Model pricing lookup table
+
+specs/016-claude-api-costs/          # (already exists)
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── contracts/
+    └── anthropic-usage-api.md
+```
+
+## Modified Files
+
+```
+src/
+├── lib/db/schema.ts                  # Add anthropic_usage_cache table + license_assignments field
+├── lib/validators.ts                 # Add anthropicApiKeyId to assignment schema
+├── components/app-sidebar.tsx        # Add user dropdown with "My Profile" link
+├── app/users/[id]/
+│   ├── page.tsx                      # Fetch cost data for admin view
+│   └── user-detail-client.tsx        # Add read-only cost section for admins
+└── actions/assignments.ts            # Support anthropicApiKeyId in assignment updates
+```
+
+## Key Architecture Decisions
+
+- **Costs computed at read time** from cached token counts × pricing table (not stored as cents). This means pricing updates apply retroactively.
+- **Cache in PostgreSQL** (not Redis) — consistent with project's single-database approach.
+- **5-minute cache TTL** — matches Anthropic API data freshness.
+- **Admin API key in env var** — single org key, not per-user.
+- **Profile at `/profile`** — separate from admin `/users/[id]` route.

--- a/specs/016-claude-api-costs/quickstart.md
+++ b/specs/016-claude-api-costs/quickstart.md
@@ -11,7 +11,7 @@
    ANTHROPIC_ADMIN_API_KEY=sk-ant-admin01-...
    ```
 3. **Database**: Neon PostgreSQL instance (existing project database).
-4. **User API Key IDs**: Each user whose costs you want to track needs their Anthropic `api_key_id` stored in their license assignment. This can be found in Claude Console under API Keys.
+4. **User API Keys**: Each user whose costs you want to track needs an Anthropic API key stored in their license assignment. The corresponding `api_key_id` is resolved automatically at first sync by decrypting the stored key and matching it against the Anthropic Admin API's key list — no manual ID entry is needed.
 
 ## Setup Steps
 

--- a/specs/016-claude-api-costs/quickstart.md
+++ b/specs/016-claude-api-costs/quickstart.md
@@ -20,7 +20,7 @@
    pnpm db:generate
    pnpm db:migrate
    ```
-   This adds the `anthropic_usage_cache` table and `anthropic_api_key_id` column to `license_assignments`.
+   This adds the `anthropic_usage_metrics` table and `anthropic_api_key_id` column to `license_assignments`.
 
 2. **Configure environment**:
    ```bash
@@ -70,7 +70,7 @@ specs/016-claude-api-costs/          # (already exists)
 
 ```
 src/
-├── lib/db/schema.ts                  # Add anthropic_usage_cache table + license_assignments field
+├── lib/db/schema.ts                  # Add anthropic_usage_metrics table + license_assignments field
 ├── lib/validators.ts                 # Add anthropicApiKeyId to assignment schema
 ├── components/app-sidebar.tsx        # Add user dropdown with "My Profile" link
 ├── app/users/[id]/
@@ -81,8 +81,8 @@ src/
 
 ## Key Architecture Decisions
 
-- **Costs computed at read time** from cached token counts × pricing table (not stored as cents). This means pricing updates apply retroactively.
-- **Cache in PostgreSQL** (not Redis) — consistent with project's single-database approach.
-- **5-minute cache TTL** — matches Anthropic API data freshness.
+- **Persistent usage history** (not a cache) — follows the `copilot_usage_metrics` pattern. Data stored permanently for long-term cost monitoring.
+- **Incremental sync** — detects latest stored date, fetches only new days. Today's data is upserted.
+- **Costs computed at read time** from stored token counts × pricing table. Pricing updates apply retroactively.
 - **Admin API key in env var** — single org key, not per-user.
 - **Profile at `/profile`** — separate from admin `/users/[id]` route.

--- a/specs/016-claude-api-costs/research.md
+++ b/specs/016-claude-api-costs/research.md
@@ -55,16 +55,22 @@ The usage_report/messages endpoint is preferred because it supports grouping by 
 - Use the `cost_report` endpoint instead: Returns USD directly but excludes Priority Tier and cannot filter by `api_key_id`. Rejected.
 - Store pricing in database: Over-engineered. Pricing changes rarely and a code constant is simpler to maintain and deploy.
 
-## R5: Caching Strategy
+## R5: Persistent Usage History (Revised from Cache)
 
-**Decision**: Cache fetched usage data in a new database table (`anthropic_usage_cache`) with a TTL-based refresh. Refresh on user request (manual) with a minimum interval of 5 minutes.
+**Decision**: Store usage data permanently in a `anthropic_usage_metrics` table with incremental sync, following the same pattern as `copilot_usage_metrics`. This is persistent history, not a cache.
 
-**Rationale**: The Anthropic API has rate limits (~1 req/min sustained) and data freshness of ~5 minutes. Caching avoids redundant API calls when multiple users view their profiles or the same user refreshes. The cache stores raw token counts per day/model/user, and cost computation happens at read time (so pricing updates apply retroactively).
+**Rationale**: Long-term cost monitoring requires historical data to survive across months and years. A TTL-based cache would lose historical data. The Anthropic API has no documented data retention limit, but relying on API availability for historical queries is fragile. Storing data permanently enables trend analysis, month-over-month comparisons, and reporting without API dependency for past periods.
+
+**Sync strategy** (mirrors `copilot_usage_metrics`):
+- **Incremental**: Detect latest stored date per user, fetch only new days
+- **Upsert**: Today's data is re-fetched and upserted (still accumulating). Past days are immutable.
+- **Backfill**: First sync fetches up to 31 days back (API max per query). Longer backfill chains multiple requests.
+- **Manual refresh**: Re-syncs current day only.
 
 **Alternatives considered**:
-- No caching (fetch on every page load): Violates rate limits with multiple concurrent users. Rejected.
-- Client-side caching only: Does not survive page reloads and doesn't help with rate limiting on the server side. Rejected.
-- Redis/memory cache: This project uses Neon PostgreSQL only. Adding Redis is unnecessary complexity for a cache with 5-minute TTL and low write volume.
+- TTL-based cache (original design): Loses historical data. Cannot support month-over-month analysis or long-term trend monitoring. Rejected after requirement clarification.
+- Fetch from API on demand for historical data: API max is 31 days per query. Fetching 12 months of history would require 12 sequential API calls on each page load. Rejected for performance and rate limit reasons.
+- Redis/memory cache: Does not persist across deployments and cannot support historical queries. Rejected.
 
 ## R6: Profile Page Architecture
 

--- a/specs/016-claude-api-costs/research.md
+++ b/specs/016-claude-api-costs/research.md
@@ -72,7 +72,7 @@ The usage_report/messages endpoint is preferred because it supports grouping by 
 - **Incremental**: Detect latest stored date per user, fetch only new days
 - **Upsert**: Today's data is re-fetched and upserted (still accumulating). Past days are immutable.
 - **Backfill**: First sync fetches up to 31 days back (API max per query). Longer backfill chains multiple requests.
-- **Manual refresh**: Re-syncs current day only.
+- **Admin manual sync**: Admins can trigger a sync for any user from the admin detail page.
 
 **Alternatives considered**:
 - TTL-based cache (original design): Loses historical data. Cannot support month-over-month analysis or long-term trend monitoring. Rejected after requirement clarification.
@@ -105,7 +105,7 @@ Note: The spec says "user avatar/menu dropdown in the header" but the existing l
 
 **Decision**: Add an `anthropic_sync_status` table (one row per user) that tracks sync start/completion timestamps. Use this as a lightweight lock to prevent concurrent syncs and enforce rate limiting.
 
-**Rationale**: The profile page exposes sync to every user (page load + manual refresh). With 100 users, concurrent syncs will rapidly exhaust the Anthropic Admin API rate limit (~1 req/min sustained). The `copilot-sync.ts` pattern lacks concurrency protection but is mitigated by admin-only triggering. The profile page needs explicit guards because any user can trigger syncs.
+**Rationale**: The profile page triggers automatic background syncs on page load when data is stale. With 100 users loading profiles, concurrent server-side syncs could exhaust the Anthropic Admin API rate limit (~1 req/min sustained). Manual sync is admin-only, but the automatic sync on page load still requires concurrency guards to prevent redundant API calls.
 
 **Guard behavior**:
 1. Check `lastSyncStartedAt`: if within 60s and no completion → sync in progress, skip

--- a/specs/016-claude-api-costs/research.md
+++ b/specs/016-claude-api-costs/research.md
@@ -136,14 +136,22 @@ Note: The spec says "user avatar/menu dropdown in the header" but the existing l
 
 **Cron route behavior** (`POST /api/anthropic/sync`):
 1. Validate `Authorization: Bearer <CRON_SECRET>` header
-2. Find all users with an `apiKeyEncrypted` on an Anthropic tool assignment
-3. For each user (sequentially to respect rate limits):
-   a. Check `anthropic_sync_status` concurrency guard
-   b. Resolve `api_key_id` if not cached
-   c. Run incremental sync
-4. Return summary of synced users and any errors
+2. Single API call fetches ALL org usage (grouped by `api_key_id` + `model`) for the sync window
+3. Results mapped to users via `api_key_id` → `userId` cache (from `anthropic_sync_status.resolvedApiKeyId`)
+4. Upsert mapped usage rows into `anthropic_usage_metrics` per user
+5. 1-2 API calls total regardless of user count (vs. N calls for N users)
+6. Return summary of synced users and any errors
 
 **Alternatives considered**:
 - Sync on profile page load (original design): Adds latency to page loads. Multiple concurrent page loads could exhaust the rate limit. Rejected.
 - Vercel Cron: Would work but locks the project into Vercel. The existing pattern uses a generic `CRON_SECRET`-protected endpoint callable by any external scheduler. Consistent with existing Copilot pattern.
 - Next.js middleware: Not suitable for long-running background tasks in serverless environments. Rejected.
+
+## R10: Global Fetch vs Per-User Fetch
+
+**Decision**: Fetch all org usage in a single API call, then map results to users.
+
+**Rationale**: With N users, per-user fetching requires N API calls at ~1 req/min = N minutes. For 100 users, that's 100+ minutes per sync cycle. Global fetch requires 1-2 calls (31 daily buckets fit in one page) regardless of user count.
+
+**Alternatives considered**:
+- Per-user filtering (original design): Scales linearly with user count, hits rate limits. Rejected.

--- a/specs/016-claude-api-costs/research.md
+++ b/specs/016-claude-api-costs/research.md
@@ -93,3 +93,20 @@ The usage_report/messages endpoint is preferred because it supports grouping by 
 - Add as sidebar nav item: Profile is a user-level concern, not a navigation category. Placing it in the sidebar footer (user area) is semantically correct.
 
 Note: The spec says "user avatar/menu dropdown in the header" but the existing layout uses a sidebar footer for user info. We'll implement the dropdown in the sidebar footer user area, which serves the same purpose (quick access to profile) within the existing design pattern.
+
+## R8: Sync Concurrency Guard
+
+**Decision**: Add an `anthropic_sync_status` table (one row per user) that tracks sync start/completion timestamps. Use this as a lightweight lock to prevent concurrent syncs and enforce rate limiting.
+
+**Rationale**: The profile page exposes sync to every user (page load + manual refresh). With 100 users, concurrent syncs will rapidly exhaust the Anthropic Admin API rate limit (~1 req/min sustained). The `copilot-sync.ts` pattern lacks concurrency protection but is mitigated by admin-only triggering. The profile page needs explicit guards because any user can trigger syncs.
+
+**Guard behavior**:
+1. Check `lastSyncStartedAt`: if within 60s and no completion → sync in progress, skip
+2. Check `lastSyncCompletedAt`: if within 60s → recently synced, skip
+3. Stale lock recovery: if started > 5 minutes ago with no completion → allow new sync
+4. On start: set `lastSyncStartedAt = now()`. On success: set `lastSyncCompletedAt = now()`.
+
+**Alternatives considered**:
+- Database advisory locks (`pg_try_advisory_lock`): More elegant but Neon serverless may not support long-held advisory locks across connection pool resets. Rejected for reliability.
+- In-memory lock (Node.js): Does not survive serverless cold starts and doesn't work across multiple instances. Rejected.
+- No guard (rely on upsert idempotency): Data would be correct but redundant API calls waste the shared org rate limit. Rejected.

--- a/specs/016-claude-api-costs/research.md
+++ b/specs/016-claude-api-costs/research.md
@@ -81,7 +81,8 @@ This eliminates any schema modifications to `license_assignments` and requires z
 - **Incremental**: Detect latest stored date per user, fetch only new days
 - **Upsert**: Today's data is re-fetched and upserted (still accumulating). Past days are immutable.
 - **Backfill**: First sync fetches up to 31 days back (API max per query). Longer backfill chains multiple requests.
-- **Admin manual sync**: Admins can trigger a sync for any user from the admin detail page.
+- **Cron-based sync**: External cron service calls `POST /api/anthropic/sync` (same pattern as Copilot sync).
+- **Admin manual sync**: Admins can trigger a sync for a specific user from the admin detail page.
 
 **Alternatives considered**:
 - TTL-based cache (original design): Loses historical data. Cannot support month-over-month analysis or long-term trend monitoring. Rejected after requirement clarification.
@@ -114,7 +115,7 @@ Note: The spec says "user avatar/menu dropdown in the header" but the existing l
 
 **Decision**: Add an `anthropic_sync_status` table (one row per user) that tracks sync start/completion timestamps. Use this as a lightweight lock to prevent concurrent syncs and enforce rate limiting.
 
-**Rationale**: The profile page triggers automatic background syncs on page load when data is stale. With 100 users loading profiles, concurrent server-side syncs could exhaust the Anthropic Admin API rate limit (~1 req/min sustained). Manual sync is admin-only, but the automatic sync on page load still requires concurrency guards to prevent redundant API calls.
+**Rationale**: The cron job syncs all users sequentially, but concurrent cron invocations (e.g., cron fires while a previous run is still processing) or simultaneous admin manual triggers could create overlapping API calls. The concurrency guard prevents redundant API calls and protects the shared org-level rate limit (~1 req/min sustained).
 
 **Guard behavior**:
 1. Check `lastSyncStartedAt`: if within 60s and no completion → sync in progress, skip
@@ -126,3 +127,23 @@ Note: The spec says "user avatar/menu dropdown in the header" but the existing l
 - Database advisory locks (`pg_try_advisory_lock`): More elegant but Neon serverless may not support long-held advisory locks across connection pool resets. Rejected for reliability.
 - In-memory lock (Node.js): Does not survive serverless cold starts and doesn't work across multiple instances. Rejected.
 - No guard (rely on upsert idempotency): Data would be correct but redundant API calls waste the shared org rate limit. Rejected.
+
+## R9: Cron-Based Sync Trigger
+
+**Decision**: Use an external cron service calling `POST /api/anthropic/sync` (protected by `CRON_SECRET`), following the exact same pattern as the Copilot sync at `POST /api/copilot/sync`.
+
+**Rationale**: The Copilot integration already establishes this pattern. The API route authenticates via `CRON_SECRET` header, finds all users with valid Anthropic API keys, and syncs each user sequentially using the incremental sync logic. This keeps sync completely decoupled from page loads — users always see pre-synced data with no latency impact.
+
+**Cron route behavior** (`POST /api/anthropic/sync`):
+1. Validate `Authorization: Bearer <CRON_SECRET>` header
+2. Find all users with an `apiKeyEncrypted` on an Anthropic tool assignment
+3. For each user (sequentially to respect rate limits):
+   a. Check `anthropic_sync_status` concurrency guard
+   b. Resolve `api_key_id` if not cached
+   c. Run incremental sync
+4. Return summary of synced users and any errors
+
+**Alternatives considered**:
+- Sync on profile page load (original design): Adds latency to page loads. Multiple concurrent page loads could exhaust the rate limit. Rejected.
+- Vercel Cron: Would work but locks the project into Vercel. The existing pattern uses a generic `CRON_SECRET`-protected endpoint callable by any external scheduler. Consistent with existing Copilot pattern.
+- Next.js middleware: Not suitable for long-running background tasks in serverless environments. Rejected.

--- a/specs/016-claude-api-costs/research.md
+++ b/specs/016-claude-api-costs/research.md
@@ -25,15 +25,24 @@ The usage_report/messages endpoint is preferred because it supports grouping by 
 - Rate limit: ~1 request/minute sustained; data freshness ~5 minutes
 - Max buckets: 31 for daily width
 
-## R2: Per-User Cost Identification
+## R2: Per-User Cost Identification (Revised)
 
-**Decision**: Store each user's Anthropic `api_key_id` in the existing `license_assignments` table (new field) and use it to filter usage queries.
+**Decision**: Resolve each user's Anthropic `api_key_id` automatically from their existing stored API key (`license_assignments.apiKeyEncrypted`) at sync time. Cache the resolved ID in `anthropic_sync_status.resolvedApiKeyId`.
 
-**Rationale**: The Anthropic Admin API groups usage by `api_key_id` (an internal Anthropic identifier for each API key). To fetch per-user costs, we need to know each user's `api_key_id`. This can be stored when the admin configures the user's API key, or resolved via an Admin API call to list organization API keys.
+**Rationale**: The Anthropic Admin API filters usage by `api_key_id` (an internal identifier), not the API key string. The existing `license_assignments` table already stores each user's encrypted API key. Rather than requiring admins to manually enter a separate `api_key_id`, we resolve it automatically:
+
+1. Decrypt the user's API key from `license_assignments.apiKeyEncrypted`
+2. Call `GET /v1/organizations/api_keys?status=active` (Admin API) to list all org API keys
+3. Match the decrypted key's suffix against each entry's `partial_key_hint` field
+4. Cache the resolved `id` as `resolvedApiKeyId` in `anthropic_sync_status`
+5. On subsequent syncs, reuse the cached ID (no re-resolution needed unless the key changes)
+
+This eliminates any schema modifications to `license_assignments` and requires zero additional admin work beyond what they already do (storing the API key).
 
 **Alternatives considered**:
-- Store `api_key_id` in a separate mapping table: Adds unnecessary schema complexity. The existing `license_assignments` table already stores the encrypted API key and is the natural place for this metadata.
-- Query all usage and filter client-side: Wastes bandwidth and exposes other users' data to the server action. Rejected for efficiency and security.
+- Add `anthropicApiKeyId` field to `license_assignments` (original plan): Requires admins to find and enter the internal Anthropic key ID separately — extra manual work and an error-prone step. Rejected.
+- Query all usage and filter client-side: Wastes bandwidth and exposes other users' data. Rejected.
+- Resolve `api_key_id` on every sync (no caching): Wastes an API call. The `api_key_id` for a given key string does not change. Caching is safe and efficient.
 
 ## R3: Admin API Key Storage
 

--- a/specs/016-claude-api-costs/research.md
+++ b/specs/016-claude-api-costs/research.md
@@ -1,0 +1,89 @@
+# Research: Claude API Cost Tracking
+
+**Feature**: 016-claude-api-costs
+**Date**: 2026-03-16
+
+## R1: Anthropic Billing API
+
+**Decision**: Use the Anthropic Admin API `usage_report/messages` endpoint with daily bucketing and model grouping.
+
+**Rationale**: The Admin API provides two relevant endpoints:
+- `GET /v1/organizations/usage_report/messages` — returns token-level usage with flexible grouping (by model, api_key_id, etc.) and daily bucketing
+- `GET /v1/organizations/cost_report` — returns USD cost data (daily only) but does NOT include Priority Tier costs
+
+The usage_report/messages endpoint is preferred because it supports grouping by both `model` and `api_key_id`, allowing per-user filtering. Cost can be computed from token counts using known pricing.
+
+**Alternatives considered**:
+- `cost_report` endpoint: Simpler (returns USD directly) but excludes Priority Tier costs and cannot group by `api_key_id` for per-user filtering. Rejected due to incomplete data.
+- Per-user API key authentication: Each user's key could theoretically query their own usage, but the usage/cost endpoints require Admin API keys (`sk-ant-admin...`), not standard API keys. Not viable.
+
+**Key API details**:
+- Authentication: `x-api-key: sk-ant-admin...` + `anthropic-version: 2023-06-01`
+- Endpoint: `GET https://api.anthropic.com/v1/organizations/usage_report/messages`
+- Parameters: `starting_at`, `ending_at` (RFC 3339), `bucket_width=1d`, `group_by[]=model&group_by[]=api_key_id`, `api_key_ids[]=<id>`
+- Response: Array of daily buckets, each with `results[]` containing `model`, `api_key_id`, `uncached_input_tokens`, `cache_read_input_tokens`, `output_tokens`, plus cache creation breakdown
+- Rate limit: ~1 request/minute sustained; data freshness ~5 minutes
+- Max buckets: 31 for daily width
+
+## R2: Per-User Cost Identification
+
+**Decision**: Store each user's Anthropic `api_key_id` in the existing `license_assignments` table (new field) and use it to filter usage queries.
+
+**Rationale**: The Anthropic Admin API groups usage by `api_key_id` (an internal Anthropic identifier for each API key). To fetch per-user costs, we need to know each user's `api_key_id`. This can be stored when the admin configures the user's API key, or resolved via an Admin API call to list organization API keys.
+
+**Alternatives considered**:
+- Store `api_key_id` in a separate mapping table: Adds unnecessary schema complexity. The existing `license_assignments` table already stores the encrypted API key and is the natural place for this metadata.
+- Query all usage and filter client-side: Wastes bandwidth and exposes other users' data to the server action. Rejected for efficiency and security.
+
+## R3: Admin API Key Storage
+
+**Decision**: Store the organization's Anthropic Admin API key as an environment variable (`ANTHROPIC_ADMIN_API_KEY`).
+
+**Rationale**: There is exactly one admin API key per organization. It is a deployment-level secret, not user-specific data. Environment variables are the established pattern for such secrets in this project (see `API_KEY_ENCRYPTION_SECRET`, `DATABASE_URL`, `NEXTAUTH_SECRET`).
+
+**Alternatives considered**:
+- Store in database (like `github_connections.tokenEncrypted`): More complex, requires a new table or connection entity. The GitHub pattern makes sense because multiple GitHub orgs can be connected; Anthropic has exactly one org admin key. YAGNI.
+- Store in a settings table: Over-engineered for a single value. Environment variable is simpler and follows existing patterns.
+
+## R4: Cost Computation Strategy
+
+**Decision**: Compute costs from token counts using a pricing lookup table stored in application code, with the ability to update pricing without schema changes.
+
+**Rationale**: The usage_report/messages endpoint returns token counts, not costs. Costs must be computed by multiplying token counts by per-model pricing. Pricing changes infrequently (roughly quarterly) and a code-level lookup table is the simplest approach that meets requirements. The spec accepts <1% variance from Console-reported costs, which this approach satisfies since we use the same token counts.
+
+**Alternatives considered**:
+- Use the `cost_report` endpoint instead: Returns USD directly but excludes Priority Tier and cannot filter by `api_key_id`. Rejected.
+- Store pricing in database: Over-engineered. Pricing changes rarely and a code constant is simpler to maintain and deploy.
+
+## R5: Caching Strategy
+
+**Decision**: Cache fetched usage data in a new database table (`anthropic_usage_cache`) with a TTL-based refresh. Refresh on user request (manual) with a minimum interval of 5 minutes.
+
+**Rationale**: The Anthropic API has rate limits (~1 req/min sustained) and data freshness of ~5 minutes. Caching avoids redundant API calls when multiple users view their profiles or the same user refreshes. The cache stores raw token counts per day/model/user, and cost computation happens at read time (so pricing updates apply retroactively).
+
+**Alternatives considered**:
+- No caching (fetch on every page load): Violates rate limits with multiple concurrent users. Rejected.
+- Client-side caching only: Does not survive page reloads and doesn't help with rate limiting on the server side. Rejected.
+- Redis/memory cache: This project uses Neon PostgreSQL only. Adding Redis is unnecessary complexity for a cache with 5-minute TTL and low write volume.
+
+## R6: Profile Page Architecture
+
+**Decision**: Create a new `/profile` route as a dedicated profile page, reusing read-only display components from the existing user detail page where applicable.
+
+**Rationale**: The existing `/users/[id]` page is admin-only with editing capabilities baked into the component structure. Creating a separate `/profile` route allows clean separation of concerns: the profile page is self-service, read-only, and restricted to the authenticated user. Shared display components (user info card, assignments list) can be extracted and reused.
+
+**Alternatives considered**:
+- Reuse `/users/[id]` with conditional rendering: The existing page mixes read/write UI heavily (React Hook Form, edit dialogs, revoke buttons). Conditionally hiding all edit UI would require extensive prop drilling and risk leaking admin functionality. Rejected for maintainability.
+- Use `/users/me` route: Semantically appealing but conflicts with the existing admin user management namespace. `/profile` is cleaner.
+
+## R7: Navigation — "My Profile" Link
+
+**Decision**: Add a "My Profile" link to the sidebar footer where user info already displays, implementing it as a dropdown menu on the user name/avatar area.
+
+**Rationale**: The current sidebar footer already shows the authenticated user's name and role. Converting this into a clickable dropdown with "My Profile" and "Sign Out" options is the most natural location and follows common dashboard patterns. The header currently only contains the sidebar trigger and is intentionally minimal.
+
+**Alternatives considered**:
+- Add to header: The header is intentionally sparse (sidebar trigger only). Adding a user menu there would require restructuring the header layout. More invasive.
+- Add as sidebar nav item: Profile is a user-level concern, not a navigation category. Placing it in the sidebar footer (user area) is semantically correct.
+
+Note: The spec says "user avatar/menu dropdown in the header" but the existing layout uses a sidebar footer for user info. We'll implement the dropdown in the sidebar footer user area, which serves the same purpose (quick access to profile) within the existing design pattern.

--- a/specs/016-claude-api-costs/research.md
+++ b/specs/016-claude-api-costs/research.md
@@ -45,15 +45,22 @@ The usage_report/messages endpoint is preferred because it supports grouping by 
 - Store in database (like `github_connections.tokenEncrypted`): More complex, requires a new table or connection entity. The GitHub pattern makes sense because multiple GitHub orgs can be connected; Anthropic has exactly one org admin key. YAGNI.
 - Store in a settings table: Over-engineered for a single value. Environment variable is simpler and follows existing patterns.
 
-## R4: Cost Computation Strategy
+## R4: Cost Computation Strategy (Revised)
 
-**Decision**: Compute costs from token counts using a pricing lookup table stored in application code, with the ability to update pricing without schema changes.
+**Decision**: Compute costs at sync time using a prefix-based pricing lookup. Store computed costs (`computedCostCents`) alongside token counts. Flag rows with unresolved pricing for admin attention.
 
-**Rationale**: The usage_report/messages endpoint returns token counts, not costs. Costs must be computed by multiplying token counts by per-model pricing. Pricing changes infrequently (roughly quarterly) and a code-level lookup table is the simplest approach that meets requirements. The spec accepts <1% variance from Console-reported costs, which this approach satisfies since we use the same token counts.
+**Rationale**: The usage_report/messages endpoint returns token counts, not costs. Costs must be computed by multiplying token counts by per-model pricing. Three key improvements over the naive approach:
+
+1. **Prefix matching instead of exact string match**: Anthropic model identifiers include version suffixes and date stamps (e.g., `claude-opus-4-6-20260301`). Prefix matching (`claude-opus-4` matches any variant) handles new versions without code changes.
+
+2. **Store computed costs at sync time**: Instead of computing on every page load, costs are stored in `computedCostCents` during sync. This provides stable historical numbers (users see consistent values), eliminates recomputation overhead, and makes it clear what cost was shown at any point.
+
+3. **Unknown model detection**: When a model doesn't match any pricing prefix, the row is flagged `pricingResolved = false` and fallback pricing is used. An admin-visible indicator surfaces unresolved rows. After updating the pricing table, an admin action recalculates affected rows.
 
 **Alternatives considered**:
 - Use the `cost_report` endpoint instead: Returns USD directly but excludes Priority Tier and cannot filter by `api_key_id`. Rejected.
 - Store pricing in database: Over-engineered. Pricing changes rarely and a code constant is simpler to maintain and deploy.
+- Compute costs purely at read time (original design): Causes historical costs to silently change when pricing is updated. Users see different numbers on different days for the same data. Rejected for consistency.
 
 ## R5: Persistent Usage History (Revised from Cache)
 

--- a/specs/016-claude-api-costs/spec.md
+++ b/specs/016-claude-api-costs/spec.md
@@ -89,7 +89,7 @@ As a user tracking my Claude API costs, I want to see a day-by-day breakdown of 
 - **FR-006**: System MUST fetch and display daily token costs grouped by model for the current month, presented as a visual chart with supporting data.
 - **FR-007**: System MUST display costs in US dollars (the standard billing currency for Claude Console).
 - **FR-008**: System MUST handle API errors gracefully, showing user-friendly error messages.
-- **FR-009**: System MUST sync usage data automatically and incrementally (fetch only new days). Manual sync MUST only be available to admins.
+- **FR-009**: System MUST sync usage data via a cron job (external scheduler calling a dedicated API endpoint), incrementally fetching only new days. Manual sync MUST only be available to admins.
 - **FR-010**: System MUST handle the case where a user has no API key configured (admin responsibility), showing a message to contact their administrator.
 - **FR-011**: System MUST handle the case where a user has no API usage, showing an appropriate empty state.
 - **FR-012**: System MUST show the date of the latest stored usage data.

--- a/specs/016-claude-api-costs/spec.md
+++ b/specs/016-claude-api-costs/spec.md
@@ -15,6 +15,8 @@
 - Q: How should users navigate to their profile page? → A: User avatar/menu dropdown in the header with a "My Profile" link.
 - Q: Do users manage their own API keys? → A: No — API key storage and updates are handled by admins using existing functionality. Users only view their cost data.
 - Q: Are daily token costs and visual chart separate views? → A: No — they are combined into a single unified view with chart and supporting data together.
+- Q: Can users view past months or only the current month? → A: Month picker — users can select any past month to view historical costs alongside the current month.
+- Q: How often should the cron job sync usage data? → A: Hourly — most up-to-date data, ~24 API calls/day.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -37,7 +39,7 @@ As an authenticated user, I want to access my own profile page so that I can vie
 
 ### User Story 2 - View Current Month's Total Cost (Priority: P1)
 
-As a user with a Claude Console API key configured in the system, I want to see the total cost incurred for the current billing month on my profile page so that I can monitor my spending at a glance.
+As a user with a Claude Console API key configured in the system, I want to see the total cost incurred for a selected month (defaulting to the current month) on my profile page so that I can monitor my spending at a glance and compare across months.
 
 **Why this priority**: Knowing the current month's total spend is the most fundamental cost tracking need. Without this, users have no visibility into their API consumption.
 
@@ -45,9 +47,10 @@ As a user with a Claude Console API key configured in the system, I want to see 
 
 **Acceptance Scenarios**:
 
-1. **Given** a user has a valid Claude Console API key stored in the system, **When** they navigate to their profile page, **Then** they see the total cost for the current calendar month displayed in US dollars.
-2. **Given** a user has no API usage for the current month, **When** they view the cost tracking section on their profile, **Then** they see a total of $0.00 with a clear indication that no usage has been recorded.
-3. **Given** a user's API key has not been configured or is invalid, **When** they view the cost tracking section, **Then** they see an informative message explaining that no API key is configured and to contact their administrator.
+1. **Given** a user has a valid Claude Console API key stored in the system, **When** they navigate to their profile page, **Then** they see the total cost for the current calendar month displayed in US dollars, with a month picker to select any past month.
+2. **Given** a user selects a past month via the month picker, **When** the selection changes, **Then** the total cost and daily breakdown update to reflect the selected month's data.
+3. **Given** a user has no API usage for the selected month, **When** they view the cost tracking section on their profile, **Then** they see a total of $0.00 with a clear indication that no usage has been recorded.
+4. **Given** a user's API key has not been configured or is invalid, **When** they view the cost tracking section, **Then** they see an informative message explaining that no API key is configured and to contact their administrator.
 
 ---
 
@@ -61,7 +64,7 @@ As a user tracking my Claude API costs, I want to see a day-by-day breakdown of 
 
 **Acceptance Scenarios**:
 
-1. **Given** a user has API usage across multiple models in the current month, **When** they view the daily cost section, **Then** they see a chart displaying daily costs grouped by model with a legend identifying each model.
+1. **Given** a user has API usage across multiple models in the selected month, **When** they view the daily cost section, **Then** they see a chart displaying daily costs grouped by model with a legend identifying each model.
 2. **Given** a user interacts with a chart data point (e.g., hover or tap), **When** the interaction occurs, **Then** a tooltip shows the exact cost and model breakdown for that day.
 3. **Given** a user has usage on some days but not others, **When** they view the daily breakdown, **Then** days with no usage are either omitted or shown as $0.00, and the display remains clear and readable.
 4. **Given** a user wants to understand cost trends, **When** they view the daily breakdown, **Then** the data is presented in a way that allows them to identify which days and models had the highest costs.
@@ -85,11 +88,11 @@ As a user tracking my Claude API costs, I want to see a day-by-day breakdown of 
 - **FR-002**: System MUST restrict profile page access so that users can only view their own profile data.
 - **FR-003**: The profile page MUST display the user's personal information (name, email, role) in read-only format — no editing capabilities.
 - **FR-004**: The profile page MUST display the user's currently assigned AI tools/licenses with tool name, tier, and assignment date in read-only format.
-- **FR-005**: System MUST fetch and display the total cost for the current calendar month using the admin-configured API key.
-- **FR-006**: System MUST fetch and display daily token costs grouped by model for the current month, presented as a visual chart with supporting data.
+- **FR-005**: System MUST display the total cost for a selected month (defaulting to the current calendar month), with a month picker allowing users to view any past month with stored data.
+- **FR-006**: System MUST display daily token costs grouped by model for the selected month, presented as a visual chart with supporting data.
 - **FR-007**: System MUST display costs in US dollars (the standard billing currency for Claude Console).
 - **FR-008**: System MUST handle API errors gracefully, showing user-friendly error messages.
-- **FR-009**: System MUST sync usage data via a cron job (external scheduler calling a dedicated API endpoint) that fetches all org usage in a single pass and maps results to individual users. Manual sync of a specific user MUST only be available to admins.
+- **FR-009**: System MUST sync usage data hourly via a cron job (external scheduler calling a dedicated API endpoint) that fetches all org usage in a single pass and maps results to individual users. Manual sync of a specific user MUST only be available to admins.
 - **FR-010**: System MUST handle the case where a user has no API key configured (admin responsibility), showing a message to contact their administrator.
 - **FR-011**: System MUST handle the case where a user has no API usage, showing an appropriate empty state.
 - **FR-012**: System MUST show the date of the latest stored usage data.
@@ -107,8 +110,8 @@ As a user tracking my Claude API costs, I want to see a day-by-day breakdown of 
 
 ### Measurable Outcomes
 
-- **SC-001**: Users can view their current month's total API cost within 3 seconds of navigating to the cost tracking section.
-- **SC-002**: Users can identify their highest-cost model and highest-cost day within the current month in under 10 seconds.
+- **SC-001**: Users can view their selected month's total API cost within 3 seconds of navigating to the cost tracking section or switching months.
+- **SC-002**: Users can identify their highest-cost model and highest-cost day within the selected month in under 10 seconds.
 - **SC-003**: Cost data displayed matches the Claude Console's reported costs with less than 1% variance (accounting for rounding).
 - **SC-004**: Users with an admin-configured API key can see cost data immediately upon first visit to their profile page.
 - **SC-005**: Users without an API key configured see a clear message directing them to contact their administrator.

--- a/specs/016-claude-api-costs/spec.md
+++ b/specs/016-claude-api-costs/spec.md
@@ -89,7 +89,7 @@ As a user tracking my Claude API costs, I want to see a day-by-day breakdown of 
 - **FR-006**: System MUST fetch and display daily token costs grouped by model for the current month, presented as a visual chart with supporting data.
 - **FR-007**: System MUST display costs in US dollars (the standard billing currency for Claude Console).
 - **FR-008**: System MUST handle API errors gracefully, showing user-friendly error messages.
-- **FR-009**: System MUST sync usage data incrementally (fetch only new days) and allow users to trigger a manual sync for the current day.
+- **FR-009**: System MUST sync usage data automatically and incrementally (fetch only new days). Manual sync MUST only be available to admins.
 - **FR-010**: System MUST handle the case where a user has no API key configured (admin responsibility), showing a message to contact their administrator.
 - **FR-011**: System MUST handle the case where a user has no API usage, showing an appropriate empty state.
 - **FR-012**: System MUST show the date of the latest stored usage data.

--- a/specs/016-claude-api-costs/spec.md
+++ b/specs/016-claude-api-costs/spec.md
@@ -89,10 +89,11 @@ As a user tracking my Claude API costs, I want to see a day-by-day breakdown of 
 - **FR-006**: System MUST fetch and display daily token costs grouped by model for the current month, presented as a visual chart with supporting data.
 - **FR-007**: System MUST display costs in US dollars (the standard billing currency for Claude Console).
 - **FR-008**: System MUST handle API errors gracefully, showing user-friendly error messages.
-- **FR-009**: System MUST refresh cost data on user request to show up-to-date information.
+- **FR-009**: System MUST sync usage data incrementally (fetch only new days) and allow users to trigger a manual sync for the current day.
 - **FR-010**: System MUST handle the case where a user has no API key configured (admin responsibility), showing a message to contact their administrator.
 - **FR-011**: System MUST handle the case where a user has no API usage, showing an appropriate empty state.
-- **FR-012**: System MUST show the date and time of the last successful data fetch.
+- **FR-012**: System MUST show the date of the latest stored usage data.
+- **FR-012a**: System MUST persist usage data permanently for long-term cost monitoring and trend analysis across months.
 - **FR-013**: System MUST display a user's Claude API cost data on the admin user detail page, visible to admin users.
 - **FR-014**: System MUST provide a "My Profile" link in the user avatar/menu dropdown in the header for navigating to the profile page.
 
@@ -118,4 +119,4 @@ As a user tracking my Claude API costs, I want to see a day-by-day breakdown of 
 - Costs are reported in US dollars, consistent with Anthropic's billing practices.
 - The system already has user authentication in place (NextAuth.js). API keys are managed by admins using existing functionality — users do not store or update their own keys.
 - Cost data granularity is at the daily level per model, as this is the standard granularity available from Claude Console billing.
-- The system will cache fetched cost data locally to reduce API calls and provide faster page loads.
+- The system will persist fetched usage data permanently for long-term monitoring. Incremental sync fetches only new days. Data is served from the database, not the API, for page loads.

--- a/specs/016-claude-api-costs/spec.md
+++ b/specs/016-claude-api-costs/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Claude API Cost Tracking
+
+**Feature Branch**: `016-claude-api-costs`
+**Created**: 2026-03-16
+**Status**: Draft
+**Input**: User description: "The users with Claude Console access via API key are able to see the costs of the current month and their daily token costs grouped by model. The goal is to enable the users to track their own costs."
+
+## Clarifications
+
+### Session 2026-03-16
+
+- Q: Does accessing the profile page require re-entering password or just standard session auth? → A: Standard session authentication — logged-in users can view their own profile without re-entering their password.
+- Q: Should the profile page also show the user's assigned AI tools/licenses? → A: Yes — show assigned tools/licenses alongside Claude API costs for a complete self-service view.
+- Q: Should admins be able to see a user's Claude API costs on the admin user detail page? → A: Yes — admins can see a user's Claude API costs on the admin user detail page.
+- Q: How should users navigate to their profile page? → A: User avatar/menu dropdown in the header with a "My Profile" link.
+- Q: Do users manage their own API keys? → A: No — API key storage and updates are handled by admins using existing functionality. Users only view their cost data.
+- Q: Are daily token costs and visual chart separate views? → A: No — they are combined into a single unified view with chart and supporting data together.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Access Personal Profile Page (Priority: P1)
+
+As an authenticated user, I want to access my own profile page so that I can view my personal information, assigned AI tools/licenses, and Claude API cost tracking data in one place. The profile page is read-only (no editing of personal details) and only accessible to the user themselves via standard session authentication.
+
+**Why this priority**: The profile page is the container for all self-service features including cost tracking and tool assignments. Without it, there is no place for users to view their own data.
+
+**Independent Test**: Can be fully tested by logging in as any user and navigating to the profile page, verifying it shows the user's own information, assigned tools, and cost data in read-only mode.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is logged in, **When** they navigate to their profile page, **Then** they see their own personal information (name, email, role) in read-only format.
+2. **Given** a user has assigned AI tools/licenses, **When** they view their profile page, **Then** they see a list of their currently assigned tools with relevant details (tool name, tier, assignment date).
+3. **Given** a user is logged in, **When** they attempt to access another user's profile, **Then** the system denies access and redirects them to their own profile.
+4. **Given** a user is not logged in, **When** they attempt to access the profile page, **Then** they are redirected to the login page.
+
+---
+
+### User Story 2 - View Current Month's Total Cost (Priority: P1)
+
+As a user with a Claude Console API key configured in the system, I want to see the total cost incurred for the current billing month on my profile page so that I can monitor my spending at a glance.
+
+**Why this priority**: Knowing the current month's total spend is the most fundamental cost tracking need. Without this, users have no visibility into their API consumption.
+
+**Independent Test**: Can be fully tested by navigating to the profile page and verifying the current month's total cost is displayed, delivering immediate spending visibility.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has a valid Claude Console API key stored in the system, **When** they navigate to their profile page, **Then** they see the total cost for the current calendar month displayed in US dollars.
+2. **Given** a user has no API usage for the current month, **When** they view the cost tracking section on their profile, **Then** they see a total of $0.00 with a clear indication that no usage has been recorded.
+3. **Given** a user's API key has not been configured or is invalid, **When** they view the cost tracking section, **Then** they see an informative message explaining that no API key is configured and to contact their administrator.
+
+---
+
+### User Story 3 - View Daily Token Costs with Visual Chart (Priority: P1)
+
+As a user tracking my Claude API costs, I want to see a day-by-day breakdown of token costs grouped by model — presented as both a visual chart and supporting data — so that I can quickly spot trends, identify which models drive my spending, and understand usage patterns over time.
+
+**Why this priority**: Daily model-level granularity is the core analytical value of this feature. Combining the chart and data in a single view gives users both at-a-glance pattern recognition and detailed numbers without switching between views.
+
+**Independent Test**: Can be fully tested by viewing the daily breakdown for the current month and verifying costs appear grouped by model in both chart and data form.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has API usage across multiple models in the current month, **When** they view the daily cost section, **Then** they see a chart displaying daily costs grouped by model with a legend identifying each model.
+2. **Given** a user interacts with a chart data point (e.g., hover or tap), **When** the interaction occurs, **Then** a tooltip shows the exact cost and model breakdown for that day.
+3. **Given** a user has usage on some days but not others, **When** they view the daily breakdown, **Then** days with no usage are either omitted or shown as $0.00, and the display remains clear and readable.
+4. **Given** a user wants to understand cost trends, **When** they view the daily breakdown, **Then** the data is presented in a way that allows them to identify which days and models had the highest costs.
+
+---
+
+### Edge Cases
+
+- What happens when the Claude Console API is temporarily unavailable? The system displays the last successfully fetched data with a timestamp and a notice that data may be stale.
+- What happens when a user has usage from a model that is newly released and not yet known to the system? The system displays the model identifier as returned by the API without failing.
+- What happens when token costs change mid-month due to pricing updates? The system reflects costs as reported by the Claude Console API (which applies the correct pricing at the time of usage).
+- What happens if the user has extremely high usage (thousands of API calls per day)? The daily aggregation still performs well and displays correctly.
+- What happens if the API key has insufficient permissions to access billing data? The system displays a specific error indicating the key lacks the required permissions.
+- What happens when an admin views the detail page of a user who has not configured an API key? The cost tracking section shows an empty state indicating no API key has been configured (without prompting the admin to add one).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide each authenticated user with a personal profile page accessible via standard session authentication (no re-authentication required).
+- **FR-002**: System MUST restrict profile page access so that users can only view their own profile data.
+- **FR-003**: The profile page MUST display the user's personal information (name, email, role) in read-only format — no editing capabilities.
+- **FR-004**: The profile page MUST display the user's currently assigned AI tools/licenses with tool name, tier, and assignment date in read-only format.
+- **FR-005**: System MUST fetch and display the total cost for the current calendar month using the admin-configured API key.
+- **FR-006**: System MUST fetch and display daily token costs grouped by model for the current month, presented as a visual chart with supporting data.
+- **FR-007**: System MUST display costs in US dollars (the standard billing currency for Claude Console).
+- **FR-008**: System MUST handle API errors gracefully, showing user-friendly error messages.
+- **FR-009**: System MUST refresh cost data on user request to show up-to-date information.
+- **FR-010**: System MUST handle the case where a user has no API key configured (admin responsibility), showing a message to contact their administrator.
+- **FR-011**: System MUST handle the case where a user has no API usage, showing an appropriate empty state.
+- **FR-012**: System MUST show the date and time of the last successful data fetch.
+- **FR-013**: System MUST display a user's Claude API cost data on the admin user detail page, visible to admin users.
+- **FR-014**: System MUST provide a "My Profile" link in the user avatar/menu dropdown in the header for navigating to the profile page.
+
+### Key Entities
+
+- **API Key Credential**: Represents a user's Claude Console API key. Linked to a single user account. Managed by admins using existing functionality. Used to authenticate requests to the Claude Console billing API.
+- **Daily Cost Record**: Represents the aggregated cost for a specific day, model, and user. Includes date, model identifier, token counts (input and output), and computed cost in US dollars.
+- **Monthly Cost Summary**: Represents the total cost for a user in a given calendar month. Derived by aggregating daily cost records.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can view their current month's total API cost within 3 seconds of navigating to the cost tracking section.
+- **SC-002**: Users can identify their highest-cost model and highest-cost day within the current month in under 10 seconds.
+- **SC-003**: Cost data displayed matches the Claude Console's reported costs with less than 1% variance (accounting for rounding).
+- **SC-004**: Users with an admin-configured API key can see cost data immediately upon first visit to their profile page.
+- **SC-005**: Users without an API key configured see a clear message directing them to contact their administrator.
+
+## Assumptions
+
+- The Claude Console provides an API or accessible endpoint that returns usage and billing data when authenticated with an API key. The specific API contract will be determined during planning.
+- Costs are reported in US dollars, consistent with Anthropic's billing practices.
+- The system already has user authentication in place (NextAuth.js). API keys are managed by admins using existing functionality — users do not store or update their own keys.
+- Cost data granularity is at the daily level per model, as this is the standard granularity available from Claude Console billing.
+- The system will cache fetched cost data locally to reduce API calls and provide faster page loads.

--- a/specs/016-claude-api-costs/spec.md
+++ b/specs/016-claude-api-costs/spec.md
@@ -89,7 +89,7 @@ As a user tracking my Claude API costs, I want to see a day-by-day breakdown of 
 - **FR-006**: System MUST fetch and display daily token costs grouped by model for the current month, presented as a visual chart with supporting data.
 - **FR-007**: System MUST display costs in US dollars (the standard billing currency for Claude Console).
 - **FR-008**: System MUST handle API errors gracefully, showing user-friendly error messages.
-- **FR-009**: System MUST sync usage data via a cron job (external scheduler calling a dedicated API endpoint), incrementally fetching only new days. Manual sync MUST only be available to admins.
+- **FR-009**: System MUST sync usage data via a cron job (external scheduler calling a dedicated API endpoint) that fetches all org usage in a single pass and maps results to individual users. Manual sync of a specific user MUST only be available to admins.
 - **FR-010**: System MUST handle the case where a user has no API key configured (admin responsibility), showing a message to contact their administrator.
 - **FR-011**: System MUST handle the case where a user has no API usage, showing an appropriate empty state.
 - **FR-012**: System MUST show the date of the latest stored usage data.

--- a/specs/016-claude-api-costs/tasks.md
+++ b/specs/016-claude-api-costs/tasks.md
@@ -19,11 +19,11 @@
 
 **Purpose**: Database schema, pricing module, and API integration utilities needed by all stories
 
-- [ ] T001 Add `anthropic_usage_metrics` and `anthropic_sync_status` tables to Drizzle schema in `src/lib/db/schema.ts` — follow the `copilot_usage_metrics` pattern. `anthropic_usage_metrics`: id, userId (FK→users), date, model, uncachedInputTokens (bigint), cacheReadInputTokens (bigint), cacheCreationInputTokens (bigint), outputTokens (bigint), computedCostCents, pricingResolved, createdAt, updatedAt. Unique constraint on (userId, date, model). `anthropic_sync_status`: id, userId (FK→users, unique), lastSyncStartedAt, lastSyncCompletedAt, lastSyncError, syncedDays, resolvedApiKeyId. Add indexes per data-model.md.
+- [x] T001 Add `anthropic_usage_metrics` and `anthropic_sync_status` tables to Drizzle schema in `src/lib/db/schema.ts` — follow the `copilot_usage_metrics` pattern. `anthropic_usage_metrics`: id, userId (FK→users), date, model, uncachedInputTokens (bigint), cacheReadInputTokens (bigint), cacheCreationInputTokens (bigint), outputTokens (bigint), computedCostCents, pricingResolved, createdAt, updatedAt. Unique constraint on (userId, date, model). `anthropic_sync_status`: id, userId (FK→users, unique), lastSyncStartedAt, lastSyncCompletedAt, lastSyncError, syncedDays, resolvedApiKeyId. Add indexes per data-model.md.
 - [ ] T002 Generate and apply database migration for the new tables via `pnpm db:generate && pnpm db:migrate`
-- [ ] T003 [P] Create Anthropic model pricing lookup module in `src/lib/anthropic-pricing.ts` — export `ModelPricing` type, `MODEL_PRICING` array with prefix-based entries for opus-4, sonnet-4, haiku-4, `resolveModelPricing(model)` function returning `{ pricing, resolved }`, and `computeCostCents(tokens, pricing)` function. Use prefix matching (longest first). Fallback to highest pricing with `resolved: false`.
-- [ ] T004 [P] Create Anthropic API key resolution module in `src/lib/anthropic-keys.ts` — export `resolveApiKeyId(decryptedKey, orgKeys)` matching by `partial_key_hint` suffix, and `fetchOrgApiKeys()` calling `GET /v1/organizations/api_keys?status=active&limit=100` with `ANTHROPIC_ADMIN_API_KEY`. Add Zod schema for API response validation.
-- [ ] T005 [P] Add TypeScript types for Anthropic API responses and internal data shapes in `src/types/index.ts` — `AnthropicUsageBucket`, `AnthropicUsageResult`, `CostData`, `DailyBreakdown`, `ProfileData`, etc. per contracts/anthropic-usage-api.md.
+- [x] T003 [P] Create Anthropic model pricing lookup module in `src/lib/anthropic-pricing.ts` — export `ModelPricing` type, `MODEL_PRICING` array with prefix-based entries for opus-4, sonnet-4, haiku-4, `resolveModelPricing(model)` function returning `{ pricing, resolved }`, and `computeCostCents(tokens, pricing)` function. Use prefix matching (longest first). Fallback to highest pricing with `resolved: false`.
+- [x] T004 [P] Create Anthropic API key resolution module in `src/lib/anthropic-keys.ts` — export `resolveApiKeyId(decryptedKey, orgKeys)` matching by `partial_key_hint` suffix, and `fetchOrgApiKeys()` calling `GET /v1/organizations/api_keys?status=active&limit=100` with `ANTHROPIC_ADMIN_API_KEY`. Add Zod schema for API response validation.
+- [x] T005 [P] Add TypeScript types for Anthropic API responses and internal data shapes in `src/types/index.ts` — `AnthropicUsageBucket`, `AnthropicUsageResult`, `CostData`, `DailyBreakdown`, `ProfileData`, etc. per contracts/anthropic-usage-api.md.
 
 **Checkpoint**: Schema deployed, pricing and key resolution modules ready.
 
@@ -35,11 +35,11 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T006 Create Anthropic sync orchestrator in `src/lib/anthropic-sync.ts` — export `runAnthropicSync()` that: (1) resolves all api_key_id→userId mappings from `anthropic_sync_status` (resolve unmapped via `fetchOrgApiKeys`), (2) fetches ALL org usage in one API call (`group_by[]=model&group_by[]=api_key_id&bucket_width=1d`), (3) maps results to users, (4) computes costs via `resolveModelPricing`, (5) upserts into `anthropic_usage_metrics` with `onConflictDoUpdate`. Follow the `copilot-sync.ts` pattern. Handle pagination (`has_more`/`next_page`). Add Zod validation for API response.
-- [ ] T007 Implement global concurrency guard in `runAnthropicSync()` — check `anthropic_sync_status` for in-progress sync (any row with `lastSyncStartedAt` < 60s ago and no completion), stale lock recovery (> 5 min), atomic lock via `lastSyncStartedAt = now()` on all rows, per-user completion/error tracking.
-- [ ] T008 Create cron API route in `src/app/api/anthropic/sync/route.ts` — `POST` handler that validates `Authorization: Bearer <CRON_SECRET>`, calls `runAnthropicSync()`, returns JSON summary `{ success, syncedUsers, skippedUsers, errors }`. Follow the exact pattern of `src/app/api/copilot/sync/route.ts`.
-- [ ] T009 Create server actions in `src/actions/anthropic-usage.ts` — (1) `getUserCostData(userId, month?)`: reads `computedCostCents` from `anthropic_usage_metrics` for the selected month, returns `CostData` shape with `monthlyTotalCents`, `dailyBreakdown`, `latestDataDate`, `hasUnresolvedPricing`. (2) `syncAnthropicUsage(userId)`: admin-only single-user sync via `requireAdmin()`, fetches filtered by `api_key_ids[]=<resolvedApiKeyId>`. (3) `recalculateUnresolvedCosts()`: admin-only, recomputes `computedCostCents` for all `pricingResolved = false` rows.
-- [ ] T010 Create `getProfileData(userId)` server action in `src/actions/anthropic-usage.ts` — fetches user info, assignments (via existing `getUserAssignments`), and cost data (via `getUserCostData`). Returns `ProfileData` type. Handles missing API key (returns `costData.available = false` with error message).
+- [x] T006 Create Anthropic sync orchestrator in `src/lib/anthropic-sync.ts` — export `runAnthropicSync()` that: (1) resolves all api_key_id→userId mappings from `anthropic_sync_status` (resolve unmapped via `fetchOrgApiKeys`), (2) fetches ALL org usage in one API call (`group_by[]=model&group_by[]=api_key_id&bucket_width=1d`), (3) maps results to users, (4) computes costs via `resolveModelPricing`, (5) upserts into `anthropic_usage_metrics` with `onConflictDoUpdate`. Follow the `copilot-sync.ts` pattern. Handle pagination (`has_more`/`next_page`). Add Zod validation for API response.
+- [x] T007 Implement global concurrency guard in `runAnthropicSync()` — check `anthropic_sync_status` for in-progress sync (any row with `lastSyncStartedAt` < 60s ago and no completion), stale lock recovery (> 5 min), atomic lock via `lastSyncStartedAt = now()` on all rows, per-user completion/error tracking.
+- [x] T008 Create cron API route in `src/app/api/anthropic/sync/route.ts` — `POST` handler that validates `Authorization: Bearer <CRON_SECRET>`, calls `runAnthropicSync()`, returns JSON summary `{ success, syncedUsers, skippedUsers, errors }`. Follow the exact pattern of `src/app/api/copilot/sync/route.ts`.
+- [x] T009 Create server actions in `src/actions/anthropic-usage.ts` — (1) `getUserCostData(userId, month?)`: reads `computedCostCents` from `anthropic_usage_metrics` for the selected month, returns `CostData` shape with `monthlyTotalCents`, `dailyBreakdown`, `latestDataDate`, `hasUnresolvedPricing`. (2) `syncAnthropicUsage(userId)`: admin-only single-user sync via `requireAdmin()`, fetches filtered by `api_key_ids[]=<resolvedApiKeyId>`. (3) `recalculateUnresolvedCosts()`: admin-only, recomputes `computedCostCents` for all `pricingResolved = false` rows.
+- [x] T010 Create `getProfileData(userId)` server action in `src/actions/anthropic-usage.ts` — fetches user info, assignments (via existing `getUserAssignments`), and cost data (via `getUserCostData`). Returns `ProfileData` type. Handles missing API key (returns `costData.available = false` with error message).
 
 **Checkpoint**: Cron sync works end-to-end. Server actions return cost data from DB. Foundation ready for UI.
 
@@ -53,12 +53,12 @@
 
 ### Implementation for User Story 1
 
-- [ ] T011 [US1] Create profile page server component in `src/app/profile/page.tsx` — get session via `auth()`, redirect to login if unauthenticated, call `getProfileData(userId)`, pass data to client component. Server component handles data fetching only.
-- [ ] T012 [US1] Create profile page client component in `src/app/profile/profile-client.tsx` — `"use client"`, receives `ProfileData` as prop. Renders profile header, assignments section, and cost tracking section (placeholder for Phase 4). Use Card components from shadcn/ui.
-- [ ] T013 [P] [US1] Create profile header component in `src/components/profile/profile-header.tsx` — displays user name, email, role badge, and profile badge in read-only format. Reuse badge styling from existing `user-detail-client.tsx`. Use shadcn Card, Badge components.
-- [ ] T014 [P] [US1] Create profile assignments component in `src/components/profile/profile-assignments.tsx` — displays user's assigned tools/licenses in a read-only list. Show tool name, tier name, assignment date, status badge. Use shadcn Card, Table, Badge components. Show empty state if no assignments.
-- [ ] T015 [US1] Add "My Profile" link to sidebar user dropdown in `src/components/app-sidebar.tsx` — convert the existing user name/role footer area into a `DropdownMenu` with "My Profile" (links to `/profile`) and "Sign Out" options. Use shadcn DropdownMenu, DropdownMenuItem. Keep ThemeToggle in the dropdown.
-- [ ] T016 [US1] Add access control to profile page — in `src/app/profile/page.tsx`, ensure the page only shows the authenticated user's own data (no `[id]` param, always uses session userId). If someone navigates to `/profile` without auth, redirect to `/api/auth/signin`.
+- [x] T011 [US1] Create profile page server component in `src/app/profile/page.tsx` — get session via `auth()`, redirect to login if unauthenticated, call `getProfileData(userId)`, pass data to client component. Server component handles data fetching only.
+- [x] T012 [US1] Create profile page client component in `src/app/profile/profile-client.tsx` — `"use client"`, receives `ProfileData` as prop. Renders profile header, assignments section, and cost tracking section (placeholder for Phase 4). Use Card components from shadcn/ui.
+- [x] T013 [P] [US1] Create profile header component in `src/components/profile/profile-header.tsx` — displays user name, email, role badge, and profile badge in read-only format. Reuse badge styling from existing `user-detail-client.tsx`. Use shadcn Card, Badge components.
+- [x] T014 [P] [US1] Create profile assignments component in `src/components/profile/profile-assignments.tsx` — displays user's assigned tools/licenses in a read-only list. Show tool name, tier name, assignment date, status badge. Use shadcn Card, Table, Badge components. Show empty state if no assignments.
+- [x] T015 [US1] Add "My Profile" link to sidebar user dropdown in `src/components/app-sidebar.tsx` — convert the existing user name/role footer area into a `DropdownMenu` with "My Profile" (links to `/profile`) and "Sign Out" options. Use shadcn DropdownMenu, DropdownMenuItem. Keep ThemeToggle in the dropdown.
+- [x] T016 [US1] Add access control to profile page — in `src/app/profile/page.tsx`, ensure the page only shows the authenticated user's own data (no `[id]` param, always uses session userId). If someone navigates to `/profile` without auth, redirect to `/api/auth/signin`.
 
 **Checkpoint**: Users can navigate to their profile via sidebar dropdown and see their info + assigned tools. Profile is read-only and self-only.
 
@@ -72,11 +72,11 @@
 
 ### Implementation for User Story 2
 
-- [ ] T017 [P] [US2] Create month picker component in `src/components/profile/month-picker.tsx` — `"use client"`, renders a select/dropdown of available months (from `latestDataDate` back to earliest stored data). Defaults to current month. Emits `onMonthChange(month: string)` callback. Use shadcn Select or Popover with calendar.
-- [ ] T018 [US2] Create cost tracking section component in `src/components/profile/cost-tracking-section.tsx` — `"use client"`, contains month picker, monthly total display (formatted as USD via `formatCurrency`), daily chart (placeholder for Phase 5), and latest data date indicator. Handles three states: (1) no API key configured → show message to contact admin, (2) no usage data → show $0.00 empty state, (3) data available → show total + chart. Fetches cost data for selected month via server action when month changes.
-- [ ] T019 [US2] Wire cost tracking section into profile page — update `src/app/profile/profile-client.tsx` to render `CostTrackingSection` with initial cost data from server, passing the data and a `refreshCostData(month)` callback that calls `getUserCostData`.
-- [ ] T020 [US2] Handle API key not configured state — in `src/components/profile/cost-tracking-section.tsx`, when `costData.available === false`, show an Alert component with message "No Claude API key configured. Contact your administrator to set up cost tracking." Use shadcn Alert with Lucide InfoIcon.
-- [ ] T021 [US2] Handle unresolved pricing indicator — when `costData.hasUnresolvedPricing === true`, show a subtle warning banner: "Some usage data may have approximate costs due to unrecognized models." Use shadcn Alert variant="warning".
+- [x] T017 [P] [US2] Create month picker component in `src/components/profile/month-picker.tsx` — `"use client"`, renders a select/dropdown of available months (from `latestDataDate` back to earliest stored data). Defaults to current month. Emits `onMonthChange(month: string)` callback. Use shadcn Select or Popover with calendar.
+- [x] T018 [US2] Create cost tracking section component in `src/components/profile/cost-tracking-section.tsx` — `"use client"`, contains month picker, monthly total display (formatted as USD via `formatCurrency`), daily chart (placeholder for Phase 5), and latest data date indicator. Handles three states: (1) no API key configured → show message to contact admin, (2) no usage data → show $0.00 empty state, (3) data available → show total + chart. Fetches cost data for selected month via server action when month changes.
+- [x] T019 [US2] Wire cost tracking section into profile page — update `src/app/profile/profile-client.tsx` to render `CostTrackingSection` with initial cost data from server, passing the data and a `refreshCostData(month)` callback that calls `getUserCostData`.
+- [x] T020 [US2] Handle API key not configured state — in `src/components/profile/cost-tracking-section.tsx`, when `costData.available === false`, show an Alert component with message "No Claude API key configured. Contact your administrator to set up cost tracking." Use shadcn Alert with Lucide InfoIcon.
+- [x] T021 [US2] Handle unresolved pricing indicator — when `costData.hasUnresolvedPricing === true`, show a subtle warning banner: "Some usage data may have approximate costs due to unrecognized models." Use shadcn Alert variant="warning".
 
 **Checkpoint**: Users see their monthly total cost, can switch months, and see appropriate empty/error states.
 
@@ -90,10 +90,10 @@
 
 ### Implementation for User Story 3
 
-- [ ] T022 [US3] Create cost chart component in `src/components/cost-chart.tsx` — `"use client"`, renders a Recharts stacked `BarChart` inside shadcn `ChartContainer`. X-axis: dates. Y-axis: cost in USD. One stacked bar segment per model. Use `ChartConfig` with `var(--chart-N)` colors per model. Include `ChartLegend` + `ChartLegendContent`. Add `accessibilityLayer` prop for a11y. Follow the existing pattern from `src/components/copilot/usage-trend-chart.tsx`.
-- [ ] T023 [US3] Add chart tooltips — use shadcn `ChartTooltip` + `ChartTooltipContent` with custom formatter showing model name and cost formatted as USD for each segment, plus daily total. Follow existing tooltip patterns.
-- [ ] T024 [US3] Integrate cost chart into cost tracking section — update `src/components/profile/cost-tracking-section.tsx` to render `CostChart` below the monthly total, passing `dailyBreakdown` data. Transform `dailyBreakdown` into Recharts-compatible format: `Array<{ date: string; [modelName]: number }>`. Handle empty data gracefully (hide chart when no data).
-- [ ] T025 [US3] Add supporting data below chart — render a compact summary below the chart showing: total for the month, number of active days, top model by cost. Use shadcn Card with grid layout.
+- [x] T022 [US3] Create cost chart component in `src/components/cost-chart.tsx` — `"use client"`, renders a Recharts stacked `BarChart` inside shadcn `ChartContainer`. X-axis: dates. Y-axis: cost in USD. One stacked bar segment per model. Use `ChartConfig` with `var(--chart-N)` colors per model. Include `ChartLegend` + `ChartLegendContent`. Add `accessibilityLayer` prop for a11y. Follow the existing pattern from `src/components/copilot/usage-trend-chart.tsx`.
+- [x] T023 [US3] Add chart tooltips — use shadcn `ChartTooltip` + `ChartTooltipContent` with custom formatter showing model name and cost formatted as USD for each segment, plus daily total. Follow existing tooltip patterns.
+- [x] T024 [US3] Integrate cost chart into cost tracking section — update `src/components/profile/cost-tracking-section.tsx` to render `CostChart` below the monthly total, passing `dailyBreakdown` data. Transform `dailyBreakdown` into Recharts-compatible format: `Array<{ date: string; [modelName]: number }>`. Handle empty data gracefully (hide chart when no data).
+- [x] T025 [US3] Add supporting data below chart — render a compact summary below the chart showing: total for the month, number of active days, top model by cost. Use shadcn Card with grid layout.
 
 **Checkpoint**: Full cost tracking view works — monthly total, month picker, daily chart with tooltips, and summary data.
 
@@ -107,9 +107,9 @@
 
 ### Implementation
 
-- [ ] T026 [P] Create reusable admin cost section component in `src/components/profile/admin-cost-section.tsx` — wraps `CostChart` and monthly total display for use in the admin context. Accepts `userId` prop and fetches cost data server-side. Includes a "Sync Now" button that calls `syncAnthropicUsage(userId)` server action with loading state and toast feedback.
-- [ ] T027 Update admin user detail server component in `src/app/users/[id]/page.tsx` — fetch cost data for the viewed user via `getUserCostData(userId)` and pass to client component as a new prop.
-- [ ] T028 Update admin user detail client component in `src/app/users/[id]/user-detail-client.tsx` — add a new "Claude API Costs" section (using the admin cost section component) below the existing "Assigned Tools" section. Show empty state if user has no API key configured (no prompt to add one per spec edge case). Include manual sync button for admins.
+- [x] T026 [P] Create reusable admin cost section component in `src/components/profile/admin-cost-section.tsx` — wraps `CostChart` and monthly total display for use in the admin context. Accepts `userId` prop and fetches cost data server-side. Includes a "Sync Now" button that calls `syncAnthropicUsage(userId)` server action with loading state and toast feedback.
+- [x] T027 Update admin user detail server component in `src/app/users/[id]/page.tsx` — fetch cost data for the viewed user via `getUserCostData(userId)` and pass to client component as a new prop.
+- [x] T028 Update admin user detail client component in `src/app/users/[id]/user-detail-client.tsx` — add a new "Claude API Costs" section (using the admin cost section component) below the existing "Assigned Tools" section. Show empty state if user has no API key configured (no prompt to add one per spec edge case). Include manual sync button for admins.
 
 **Checkpoint**: Admins can view any user's cost data and trigger manual syncs from the user detail page.
 
@@ -119,10 +119,10 @@
 
 **Purpose**: Accessibility, loading states, and validation
 
-- [ ] T029 [P] Add loading states to profile page — add Suspense boundaries and skeleton components for profile header, assignments, and cost tracking section in `src/app/profile/page.tsx` and `src/app/profile/profile-client.tsx`. Use shadcn Skeleton component.
+- [x] T029 [P] Add loading states to profile page — add Suspense boundaries and skeleton components for profile header, assignments, and cost tracking section in `src/app/profile/page.tsx` and `src/app/profile/profile-client.tsx`. Use shadcn Skeleton component.
 - [ ] T030 [P] Verify accessibility — ensure chart has `accessibilityLayer`, all interactive elements are keyboard navigable, color is not sole indicator (legend labels present), focus rings on month picker and buttons. Test with screen reader.
 - [ ] T031 Validate end-to-end flow per quickstart.md — set `ANTHROPIC_ADMIN_API_KEY` env var, trigger cron sync, verify data appears on profile page, verify admin can see and sync user data.
-- [ ] T032 Update `src/components/profile/cost-tracking-section.tsx` to show "Data last synced: [date]" indicator using `latestDataDate` from cost data response.
+- [x] T032 Update `src/components/profile/cost-tracking-section.tsx` to show "Data last synced: [date]" indicator using `latestDataDate` from cost data response.
 
 ---
 

--- a/specs/016-claude-api-costs/tasks.md
+++ b/specs/016-claude-api-costs/tasks.md
@@ -1,0 +1,214 @@
+# Tasks: Claude API Cost Tracking
+
+**Input**: Design documents from `/specs/016-claude-api-costs/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Not explicitly requested — test tasks omitted.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Database schema, pricing module, and API integration utilities needed by all stories
+
+- [ ] T001 Add `anthropic_usage_metrics` and `anthropic_sync_status` tables to Drizzle schema in `src/lib/db/schema.ts` — follow the `copilot_usage_metrics` pattern. `anthropic_usage_metrics`: id, userId (FK→users), date, model, uncachedInputTokens (bigint), cacheReadInputTokens (bigint), cacheCreationInputTokens (bigint), outputTokens (bigint), computedCostCents, pricingResolved, createdAt, updatedAt. Unique constraint on (userId, date, model). `anthropic_sync_status`: id, userId (FK→users, unique), lastSyncStartedAt, lastSyncCompletedAt, lastSyncError, syncedDays, resolvedApiKeyId. Add indexes per data-model.md.
+- [ ] T002 Generate and apply database migration for the new tables via `pnpm db:generate && pnpm db:migrate`
+- [ ] T003 [P] Create Anthropic model pricing lookup module in `src/lib/anthropic-pricing.ts` — export `ModelPricing` type, `MODEL_PRICING` array with prefix-based entries for opus-4, sonnet-4, haiku-4, `resolveModelPricing(model)` function returning `{ pricing, resolved }`, and `computeCostCents(tokens, pricing)` function. Use prefix matching (longest first). Fallback to highest pricing with `resolved: false`.
+- [ ] T004 [P] Create Anthropic API key resolution module in `src/lib/anthropic-keys.ts` — export `resolveApiKeyId(decryptedKey, orgKeys)` matching by `partial_key_hint` suffix, and `fetchOrgApiKeys()` calling `GET /v1/organizations/api_keys?status=active&limit=100` with `ANTHROPIC_ADMIN_API_KEY`. Add Zod schema for API response validation.
+- [ ] T005 [P] Add TypeScript types for Anthropic API responses and internal data shapes in `src/types/index.ts` — `AnthropicUsageBucket`, `AnthropicUsageResult`, `CostData`, `DailyBreakdown`, `ProfileData`, etc. per contracts/anthropic-usage-api.md.
+
+**Checkpoint**: Schema deployed, pricing and key resolution modules ready.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Sync orchestrator and cron endpoint — MUST be complete before user stories can display data
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T006 Create Anthropic sync orchestrator in `src/lib/anthropic-sync.ts` — export `runAnthropicSync()` that: (1) resolves all api_key_id→userId mappings from `anthropic_sync_status` (resolve unmapped via `fetchOrgApiKeys`), (2) fetches ALL org usage in one API call (`group_by[]=model&group_by[]=api_key_id&bucket_width=1d`), (3) maps results to users, (4) computes costs via `resolveModelPricing`, (5) upserts into `anthropic_usage_metrics` with `onConflictDoUpdate`. Follow the `copilot-sync.ts` pattern. Handle pagination (`has_more`/`next_page`). Add Zod validation for API response.
+- [ ] T007 Implement global concurrency guard in `runAnthropicSync()` — check `anthropic_sync_status` for in-progress sync (any row with `lastSyncStartedAt` < 60s ago and no completion), stale lock recovery (> 5 min), atomic lock via `lastSyncStartedAt = now()` on all rows, per-user completion/error tracking.
+- [ ] T008 Create cron API route in `src/app/api/anthropic/sync/route.ts` — `POST` handler that validates `Authorization: Bearer <CRON_SECRET>`, calls `runAnthropicSync()`, returns JSON summary `{ success, syncedUsers, skippedUsers, errors }`. Follow the exact pattern of `src/app/api/copilot/sync/route.ts`.
+- [ ] T009 Create server actions in `src/actions/anthropic-usage.ts` — (1) `getUserCostData(userId, month?)`: reads `computedCostCents` from `anthropic_usage_metrics` for the selected month, returns `CostData` shape with `monthlyTotalCents`, `dailyBreakdown`, `latestDataDate`, `hasUnresolvedPricing`. (2) `syncAnthropicUsage(userId)`: admin-only single-user sync via `requireAdmin()`, fetches filtered by `api_key_ids[]=<resolvedApiKeyId>`. (3) `recalculateUnresolvedCosts()`: admin-only, recomputes `computedCostCents` for all `pricingResolved = false` rows.
+- [ ] T010 Create `getProfileData(userId)` server action in `src/actions/anthropic-usage.ts` — fetches user info, assignments (via existing `getUserAssignments`), and cost data (via `getUserCostData`). Returns `ProfileData` type. Handles missing API key (returns `costData.available = false` with error message).
+
+**Checkpoint**: Cron sync works end-to-end. Server actions return cost data from DB. Foundation ready for UI.
+
+---
+
+## Phase 3: User Story 1 — Access Personal Profile Page (Priority: P1) 🎯 MVP
+
+**Goal**: Authenticated users can access their own read-only profile page showing personal info and assigned tools/licenses.
+
+**Independent Test**: Log in as any user → click "My Profile" in sidebar → see own name, email, role, and assigned tools. Cannot access another user's profile.
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Create profile page server component in `src/app/profile/page.tsx` — get session via `auth()`, redirect to login if unauthenticated, call `getProfileData(userId)`, pass data to client component. Server component handles data fetching only.
+- [ ] T012 [US1] Create profile page client component in `src/app/profile/profile-client.tsx` — `"use client"`, receives `ProfileData` as prop. Renders profile header, assignments section, and cost tracking section (placeholder for Phase 4). Use Card components from shadcn/ui.
+- [ ] T013 [P] [US1] Create profile header component in `src/components/profile/profile-header.tsx` — displays user name, email, role badge, and profile badge in read-only format. Reuse badge styling from existing `user-detail-client.tsx`. Use shadcn Card, Badge components.
+- [ ] T014 [P] [US1] Create profile assignments component in `src/components/profile/profile-assignments.tsx` — displays user's assigned tools/licenses in a read-only list. Show tool name, tier name, assignment date, status badge. Use shadcn Card, Table, Badge components. Show empty state if no assignments.
+- [ ] T015 [US1] Add "My Profile" link to sidebar user dropdown in `src/components/app-sidebar.tsx` — convert the existing user name/role footer area into a `DropdownMenu` with "My Profile" (links to `/profile`) and "Sign Out" options. Use shadcn DropdownMenu, DropdownMenuItem. Keep ThemeToggle in the dropdown.
+- [ ] T016 [US1] Add access control to profile page — in `src/app/profile/page.tsx`, ensure the page only shows the authenticated user's own data (no `[id]` param, always uses session userId). If someone navigates to `/profile` without auth, redirect to `/api/auth/signin`.
+
+**Checkpoint**: Users can navigate to their profile via sidebar dropdown and see their info + assigned tools. Profile is read-only and self-only.
+
+---
+
+## Phase 4: User Story 2 — View Monthly Total Cost with Month Picker (Priority: P1)
+
+**Goal**: Users see their total cost for a selected month (defaulting to current) with a month picker to browse historical data.
+
+**Independent Test**: Log in as user with synced cost data → navigate to profile → see current month's total cost → switch to a past month via picker → see that month's total.
+
+### Implementation for User Story 2
+
+- [ ] T017 [P] [US2] Create month picker component in `src/components/profile/month-picker.tsx` — `"use client"`, renders a select/dropdown of available months (from `latestDataDate` back to earliest stored data). Defaults to current month. Emits `onMonthChange(month: string)` callback. Use shadcn Select or Popover with calendar.
+- [ ] T018 [US2] Create cost tracking section component in `src/components/profile/cost-tracking-section.tsx` — `"use client"`, contains month picker, monthly total display (formatted as USD via `formatCurrency`), daily chart (placeholder for Phase 5), and latest data date indicator. Handles three states: (1) no API key configured → show message to contact admin, (2) no usage data → show $0.00 empty state, (3) data available → show total + chart. Fetches cost data for selected month via server action when month changes.
+- [ ] T019 [US2] Wire cost tracking section into profile page — update `src/app/profile/profile-client.tsx` to render `CostTrackingSection` with initial cost data from server, passing the data and a `refreshCostData(month)` callback that calls `getUserCostData`.
+- [ ] T020 [US2] Handle API key not configured state — in `src/components/profile/cost-tracking-section.tsx`, when `costData.available === false`, show an Alert component with message "No Claude API key configured. Contact your administrator to set up cost tracking." Use shadcn Alert with Lucide InfoIcon.
+- [ ] T021 [US2] Handle unresolved pricing indicator — when `costData.hasUnresolvedPricing === true`, show a subtle warning banner: "Some usage data may have approximate costs due to unrecognized models." Use shadcn Alert variant="warning".
+
+**Checkpoint**: Users see their monthly total cost, can switch months, and see appropriate empty/error states.
+
+---
+
+## Phase 5: User Story 3 — View Daily Token Costs with Visual Chart (Priority: P1)
+
+**Goal**: Users see a daily breakdown of costs by model as a stacked bar chart with tooltips, integrated into the cost tracking section.
+
+**Independent Test**: Log in as user with multi-model usage → see stacked bar chart with per-model colors → hover over a bar → tooltip shows exact cost and model breakdown for that day.
+
+### Implementation for User Story 3
+
+- [ ] T022 [US3] Create cost chart component in `src/components/cost-chart.tsx` — `"use client"`, renders a Recharts stacked `BarChart` inside shadcn `ChartContainer`. X-axis: dates. Y-axis: cost in USD. One stacked bar segment per model. Use `ChartConfig` with `var(--chart-N)` colors per model. Include `ChartLegend` + `ChartLegendContent`. Add `accessibilityLayer` prop for a11y. Follow the existing pattern from `src/components/copilot/usage-trend-chart.tsx`.
+- [ ] T023 [US3] Add chart tooltips — use shadcn `ChartTooltip` + `ChartTooltipContent` with custom formatter showing model name and cost formatted as USD for each segment, plus daily total. Follow existing tooltip patterns.
+- [ ] T024 [US3] Integrate cost chart into cost tracking section — update `src/components/profile/cost-tracking-section.tsx` to render `CostChart` below the monthly total, passing `dailyBreakdown` data. Transform `dailyBreakdown` into Recharts-compatible format: `Array<{ date: string; [modelName]: number }>`. Handle empty data gracefully (hide chart when no data).
+- [ ] T025 [US3] Add supporting data below chart — render a compact summary below the chart showing: total for the month, number of active days, top model by cost. Use shadcn Card with grid layout.
+
+**Checkpoint**: Full cost tracking view works — monthly total, month picker, daily chart with tooltips, and summary data.
+
+---
+
+## Phase 6: Admin Cost View on User Detail Page
+
+**Goal**: Admins can see a user's Claude API cost data on the existing admin user detail page, plus trigger a manual sync.
+
+**Independent Test**: Log in as admin → navigate to a user's detail page → see their cost data (same chart/table as profile) → click "Sync" to trigger a fresh sync for that user.
+
+### Implementation
+
+- [ ] T026 [P] Create reusable admin cost section component in `src/components/profile/admin-cost-section.tsx` — wraps `CostChart` and monthly total display for use in the admin context. Accepts `userId` prop and fetches cost data server-side. Includes a "Sync Now" button that calls `syncAnthropicUsage(userId)` server action with loading state and toast feedback.
+- [ ] T027 Update admin user detail server component in `src/app/users/[id]/page.tsx` — fetch cost data for the viewed user via `getUserCostData(userId)` and pass to client component as a new prop.
+- [ ] T028 Update admin user detail client component in `src/app/users/[id]/user-detail-client.tsx` — add a new "Claude API Costs" section (using the admin cost section component) below the existing "Assigned Tools" section. Show empty state if user has no API key configured (no prompt to add one per spec edge case). Include manual sync button for admins.
+
+**Checkpoint**: Admins can view any user's cost data and trigger manual syncs from the user detail page.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Accessibility, loading states, and validation
+
+- [ ] T029 [P] Add loading states to profile page — add Suspense boundaries and skeleton components for profile header, assignments, and cost tracking section in `src/app/profile/page.tsx` and `src/app/profile/profile-client.tsx`. Use shadcn Skeleton component.
+- [ ] T030 [P] Verify accessibility — ensure chart has `accessibilityLayer`, all interactive elements are keyboard navigable, color is not sole indicator (legend labels present), focus rings on month picker and buttons. Test with screen reader.
+- [ ] T031 Validate end-to-end flow per quickstart.md — set `ANTHROPIC_ADMIN_API_KEY` env var, trigger cron sync, verify data appears on profile page, verify admin can see and sync user data.
+- [ ] T032 Update `src/components/profile/cost-tracking-section.tsx` to show "Data last synced: [date]" indicator using `latestDataDate` from cost data response.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **User Stories (Phase 3-5)**: All depend on Foundational phase completion
+  - US1 (Profile Page) can start independently after Phase 2
+  - US2 (Monthly Total) depends on US1 (needs the profile page container)
+  - US3 (Daily Chart) depends on US2 (needs the cost tracking section container)
+- **Admin Cost View (Phase 6)**: Depends on Phase 2 (server actions) + Phase 5 (chart component to reuse)
+- **Polish (Phase 7)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) — no dependencies on other stories
+- **User Story 2 (P1)**: Depends on US1 (profile page must exist as container)
+- **User Story 3 (P1)**: Depends on US2 (cost tracking section must exist)
+- **Admin View**: Depends on Phase 2 + US3 (reuses chart component)
+
+### Within Each User Story
+
+- Models/components before integration
+- Parallel tasks ([P]) can run concurrently
+- Commit after each task or logical group
+
+### Parallel Opportunities
+
+- T003, T004, T005 can all run in parallel (Phase 1 — different files)
+- T013, T014 can run in parallel (Phase 3 — independent components)
+- T017 can run in parallel with other US2 prep (Phase 4)
+- T026 can run in parallel with other Phase 6 tasks
+- T029, T030 can run in parallel (Phase 7 — different concerns)
+
+---
+
+## Parallel Example: Phase 1 Setup
+
+```bash
+# Launch these three tasks together (different files, no dependencies):
+Task T003: "Create pricing module in src/lib/anthropic-pricing.ts"
+Task T004: "Create key resolution module in src/lib/anthropic-keys.ts"
+Task T005: "Add TypeScript types in src/types/index.ts"
+```
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch profile sub-components together (different files):
+Task T013: "Create profile-header.tsx"
+Task T014: "Create profile-assignments.tsx"
+# Then integrate into the profile page (depends on both):
+Task T012: "Create profile-client.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (schema, pricing, keys)
+2. Complete Phase 2: Foundational (sync orchestrator, cron route, server actions)
+3. Complete Phase 3: User Story 1 (profile page with info + assignments)
+4. **STOP and VALIDATE**: Profile page works, users can navigate to it
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Setup + Foundational → Cron sync works, data flows into DB
+2. Add US1 (Profile Page) → Users can see their info and assignments
+3. Add US2 (Monthly Total + Month Picker) → Users see cost totals, can browse months
+4. Add US3 (Daily Chart) → Full cost visualization with chart
+5. Add Admin View → Admins see costs on user detail page + manual sync
+6. Polish → Loading states, accessibility, validation
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Commit after each task or logical group
+- The cron sync (Phase 2) should be verified working before starting UI work
+- All cost data is read from the database — the profile page never calls the Anthropic API directly
+- Follow existing patterns: `copilot-sync.ts` for sync, `copilot/usage-trend-chart.tsx` for charts, `user-detail-client.tsx` for admin page

--- a/src/actions/anthropic-usage.ts
+++ b/src/actions/anthropic-usage.ts
@@ -54,17 +54,39 @@ export async function getUserCostData(
     };
   }
 
-  // Determine month boundaries
+  // Determine month boundaries (UTC-consistent)
   const now = new Date();
   const targetMonth =
-    month ?? `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-  const [yearStr, monthStr] = targetMonth.split("-");
-  const year = parseInt(yearStr, 10);
-  const mon = parseInt(monthStr, 10);
+    month ?? `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+
+  // Validate month format: YYYY-MM with month 01–12
+  const monthMatch = targetMonth.match(/^(\d{4})-(\d{2})$/);
+  if (!monthMatch) {
+    return {
+      available: false,
+      error: "Invalid month format. Expected YYYY-MM.",
+      monthlyTotalCents: 0,
+      dailyBreakdown: [],
+      latestDataDate: null,
+      hasUnresolvedPricing: false,
+    };
+  }
+  const year = parseInt(monthMatch[1], 10);
+  const mon = parseInt(monthMatch[2], 10);
+  if (mon < 1 || mon > 12) {
+    return {
+      available: false,
+      error: "Invalid month. Must be between 01 and 12.",
+      monthlyTotalCents: 0,
+      dailyBreakdown: [],
+      latestDataDate: null,
+      hasUnresolvedPricing: false,
+    };
+  }
 
   const startDate = `${targetMonth}-01`;
   // End date: last day of the month
-  const lastDay = new Date(year, mon, 0).getDate();
+  const lastDay = new Date(Date.UTC(year, mon, 0)).getUTCDate();
   const endDate = `${targetMonth}-${String(lastDay).padStart(2, "0")}`;
 
   // Check if the user has an active Anthropic assignment with API key configured
@@ -182,6 +204,16 @@ export async function getUserCostData(
 // ---------------------------------------------------------------------------
 
 export async function getProfileData(userId: number): Promise<ProfileData> {
+  // Auth check: caller must be the same user or an admin
+  const session = await auth();
+  if (!session?.user) {
+    throw new Error("Unauthorized — not signed in.");
+  }
+  const callerId = Number(session.user.id);
+  if (callerId !== userId && session.user.role !== "admin") {
+    throw new Error("Unauthorized — you can only view your own profile.");
+  }
+
   const user = await db.query.users.findFirst({
     where: eq(users.id, userId),
   });
@@ -236,6 +268,12 @@ export async function getProfileData(userId: number): Promise<ProfileData> {
 // ---------------------------------------------------------------------------
 
 export async function getAvailableMonths(userId: number): Promise<string[]> {
+  // Auth check: caller must be the same user or an admin
+  const session = await auth();
+  if (!session?.user) return [];
+  const callerId = Number(session.user.id);
+  if (callerId !== userId && session.user.role !== "admin") return [];
+
   const monthRows = await db
     .selectDistinct({
       month: sql<string>`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM')`,

--- a/src/actions/anthropic-usage.ts
+++ b/src/actions/anthropic-usage.ts
@@ -13,6 +13,7 @@ import { requireAdmin } from "@/lib/auth-helpers";
 import { syncSingleUser } from "@/lib/anthropic-sync";
 import { resolveModelPricing, computeCostCents } from "@/lib/anthropic-pricing";
 import { revalidatePath } from "next/cache";
+import { getCurrentMonth } from "@/lib/utils";
 import type {
   CostData,
   ProfileData,
@@ -201,6 +202,27 @@ export async function getProfileData(userId: number): Promise<ProfileData> {
     })),
     costData,
   };
+}
+
+// ---------------------------------------------------------------------------
+// getAvailableMonths — distinct months with usage data for a user
+// ---------------------------------------------------------------------------
+
+export async function getAvailableMonths(userId: number): Promise<string[]> {
+  const monthRows = await db
+    .selectDistinct({
+      month: sql<string>`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM')`,
+    })
+    .from(anthropicUsageMetrics)
+    .where(eq(anthropicUsageMetrics.userId, userId))
+    .orderBy(sql`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM') DESC`);
+
+  const months = monthRows.map((r) => r.month);
+  const currentMonth = getCurrentMonth();
+  if (!months.includes(currentMonth)) {
+    months.unshift(currentMonth);
+  }
+  return months;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/actions/anthropic-usage.ts
+++ b/src/actions/anthropic-usage.ts
@@ -287,7 +287,12 @@ export async function syncAnthropicUsage(
 // ---------------------------------------------------------------------------
 
 export async function syncAllAnthropicUsage(): Promise<
-  ActionResult<{ syncedUsers: number; skippedUsers: number; errorCount: number }>
+  ActionResult<{
+    syncedUsers: number;
+    skippedUsers: number;
+    errorCount: number;
+    firstError: string | null;
+  }>
 > {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
@@ -303,6 +308,7 @@ export async function syncAllAnthropicUsage(): Promise<
         syncedUsers: summary.syncedUsers,
         skippedUsers: summary.skippedUsers,
         errorCount: summary.errors.length,
+        firstError: summary.errors[0]?.error ?? null,
       },
     };
   } catch (err) {

--- a/src/actions/anthropic-usage.ts
+++ b/src/actions/anthropic-usage.ts
@@ -8,10 +8,10 @@ import {
   accessTiers,
   users,
 } from "@/lib/db/schema";
-import { eq, and, sql, between, desc, isNotNull } from "drizzle-orm";
+import { eq, and, sql, between, isNotNull } from "drizzle-orm";
 import { requireAdmin } from "@/lib/auth-helpers";
 import { auth } from "@/lib/auth";
-import { syncSingleUser, runAnthropicSync } from "@/lib/anthropic-sync";
+import { syncSingleUser, runAnthropicSync, anthropicToolFilter } from "@/lib/anthropic-sync";
 import { resolveModelPricing, computeCostCents } from "@/lib/anthropic-pricing";
 import { revalidatePath } from "next/cache";
 import { getCurrentMonth } from "@/lib/utils";
@@ -77,7 +77,7 @@ export async function getUserCostData(
         eq(licenseAssignments.userId, userId),
         eq(licenseAssignments.status, "active"),
         isNotNull(licenseAssignments.apiKeyEncrypted),
-        sql`(${aiTools.vendor} ILIKE '%anthropic%' OR ${aiTools.name} ILIKE '%claude%')`
+        anthropicToolFilter
       )
     )
     .limit(1);

--- a/src/actions/anthropic-usage.ts
+++ b/src/actions/anthropic-usage.ts
@@ -1,0 +1,297 @@
+"use server";
+
+import { db } from "@/lib/db";
+import {
+  anthropicUsageMetrics,
+  licenseAssignments,
+  aiTools,
+  accessTiers,
+  users,
+} from "@/lib/db/schema";
+import { eq, and, sql, between, desc } from "drizzle-orm";
+import { requireAdmin } from "@/lib/auth-helpers";
+import { syncSingleUser } from "@/lib/anthropic-sync";
+import { resolveModelPricing, computeCostCents } from "@/lib/anthropic-pricing";
+import { revalidatePath } from "next/cache";
+import type {
+  CostData,
+  ProfileData,
+  ActionResult,
+  DailyModelCost,
+} from "@/types";
+
+// ---------------------------------------------------------------------------
+// getUserCostData — fetch daily Anthropic API cost breakdown for a user
+// ---------------------------------------------------------------------------
+
+export async function getUserCostData(
+  userId: number,
+  month?: string
+): Promise<CostData> {
+  // Determine month boundaries
+  const now = new Date();
+  const targetMonth =
+    month ?? `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  const [yearStr, monthStr] = targetMonth.split("-");
+  const year = parseInt(yearStr, 10);
+  const mon = parseInt(monthStr, 10);
+
+  const startDate = `${targetMonth}-01`;
+  // End date: last day of the month
+  const lastDay = new Date(year, mon, 0).getDate();
+  const endDate = `${targetMonth}-${String(lastDay).padStart(2, "0")}`;
+
+  // Check if the user has any Anthropic API key via license_assignments + ai_tools
+  const [anthropicAssignment] = await db
+    .select({ id: licenseAssignments.id })
+    .from(licenseAssignments)
+    .innerJoin(aiTools, eq(licenseAssignments.toolId, aiTools.id))
+    .where(
+      and(
+        eq(licenseAssignments.userId, userId),
+        sql`(${aiTools.vendor} ILIKE '%anthropic%' OR ${aiTools.name} ILIKE '%claude%')`
+      )
+    )
+    .limit(1);
+
+  if (!anthropicAssignment) {
+    return {
+      available: false,
+      error:
+        "No Claude API key configured. Contact your administrator.",
+      monthlyTotalCents: 0,
+      dailyBreakdown: [],
+      latestDataDate: null,
+      hasUnresolvedPricing: false,
+    };
+  }
+
+  // Query usage metrics for the user in the date range
+  const metrics = await db
+    .select()
+    .from(anthropicUsageMetrics)
+    .where(
+      and(
+        eq(anthropicUsageMetrics.userId, userId),
+        between(anthropicUsageMetrics.date, startDate, endDate)
+      )
+    )
+    .orderBy(anthropicUsageMetrics.date);
+
+  if (metrics.length === 0) {
+    return {
+      available: true,
+      monthlyTotalCents: 0,
+      dailyBreakdown: [],
+      latestDataDate: null,
+      hasUnresolvedPricing: false,
+    };
+  }
+
+  // Aggregate by date
+  const dailyMap = new Map<
+    string,
+    { models: DailyModelCost[]; totalCents: number }
+  >();
+  let monthlyTotalCents = 0;
+  let latestDataDate: string | null = null;
+  let hasUnresolvedPricing = false;
+
+  for (const row of metrics) {
+    const dateStr = row.date;
+    if (!latestDataDate || dateStr > latestDataDate) {
+      latestDataDate = dateStr;
+    }
+    if (!row.pricingResolved) {
+      hasUnresolvedPricing = true;
+    }
+
+    const inputTokens =
+      row.uncachedInputTokens +
+      row.cacheReadInputTokens +
+      row.cacheCreationInputTokens;
+
+    const modelEntry: DailyModelCost = {
+      model: row.model,
+      costCents: row.computedCostCents,
+      inputTokens,
+      outputTokens: row.outputTokens,
+    };
+
+    const existing = dailyMap.get(dateStr);
+    if (existing) {
+      existing.models.push(modelEntry);
+      existing.totalCents += row.computedCostCents;
+    } else {
+      dailyMap.set(dateStr, {
+        models: [modelEntry],
+        totalCents: row.computedCostCents,
+      });
+    }
+
+    monthlyTotalCents += row.computedCostCents;
+  }
+
+  const dailyBreakdown = Array.from(dailyMap.entries())
+    .map(([date, data]) => ({
+      date,
+      models: data.models,
+      totalCents: data.totalCents,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return {
+    available: true,
+    monthlyTotalCents,
+    dailyBreakdown,
+    latestDataDate,
+    hasUnresolvedPricing,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getProfileData — fetch user profile with assignments and cost data
+// ---------------------------------------------------------------------------
+
+export async function getProfileData(userId: number): Promise<ProfileData> {
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+  });
+
+  if (!user) {
+    throw new Error(`User not found: ${userId}`);
+  }
+
+  // Fetch active assignments with tool and tier info
+  const assignments = await db
+    .select({
+      id: licenseAssignments.id,
+      toolName: aiTools.name,
+      tierName: accessTiers.name,
+      assignedAt: licenseAssignments.assignedAt,
+      status: licenseAssignments.status,
+    })
+    .from(licenseAssignments)
+    .innerJoin(aiTools, eq(licenseAssignments.toolId, aiTools.id))
+    .innerJoin(accessTiers, eq(licenseAssignments.tierId, accessTiers.id))
+    .where(
+      and(
+        eq(licenseAssignments.userId, userId),
+        eq(licenseAssignments.status, "active")
+      )
+    );
+
+  const costData = await getUserCostData(userId);
+
+  return {
+    user: {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role as "admin" | "viewer",
+      circle: user.circle,
+      profile: user.profile as "boost" | "maxed" | "indie" | null,
+    },
+    assignments: assignments.map((a) => ({
+      id: a.id,
+      toolName: a.toolName,
+      tierName: a.tierName,
+      assignedAt: a.assignedAt,
+      status: a.status as "active" | "inactive",
+    })),
+    costData,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// syncAnthropicUsage — admin-only manual sync for a single user
+// ---------------------------------------------------------------------------
+
+export async function syncAnthropicUsage(
+  userId: number
+): Promise<ActionResult<{ syncedDays: number; latestDate: string | null }>> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  try {
+    const result = await syncSingleUser(userId);
+
+    revalidatePath(`/admin/users/${userId}`);
+
+    return {
+      success: true,
+      data: result,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error:
+        err instanceof Error
+          ? err.message
+          : "Failed to sync Anthropic usage data",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// recalculateUnresolvedCosts — admin-only repricing of unresolved rows
+// ---------------------------------------------------------------------------
+
+export async function recalculateUnresolvedCosts(): Promise<
+  ActionResult<{ updatedRows: number; stillUnresolved: number }>
+> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  try {
+    // Fetch all rows where pricing was not resolved
+    const unresolvedRows = await db
+      .select()
+      .from(anthropicUsageMetrics)
+      .where(eq(anthropicUsageMetrics.pricingResolved, false));
+
+    let updatedRows = 0;
+    let stillUnresolved = 0;
+
+    for (const row of unresolvedRows) {
+      const { pricing, resolved } = resolveModelPricing(row.model);
+      const newCostCents = computeCostCents(
+        {
+          uncachedInputTokens: row.uncachedInputTokens,
+          cacheReadInputTokens: row.cacheReadInputTokens,
+          cacheCreationInputTokens: row.cacheCreationInputTokens,
+          outputTokens: row.outputTokens,
+        },
+        pricing
+      );
+
+      await db
+        .update(anthropicUsageMetrics)
+        .set({
+          computedCostCents: newCostCents,
+          pricingResolved: resolved,
+          updatedAt: new Date(),
+        })
+        .where(eq(anthropicUsageMetrics.id, row.id));
+
+      if (resolved) {
+        updatedRows++;
+      } else {
+        stillUnresolved++;
+      }
+    }
+
+    return {
+      success: true,
+      data: { updatedRows, stillUnresolved },
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error:
+        err instanceof Error
+          ? err.message
+          : "Failed to recalculate unresolved costs",
+    };
+  }
+}

--- a/src/actions/anthropic-usage.ts
+++ b/src/actions/anthropic-usage.ts
@@ -8,8 +8,9 @@ import {
   accessTiers,
   users,
 } from "@/lib/db/schema";
-import { eq, and, sql, between, desc } from "drizzle-orm";
+import { eq, and, sql, between, desc, isNotNull } from "drizzle-orm";
 import { requireAdmin } from "@/lib/auth-helpers";
+import { auth } from "@/lib/auth";
 import { syncSingleUser } from "@/lib/anthropic-sync";
 import { resolveModelPricing, computeCostCents } from "@/lib/anthropic-pricing";
 import { revalidatePath } from "next/cache";
@@ -29,6 +30,30 @@ export async function getUserCostData(
   userId: number,
   month?: string
 ): Promise<CostData> {
+  // Auth check: caller must be the same user or an admin
+  const session = await auth();
+  if (!session?.user) {
+    return {
+      available: false,
+      error: "Unauthorized — not signed in.",
+      monthlyTotalCents: 0,
+      dailyBreakdown: [],
+      latestDataDate: null,
+      hasUnresolvedPricing: false,
+    };
+  }
+  const callerId = Number(session.user.id);
+  if (callerId !== userId && session.user.role !== "admin") {
+    return {
+      available: false,
+      error: "Unauthorized — you can only view your own cost data.",
+      monthlyTotalCents: 0,
+      dailyBreakdown: [],
+      latestDataDate: null,
+      hasUnresolvedPricing: false,
+    };
+  }
+
   // Determine month boundaries
   const now = new Date();
   const targetMonth =
@@ -42,7 +67,7 @@ export async function getUserCostData(
   const lastDay = new Date(year, mon, 0).getDate();
   const endDate = `${targetMonth}-${String(lastDay).padStart(2, "0")}`;
 
-  // Check if the user has any Anthropic API key via license_assignments + ai_tools
+  // Check if the user has an active Anthropic assignment with API key configured
   const [anthropicAssignment] = await db
     .select({ id: licenseAssignments.id })
     .from(licenseAssignments)
@@ -50,6 +75,8 @@ export async function getUserCostData(
     .where(
       and(
         eq(licenseAssignments.userId, userId),
+        eq(licenseAssignments.status, "active"),
+        isNotNull(licenseAssignments.apiKeyEncrypted),
         sql`(${aiTools.vendor} ILIKE '%anthropic%' OR ${aiTools.name} ILIKE '%claude%')`
       )
     )
@@ -238,7 +265,7 @@ export async function syncAnthropicUsage(
   try {
     const result = await syncSingleUser(userId);
 
-    revalidatePath(`/admin/users/${userId}`);
+    revalidatePath(`/users/${userId}`);
 
     return {
       success: true,

--- a/src/actions/anthropic-usage.ts
+++ b/src/actions/anthropic-usage.ts
@@ -11,7 +11,7 @@ import {
 import { eq, and, sql, between, desc, isNotNull } from "drizzle-orm";
 import { requireAdmin } from "@/lib/auth-helpers";
 import { auth } from "@/lib/auth";
-import { syncSingleUser } from "@/lib/anthropic-sync";
+import { syncSingleUser, runAnthropicSync } from "@/lib/anthropic-sync";
 import { resolveModelPricing, computeCostCents } from "@/lib/anthropic-pricing";
 import { revalidatePath } from "next/cache";
 import { getCurrentMonth } from "@/lib/utils";
@@ -270,6 +270,40 @@ export async function syncAnthropicUsage(
     return {
       success: true,
       data: result,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error:
+        err instanceof Error
+          ? err.message
+          : "Failed to sync Anthropic usage data",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// syncAllAnthropicUsage — admin-only manual sync for all users
+// ---------------------------------------------------------------------------
+
+export async function syncAllAnthropicUsage(): Promise<
+  ActionResult<{ syncedUsers: number; skippedUsers: number; errorCount: number }>
+> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  try {
+    const summary = await runAnthropicSync();
+
+    revalidatePath("/users");
+
+    return {
+      success: true,
+      data: {
+        syncedUsers: summary.syncedUsers,
+        skippedUsers: summary.skippedUsers,
+        errorCount: summary.errors.length,
+      },
     };
   } catch (err) {
     return {

--- a/src/app/api/anthropic/sync/route.ts
+++ b/src/app/api/anthropic/sync/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runAnthropicSync } from "@/lib/anthropic-sync";
+
+export async function POST(request: NextRequest) {
+  // Authenticate with CRON_SECRET
+  const authHeader = request.headers.get("authorization");
+  const expectedToken = process.env.CRON_SECRET;
+
+  if (!expectedToken || authHeader !== `Bearer ${expectedToken}`) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const summary = await runAnthropicSync();
+
+    return NextResponse.json({
+      success: true,
+      ...summary,
+    });
+  } catch (err) {
+    console.error("Cron Anthropic sync failed:", err);
+    return NextResponse.json(
+      {
+        success: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,9 +1,7 @@
-import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { getProfileData, getAvailableMonths } from "@/actions/anthropic-usage";
 import { ProfileClient } from "./profile-client";
-import { Skeleton } from "@/components/ui/skeleton";
 
 export default async function ProfilePage() {
   const session = await auth();
@@ -19,22 +17,6 @@ export default async function ProfilePage() {
   ]);
 
   return (
-    <Suspense fallback={<ProfileSkeleton />}>
-      <ProfileClient data={profileData} availableMonths={availableMonths} />
-    </Suspense>
-  );
-}
-
-function ProfileSkeleton() {
-  return (
-    <div className="mx-auto max-w-4xl space-y-6 p-6">
-      <div>
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="mt-2 h-4 w-72" />
-      </div>
-      <Skeleton className="h-32 w-full rounded-lg" />
-      <Skeleton className="h-48 w-full rounded-lg" />
-      <Skeleton className="h-96 w-full rounded-lg" />
-    </div>
+    <ProfileClient data={profileData} availableMonths={availableMonths} />
   );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getProfileData } from "@/actions/anthropic-usage";
+import { ProfileClient } from "./profile-client";
+
+export default async function ProfilePage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/api/auth/signin");
+  }
+
+  const userId = Number(session.user.id);
+  const profileData = await getProfileData(userId);
+
+  return <ProfileClient data={profileData} />;
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { getProfileData } from "@/actions/anthropic-usage";
@@ -5,6 +6,7 @@ import { db } from "@/lib/db";
 import { anthropicUsageMetrics } from "@/lib/db/schema";
 import { eq, sql } from "drizzle-orm";
 import { ProfileClient } from "./profile-client";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default async function ProfilePage() {
   const session = await auth();
@@ -36,5 +38,23 @@ export default async function ProfilePage() {
     availableMonths.unshift(currentMonth);
   }
 
-  return <ProfileClient data={profileData} availableMonths={availableMonths} />;
+  return (
+    <Suspense fallback={<ProfileSkeleton />}>
+      <ProfileClient data={profileData} availableMonths={availableMonths} />
+    </Suspense>
+  );
+}
+
+function ProfileSkeleton() {
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <div>
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="mt-2 h-4 w-72" />
+      </div>
+      <Skeleton className="h-32 w-full rounded-lg" />
+      <Skeleton className="h-48 w-full rounded-lg" />
+      <Skeleton className="h-96 w-full rounded-lg" />
+    </div>
+  );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,9 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { getProfileData } from "@/actions/anthropic-usage";
+import { db } from "@/lib/db";
+import { anthropicUsageMetrics } from "@/lib/db/schema";
+import { eq, sql } from "drizzle-orm";
 import { ProfileClient } from "./profile-client";
 
 export default async function ProfilePage() {
@@ -13,5 +16,25 @@ export default async function ProfilePage() {
   const userId = Number(session.user.id);
   const profileData = await getProfileData(userId);
 
-  return <ProfileClient data={profileData} />;
+  // Fetch available months for the month picker
+  const monthRows = await db
+    .selectDistinct({
+      month: sql<string>`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM')`,
+    })
+    .from(anthropicUsageMetrics)
+    .where(eq(anthropicUsageMetrics.userId, userId))
+    .orderBy(
+      sql`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM') DESC`
+    );
+
+  const availableMonths = monthRows.map((r) => r.month);
+
+  // Ensure current month is always in the list
+  const now = new Date();
+  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  if (!availableMonths.includes(currentMonth)) {
+    availableMonths.unshift(currentMonth);
+  }
+
+  return <ProfileClient data={profileData} availableMonths={availableMonths} />;
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,10 +1,7 @@
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
-import { getProfileData } from "@/actions/anthropic-usage";
-import { db } from "@/lib/db";
-import { anthropicUsageMetrics } from "@/lib/db/schema";
-import { eq, sql } from "drizzle-orm";
+import { getProfileData, getAvailableMonths } from "@/actions/anthropic-usage";
 import { ProfileClient } from "./profile-client";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -16,27 +13,10 @@ export default async function ProfilePage() {
   }
 
   const userId = Number(session.user.id);
-  const profileData = await getProfileData(userId);
-
-  // Fetch available months for the month picker
-  const monthRows = await db
-    .selectDistinct({
-      month: sql<string>`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM')`,
-    })
-    .from(anthropicUsageMetrics)
-    .where(eq(anthropicUsageMetrics.userId, userId))
-    .orderBy(
-      sql`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM') DESC`
-    );
-
-  const availableMonths = monthRows.map((r) => r.month);
-
-  // Ensure current month is always in the list
-  const now = new Date();
-  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-  if (!availableMonths.includes(currentMonth)) {
-    availableMonths.unshift(currentMonth);
-  }
+  const [profileData, availableMonths] = await Promise.all([
+    getProfileData(userId),
+    getAvailableMonths(userId),
+  ]);
 
   return (
     <Suspense fallback={<ProfileSkeleton />}>

--- a/src/app/profile/profile-client.tsx
+++ b/src/app/profile/profile-client.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { ProfileHeader } from "@/components/profile/profile-header";
+import { ProfileAssignments } from "@/components/profile/profile-assignments";
+import type { ProfileData } from "@/types";
+
+type ProfileClientProps = {
+  data: ProfileData;
+};
+
+export function ProfileClient({ data }: ProfileClientProps) {
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">My Profile</h1>
+        <p className="text-muted-foreground">
+          Your personal information and assigned tools.
+        </p>
+      </div>
+
+      <ProfileHeader user={data.user} />
+      <ProfileAssignments assignments={data.assignments} />
+
+      {/* Cost tracking section will be added in Phase 4 (US2) */}
+    </div>
+  );
+}

--- a/src/app/profile/profile-client.tsx
+++ b/src/app/profile/profile-client.tsx
@@ -2,26 +2,31 @@
 
 import { ProfileHeader } from "@/components/profile/profile-header";
 import { ProfileAssignments } from "@/components/profile/profile-assignments";
+import { CostTrackingSection } from "@/components/profile/cost-tracking-section";
 import type { ProfileData } from "@/types";
 
 type ProfileClientProps = {
   data: ProfileData;
+  availableMonths: string[];
 };
 
-export function ProfileClient({ data }: ProfileClientProps) {
+export function ProfileClient({ data, availableMonths }: ProfileClientProps) {
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">My Profile</h1>
         <p className="text-muted-foreground">
-          Your personal information and assigned tools.
+          Your personal information, assigned tools, and API costs.
         </p>
       </div>
 
       <ProfileHeader user={data.user} />
       <ProfileAssignments assignments={data.assignments} />
-
-      {/* Cost tracking section will be added in Phase 4 (US2) */}
+      <CostTrackingSection
+        userId={data.user.id}
+        initialData={data.costData}
+        availableMonths={availableMonths}
+      />
     </div>
   );
 }

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,12 +1,9 @@
 import { notFound } from "next/navigation";
-import { eq, sql } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { getUserById, getUserAssignments } from "@/actions/users";
 import { getEntityHistory } from "@/actions/history";
 import { getGitHubProfile } from "@/actions/github";
-import { getUserCostData } from "@/actions/anthropic-usage";
-import { db } from "@/lib/db";
-import { anthropicUsageMetrics } from "@/lib/db/schema";
+import { getUserCostData, getAvailableMonths } from "@/actions/anthropic-usage";
 import { UserDetailClient } from "./user-detail-client";
 import { AuthGuard } from "@/components/auth-guard";
 
@@ -25,32 +22,15 @@ export default async function UserDetailPage({
   const user = await getUserById(userId);
   if (!user) notFound();
 
-  const [assignments, historyResult, ghResult] = await Promise.all([
+  const [assignments, historyResult, ghResult, costData, costAvailableMonths] = await Promise.all([
     getUserAssignments(userId),
     getEntityHistory("user", userId),
     getGitHubProfile(userId),
+    getUserCostData(userId),
+    getAvailableMonths(userId),
   ]);
   const history = historyResult.success ? historyResult.data.records : [];
   const githubProfile = ghResult.success ? ghResult.data.profile : null;
-
-  // Fetch Claude API cost data
-  const costData = await getUserCostData(Number(params.id));
-
-  // Fetch available months for this user
-  const costMonthRows = await db
-    .selectDistinct({
-      month: sql<string>`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM')`,
-    })
-    .from(anthropicUsageMetrics)
-    .where(eq(anthropicUsageMetrics.userId, Number(params.id)))
-    .orderBy(sql`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM') DESC`);
-
-  const costAvailableMonths = costMonthRows.map((r) => r.month);
-  const now = new Date();
-  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-  if (!costAvailableMonths.includes(currentMonth)) {
-    costAvailableMonths.unshift(currentMonth);
-  }
 
   return (
     <AuthGuard requiredRole="admin">

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,8 +1,12 @@
 import { notFound } from "next/navigation";
+import { eq, sql } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { getUserById, getUserAssignments } from "@/actions/users";
 import { getEntityHistory } from "@/actions/history";
 import { getGitHubProfile } from "@/actions/github";
+import { getUserCostData } from "@/actions/anthropic-usage";
+import { db } from "@/lib/db";
+import { anthropicUsageMetrics } from "@/lib/db/schema";
 import { UserDetailClient } from "./user-detail-client";
 import { AuthGuard } from "@/components/auth-guard";
 
@@ -29,6 +33,25 @@ export default async function UserDetailPage({
   const history = historyResult.success ? historyResult.data.records : [];
   const githubProfile = ghResult.success ? ghResult.data.profile : null;
 
+  // Fetch Claude API cost data
+  const costData = await getUserCostData(Number(params.id));
+
+  // Fetch available months for this user
+  const costMonthRows = await db
+    .selectDistinct({
+      month: sql<string>`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM')`,
+    })
+    .from(anthropicUsageMetrics)
+    .where(eq(anthropicUsageMetrics.userId, Number(params.id)))
+    .orderBy(sql`TO_CHAR(${anthropicUsageMetrics.date}, 'YYYY-MM') DESC`);
+
+  const costAvailableMonths = costMonthRows.map((r) => r.month);
+  const now = new Date();
+  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  if (!costAvailableMonths.includes(currentMonth)) {
+    costAvailableMonths.unshift(currentMonth);
+  }
+
   return (
     <AuthGuard requiredRole="admin">
       <UserDetailClient
@@ -37,6 +60,8 @@ export default async function UserDetailPage({
         history={history}
         isAdmin={isAdmin}
         githubProfile={githubProfile}
+        costData={costData}
+        costAvailableMonths={costAvailableMonths}
       />
     </AuthGuard>
   );

--- a/src/app/users/[id]/user-detail-client.tsx
+++ b/src/app/users/[id]/user-detail-client.tsx
@@ -8,7 +8,8 @@ import { updateUser, deactivateUser } from "@/actions/users";
 import { updateUserSchema, type UpdateUserInput } from "@/lib/validators";
 import { revokeLicense } from "@/actions/assignments";
 import { formatCurrency, formatDate } from "@/lib/utils";
-import type { User, ChangeHistoryRecord } from "@/types";
+import type { User, ChangeHistoryRecord, CostData } from "@/types";
+import { AdminCostSection } from "@/components/profile/admin-cost-section";
 import { Github, ExternalLink, BookOpen } from "lucide-react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
@@ -77,6 +78,8 @@ interface Props {
   history: ChangeHistoryRecord[];
   isAdmin: boolean;
   githubProfile?: GitHubProfileData | null;
+  costData: CostData;
+  costAvailableMonths: string[];
 }
 
 export function UserDetailClient({
@@ -85,6 +88,8 @@ export function UserDetailClient({
   history,
   isAdmin,
   githubProfile,
+  costData,
+  costAvailableMonths,
 }: Props) {
   const router = useRouter();
 
@@ -418,6 +423,8 @@ export function UserDetailClient({
           )}
         </CardContent>
       </Card>
+
+      <AdminCostSection userId={user.id} initialData={costData} availableMonths={costAvailableMonths} />
 
       <Card>
         <CardHeader>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -4,6 +4,7 @@ import { auth } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
 import { Plus, Download } from "lucide-react";
 import { UsersTable } from "./users-table";
+import { SyncAllButton } from "./sync-all-button";
 import { AuthGuard } from "@/components/auth-guard";
 
 export default async function UsersPage() {
@@ -21,6 +22,7 @@ export default async function UsersPage() {
           </div>
           {isAdmin && (
             <div className="flex gap-2">
+              <SyncAllButton />
               <Button variant="outline" asChild>
                 <a href="/api/export/users" download>
                   <Download className="mr-2 size-4" />

--- a/src/app/users/sync-all-button.tsx
+++ b/src/app/users/sync-all-button.tsx
@@ -14,12 +14,19 @@ export function SyncAllButton() {
     try {
       const result = await syncAllAnthropicUsage();
       if (result.success) {
-        const { syncedUsers, skippedUsers, errorCount } = result.data;
-        toast.success(
-          `Synced ${syncedUsers} user${syncedUsers !== 1 ? "s" : ""}` +
-            (skippedUsers > 0 ? `, ${skippedUsers} skipped` : "") +
-            (errorCount > 0 ? `, ${errorCount} error${errorCount !== 1 ? "s" : ""}` : "")
-        );
+        const { syncedUsers, skippedUsers, errorCount, firstError } =
+          result.data;
+        if (errorCount > 0 && syncedUsers === 0) {
+          toast.error(firstError ?? `Sync failed with ${errorCount} error(s)`);
+        } else {
+          toast.success(
+            `Synced ${syncedUsers} user${syncedUsers !== 1 ? "s" : ""}` +
+              (skippedUsers > 0 ? `, ${skippedUsers} skipped` : "") +
+              (errorCount > 0
+                ? `, ${errorCount} error${errorCount !== 1 ? "s" : ""}`
+                : "")
+          );
+        }
       } else {
         toast.error(result.error);
       }

--- a/src/app/users/sync-all-button.tsx
+++ b/src/app/users/sync-all-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+import { syncAllAnthropicUsage } from "@/actions/anthropic-usage";
+import { toast } from "sonner";
+
+export function SyncAllButton() {
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  async function handleSyncAll() {
+    setIsSyncing(true);
+    try {
+      const result = await syncAllAnthropicUsage();
+      if (result.success) {
+        const { syncedUsers, skippedUsers, errorCount } = result.data;
+        toast.success(
+          `Synced ${syncedUsers} user${syncedUsers !== 1 ? "s" : ""}` +
+            (skippedUsers > 0 ? `, ${skippedUsers} skipped` : "") +
+            (errorCount > 0 ? `, ${errorCount} error${errorCount !== 1 ? "s" : ""}` : "")
+        );
+      } else {
+        toast.error(result.error);
+      }
+    } catch {
+      toast.error("Failed to sync usage data.");
+    } finally {
+      setIsSyncing(false);
+    }
+  }
+
+  return (
+    <Button variant="outline" onClick={handleSyncAll} disabled={isSyncing}>
+      <RefreshCw
+        className={`mr-2 size-4 ${isSyncing ? "animate-spin" : ""}`}
+      />
+      Sync Claude Costs
+    </Button>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Settings,
   LogOut,
   LogIn,
+  UserCircle,
 } from "lucide-react";
 import { signOut } from "next-auth/react";
 import {
@@ -29,6 +30,13 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { ThemeToggle } from "@/components/theme-toggle";
 import type { UserRole } from "@/types";
 
@@ -108,23 +116,30 @@ export function AppSidebar({
       <SidebarFooter className="border-t p-4">
         {isAuthenticated ? (
           <div className="flex items-center justify-between">
-            <div className="min-w-0">
-              <p className="truncate text-sm font-medium">{userName}</p>
-              <p className="text-xs text-muted-foreground capitalize">
-                {userRole}
-              </p>
-            </div>
-            <div className="flex items-center gap-1">
-              <ThemeToggle />
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => signOut({ callbackUrl: "/login" })}
-                aria-label="Sign out"
-              >
-                <LogOut className="size-4" />
-              </Button>
-            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="h-auto min-w-0 flex-1 justify-start gap-2 px-2 py-1.5 text-left">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">{userName}</p>
+                    <p className="text-xs text-muted-foreground capitalize">{userRole}</p>
+                  </div>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-48">
+                <DropdownMenuItem asChild>
+                  <Link href="/profile">
+                    <UserCircle className="mr-2 size-4" />
+                    My Profile
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login" })}>
+                  <LogOut className="mr-2 size-4" />
+                  Sign Out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <ThemeToggle />
           </div>
         ) : (
           <Button asChild className="w-full">

--- a/src/components/cost-chart.tsx
+++ b/src/components/cost-chart.tsx
@@ -96,7 +96,7 @@ export function CostChart({ dailyBreakdown }: CostChartProps) {
         <ChartTooltip
           content={
             <ChartTooltipContent
-              formatter={(value: number) => `$${value.toFixed(2)}`}
+              formatter={(value) => `$${Number(value).toFixed(2)}`}
             />
           }
         />

--- a/src/components/cost-chart.tsx
+++ b/src/components/cost-chart.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useMemo } from "react";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
+import type { DailyBreakdown } from "@/types";
+
+// Color palette for models
+const MODEL_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+function formatModelName(model: string): string {
+  // "claude-opus-4-6" → "Opus 4.6"
+  const match = model.match(/claude-(\w+)-(\d+)(?:-(\d+))?/);
+  if (match) {
+    const name = match[1].charAt(0).toUpperCase() + match[1].slice(1);
+    const version = match[3] ? `${match[2]}.${match[3]}` : match[2];
+    return `${name} ${version}`;
+  }
+  return model;
+}
+
+type CostChartProps = {
+  dailyBreakdown: DailyBreakdown[];
+};
+
+export function CostChart({ dailyBreakdown }: CostChartProps) {
+  // Extract unique models and build chart config + data
+  const { chartData, chartConfig, modelKeys } = useMemo(() => {
+    const modelSet = new Set<string>();
+    for (const day of dailyBreakdown) {
+      for (const m of day.models) {
+        modelSet.add(m.model);
+      }
+    }
+    const models = Array.from(modelSet).sort();
+
+    const config: ChartConfig = {};
+    models.forEach((model, i) => {
+      config[model] = {
+        label: formatModelName(model),
+        color: MODEL_COLORS[i % MODEL_COLORS.length],
+      };
+    });
+
+    const data = dailyBreakdown.map((day) => {
+      const point: Record<string, string | number> = { date: day.date };
+      for (const m of day.models) {
+        point[m.model] = m.costCents / 100; // Convert cents to dollars for display
+      }
+      return point;
+    });
+
+    return { chartData: data, chartConfig: config, modelKeys: models };
+  }, [dailyBreakdown]);
+
+  if (dailyBreakdown.length === 0) {
+    return null;
+  }
+
+  return (
+    <ChartContainer config={chartConfig} className="min-h-[300px] w-full">
+      <BarChart data={chartData} accessibilityLayer>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(value: string) => {
+            const date = new Date(value + "T00:00:00");
+            return date.toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+            });
+          }}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(value: number) => `$${value.toFixed(0)}`}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              formatter={(value: number) => `$${value.toFixed(2)}`}
+            />
+          }
+        />
+        <ChartLegend content={<ChartLegendContent />} />
+        {modelKeys.map((model, i) => (
+          <Bar
+            key={model}
+            dataKey={model}
+            stackId="cost"
+            fill={MODEL_COLORS[i % MODEL_COLORS.length]}
+            radius={
+              i === modelKeys.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]
+            }
+          />
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/src/components/profile/admin-cost-section.tsx
+++ b/src/components/profile/admin-cost-section.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { MonthPicker } from "./month-picker";
+import { CostChart } from "@/components/cost-chart";
+import { formatCurrency } from "@/lib/utils";
+import {
+  getUserCostData,
+  syncAnthropicUsage,
+} from "@/actions/anthropic-usage";
+import { DollarSign, Info, RefreshCw, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import type { CostData } from "@/types";
+
+type AdminCostSectionProps = {
+  userId: number;
+  initialData: CostData;
+  availableMonths: string[];
+};
+
+function getCurrentMonth(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+}
+
+export function AdminCostSection({
+  userId,
+  initialData,
+  availableMonths,
+}: AdminCostSectionProps) {
+  const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth());
+  const [costData, setCostData] = useState<CostData>(initialData);
+  const [isPending, startTransition] = useTransition();
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  function handleMonthChange(month: string) {
+    setSelectedMonth(month);
+    startTransition(async () => {
+      const data = await getUserCostData(userId, month);
+      setCostData(data);
+    });
+  }
+
+  async function handleSync() {
+    setIsSyncing(true);
+    try {
+      const result = await syncAnthropicUsage(userId);
+      if (result.success) {
+        toast.success(
+          `Synced ${result.data.syncedDays} days of usage data.`
+        );
+        // Refresh current month data
+        const data = await getUserCostData(userId, selectedMonth);
+        setCostData(data);
+      } else {
+        toast.error(result.error);
+      }
+    } catch {
+      toast.error("Failed to sync usage data.");
+    } finally {
+      setIsSyncing(false);
+    }
+  }
+
+  if (!costData.available) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <DollarSign className="size-5" />
+            Claude API Costs
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert>
+            <Info className="size-4" />
+            <AlertDescription>
+              No API key configured for this user.
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <DollarSign className="size-5" />
+            Claude API Costs
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            <MonthPicker
+              value={selectedMonth}
+              onChange={handleMonthChange}
+              months={availableMonths}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSync}
+              disabled={isSyncing}
+            >
+              <RefreshCw
+                className={`mr-1 size-4 ${isSyncing ? "animate-spin" : ""}`}
+              />
+              Sync
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {costData.hasUnresolvedPricing && (
+          <Alert variant="destructive">
+            <AlertTriangle className="size-4" />
+            <AlertDescription>
+              Some usage data may have approximate costs due to unrecognized
+              models.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="rounded-lg border p-4">
+          <p className="text-sm text-muted-foreground">Monthly Total</p>
+          <p className={`text-3xl font-bold ${isPending ? "opacity-50" : ""}`}>
+            {formatCurrency(costData.monthlyTotalCents)}
+          </p>
+          {costData.latestDataDate && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Data through {costData.latestDataDate}
+            </p>
+          )}
+        </div>
+
+        {costData.monthlyTotalCents === 0 &&
+          costData.dailyBreakdown.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No usage recorded for this month.
+            </p>
+          )}
+
+        {costData.dailyBreakdown.length > 0 && (
+          <div className={isPending ? "opacity-50" : ""}>
+            <CostChart dailyBreakdown={costData.dailyBreakdown} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/admin-cost-section.tsx
+++ b/src/components/profile/admin-cost-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { CostTrackingSection } from "./cost-tracking-section";
 import { syncAnthropicUsage } from "@/actions/anthropic-usage";
@@ -20,6 +20,7 @@ export function AdminCostSection({
   availableMonths,
 }: AdminCostSectionProps) {
   const [isSyncing, setIsSyncing] = useState(false);
+  const refreshRef = useRef<(() => void) | null>(null);
 
   async function handleSync() {
     setIsSyncing(true);
@@ -29,6 +30,8 @@ export function AdminCostSection({
         toast.success(
           `Synced ${result.data.syncedDays} days of usage data.`
         );
+        // Refresh cost data after successful sync
+        refreshRef.current?.();
       } else {
         toast.error(result.error);
       }
@@ -45,19 +48,22 @@ export function AdminCostSection({
       initialData={initialData}
       availableMonths={availableMonths}
       showSummaryStats={false}
-      headerActions={
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleSync}
-          disabled={isSyncing}
-        >
-          <RefreshCw
-            className={`mr-1 size-4 ${isSyncing ? "animate-spin" : ""}`}
-          />
-          Sync
-        </Button>
-      }
+      headerActions={(onRefresh) => {
+        refreshRef.current = onRefresh;
+        return (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSync}
+            disabled={isSyncing}
+          >
+            <RefreshCw
+              className={`mr-1 size-4 ${isSyncing ? "animate-spin" : ""}`}
+            />
+            Sync
+          </Button>
+        );
+      }}
     />
   );
 }

--- a/src/components/profile/admin-cost-section.tsx
+++ b/src/components/profile/admin-cost-section.tsx
@@ -6,7 +6,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { MonthPicker } from "./month-picker";
 import { CostChart } from "@/components/cost-chart";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, getCurrentMonth } from "@/lib/utils";
 import {
   getUserCostData,
   syncAnthropicUsage,
@@ -20,11 +20,6 @@ type AdminCostSectionProps = {
   initialData: CostData;
   availableMonths: string[];
 };
-
-function getCurrentMonth(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-}
 
 export function AdminCostSection({
   userId,

--- a/src/components/profile/admin-cost-section.tsx
+++ b/src/components/profile/admin-cost-section.tsx
@@ -34,8 +34,12 @@ export function AdminCostSection({
   function handleMonthChange(month: string) {
     setSelectedMonth(month);
     startTransition(async () => {
-      const data = await getUserCostData(userId, month);
-      setCostData(data);
+      try {
+        const data = await getUserCostData(userId, month);
+        setCostData(data);
+      } catch {
+        toast.error("Failed to load cost data. Please try again.");
+      }
     });
   }
 

--- a/src/components/profile/admin-cost-section.tsx
+++ b/src/components/profile/admin-cost-section.tsx
@@ -1,17 +1,10 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { MonthPicker } from "./month-picker";
-import { CostChart } from "@/components/cost-chart";
-import { formatCurrency, getCurrentMonth } from "@/lib/utils";
-import {
-  getUserCostData,
-  syncAnthropicUsage,
-} from "@/actions/anthropic-usage";
-import { DollarSign, Info, RefreshCw, AlertTriangle } from "lucide-react";
+import { CostTrackingSection } from "./cost-tracking-section";
+import { syncAnthropicUsage } from "@/actions/anthropic-usage";
+import { RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import type { CostData } from "@/types";
 
@@ -26,22 +19,7 @@ export function AdminCostSection({
   initialData,
   availableMonths,
 }: AdminCostSectionProps) {
-  const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth());
-  const [costData, setCostData] = useState<CostData>(initialData);
-  const [isPending, startTransition] = useTransition();
   const [isSyncing, setIsSyncing] = useState(false);
-
-  function handleMonthChange(month: string) {
-    setSelectedMonth(month);
-    startTransition(async () => {
-      try {
-        const data = await getUserCostData(userId, month);
-        setCostData(data);
-      } catch {
-        toast.error("Failed to load cost data. Please try again.");
-      }
-    });
-  }
 
   async function handleSync() {
     setIsSyncing(true);
@@ -51,9 +29,6 @@ export function AdminCostSection({
         toast.success(
           `Synced ${result.data.syncedDays} days of usage data.`
         );
-        // Refresh current month data
-        const data = await getUserCostData(userId, selectedMonth);
-        setCostData(data);
       } else {
         toast.error(result.error);
       }
@@ -64,91 +39,25 @@ export function AdminCostSection({
     }
   }
 
-  if (!costData.available) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-lg">
-            <DollarSign className="size-5" />
-            Claude API Costs
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Alert>
-            <Info className="size-4" />
-            <AlertDescription>
-              No API key configured for this user.
-            </AlertDescription>
-          </Alert>
-        </CardContent>
-      </Card>
-    );
-  }
-
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-2 text-lg">
-            <DollarSign className="size-5" />
-            Claude API Costs
-          </CardTitle>
-          <div className="flex items-center gap-2">
-            <MonthPicker
-              value={selectedMonth}
-              onChange={handleMonthChange}
-              months={availableMonths}
-            />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleSync}
-              disabled={isSyncing}
-            >
-              <RefreshCw
-                className={`mr-1 size-4 ${isSyncing ? "animate-spin" : ""}`}
-              />
-              Sync
-            </Button>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {costData.hasUnresolvedPricing && (
-          <Alert variant="destructive">
-            <AlertTriangle className="size-4" />
-            <AlertDescription>
-              Some usage data may have approximate costs due to unrecognized
-              models.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        <div className="rounded-lg border p-4">
-          <p className="text-sm text-muted-foreground">Monthly Total</p>
-          <p className={`text-3xl font-bold ${isPending ? "opacity-50" : ""}`}>
-            {formatCurrency(costData.monthlyTotalCents)}
-          </p>
-          {costData.latestDataDate && (
-            <p className="mt-1 text-xs text-muted-foreground">
-              Data through {costData.latestDataDate}
-            </p>
-          )}
-        </div>
-
-        {costData.monthlyTotalCents === 0 &&
-          costData.dailyBreakdown.length === 0 && (
-            <p className="text-sm text-muted-foreground">
-              No usage recorded for this month.
-            </p>
-          )}
-
-        {costData.dailyBreakdown.length > 0 && (
-          <div className={isPending ? "opacity-50" : ""}>
-            <CostChart dailyBreakdown={costData.dailyBreakdown} />
-          </div>
-        )}
-      </CardContent>
-    </Card>
+    <CostTrackingSection
+      userId={userId}
+      initialData={initialData}
+      availableMonths={availableMonths}
+      showSummaryStats={false}
+      headerActions={
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleSync}
+          disabled={isSyncing}
+        >
+          <RefreshCw
+            className={`mr-1 size-4 ${isSyncing ? "animate-spin" : ""}`}
+          />
+          Sync
+        </Button>
+      }
+    />
   );
 }

--- a/src/components/profile/cost-tracking-section.tsx
+++ b/src/components/profile/cost-tracking-section.tsx
@@ -15,8 +15,8 @@ type CostTrackingSectionProps = {
   userId: number;
   initialData: CostData;
   availableMonths: string[];
-  /** Optional header actions (e.g. admin sync button) rendered next to the month picker */
-  headerActions?: React.ReactNode;
+  /** Optional header actions rendered next to the month picker. Receives a refresh callback. */
+  headerActions?: (onRefresh: () => void) => React.ReactNode;
   /** Whether to show summary stats below the chart (default: true) */
   showSummaryStats?: boolean;
 };
@@ -116,7 +116,7 @@ export function CostTrackingSection({
               onChange={handleMonthChange}
               months={availableMonths}
             />
-            {headerActions}
+            {headerActions?.(refreshData)}
           </div>
         </div>
       </CardHeader>

--- a/src/components/profile/cost-tracking-section.tsx
+++ b/src/components/profile/cost-tracking-section.tsx
@@ -6,6 +6,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { MonthPicker } from "./month-picker";
 import { formatCurrency } from "@/lib/utils";
 import { getUserCostData } from "@/actions/anthropic-usage";
+import { CostChart } from "@/components/cost-chart";
 import { DollarSign, Info, AlertTriangle } from "lucide-react";
 import type { CostData } from "@/types";
 
@@ -108,7 +109,63 @@ export function CostTrackingSection({
             </p>
           )}
 
-        {/* Chart placeholder - will be added in Phase 5 (US3) */}
+        {/* Daily cost chart */}
+        {costData.dailyBreakdown.length > 0 && (
+          <div className={isPending ? "opacity-50" : ""}>
+            <CostChart dailyBreakdown={costData.dailyBreakdown} />
+          </div>
+        )}
+
+        {/* Summary stats */}
+        {costData.dailyBreakdown.length > 0 && (
+          <div className="grid grid-cols-3 gap-4 text-center">
+            <div className="rounded-lg border p-3">
+              <p className="text-sm text-muted-foreground">Active Days</p>
+              <p className="text-lg font-semibold">
+                {costData.dailyBreakdown.length}
+              </p>
+            </div>
+            <div className="rounded-lg border p-3">
+              <p className="text-sm text-muted-foreground">Top Model</p>
+              <p className="text-lg font-semibold truncate">
+                {(() => {
+                  const modelTotals = new Map<string, number>();
+                  for (const day of costData.dailyBreakdown) {
+                    for (const m of day.models) {
+                      modelTotals.set(
+                        m.model,
+                        (modelTotals.get(m.model) ?? 0) + m.costCents
+                      );
+                    }
+                  }
+                  const top = Array.from(modelTotals.entries()).sort(
+                    (a, b) => b[1] - a[1]
+                  )[0];
+                  if (!top) return "—";
+                  const match = top[0].match(/claude-(\w+)/);
+                  return match
+                    ? match[1].charAt(0).toUpperCase() + match[1].slice(1)
+                    : top[0];
+                })()}
+              </p>
+            </div>
+            <div className="rounded-lg border p-3">
+              <p className="text-sm text-muted-foreground">Peak Day</p>
+              <p className="text-lg font-semibold">
+                {(() => {
+                  const peak = costData.dailyBreakdown.reduce((max, day) =>
+                    day.totalCents > max.totalCents ? day : max
+                  );
+                  const d = new Date(peak.date + "T00:00:00");
+                  return d.toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  });
+                })()}
+              </p>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/profile/cost-tracking-section.tsx
+++ b/src/components/profile/cost-tracking-section.tsx
@@ -15,12 +15,18 @@ type CostTrackingSectionProps = {
   userId: number;
   initialData: CostData;
   availableMonths: string[];
+  /** Optional header actions (e.g. admin sync button) rendered next to the month picker */
+  headerActions?: React.ReactNode;
+  /** Whether to show summary stats below the chart (default: true) */
+  showSummaryStats?: boolean;
 };
 
 export function CostTrackingSection({
   userId,
   initialData,
   availableMonths,
+  headerActions,
+  showSummaryStats = true,
 }: CostTrackingSectionProps) {
   const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth());
   const [costData, setCostData] = useState<CostData>(initialData);
@@ -61,6 +67,18 @@ export function CostTrackingSection({
     });
   }
 
+  /** Allow parent (admin sync) to refresh cost data after a sync */
+  function refreshData() {
+    startTransition(async () => {
+      try {
+        const data = await getUserCostData(userId, selectedMonth);
+        setCostData(data);
+      } catch {
+        toast.error("Failed to refresh cost data.");
+      }
+    });
+  }
+
   // State 1: No API key configured
   if (!costData.available) {
     return (
@@ -92,11 +110,14 @@ export function CostTrackingSection({
             <DollarSign className="size-5" />
             Claude API Costs
           </CardTitle>
-          <MonthPicker
-            value={selectedMonth}
-            onChange={handleMonthChange}
-            months={availableMonths}
-          />
+          <div className="flex items-center gap-2">
+            <MonthPicker
+              value={selectedMonth}
+              onChange={handleMonthChange}
+              months={availableMonths}
+            />
+            {headerActions}
+          </div>
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -140,7 +161,7 @@ export function CostTrackingSection({
         )}
 
         {/* Summary stats */}
-        {costData.dailyBreakdown.length > 0 && (
+        {showSummaryStats && costData.dailyBreakdown.length > 0 && (
           <div className="grid grid-cols-3 gap-4 text-center">
             <div className="rounded-lg border p-3">
               <p className="text-sm text-muted-foreground">Active Days</p>

--- a/src/components/profile/cost-tracking-section.tsx
+++ b/src/components/profile/cost-tracking-section.tsx
@@ -8,6 +8,7 @@ import { formatCurrency, getCurrentMonth } from "@/lib/utils";
 import { getUserCostData } from "@/actions/anthropic-usage";
 import { CostChart } from "@/components/cost-chart";
 import { DollarSign, Info, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
 import type { CostData } from "@/types";
 
 type CostTrackingSectionProps = {
@@ -51,8 +52,12 @@ export function CostTrackingSection({
   function handleMonthChange(month: string) {
     setSelectedMonth(month);
     startTransition(async () => {
-      const data = await getUserCostData(userId, month);
-      setCostData(data);
+      try {
+        const data = await getUserCostData(userId, month);
+        setCostData(data);
+      } catch {
+        toast.error("Failed to load cost data. Please try again.");
+      }
     });
   }
 

--- a/src/components/profile/cost-tracking-section.tsx
+++ b/src/components/profile/cost-tracking-section.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { MonthPicker } from "./month-picker";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, getCurrentMonth } from "@/lib/utils";
 import { getUserCostData } from "@/actions/anthropic-usage";
 import { CostChart } from "@/components/cost-chart";
 import { DollarSign, Info, AlertTriangle } from "lucide-react";
@@ -16,11 +16,6 @@ type CostTrackingSectionProps = {
   availableMonths: string[];
 };
 
-function getCurrentMonth(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-}
-
 export function CostTrackingSection({
   userId,
   initialData,
@@ -29,6 +24,29 @@ export function CostTrackingSection({
   const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth());
   const [costData, setCostData] = useState<CostData>(initialData);
   const [isPending, startTransition] = useTransition();
+
+  const topModelName = useMemo(() => {
+    if (costData.dailyBreakdown.length === 0) return "—";
+    const modelTotals = new Map<string, number>();
+    for (const day of costData.dailyBreakdown) {
+      for (const m of day.models) {
+        modelTotals.set(m.model, (modelTotals.get(m.model) ?? 0) + m.costCents);
+      }
+    }
+    const top = Array.from(modelTotals.entries()).sort((a, b) => b[1] - a[1])[0];
+    if (!top) return "—";
+    const match = top[0].match(/claude-(\w+)/);
+    return match ? match[1].charAt(0).toUpperCase() + match[1].slice(1) : top[0];
+  }, [costData.dailyBreakdown]);
+
+  const peakDayLabel = useMemo(() => {
+    if (costData.dailyBreakdown.length === 0) return "—";
+    const peak = costData.dailyBreakdown.reduce((max, day) =>
+      day.totalCents > max.totalCents ? day : max
+    );
+    const d = new Date(peak.date + "T00:00:00");
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  }, [costData.dailyBreakdown]);
 
   function handleMonthChange(month: string) {
     setSelectedMonth(month);
@@ -128,40 +146,13 @@ export function CostTrackingSection({
             <div className="rounded-lg border p-3">
               <p className="text-sm text-muted-foreground">Top Model</p>
               <p className="text-lg font-semibold truncate">
-                {(() => {
-                  const modelTotals = new Map<string, number>();
-                  for (const day of costData.dailyBreakdown) {
-                    for (const m of day.models) {
-                      modelTotals.set(
-                        m.model,
-                        (modelTotals.get(m.model) ?? 0) + m.costCents
-                      );
-                    }
-                  }
-                  const top = Array.from(modelTotals.entries()).sort(
-                    (a, b) => b[1] - a[1]
-                  )[0];
-                  if (!top) return "—";
-                  const match = top[0].match(/claude-(\w+)/);
-                  return match
-                    ? match[1].charAt(0).toUpperCase() + match[1].slice(1)
-                    : top[0];
-                })()}
+                {topModelName}
               </p>
             </div>
             <div className="rounded-lg border p-3">
               <p className="text-sm text-muted-foreground">Peak Day</p>
               <p className="text-lg font-semibold">
-                {(() => {
-                  const peak = costData.dailyBreakdown.reduce((max, day) =>
-                    day.totalCents > max.totalCents ? day : max
-                  );
-                  const d = new Date(peak.date + "T00:00:00");
-                  return d.toLocaleDateString("en-US", {
-                    month: "short",
-                    day: "numeric",
-                  });
-                })()}
+                {peakDayLabel}
               </p>
             </div>
           </div>

--- a/src/components/profile/cost-tracking-section.tsx
+++ b/src/components/profile/cost-tracking-section.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { MonthPicker } from "./month-picker";
+import { formatCurrency } from "@/lib/utils";
+import { getUserCostData } from "@/actions/anthropic-usage";
+import { DollarSign, Info, AlertTriangle } from "lucide-react";
+import type { CostData } from "@/types";
+
+type CostTrackingSectionProps = {
+  userId: number;
+  initialData: CostData;
+  availableMonths: string[];
+};
+
+function getCurrentMonth(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+}
+
+export function CostTrackingSection({
+  userId,
+  initialData,
+  availableMonths,
+}: CostTrackingSectionProps) {
+  const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth());
+  const [costData, setCostData] = useState<CostData>(initialData);
+  const [isPending, startTransition] = useTransition();
+
+  function handleMonthChange(month: string) {
+    setSelectedMonth(month);
+    startTransition(async () => {
+      const data = await getUserCostData(userId, month);
+      setCostData(data);
+    });
+  }
+
+  // State 1: No API key configured
+  if (!costData.available) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <DollarSign className="size-5" />
+            Claude API Costs
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert>
+            <Info className="size-4" />
+            <AlertDescription>
+              {costData.error ||
+                "No Claude API key configured. Contact your administrator to set up cost tracking."}
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <DollarSign className="size-5" />
+            Claude API Costs
+          </CardTitle>
+          <MonthPicker
+            value={selectedMonth}
+            onChange={handleMonthChange}
+            months={availableMonths}
+          />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Unresolved pricing warning */}
+        {costData.hasUnresolvedPricing && (
+          <Alert variant="destructive">
+            <AlertTriangle className="size-4" />
+            <AlertDescription>
+              Some usage data may have approximate costs due to unrecognized
+              models.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Monthly total */}
+        <div className="rounded-lg border p-4">
+          <p className="text-sm text-muted-foreground">Monthly Total</p>
+          <p className={`text-3xl font-bold ${isPending ? "opacity-50" : ""}`}>
+            {formatCurrency(costData.monthlyTotalCents)}
+          </p>
+          {costData.latestDataDate && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Data through {costData.latestDataDate}
+            </p>
+          )}
+        </div>
+
+        {/* State 2: No usage data */}
+        {costData.monthlyTotalCents === 0 &&
+          costData.dailyBreakdown.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No usage recorded for this month.
+            </p>
+          )}
+
+        {/* Chart placeholder - will be added in Phase 5 (US3) */}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/month-picker.tsx
+++ b/src/components/profile/month-picker.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type MonthPickerProps = {
+  value: string; // "YYYY-MM"
+  onChange: (month: string) => void;
+  months: string[]; // Available months in "YYYY-MM" format, newest first
+};
+
+function formatMonthLabel(month: string): string {
+  const [year, m] = month.split("-");
+  const date = new Date(Number(year), Number(m) - 1, 1);
+  return date.toLocaleDateString("en-US", { year: "numeric", month: "long" });
+}
+
+export function MonthPicker({ value, onChange, months }: MonthPickerProps) {
+  // If no months available, generate current month
+  const options = months.length > 0 ? months : [value];
+
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder="Select month" />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((month) => (
+          <SelectItem key={month} value={month}>
+            {formatMonthLabel(month)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/profile/profile-assignments.tsx
+++ b/src/components/profile/profile-assignments.tsx
@@ -1,0 +1,70 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { KeyRound } from "lucide-react";
+import { formatDate } from "@/lib/utils";
+
+type Assignment = {
+  id: number;
+  toolName: string;
+  tierName: string;
+  assignedAt: Date;
+  status: "active" | "inactive";
+};
+
+type ProfileAssignmentsProps = {
+  assignments: Assignment[];
+};
+
+export function ProfileAssignments({ assignments }: ProfileAssignmentsProps) {
+  if (assignments.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <KeyRound className="size-5" />
+            Assigned Tools
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No tools assigned yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <KeyRound className="size-5" />
+          Assigned Tools
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {assignments.map((a) => (
+            <div
+              key={a.id}
+              className="flex items-center justify-between rounded-lg border p-3"
+            >
+              <div>
+                <p className="font-medium">{a.toolName}</p>
+                <p className="text-sm text-muted-foreground">
+                  {a.tierName} &middot; Assigned {formatDate(a.assignedAt)}
+                </p>
+              </div>
+              <Badge
+                variant={a.status === "active" ? "default" : "secondary"}
+                className="capitalize"
+              >
+                {a.status}
+              </Badge>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/profile-header.tsx
+++ b/src/components/profile/profile-header.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { User } from "lucide-react";
+
+type ProfileHeaderProps = {
+  user: {
+    name: string;
+    email: string;
+    role: "admin" | "viewer";
+    circle: string | null;
+    profile: "boost" | "maxed" | "indie" | null;
+  };
+};
+
+export function ProfileHeader({ user }: ProfileHeaderProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-full bg-primary/10">
+            <User className="size-5 text-primary" />
+          </div>
+          <div>
+            <CardTitle className="text-xl">{user.name}</CardTitle>
+            <p className="text-sm text-muted-foreground">{user.email}</p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="secondary" className="capitalize">
+            {user.role}
+          </Badge>
+          {user.profile && (
+            <Badge variant="outline" className="capitalize">
+              {user.profile}
+            </Badge>
+          )}
+          {user.circle && (
+            <Badge variant="outline">{user.circle}</Badge>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/anthropic-constants.ts
+++ b/src/lib/anthropic-constants.ts
@@ -1,0 +1,1 @@
+export const ANTHROPIC_API_VERSION = "2023-06-01";

--- a/src/lib/anthropic-keys.ts
+++ b/src/lib/anthropic-keys.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+export const orgApiKeySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  partial_key_hint: z.string(),
+  status: z.string(),
+  type: z.string(),
+});
+
+export const orgApiKeysResponseSchema = z.object({
+  data: z.array(orgApiKeySchema),
+  has_more: z.boolean(),
+});
+
+export type OrgApiKey = z.infer<typeof orgApiKeySchema>;
+
+export async function fetchOrgApiKeys(): Promise<OrgApiKey[]> {
+  const adminKey = process.env.ANTHROPIC_ADMIN_API_KEY;
+  if (!adminKey) {
+    throw new Error(
+      "ANTHROPIC_ADMIN_API_KEY environment variable is not set"
+    );
+  }
+
+  const url =
+    "https://api.anthropic.com/v1/organizations/api_keys?status=active&limit=100";
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "x-api-key": adminKey,
+      "anthropic-version": "2023-06-01",
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch org API keys: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const json: unknown = await response.json();
+  const parsed = orgApiKeysResponseSchema.parse(json);
+
+  if (parsed.has_more) {
+    console.warn(
+      "Warning: more than 100 active API keys exist. Pagination not yet implemented — some keys may be missing."
+    );
+  }
+
+  return parsed.data;
+}
+
+export function resolveApiKeyId(
+  decryptedKey: string,
+  orgKeys: OrgApiKey[]
+): string | null {
+  for (const orgKey of orgKeys) {
+    const suffix = orgKey.partial_key_hint.replace(/^[.\u2026]+/, "");
+    if (suffix && decryptedKey.endsWith(suffix)) {
+      return orgKey.id;
+    }
+  }
+  return null;
+}

--- a/src/lib/anthropic-keys.ts
+++ b/src/lib/anthropic-keys.ts
@@ -58,7 +58,21 @@ export function resolveApiKeyId(
   orgKeys: OrgApiKey[]
 ): string | null {
   for (const orgKey of orgKeys) {
-    const suffix = orgKey.partial_key_hint.replace(/^[.\u2026]+/, "");
+    const hint = orgKey.partial_key_hint;
+
+    // Extract suffix after the last ellipsis pattern (e.g. "sk-ant-...xyzw" → "xyzw")
+    const ellipsisPatterns = ["...", "\u2026"];
+    let suffix = hint;
+    for (const pat of ellipsisPatterns) {
+      const idx = hint.lastIndexOf(pat);
+      if (idx !== -1) {
+        suffix = hint.slice(idx + pat.length);
+        break;
+      }
+    }
+    // Also strip any remaining leading dots
+    suffix = suffix.replace(/^\.+/, "");
+
     if (suffix && decryptedKey.endsWith(suffix)) {
       return orgKey.id;
     }

--- a/src/lib/anthropic-keys.ts
+++ b/src/lib/anthropic-keys.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ANTHROPIC_API_VERSION } from "@/lib/anthropic-constants";
 
 export const orgApiKeySchema = z.object({
   id: z.string(),
@@ -30,7 +31,7 @@ export async function fetchOrgApiKeys(): Promise<OrgApiKey[]> {
     method: "GET",
     headers: {
       "x-api-key": adminKey,
-      "anthropic-version": "2023-06-01",
+      "anthropic-version": ANTHROPIC_API_VERSION,
       "Content-Type": "application/json",
     },
   });

--- a/src/lib/anthropic-pricing.ts
+++ b/src/lib/anthropic-pricing.ts
@@ -7,10 +7,17 @@ export type ModelPricing = {
 };
 
 /**
- * Anthropic model pricing table, ordered by prefix length (longest first)
- * so that the most specific prefix matches first.
+ * Anthropic model pricing table, ordered with highest-priced first for safe
+ * fallback. Index 0 (Opus) is used when no prefix matches an unknown model.
  */
 export const MODEL_PRICING: ModelPricing[] = [
+  {
+    prefix: "claude-opus-4",
+    inputPerMToken: 15,
+    outputPerMToken: 75,
+    cacheReadPerMToken: 1.5,
+    cacheWritePerMToken: 18.75,
+  },
   {
     prefix: "claude-sonnet-4",
     inputPerMToken: 3,
@@ -24,13 +31,6 @@ export const MODEL_PRICING: ModelPricing[] = [
     outputPerMToken: 4,
     cacheReadPerMToken: 0.08,
     cacheWritePerMToken: 1,
-  },
-  {
-    prefix: "claude-opus-4",
-    inputPerMToken: 15,
-    outputPerMToken: 75,
-    cacheReadPerMToken: 1.5,
-    cacheWritePerMToken: 18.75,
   },
 ];
 

--- a/src/lib/anthropic-pricing.ts
+++ b/src/lib/anthropic-pricing.ts
@@ -7,18 +7,44 @@ export type ModelPricing = {
 };
 
 /**
- * Anthropic model pricing table, ordered with highest-priced first for safe
- * fallback. Index 0 (Opus) is used when no prefix matches an unknown model.
+ * Anthropic model pricing table, ordered by prefix length (longest first)
+ * so that the most specific prefix matches first.
+ * Index 0 (Opus 4.0/4.1 — highest priced) is used as fallback for unknown models.
+ *
+ * Pricing source: https://docs.anthropic.com/en/docs/about-claude/pricing
  */
 export const MODEL_PRICING: ModelPricing[] = [
-  // Pricing source: https://docs.anthropic.com/en/docs/about-claude/models
+  // Opus 4.0 / 4.1 — $15/$75 (highest pricing, used as fallback)
   {
-    prefix: "claude-opus-4",
+    prefix: "claude-opus-4-0",
     inputPerMToken: 15,
     outputPerMToken: 75,
     cacheReadPerMToken: 1.5,
     cacheWritePerMToken: 18.75,
   },
+  {
+    prefix: "claude-opus-4-1",
+    inputPerMToken: 15,
+    outputPerMToken: 75,
+    cacheReadPerMToken: 1.5,
+    cacheWritePerMToken: 18.75,
+  },
+  // Opus 4.5 / 4.6 — $5/$25
+  {
+    prefix: "claude-opus-4-5",
+    inputPerMToken: 5,
+    outputPerMToken: 25,
+    cacheReadPerMToken: 0.5,
+    cacheWritePerMToken: 6.25,
+  },
+  {
+    prefix: "claude-opus-4-6",
+    inputPerMToken: 5,
+    outputPerMToken: 25,
+    cacheReadPerMToken: 0.5,
+    cacheWritePerMToken: 6.25,
+  },
+  // Sonnet 4.x — all $3/$15
   {
     prefix: "claude-sonnet-4",
     inputPerMToken: 3,
@@ -26,8 +52,17 @@ export const MODEL_PRICING: ModelPricing[] = [
     cacheReadPerMToken: 0.3,
     cacheWritePerMToken: 3.75,
   },
+  // Haiku 4.5 — $1/$5
   {
-    prefix: "claude-haiku-4",
+    prefix: "claude-haiku-4-5",
+    inputPerMToken: 1,
+    outputPerMToken: 5,
+    cacheReadPerMToken: 0.1,
+    cacheWritePerMToken: 1.25,
+  },
+  // Haiku 3.5 — $0.80/$4
+  {
+    prefix: "claude-haiku-3-5",
     inputPerMToken: 0.8,
     outputPerMToken: 4,
     cacheReadPerMToken: 0.08,

--- a/src/lib/anthropic-pricing.ts
+++ b/src/lib/anthropic-pricing.ts
@@ -13,10 +13,10 @@ export type ModelPricing = {
 export const MODEL_PRICING: ModelPricing[] = [
   {
     prefix: "claude-opus-4",
-    inputPerMToken: 15,
-    outputPerMToken: 75,
-    cacheReadPerMToken: 1.5,
-    cacheWritePerMToken: 18.75,
+    inputPerMToken: 5,
+    outputPerMToken: 25,
+    cacheReadPerMToken: 0.5,
+    cacheWritePerMToken: 6.25,
   },
   {
     prefix: "claude-sonnet-4",
@@ -27,10 +27,10 @@ export const MODEL_PRICING: ModelPricing[] = [
   },
   {
     prefix: "claude-haiku-4",
-    inputPerMToken: 0.8,
-    outputPerMToken: 4,
-    cacheReadPerMToken: 0.08,
-    cacheWritePerMToken: 1,
+    inputPerMToken: 1,
+    outputPerMToken: 5,
+    cacheReadPerMToken: 0.1,
+    cacheWritePerMToken: 1.25,
   },
 ];
 

--- a/src/lib/anthropic-pricing.ts
+++ b/src/lib/anthropic-pricing.ts
@@ -11,12 +11,13 @@ export type ModelPricing = {
  * fallback. Index 0 (Opus) is used when no prefix matches an unknown model.
  */
 export const MODEL_PRICING: ModelPricing[] = [
+  // Pricing source: https://docs.anthropic.com/en/docs/about-claude/models
   {
     prefix: "claude-opus-4",
-    inputPerMToken: 5,
-    outputPerMToken: 25,
-    cacheReadPerMToken: 0.5,
-    cacheWritePerMToken: 6.25,
+    inputPerMToken: 15,
+    outputPerMToken: 75,
+    cacheReadPerMToken: 1.5,
+    cacheWritePerMToken: 18.75,
   },
   {
     prefix: "claude-sonnet-4",
@@ -27,10 +28,10 @@ export const MODEL_PRICING: ModelPricing[] = [
   },
   {
     prefix: "claude-haiku-4",
-    inputPerMToken: 1,
-    outputPerMToken: 5,
-    cacheReadPerMToken: 0.1,
-    cacheWritePerMToken: 1.25,
+    inputPerMToken: 0.8,
+    outputPerMToken: 4,
+    cacheReadPerMToken: 0.08,
+    cacheWritePerMToken: 1,
   },
 ];
 

--- a/src/lib/anthropic-pricing.ts
+++ b/src/lib/anthropic-pricing.ts
@@ -1,0 +1,74 @@
+export type ModelPricing = {
+  prefix: string;
+  inputPerMToken: number;
+  outputPerMToken: number;
+  cacheReadPerMToken: number;
+  cacheWritePerMToken: number;
+};
+
+/**
+ * Anthropic model pricing table, ordered by prefix length (longest first)
+ * so that the most specific prefix matches first.
+ */
+export const MODEL_PRICING: ModelPricing[] = [
+  {
+    prefix: "claude-sonnet-4",
+    inputPerMToken: 3,
+    outputPerMToken: 15,
+    cacheReadPerMToken: 0.3,
+    cacheWritePerMToken: 3.75,
+  },
+  {
+    prefix: "claude-haiku-4",
+    inputPerMToken: 0.8,
+    outputPerMToken: 4,
+    cacheReadPerMToken: 0.08,
+    cacheWritePerMToken: 1,
+  },
+  {
+    prefix: "claude-opus-4",
+    inputPerMToken: 15,
+    outputPerMToken: 75,
+    cacheReadPerMToken: 1.5,
+    cacheWritePerMToken: 18.75,
+  },
+];
+
+/**
+ * Resolve pricing for a model string using prefix matching.
+ * Returns the first entry whose prefix matches the start of the model string.
+ * Falls back to the highest pricing (index 0) with resolved=false if no match.
+ */
+export function resolveModelPricing(model: string): {
+  pricing: ModelPricing;
+  resolved: boolean;
+} {
+  for (const entry of MODEL_PRICING) {
+    if (model.startsWith(entry.prefix)) {
+      return { pricing: entry, resolved: true };
+    }
+  }
+  return { pricing: MODEL_PRICING[0], resolved: false };
+}
+
+/**
+ * Compute cost in cents from token counts and pricing per million tokens.
+ */
+export function computeCostCents(
+  tokens: {
+    uncachedInputTokens: number;
+    cacheReadInputTokens: number;
+    cacheCreationInputTokens: number;
+    outputTokens: number;
+  },
+  pricing: ModelPricing,
+): number {
+  const dollarCost =
+    (tokens.uncachedInputTokens * pricing.inputPerMToken) / 1_000_000 +
+    (tokens.cacheReadInputTokens * pricing.cacheReadPerMToken) / 1_000_000 +
+    (tokens.cacheCreationInputTokens * pricing.cacheWritePerMToken) /
+      1_000_000 +
+    (tokens.outputTokens * pricing.outputPerMToken) / 1_000_000;
+
+  return Math.round(dollarCost * 100);
+}

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -5,14 +5,24 @@ import {
   licenseAssignments,
   aiTools,
 } from "@/lib/db/schema";
-import { eq, and, sql, desc, isNotNull } from "drizzle-orm";
+import { eq, and, sql, desc, isNotNull, inArray } from "drizzle-orm";
 import { decryptApiKey } from "@/lib/crypto";
 import { fetchOrgApiKeys, resolveApiKeyId } from "@/lib/anthropic-keys";
 import {
   resolveModelPricing,
   computeCostCents,
 } from "@/lib/anthropic-pricing";
+import { ANTHROPIC_API_VERSION } from "@/lib/anthropic-constants";
 import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LOCK_USER_ID = 0;
+const LOCK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes — stale lock threshold
+const LOCK_COOLDOWN_MS = 60 * 1000; // 60 seconds — minimum between syncs
+const DEFAULT_BACKFILL_DAYS = 31;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,6 +64,13 @@ const usageReportResponseSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Shared: SQL condition for Anthropic tool matching
+// ---------------------------------------------------------------------------
+
+/** SQL filter for license_assignments joined with ai_tools that match Anthropic/Claude tools */
+export const anthropicToolFilter = sql`(${aiTools.vendor} ILIKE '%anthropic%' OR ${aiTools.name} ILIKE '%claude%')`;
+
+// ---------------------------------------------------------------------------
 // Helper: fetch usage from Anthropic Admin API
 // ---------------------------------------------------------------------------
 
@@ -73,7 +90,7 @@ async function fetchAnthropicUsage(
     "bucket_width=1d",
     "group_by[]=model",
     "group_by[]=api_key_id",
-    "limit=31",
+    `limit=${DEFAULT_BACKFILL_DAYS}`,
   ];
 
   if (apiKeyIds) {
@@ -90,7 +107,7 @@ async function fetchAnthropicUsage(
     const res = await fetch(url, {
       headers: {
         "x-api-key": adminKey,
-        "anthropic-version": "2023-06-01",
+        "anthropic-version": ANTHROPIC_API_VERSION,
         "Content-Type": "application/json",
       },
     });
@@ -142,7 +159,7 @@ async function resolveAllMappings(): Promise<Map<string, number>> {
       and(
         eq(licenseAssignments.status, "active"),
         isNotNull(licenseAssignments.apiKeyEncrypted),
-        sql`(LOWER(${aiTools.vendor}) LIKE '%anthropic%' OR LOWER(${aiTools.name}) LIKE '%claude%')`
+        anthropicToolFilter
       )
     );
 
@@ -193,7 +210,7 @@ function computeSyncWindow(latestDateStr: string | null): { startingAt: string; 
     startDate.setUTCDate(startDate.getUTCDate() - 1);
   } else {
     startDate = new Date(now);
-    startDate.setUTCDate(startDate.getUTCDate() - 31);
+    startDate.setUTCDate(startDate.getUTCDate() - DEFAULT_BACKFILL_DAYS);
   }
   const endDate = new Date(now);
   endDate.setUTCDate(endDate.getUTCDate() + 1);
@@ -205,59 +222,78 @@ function computeSyncWindow(latestDateStr: string | null): { startingAt: string; 
 }
 
 // ---------------------------------------------------------------------------
-// Helper: upsert a single usage row
+// Helper: prepare a usage row for batch upsert
 // ---------------------------------------------------------------------------
 
-async function upsertUsageRow(
+function prepareUsageRow(
   userId: number,
   bucketDate: string,
   result: z.infer<typeof usageBucketResultSchema>
 ) {
   const model = result.model;
-  if (!model) return;
+  if (!model) return null;
 
   const cacheCreationTokens =
     (result.cache_creation?.ephemeral_5m_input_tokens ?? 0) +
     (result.cache_creation?.ephemeral_1h_input_tokens ?? 0);
-  const tokens = {
-    uncachedInputTokens: result.uncached_input_tokens,
-    cacheReadInputTokens: result.cache_read_input_tokens,
-    cacheCreationInputTokens: cacheCreationTokens,
-    outputTokens: result.output_tokens,
-  };
   const { pricing, resolved } = resolveModelPricing(model);
-  const costCents = computeCostCents(tokens, pricing);
-
-  await db
-    .insert(anthropicUsageMetrics)
-    .values({
-      userId,
-      date: bucketDate,
-      model,
+  const costCents = computeCostCents(
+    {
       uncachedInputTokens: result.uncached_input_tokens,
       cacheReadInputTokens: result.cache_read_input_tokens,
       cacheCreationInputTokens: cacheCreationTokens,
       outputTokens: result.output_tokens,
-      computedCostCents: costCents,
-      pricingResolved: resolved,
-      updatedAt: new Date(),
-    })
-    .onConflictDoUpdate({
-      target: [
-        anthropicUsageMetrics.userId,
-        anthropicUsageMetrics.date,
-        anthropicUsageMetrics.model,
-      ],
-      set: {
-        uncachedInputTokens: result.uncached_input_tokens,
-        cacheReadInputTokens: result.cache_read_input_tokens,
-        cacheCreationInputTokens: cacheCreationTokens,
-        outputTokens: result.output_tokens,
-        computedCostCents: costCents,
-        pricingResolved: resolved,
-        updatedAt: new Date(),
-      },
-    });
+    },
+    pricing
+  );
+
+  return {
+    userId,
+    date: bucketDate,
+    model,
+    uncachedInputTokens: result.uncached_input_tokens,
+    cacheReadInputTokens: result.cache_read_input_tokens,
+    cacheCreationInputTokens: cacheCreationTokens,
+    outputTokens: result.output_tokens,
+    computedCostCents: costCents,
+    pricingResolved: resolved,
+    updatedAt: new Date(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: batch upsert usage rows
+// ---------------------------------------------------------------------------
+
+const BATCH_SIZE = 50;
+
+async function batchUpsertUsageRows(
+  rows: NonNullable<ReturnType<typeof prepareUsageRow>>[]
+) {
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE);
+    for (const row of batch) {
+      await db
+        .insert(anthropicUsageMetrics)
+        .values(row)
+        .onConflictDoUpdate({
+          target: [
+            anthropicUsageMetrics.userId,
+            anthropicUsageMetrics.date,
+            anthropicUsageMetrics.model,
+          ],
+          set: {
+            uncachedInputTokens: row.uncachedInputTokens,
+            cacheReadInputTokens: row.cacheReadInputTokens,
+            cacheCreationInputTokens: row.cacheCreationInputTokens,
+            outputTokens: row.outputTokens,
+            computedCostCents: row.computedCostCents,
+            pricingResolved: row.pricingResolved,
+            updatedAt: row.updatedAt,
+          },
+        });
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -268,7 +304,6 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
   const summary: SyncSummary = { syncedUsers: 0, skippedUsers: 0, errors: [] };
 
   // Ensure a dedicated global lock row exists (userId=0 sentinel)
-  const LOCK_USER_ID = 0;
   await db
     .insert(anthropicSyncStatus)
     .values({ userId: LOCK_USER_ID })
@@ -287,14 +322,12 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
         recentSync.lastSyncCompletedAt < recentSync.lastSyncStartedAt);
 
     if (isInProgress) {
-      // If started < 5 minutes ago, it's still running — skip
-      if (nowMs - startedMs < 5 * 60 * 1000) {
+      if (nowMs - startedMs < LOCK_TIMEOUT_MS) {
         return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync already in progress" }] };
       }
-      // Stale lock (> 5 min) — allow new sync
+      // Stale lock — allow new sync
     } else if (recentSync.lastSyncCompletedAt &&
-               nowMs - recentSync.lastSyncCompletedAt.getTime() < 60 * 1000) {
-      // Completed less than 60 seconds ago — skip
+               nowMs - recentSync.lastSyncCompletedAt.getTime() < LOCK_COOLDOWN_MS) {
       return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync completed recently" }] };
     }
   }
@@ -328,7 +361,9 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
     // Track which users received data
     const usersWithData = new Set<number>();
 
-    // Process each bucket (day)
+    // Collect all rows for batch upsert
+    const pendingRows: NonNullable<ReturnType<typeof prepareUsageRow>>[] = [];
+
     for (const bucket of response.data) {
       const bucketDate = bucket.starting_at.split("T")[0];
 
@@ -338,23 +373,25 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
         if (!apiKeyId || !model) continue;
 
         const userId = apiKeyToUser.get(apiKeyId);
-        if (!userId) {
-          // Unknown key — skip silently
-          continue;
-        }
+        if (!userId) continue;
 
         usersWithData.add(userId);
 
-        await upsertUsageRow(userId, bucketDate, result);
+        const row = prepareUsageRow(userId, bucketDate, result);
+        if (row) pendingRows.push(row);
       }
     }
 
-    // Update sync status per user
-    for (const userId of usersWithData) {
+    // Batch upsert all collected rows
+    await batchUpsertUsageRows(pendingRows);
+
+    // Batch update sync status for all users that received data
+    const userIds = Array.from(usersWithData);
+    if (userIds.length > 0) {
       await db
         .update(anthropicSyncStatus)
         .set({ lastSyncCompletedAt: new Date(), lastSyncError: null })
-        .where(eq(anthropicSyncStatus.userId, userId));
+        .where(inArray(anthropicSyncStatus.userId, userIds));
     }
 
     // Mark completion on lock row
@@ -416,7 +453,7 @@ export async function syncSingleUser(userId: number): Promise<{ syncedDays: numb
           eq(licenseAssignments.userId, userId),
           eq(licenseAssignments.status, "active"),
           isNotNull(licenseAssignments.apiKeyEncrypted),
-          sql`(LOWER(${aiTools.vendor}) LIKE '%anthropic%' OR LOWER(${aiTools.name}) LIKE '%claude%')`
+          anthropicToolFilter
         )
       )
       .limit(1);
@@ -451,6 +488,8 @@ export async function syncSingleUser(userId: number): Promise<{ syncedDays: numb
   // Fetch filtered by this user's API key
   const response = await fetchAnthropicUsage(startingAt, endingAt, [syncStatus.resolvedApiKeyId!]);
 
+  // Collect all rows for batch upsert
+  const pendingRows: NonNullable<ReturnType<typeof prepareUsageRow>>[] = [];
   let syncedDays = 0;
   let latestDate: string | null = null;
 
@@ -458,7 +497,8 @@ export async function syncSingleUser(userId: number): Promise<{ syncedDays: numb
     const bucketDate = bucket.starting_at.split("T")[0];
 
     for (const result of bucket.results) {
-      await upsertUsageRow(userId, bucketDate, result);
+      const row = prepareUsageRow(userId, bucketDate, result);
+      if (row) pendingRows.push(row);
     }
 
     syncedDays++;
@@ -466,6 +506,9 @@ export async function syncSingleUser(userId: number): Promise<{ syncedDays: numb
       latestDate = bucketDate;
     }
   }
+
+  // Batch upsert all collected rows
+  await batchUpsertUsageRows(pendingRows);
 
   await db
     .update(anthropicSyncStatus)

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -6,7 +6,6 @@ import {
   anthropicSyncStatus,
   licenseAssignments,
   aiTools,
-  users,
 } from "@/lib/db/schema";
 import { eq, and, sql, desc, isNotNull } from "drizzle-orm";
 import { decryptApiKey } from "@/lib/crypto";
@@ -134,9 +133,8 @@ async function resolveAllMappings(): Promise<Map<string, number>> {
     );
 
   // Filter to users without cached mapping
-  const unmapped = usersWithKeys.filter(
-    (u) => !Array.from(mapping.values()).includes(u.userId)
-  );
+  const mappedUserIds = new Set(mapping.values());
+  const unmapped = usersWithKeys.filter((u) => !mappedUserIds.has(u.userId));
 
   if (unmapped.length > 0) {
     // Fetch org API keys to resolve
@@ -168,6 +166,85 @@ async function resolveAllMappings(): Promise<Map<string, number>> {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: compute sync date window
+// ---------------------------------------------------------------------------
+
+function computeSyncWindow(latestDateStr: string | null): { startingAt: string; endingAt: string } {
+  const now = new Date();
+  let startDate: Date;
+  if (latestDateStr) {
+    startDate = new Date(latestDateStr);
+    startDate.setUTCDate(startDate.getUTCDate() + 1);
+  } else {
+    startDate = new Date(now);
+    startDate.setUTCDate(startDate.getUTCDate() - 31);
+  }
+  const endDate = new Date(now);
+  endDate.setUTCDate(endDate.getUTCDate() + 1);
+
+  return {
+    startingAt: startDate.toISOString().replace(/\.\d+Z$/, "Z"),
+    endingAt: endDate.toISOString().replace(/\.\d+Z$/, "Z"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: upsert a single usage row
+// ---------------------------------------------------------------------------
+
+async function upsertUsageRow(
+  userId: number,
+  bucketDate: string,
+  result: z.infer<typeof usageBucketResultSchema>
+) {
+  const model = result.model;
+  if (!model) return;
+
+  const cacheCreationTokens =
+    (result.cache_creation?.ephemeral_5m_input_tokens ?? 0) +
+    (result.cache_creation?.ephemeral_1h_input_tokens ?? 0);
+  const tokens = {
+    uncachedInputTokens: result.uncached_input_tokens,
+    cacheReadInputTokens: result.cache_read_input_tokens,
+    cacheCreationInputTokens: cacheCreationTokens,
+    outputTokens: result.output_tokens,
+  };
+  const { pricing, resolved } = resolveModelPricing(model);
+  const costCents = computeCostCents(tokens, pricing);
+
+  await db
+    .insert(anthropicUsageMetrics)
+    .values({
+      userId,
+      date: bucketDate,
+      model,
+      uncachedInputTokens: result.uncached_input_tokens,
+      cacheReadInputTokens: result.cache_read_input_tokens,
+      cacheCreationInputTokens: cacheCreationTokens,
+      outputTokens: result.output_tokens,
+      computedCostCents: costCents,
+      pricingResolved: resolved,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [
+        anthropicUsageMetrics.userId,
+        anthropicUsageMetrics.date,
+        anthropicUsageMetrics.model,
+      ],
+      set: {
+        uncachedInputTokens: result.uncached_input_tokens,
+        cacheReadInputTokens: result.cache_read_input_tokens,
+        cacheCreationInputTokens: cacheCreationTokens,
+        outputTokens: result.output_tokens,
+        computedCostCents: costCents,
+        pricingResolved: resolved,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Global sync: fetch all org usage and distribute to users
 // ---------------------------------------------------------------------------
 
@@ -175,32 +252,35 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
   const summary: SyncSummary = { syncedUsers: 0, skippedUsers: 0, errors: [] };
 
   // Global concurrency guard: check if any sync is in progress
-  const inProgress = await db.query.anthropicSyncStatus.findFirst({
-    where: and(
-      isNotNull(anthropicSyncStatus.lastSyncStartedAt),
-      sql`${anthropicSyncStatus.lastSyncStartedAt} > NOW() - INTERVAL '60 seconds'`,
-      sql`(${anthropicSyncStatus.lastSyncCompletedAt} IS NULL OR ${anthropicSyncStatus.lastSyncCompletedAt} < ${anthropicSyncStatus.lastSyncStartedAt})`
-    ),
+  const recentSync = await db.query.anthropicSyncStatus.findFirst({
+    where: isNotNull(anthropicSyncStatus.lastSyncStartedAt),
+    orderBy: desc(anthropicSyncStatus.lastSyncStartedAt),
   });
 
-  if (inProgress) {
-    // Check for stale lock (> 5 min)
-    const staleCheck = await db.query.anthropicSyncStatus.findFirst({
-      where: and(
-        isNotNull(anthropicSyncStatus.lastSyncStartedAt),
-        sql`${anthropicSyncStatus.lastSyncStartedAt} > NOW() - INTERVAL '5 minutes'`,
-        sql`(${anthropicSyncStatus.lastSyncCompletedAt} IS NULL OR ${anthropicSyncStatus.lastSyncCompletedAt} < ${anthropicSyncStatus.lastSyncStartedAt})`
-      ),
-    });
-    if (staleCheck) {
-      return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync already in progress" }] };
+  if (recentSync?.lastSyncStartedAt) {
+    const startedMs = recentSync.lastSyncStartedAt.getTime();
+    const nowMs = Date.now();
+    const isInProgress =
+      (!recentSync.lastSyncCompletedAt ||
+        recentSync.lastSyncCompletedAt < recentSync.lastSyncStartedAt);
+
+    if (isInProgress) {
+      // If started < 5 minutes ago, it's still running — skip
+      if (nowMs - startedMs < 5 * 60 * 1000) {
+        return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync already in progress" }] };
+      }
+      // Stale lock (> 5 min) — allow new sync
+    } else if (nowMs - startedMs < 60 * 1000) {
+      // Completed less than 60 seconds ago — skip
+      return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync completed recently" }] };
     }
   }
 
-  // Set global lock
+  // Set global lock on all sync status rows
   await db
     .update(anthropicSyncStatus)
-    .set({ lastSyncStartedAt: new Date(), lastSyncError: null });
+    .set({ lastSyncStartedAt: new Date(), lastSyncError: null })
+    .where(isNotNull(anthropicSyncStatus.userId));
 
   try {
     // Resolve all mappings
@@ -214,24 +294,7 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
       .select({ maxDate: sql<string>`MAX(${anthropicUsageMetrics.date})` })
       .from(anthropicUsageMetrics);
 
-    const now = new Date();
-    let startDate: Date;
-    if (oldestLatest[0]?.maxDate) {
-      startDate = new Date(oldestLatest[0].maxDate);
-      // Start from the day after the latest stored date
-      startDate.setUTCDate(startDate.getUTCDate() + 1);
-    } else {
-      // No data: backfill 31 days
-      startDate = new Date(now);
-      startDate.setUTCDate(startDate.getUTCDate() - 31);
-    }
-
-    // End date is tomorrow (to include today)
-    const endDate = new Date(now);
-    endDate.setUTCDate(endDate.getUTCDate() + 1);
-
-    const startingAt = startDate.toISOString().replace(/\.\d+Z$/, "Z");
-    const endingAt = endDate.toISOString().replace(/\.\d+Z$/, "Z");
+    const { startingAt, endingAt } = computeSyncWindow(oldestLatest[0]?.maxDate ?? null);
 
     // Fetch all org usage in one call
     const response = await fetchAnthropicUsage(startingAt, endingAt);
@@ -256,50 +319,7 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
 
         usersWithData.add(userId);
 
-        // Compute cost
-        const cacheCreationTokens =
-          (result.cache_creation?.ephemeral_5m_input_tokens ?? 0) +
-          (result.cache_creation?.ephemeral_1h_input_tokens ?? 0);
-        const tokens = {
-          uncachedInputTokens: result.uncached_input_tokens,
-          cacheReadInputTokens: result.cache_read_input_tokens,
-          cacheCreationInputTokens: cacheCreationTokens,
-          outputTokens: result.output_tokens,
-        };
-        const { pricing, resolved } = resolveModelPricing(model);
-        const costCents = computeCostCents(tokens, pricing);
-
-        // Upsert
-        await db
-          .insert(anthropicUsageMetrics)
-          .values({
-            userId,
-            date: bucketDate,
-            model,
-            uncachedInputTokens: result.uncached_input_tokens,
-            cacheReadInputTokens: result.cache_read_input_tokens,
-            cacheCreationInputTokens: cacheCreationTokens,
-            outputTokens: result.output_tokens,
-            computedCostCents: costCents,
-            pricingResolved: resolved,
-            updatedAt: new Date(),
-          })
-          .onConflictDoUpdate({
-            target: [
-              anthropicUsageMetrics.userId,
-              anthropicUsageMetrics.date,
-              anthropicUsageMetrics.model,
-            ],
-            set: {
-              uncachedInputTokens: result.uncached_input_tokens,
-              cacheReadInputTokens: result.cache_read_input_tokens,
-              cacheCreationInputTokens: cacheCreationTokens,
-              outputTokens: result.output_tokens,
-              computedCostCents: costCents,
-              pricingResolved: resolved,
-              updatedAt: new Date(),
-            },
-          });
+        await upsertUsageRow(userId, bucketDate, result);
       }
     }
 
@@ -319,7 +339,8 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
     // Set error on all sync status rows
     await db
       .update(anthropicSyncStatus)
-      .set({ lastSyncError: errorMsg.slice(0, 500) });
+      .set({ lastSyncError: errorMsg.slice(0, 500) })
+      .where(isNotNull(anthropicSyncStatus.userId));
     summary.errors.push({ userId: 0, error: errorMsg });
   }
 
@@ -380,21 +401,7 @@ export async function syncSingleUser(userId: number): Promise<{ syncedDays: numb
     orderBy: desc(anthropicUsageMetrics.date),
   });
 
-  const now = new Date();
-  let startDate: Date;
-  if (latestRow) {
-    startDate = new Date(latestRow.date);
-    startDate.setUTCDate(startDate.getUTCDate() + 1);
-  } else {
-    startDate = new Date(now);
-    startDate.setUTCDate(startDate.getUTCDate() - 31);
-  }
-
-  const endDate = new Date(now);
-  endDate.setUTCDate(endDate.getUTCDate() + 1);
-
-  const startingAt = startDate.toISOString().replace(/\.\d+Z$/, "Z");
-  const endingAt = endDate.toISOString().replace(/\.\d+Z$/, "Z");
+  const { startingAt, endingAt } = computeSyncWindow(latestRow?.date ?? null);
 
   // Fetch filtered by this user's API key
   const response = await fetchAnthropicUsage(startingAt, endingAt, [syncStatus.resolvedApiKeyId]);
@@ -406,50 +413,7 @@ export async function syncSingleUser(userId: number): Promise<{ syncedDays: numb
     const bucketDate = bucket.starting_at.split("T")[0];
 
     for (const result of bucket.results) {
-      if (!result.model) continue;
-
-      const cacheCreationTokens =
-        (result.cache_creation?.ephemeral_5m_input_tokens ?? 0) +
-        (result.cache_creation?.ephemeral_1h_input_tokens ?? 0);
-      const tokens = {
-        uncachedInputTokens: result.uncached_input_tokens,
-        cacheReadInputTokens: result.cache_read_input_tokens,
-        cacheCreationInputTokens: cacheCreationTokens,
-        outputTokens: result.output_tokens,
-      };
-      const { pricing, resolved } = resolveModelPricing(result.model);
-      const costCents = computeCostCents(tokens, pricing);
-
-      await db
-        .insert(anthropicUsageMetrics)
-        .values({
-          userId,
-          date: bucketDate,
-          model: result.model,
-          uncachedInputTokens: result.uncached_input_tokens,
-          cacheReadInputTokens: result.cache_read_input_tokens,
-          cacheCreationInputTokens: cacheCreationTokens,
-          outputTokens: result.output_tokens,
-          computedCostCents: costCents,
-          pricingResolved: resolved,
-          updatedAt: new Date(),
-        })
-        .onConflictDoUpdate({
-          target: [
-            anthropicUsageMetrics.userId,
-            anthropicUsageMetrics.date,
-            anthropicUsageMetrics.model,
-          ],
-          set: {
-            uncachedInputTokens: result.uncached_input_tokens,
-            cacheReadInputTokens: result.cache_read_input_tokens,
-            cacheCreationInputTokens: cacheCreationTokens,
-            outputTokens: result.output_tokens,
-            computedCostCents: costCents,
-            pricingResolved: resolved,
-            updatedAt: new Date(),
-          },
-        });
+      await upsertUsageRow(userId, bucketDate, result);
     }
 
     syncedDays++;

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { db } from "@/lib/db";
 import {
   anthropicUsageMetrics,
@@ -361,11 +359,10 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
     console.error("Anthropic sync failed:", errorMsg);
-    // Set error on all sync status rows
+    // Set error on all sync status rows (including lock row userId=0)
     await db
       .update(anthropicSyncStatus)
-      .set({ lastSyncError: errorMsg.slice(0, 500) })
-      .where(isNotNull(anthropicSyncStatus.userId));
+      .set({ lastSyncError: errorMsg.slice(0, 500) });
     summary.errors.push({ userId: 0, error: errorMsg });
   }
 

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -312,12 +312,15 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
       return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "No users with resolved API keys" }] };
     }
 
-    // Determine sync window: oldest MAX(date) across all users, or 31 days back
-    const oldestLatest = await db
-      .select({ maxDate: sql<string>`MAX(${anthropicUsageMetrics.date})` })
-      .from(anthropicUsageMetrics);
+    // Sync All always fetches the full current month so every day is refreshed
+    const now = new Date();
+    const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+    const tomorrow = new Date(now);
+    tomorrow.setUTCHours(0, 0, 0, 0);
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
 
-    const { startingAt, endingAt } = computeSyncWindow(oldestLatest[0]?.maxDate ?? null);
+    const startingAt = monthStart.toISOString().replace(/\.\d+Z$/, "Z");
+    const endingAt = tomorrow.toISOString().replace(/\.\d+Z$/, "Z");
 
     // Fetch all org usage in one call
     const response = await fetchAnthropicUsage(startingAt, endingAt);

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -128,7 +128,7 @@ async function resolveAllMappings(): Promise<Map<string, number>> {
       and(
         eq(licenseAssignments.status, "active"),
         isNotNull(licenseAssignments.apiKeyEncrypted),
-        sql`LOWER(${aiTools.vendor}) LIKE '%anthropic%' OR LOWER(${aiTools.name}) LIKE '%claude%'`
+        sql`(LOWER(${aiTools.vendor}) LIKE '%anthropic%' OR LOWER(${aiTools.name}) LIKE '%claude%')`
       )
     );
 
@@ -171,9 +171,11 @@ async function resolveAllMappings(): Promise<Map<string, number>> {
 
 function computeSyncWindow(latestDateStr: string | null): { startingAt: string; endingAt: string } {
   const now = new Date();
+  now.setUTCHours(0, 0, 0, 0);
   let startDate: Date;
   if (latestDateStr) {
     startDate = new Date(latestDateStr);
+    startDate.setUTCHours(0, 0, 0, 0);
     startDate.setUTCDate(startDate.getUTCDate() + 1);
   } else {
     startDate = new Date(now);
@@ -332,7 +334,7 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
     }
 
     summary.syncedUsers = usersWithData.size;
-    summary.skippedUsers = apiKeyToUser.size - usersWithData.size;
+    summary.skippedUsers = new Set(apiKeyToUser.values()).size - usersWithData.size;
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
     console.error("Anthropic sync failed:", errorMsg);

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -1,0 +1,471 @@
+"use server";
+
+import { db } from "@/lib/db";
+import {
+  anthropicUsageMetrics,
+  anthropicSyncStatus,
+  licenseAssignments,
+  aiTools,
+  users,
+} from "@/lib/db/schema";
+import { eq, and, sql, desc, isNotNull } from "drizzle-orm";
+import { decryptApiKey } from "@/lib/crypto";
+import { fetchOrgApiKeys, resolveApiKeyId } from "@/lib/anthropic-keys";
+import {
+  resolveModelPricing,
+  computeCostCents,
+} from "@/lib/anthropic-pricing";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SyncSummary {
+  syncedUsers: number;
+  skippedUsers: number;
+  errors: Array<{ userId: number; error: string }>;
+}
+
+// Zod schema for Anthropic usage_report response
+const usageBucketResultSchema = z.object({
+  model: z.string().nullable().optional(),
+  api_key_id: z.string().nullable().optional(),
+  uncached_input_tokens: z.number().default(0),
+  cache_read_input_tokens: z.number().default(0),
+  cache_creation: z
+    .object({
+      ephemeral_5m_input_tokens: z.number().default(0),
+      ephemeral_1h_input_tokens: z.number().default(0),
+    })
+    .optional()
+    .default({}),
+  output_tokens: z.number().default(0),
+});
+
+const usageBucketSchema = z.object({
+  starting_at: z.string(),
+  ending_at: z.string(),
+  results: z.array(usageBucketResultSchema),
+});
+
+const usageReportResponseSchema = z.object({
+  data: z.array(usageBucketSchema),
+  has_more: z.boolean(),
+  next_page: z.string().nullable().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Helper: fetch usage from Anthropic Admin API
+// ---------------------------------------------------------------------------
+
+async function fetchAnthropicUsage(
+  startingAt: string,
+  endingAt: string,
+  apiKeyIds?: string[]
+): Promise<z.infer<typeof usageReportResponseSchema>> {
+  const adminKey = process.env.ANTHROPIC_ADMIN_API_KEY;
+  if (!adminKey) throw new Error("ANTHROPIC_ADMIN_API_KEY is not set");
+
+  const params = new URLSearchParams();
+  params.set("starting_at", startingAt);
+  params.set("ending_at", endingAt);
+  params.set("bucket_width", "1d");
+  params.append("group_by[]", "model");
+  params.append("group_by[]", "api_key_id");
+  params.set("limit", "31");
+
+  if (apiKeyIds) {
+    for (const id of apiKeyIds) {
+      params.append("api_key_ids[]", id);
+    }
+  }
+
+  const res = await fetch(
+    `https://api.anthropic.com/v1/organizations/usage_report/messages?${params.toString()}`,
+    {
+      headers: {
+        "x-api-key": adminKey,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Anthropic API error ${res.status}: ${body}`);
+  }
+
+  return usageReportResponseSchema.parse(await res.json());
+}
+
+// ---------------------------------------------------------------------------
+// Helper: resolve all api_key_id → userId mappings
+// ---------------------------------------------------------------------------
+
+async function resolveAllMappings(): Promise<Map<string, number>> {
+  const mapping = new Map<string, number>();
+
+  // Get existing cached mappings
+  const existing = await db.query.anthropicSyncStatus.findMany({
+    where: isNotNull(anthropicSyncStatus.resolvedApiKeyId),
+  });
+  for (const row of existing) {
+    if (row.resolvedApiKeyId) {
+      mapping.set(row.resolvedApiKeyId, row.userId);
+    }
+  }
+
+  // Find users with Anthropic API keys but no cached mapping
+  const usersWithKeys = await db
+    .select({
+      userId: licenseAssignments.userId,
+      apiKeyEncrypted: licenseAssignments.apiKeyEncrypted,
+    })
+    .from(licenseAssignments)
+    .innerJoin(aiTools, eq(licenseAssignments.toolId, aiTools.id))
+    .where(
+      and(
+        eq(licenseAssignments.status, "active"),
+        isNotNull(licenseAssignments.apiKeyEncrypted),
+        sql`LOWER(${aiTools.vendor}) LIKE '%anthropic%' OR LOWER(${aiTools.name}) LIKE '%claude%'`
+      )
+    );
+
+  // Filter to users without cached mapping
+  const unmapped = usersWithKeys.filter(
+    (u) => !Array.from(mapping.values()).includes(u.userId)
+  );
+
+  if (unmapped.length > 0) {
+    // Fetch org API keys to resolve
+    const orgKeys = await fetchOrgApiKeys();
+
+    for (const u of unmapped) {
+      if (!u.apiKeyEncrypted) continue;
+      try {
+        const decrypted = await decryptApiKey(u.apiKeyEncrypted);
+        const apiKeyId = resolveApiKeyId(decrypted, orgKeys);
+        if (apiKeyId) {
+          mapping.set(apiKeyId, u.userId);
+          // Upsert sync status with resolved ID
+          await db
+            .insert(anthropicSyncStatus)
+            .values({ userId: u.userId, resolvedApiKeyId: apiKeyId })
+            .onConflictDoUpdate({
+              target: [anthropicSyncStatus.userId],
+              set: { resolvedApiKeyId: apiKeyId },
+            });
+        }
+      } catch (err) {
+        console.error(`Failed to resolve API key for user ${u.userId}:`, err);
+      }
+    }
+  }
+
+  return mapping;
+}
+
+// ---------------------------------------------------------------------------
+// Global sync: fetch all org usage and distribute to users
+// ---------------------------------------------------------------------------
+
+export async function runAnthropicSync(): Promise<SyncSummary> {
+  const summary: SyncSummary = { syncedUsers: 0, skippedUsers: 0, errors: [] };
+
+  // Global concurrency guard: check if any sync is in progress
+  const inProgress = await db.query.anthropicSyncStatus.findFirst({
+    where: and(
+      isNotNull(anthropicSyncStatus.lastSyncStartedAt),
+      sql`${anthropicSyncStatus.lastSyncStartedAt} > NOW() - INTERVAL '60 seconds'`,
+      sql`(${anthropicSyncStatus.lastSyncCompletedAt} IS NULL OR ${anthropicSyncStatus.lastSyncCompletedAt} < ${anthropicSyncStatus.lastSyncStartedAt})`
+    ),
+  });
+
+  if (inProgress) {
+    // Check for stale lock (> 5 min)
+    const staleCheck = await db.query.anthropicSyncStatus.findFirst({
+      where: and(
+        isNotNull(anthropicSyncStatus.lastSyncStartedAt),
+        sql`${anthropicSyncStatus.lastSyncStartedAt} > NOW() - INTERVAL '5 minutes'`,
+        sql`(${anthropicSyncStatus.lastSyncCompletedAt} IS NULL OR ${anthropicSyncStatus.lastSyncCompletedAt} < ${anthropicSyncStatus.lastSyncStartedAt})`
+      ),
+    });
+    if (staleCheck) {
+      return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync already in progress" }] };
+    }
+  }
+
+  // Set global lock
+  await db
+    .update(anthropicSyncStatus)
+    .set({ lastSyncStartedAt: new Date(), lastSyncError: null });
+
+  try {
+    // Resolve all mappings
+    const apiKeyToUser = await resolveAllMappings();
+    if (apiKeyToUser.size === 0) {
+      return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "No users with resolved API keys" }] };
+    }
+
+    // Determine sync window: oldest MAX(date) across all users, or 31 days back
+    const oldestLatest = await db
+      .select({ maxDate: sql<string>`MAX(${anthropicUsageMetrics.date})` })
+      .from(anthropicUsageMetrics);
+
+    const now = new Date();
+    let startDate: Date;
+    if (oldestLatest[0]?.maxDate) {
+      startDate = new Date(oldestLatest[0].maxDate);
+      // Start from the day after the latest stored date
+      startDate.setUTCDate(startDate.getUTCDate() + 1);
+    } else {
+      // No data: backfill 31 days
+      startDate = new Date(now);
+      startDate.setUTCDate(startDate.getUTCDate() - 31);
+    }
+
+    // End date is tomorrow (to include today)
+    const endDate = new Date(now);
+    endDate.setUTCDate(endDate.getUTCDate() + 1);
+
+    const startingAt = startDate.toISOString().replace(/\.\d+Z$/, "Z");
+    const endingAt = endDate.toISOString().replace(/\.\d+Z$/, "Z");
+
+    // Fetch all org usage in one call
+    const response = await fetchAnthropicUsage(startingAt, endingAt);
+
+    // Track which users received data
+    const usersWithData = new Set<number>();
+
+    // Process each bucket (day)
+    for (const bucket of response.data) {
+      const bucketDate = bucket.starting_at.split("T")[0];
+
+      for (const result of bucket.results) {
+        const apiKeyId = result.api_key_id;
+        const model = result.model;
+        if (!apiKeyId || !model) continue;
+
+        const userId = apiKeyToUser.get(apiKeyId);
+        if (!userId) {
+          // Unknown key — skip silently
+          continue;
+        }
+
+        usersWithData.add(userId);
+
+        // Compute cost
+        const cacheCreationTokens =
+          (result.cache_creation?.ephemeral_5m_input_tokens ?? 0) +
+          (result.cache_creation?.ephemeral_1h_input_tokens ?? 0);
+        const tokens = {
+          uncachedInputTokens: result.uncached_input_tokens,
+          cacheReadInputTokens: result.cache_read_input_tokens,
+          cacheCreationInputTokens: cacheCreationTokens,
+          outputTokens: result.output_tokens,
+        };
+        const { pricing, resolved } = resolveModelPricing(model);
+        const costCents = computeCostCents(tokens, pricing);
+
+        // Upsert
+        await db
+          .insert(anthropicUsageMetrics)
+          .values({
+            userId,
+            date: bucketDate,
+            model,
+            uncachedInputTokens: result.uncached_input_tokens,
+            cacheReadInputTokens: result.cache_read_input_tokens,
+            cacheCreationInputTokens: cacheCreationTokens,
+            outputTokens: result.output_tokens,
+            computedCostCents: costCents,
+            pricingResolved: resolved,
+            updatedAt: new Date(),
+          })
+          .onConflictDoUpdate({
+            target: [
+              anthropicUsageMetrics.userId,
+              anthropicUsageMetrics.date,
+              anthropicUsageMetrics.model,
+            ],
+            set: {
+              uncachedInputTokens: result.uncached_input_tokens,
+              cacheReadInputTokens: result.cache_read_input_tokens,
+              cacheCreationInputTokens: cacheCreationTokens,
+              outputTokens: result.output_tokens,
+              computedCostCents: costCents,
+              pricingResolved: resolved,
+              updatedAt: new Date(),
+            },
+          });
+      }
+    }
+
+    // Update sync status per user
+    for (const userId of usersWithData) {
+      await db
+        .update(anthropicSyncStatus)
+        .set({ lastSyncCompletedAt: new Date(), lastSyncError: null })
+        .where(eq(anthropicSyncStatus.userId, userId));
+    }
+
+    summary.syncedUsers = usersWithData.size;
+    summary.skippedUsers = apiKeyToUser.size - usersWithData.size;
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    console.error("Anthropic sync failed:", errorMsg);
+    // Set error on all sync status rows
+    await db
+      .update(anthropicSyncStatus)
+      .set({ lastSyncError: errorMsg.slice(0, 500) });
+    summary.errors.push({ userId: 0, error: errorMsg });
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Single-user sync (admin manual trigger)
+// ---------------------------------------------------------------------------
+
+export async function syncSingleUser(userId: number): Promise<{ syncedDays: number; latestDate: string | null }> {
+  // Get or create sync status
+  let syncStatus = await db.query.anthropicSyncStatus.findFirst({
+    where: eq(anthropicSyncStatus.userId, userId),
+  });
+
+  if (!syncStatus) {
+    const [created] = await db
+      .insert(anthropicSyncStatus)
+      .values({ userId })
+      .returning();
+    syncStatus = created;
+  }
+
+  // Resolve API key ID if not cached
+  if (!syncStatus.resolvedApiKeyId) {
+    const assignment = await db.query.licenseAssignments.findFirst({
+      where: and(
+        eq(licenseAssignments.userId, userId),
+        eq(licenseAssignments.status, "active"),
+        isNotNull(licenseAssignments.apiKeyEncrypted)
+      ),
+      with: { tool: true },
+    });
+
+    if (!assignment?.apiKeyEncrypted) {
+      throw new Error("No API key configured for this user");
+    }
+
+    const decrypted = await decryptApiKey(assignment.apiKeyEncrypted);
+    const orgKeys = await fetchOrgApiKeys();
+    const apiKeyId = resolveApiKeyId(decrypted, orgKeys);
+    if (!apiKeyId) {
+      throw new Error("Could not resolve API key ID from org keys");
+    }
+
+    await db
+      .update(anthropicSyncStatus)
+      .set({ resolvedApiKeyId: apiKeyId })
+      .where(eq(anthropicSyncStatus.userId, userId));
+
+    syncStatus = { ...syncStatus, resolvedApiKeyId: apiKeyId };
+  }
+
+  // Determine start date
+  const latestRow = await db.query.anthropicUsageMetrics.findFirst({
+    where: eq(anthropicUsageMetrics.userId, userId),
+    orderBy: desc(anthropicUsageMetrics.date),
+  });
+
+  const now = new Date();
+  let startDate: Date;
+  if (latestRow) {
+    startDate = new Date(latestRow.date);
+    startDate.setUTCDate(startDate.getUTCDate() + 1);
+  } else {
+    startDate = new Date(now);
+    startDate.setUTCDate(startDate.getUTCDate() - 31);
+  }
+
+  const endDate = new Date(now);
+  endDate.setUTCDate(endDate.getUTCDate() + 1);
+
+  const startingAt = startDate.toISOString().replace(/\.\d+Z$/, "Z");
+  const endingAt = endDate.toISOString().replace(/\.\d+Z$/, "Z");
+
+  // Fetch filtered by this user's API key
+  const response = await fetchAnthropicUsage(startingAt, endingAt, [syncStatus.resolvedApiKeyId]);
+
+  let syncedDays = 0;
+  let latestDate: string | null = null;
+
+  for (const bucket of response.data) {
+    const bucketDate = bucket.starting_at.split("T")[0];
+
+    for (const result of bucket.results) {
+      if (!result.model) continue;
+
+      const cacheCreationTokens =
+        (result.cache_creation?.ephemeral_5m_input_tokens ?? 0) +
+        (result.cache_creation?.ephemeral_1h_input_tokens ?? 0);
+      const tokens = {
+        uncachedInputTokens: result.uncached_input_tokens,
+        cacheReadInputTokens: result.cache_read_input_tokens,
+        cacheCreationInputTokens: cacheCreationTokens,
+        outputTokens: result.output_tokens,
+      };
+      const { pricing, resolved } = resolveModelPricing(result.model);
+      const costCents = computeCostCents(tokens, pricing);
+
+      await db
+        .insert(anthropicUsageMetrics)
+        .values({
+          userId,
+          date: bucketDate,
+          model: result.model,
+          uncachedInputTokens: result.uncached_input_tokens,
+          cacheReadInputTokens: result.cache_read_input_tokens,
+          cacheCreationInputTokens: cacheCreationTokens,
+          outputTokens: result.output_tokens,
+          computedCostCents: costCents,
+          pricingResolved: resolved,
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [
+            anthropicUsageMetrics.userId,
+            anthropicUsageMetrics.date,
+            anthropicUsageMetrics.model,
+          ],
+          set: {
+            uncachedInputTokens: result.uncached_input_tokens,
+            cacheReadInputTokens: result.cache_read_input_tokens,
+            cacheCreationInputTokens: cacheCreationTokens,
+            outputTokens: result.output_tokens,
+            computedCostCents: costCents,
+            pricingResolved: resolved,
+            updatedAt: new Date(),
+          },
+        });
+    }
+
+    syncedDays++;
+    if (!latestDate || bucketDate > latestDate) {
+      latestDate = bucketDate;
+    }
+  }
+
+  await db
+    .update(anthropicSyncStatus)
+    .set({
+      lastSyncCompletedAt: new Date(),
+      lastSyncError: null,
+      syncedDays,
+    })
+    .where(eq(anthropicSyncStatus.userId, userId));
+
+  return { syncedDays, latestDate };
+}

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -80,23 +80,35 @@ async function fetchAnthropicUsage(
     }
   }
 
-  const res = await fetch(
-    `https://api.anthropic.com/v1/organizations/usage_report/messages?${params.toString()}`,
-    {
+  let url: string | null =
+    `https://api.anthropic.com/v1/organizations/usage_report/messages?${params.toString()}`;
+  const allData: z.infer<typeof usageBucketSchema>[] = [];
+
+  while (url) {
+    const res = await fetch(url, {
       headers: {
         "x-api-key": adminKey,
         "anthropic-version": "2023-06-01",
         "Content-Type": "application/json",
       },
-    }
-  );
+    });
 
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Anthropic API error ${res.status}: ${body}`);
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Anthropic API error ${res.status}: ${body}`);
+    }
+
+    const page = usageReportResponseSchema.parse(await res.json());
+    allData.push(...page.data);
+
+    if (page.has_more && page.next_page) {
+      url = page.next_page;
+    } else {
+      url = null;
+    }
   }
 
-  return usageReportResponseSchema.parse(await res.json());
+  return { data: allData, has_more: false, next_page: null };
 }
 
 // ---------------------------------------------------------------------------
@@ -253,10 +265,16 @@ async function upsertUsageRow(
 export async function runAnthropicSync(): Promise<SyncSummary> {
   const summary: SyncSummary = { syncedUsers: 0, skippedUsers: 0, errors: [] };
 
-  // Global concurrency guard: check if any sync is in progress
+  // Ensure a dedicated global lock row exists (userId=0 sentinel)
+  const LOCK_USER_ID = 0;
+  await db
+    .insert(anthropicSyncStatus)
+    .values({ userId: LOCK_USER_ID })
+    .onConflictDoNothing({ target: [anthropicSyncStatus.userId] });
+
+  // Global concurrency guard: check the lock row
   const recentSync = await db.query.anthropicSyncStatus.findFirst({
-    where: isNotNull(anthropicSyncStatus.lastSyncStartedAt),
-    orderBy: desc(anthropicSyncStatus.lastSyncStartedAt),
+    where: eq(anthropicSyncStatus.userId, LOCK_USER_ID),
   });
 
   if (recentSync?.lastSyncStartedAt) {
@@ -278,11 +296,11 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
     }
   }
 
-  // Set global lock on all sync status rows
+  // Set global lock on the lock row
   await db
     .update(anthropicSyncStatus)
     .set({ lastSyncStartedAt: new Date(), lastSyncError: null })
-    .where(isNotNull(anthropicSyncStatus.userId));
+    .where(eq(anthropicSyncStatus.userId, LOCK_USER_ID));
 
   try {
     // Resolve all mappings
@@ -332,6 +350,11 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
         .set({ lastSyncCompletedAt: new Date(), lastSyncError: null })
         .where(eq(anthropicSyncStatus.userId, userId));
     }
+
+    // Mark completion on ALL sync status rows (including lock row and users without data)
+    await db
+      .update(anthropicSyncStatus)
+      .set({ lastSyncCompletedAt: new Date(), lastSyncError: null });
 
     summary.syncedUsers = usersWithData.size;
     summary.skippedUsers = new Set(apiKeyToUser.values()).size - usersWithData.size;

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -35,6 +35,7 @@ const usageBucketResultSchema = z.object({
       ephemeral_5m_input_tokens: z.number().default(0),
       ephemeral_1h_input_tokens: z.number().default(0),
     })
+    .nullable()
     .optional()
     .default({ ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 }),
   output_tokens: z.number().default(0),

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -390,16 +390,29 @@ export async function syncSingleUser(userId: number): Promise<{ syncedDays: numb
     syncStatus = created;
   }
 
+  // Mark sync start time
+  await db
+    .update(anthropicSyncStatus)
+    .set({ lastSyncStartedAt: new Date(), lastSyncError: null })
+    .where(eq(anthropicSyncStatus.userId, userId));
+
   // Resolve API key ID if not cached
   if (!syncStatus.resolvedApiKeyId) {
-    const assignment = await db.query.licenseAssignments.findFirst({
-      where: and(
-        eq(licenseAssignments.userId, userId),
-        eq(licenseAssignments.status, "active"),
-        isNotNull(licenseAssignments.apiKeyEncrypted)
-      ),
-      with: { tool: true },
-    });
+    const [assignment] = await db
+      .select({
+        apiKeyEncrypted: licenseAssignments.apiKeyEncrypted,
+      })
+      .from(licenseAssignments)
+      .innerJoin(aiTools, eq(licenseAssignments.toolId, aiTools.id))
+      .where(
+        and(
+          eq(licenseAssignments.userId, userId),
+          eq(licenseAssignments.status, "active"),
+          isNotNull(licenseAssignments.apiKeyEncrypted),
+          sql`(LOWER(${aiTools.vendor}) LIKE '%anthropic%' OR LOWER(${aiTools.name}) LIKE '%claude%')`
+        )
+      )
+      .limit(1);
 
     if (!assignment?.apiKeyEncrypted) {
       throw new Error("No API key configured for this user");

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -38,7 +38,7 @@ const usageBucketResultSchema = z.object({
       ephemeral_1h_input_tokens: z.number().default(0),
     })
     .optional()
-    .default({}),
+    .default({ ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 }),
   output_tokens: z.number().default(0),
 });
 
@@ -442,7 +442,7 @@ export async function syncSingleUser(userId: number): Promise<{ syncedDays: numb
   const { startingAt, endingAt } = computeSyncWindow(latestRow?.date ?? null);
 
   // Fetch filtered by this user's API key
-  const response = await fetchAnthropicUsage(startingAt, endingAt, [syncStatus.resolvedApiKeyId]);
+  const response = await fetchAnthropicUsage(startingAt, endingAt, [syncStatus.resolvedApiKeyId!]);
 
   let syncedDays = 0;
   let latestDate: string | null = null;

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -64,22 +64,25 @@ async function fetchAnthropicUsage(
   const adminKey = process.env.ANTHROPIC_ADMIN_API_KEY;
   if (!adminKey) throw new Error("ANTHROPIC_ADMIN_API_KEY is not set");
 
-  const params = new URLSearchParams();
-  params.set("starting_at", startingAt);
-  params.set("ending_at", endingAt);
-  params.set("bucket_width", "1d");
-  params.append("group_by[]", "model");
-  params.append("group_by[]", "api_key_id");
-  params.set("limit", "31");
+  // Build query string manually — URLSearchParams encodes [] as %5B%5D
+  // which the Anthropic API does not recognise for array parameters.
+  const parts = [
+    `starting_at=${encodeURIComponent(startingAt)}`,
+    `ending_at=${encodeURIComponent(endingAt)}`,
+    "bucket_width=1d",
+    "group_by[]=model",
+    "group_by[]=api_key_id",
+    "limit=31",
+  ];
 
   if (apiKeyIds) {
     for (const id of apiKeyIds) {
-      params.append("api_key_ids[]", id);
+      parts.push(`api_key_ids[]=${encodeURIComponent(id)}`);
     }
   }
 
   let url: string | null =
-    `https://api.anthropic.com/v1/organizations/usage_report/messages?${params.toString()}`;
+    `https://api.anthropic.com/v1/organizations/usage_report/messages?${parts.join("&")}`;
   const allData: z.infer<typeof usageBucketSchema>[] = [];
 
   while (url) {

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -99,12 +99,17 @@ async function fetchAnthropicUsage(
     }
   }
 
-  let url: string | null =
-    `https://api.anthropic.com/v1/organizations/usage_report/messages?${parts.join("&")}`;
+  const baseUrl = "https://api.anthropic.com/v1/organizations/usage_report/messages";
+  const baseQuery = parts.join("&");
+  let nextPageToken: string | null = null;
   const allData: z.infer<typeof usageBucketSchema>[] = [];
 
-  while (url) {
-    const res = await fetch(url, {
+  do {
+    const query = nextPageToken
+      ? `${baseQuery}&page=${encodeURIComponent(nextPageToken)}`
+      : baseQuery;
+
+    const res = await fetch(`${baseUrl}?${query}`, {
       headers: {
         "x-api-key": adminKey,
         "anthropic-version": ANTHROPIC_API_VERSION,
@@ -120,12 +125,8 @@ async function fetchAnthropicUsage(
     const page = usageReportResponseSchema.parse(await res.json());
     allData.push(...page.data);
 
-    if (page.has_more && page.next_page) {
-      url = page.next_page;
-    } else {
-      url = null;
-    }
-  }
+    nextPageToken = page.has_more && page.next_page ? page.next_page : null;
+  } while (nextPageToken);
 
   return { data: allData, has_more: false, next_page: null };
 }
@@ -147,11 +148,12 @@ async function resolveAllMappings(): Promise<Map<string, number>> {
     }
   }
 
-  // Find users with Anthropic API keys but no cached mapping
+  // Find all users with Anthropic API keys
   const usersWithKeys = await db
     .select({
       userId: licenseAssignments.userId,
       apiKeyEncrypted: licenseAssignments.apiKeyEncrypted,
+      keyUpdatedAt: licenseAssignments.updatedAt,
     })
     .from(licenseAssignments)
     .innerJoin(aiTools, eq(licenseAssignments.toolId, aiTools.id))
@@ -163,9 +165,26 @@ async function resolveAllMappings(): Promise<Map<string, number>> {
       )
     );
 
-  // Filter to users without cached mapping
+  // Build a set of existing sync status rows with their timestamps for staleness check
+  const existingSyncMap = new Map(
+    existing.map((row) => [row.userId, row])
+  );
+
+  // Re-resolve if: no cached mapping, or the assignment was updated after the last resolve
+  const needsResolve = usersWithKeys.filter((u) => {
+    if (!mapping.has(u.userId.toString()) && !Array.from(mapping.values()).includes(u.userId)) {
+      // No cached mapping for this user
+      return true;
+    }
+    // Check if key was updated since we last resolved
+    const syncRow = existingSyncMap.get(u.userId);
+    if (syncRow?.resolvedApiKeyId && u.keyUpdatedAt > (syncRow.lastSyncCompletedAt ?? new Date(0))) {
+      return true;
+    }
+    return false;
+  });
   const mappedUserIds = new Set(mapping.values());
-  const unmapped = usersWithKeys.filter((u) => !mappedUserIds.has(u.userId));
+  const unmapped = needsResolve;
 
   if (unmapped.length > 0) {
     // Fetch org API keys to resolve
@@ -272,27 +291,25 @@ async function batchUpsertUsageRows(
 ) {
   for (let i = 0; i < rows.length; i += BATCH_SIZE) {
     const batch = rows.slice(i, i + BATCH_SIZE);
-    for (const row of batch) {
-      await db
-        .insert(anthropicUsageMetrics)
-        .values(row)
-        .onConflictDoUpdate({
-          target: [
-            anthropicUsageMetrics.userId,
-            anthropicUsageMetrics.date,
-            anthropicUsageMetrics.model,
-          ],
-          set: {
-            uncachedInputTokens: row.uncachedInputTokens,
-            cacheReadInputTokens: row.cacheReadInputTokens,
-            cacheCreationInputTokens: row.cacheCreationInputTokens,
-            outputTokens: row.outputTokens,
-            computedCostCents: row.computedCostCents,
-            pricingResolved: row.pricingResolved,
-            updatedAt: row.updatedAt,
-          },
-        });
-    }
+    await db
+      .insert(anthropicUsageMetrics)
+      .values(batch)
+      .onConflictDoUpdate({
+        target: [
+          anthropicUsageMetrics.userId,
+          anthropicUsageMetrics.date,
+          anthropicUsageMetrics.model,
+        ],
+        set: {
+          uncachedInputTokens: sql`excluded.uncached_input_tokens`,
+          cacheReadInputTokens: sql`excluded.cache_read_input_tokens`,
+          cacheCreationInputTokens: sql`excluded.cache_creation_input_tokens`,
+          outputTokens: sql`excluded.output_tokens`,
+          computedCostCents: sql`excluded.computed_cost_cents`,
+          pricingResolved: sql`excluded.pricing_resolved`,
+          updatedAt: sql`excluded.updated_at`,
+        },
+      });
   }
 }
 
@@ -309,34 +326,42 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
     .values({ userId: LOCK_USER_ID })
     .onConflictDoNothing({ target: [anthropicSyncStatus.userId] });
 
-  // Global concurrency guard: check the lock row
-  const recentSync = await db.query.anthropicSyncStatus.findFirst({
-    where: eq(anthropicSyncStatus.userId, LOCK_USER_ID),
-  });
+  // Atomic lock acquisition: only proceed if the row is not locked or lock is stale
+  const now = new Date();
+  const staleThreshold = new Date(now.getTime() - LOCK_TIMEOUT_MS);
+  const cooldownThreshold = new Date(now.getTime() - LOCK_COOLDOWN_MS);
 
-  if (recentSync?.lastSyncStartedAt) {
-    const startedMs = recentSync.lastSyncStartedAt.getTime();
-    const nowMs = Date.now();
-    const isInProgress =
-      (!recentSync.lastSyncCompletedAt ||
-        recentSync.lastSyncCompletedAt < recentSync.lastSyncStartedAt);
-
-    if (isInProgress) {
-      if (nowMs - startedMs < LOCK_TIMEOUT_MS) {
-        return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync already in progress" }] };
-      }
-      // Stale lock — allow new sync
-    } else if (recentSync.lastSyncCompletedAt &&
-               nowMs - recentSync.lastSyncCompletedAt.getTime() < LOCK_COOLDOWN_MS) {
-      return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync completed recently" }] };
-    }
-  }
-
-  // Set global lock on the lock row
-  await db
+  const [lockAcquired] = await db
     .update(anthropicSyncStatus)
-    .set({ lastSyncStartedAt: new Date(), lastSyncError: null })
-    .where(eq(anthropicSyncStatus.userId, LOCK_USER_ID));
+    .set({ lastSyncStartedAt: now, lastSyncError: null })
+    .where(
+      and(
+        eq(anthropicSyncStatus.userId, LOCK_USER_ID),
+        sql`(
+          ${anthropicSyncStatus.lastSyncStartedAt} IS NULL
+          OR (
+            ${anthropicSyncStatus.lastSyncCompletedAt} IS NOT NULL
+            AND ${anthropicSyncStatus.lastSyncCompletedAt} >= ${anthropicSyncStatus.lastSyncStartedAt}
+            AND ${anthropicSyncStatus.lastSyncCompletedAt} < ${cooldownThreshold}
+          )
+          OR (
+            ${anthropicSyncStatus.lastSyncCompletedAt} IS NOT NULL
+            AND ${anthropicSyncStatus.lastSyncCompletedAt} >= ${anthropicSyncStatus.lastSyncStartedAt}
+            AND ${anthropicSyncStatus.lastSyncStartedAt} < ${cooldownThreshold}
+          )
+          OR (
+            (${anthropicSyncStatus.lastSyncCompletedAt} IS NULL
+             OR ${anthropicSyncStatus.lastSyncCompletedAt} < ${anthropicSyncStatus.lastSyncStartedAt})
+            AND ${anthropicSyncStatus.lastSyncStartedAt} < ${staleThreshold}
+          )
+        )`
+      )
+    )
+    .returning();
+
+  if (!lockAcquired) {
+    return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync already in progress or completed recently" }] };
+  }
 
   try {
     // Resolve all mappings
@@ -345,15 +370,13 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
       return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "No users with resolved API keys" }] };
     }
 
-    // Sync All always fetches the full current month so every day is refreshed
-    const now = new Date();
-    const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-    const tomorrow = new Date(now);
-    tomorrow.setUTCHours(0, 0, 0, 0);
-    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+    // Incremental sync: start from the latest stored date (or 31 days back)
+    // This handles month boundaries correctly — if cron was down, it backfills
+    const oldestLatest = await db
+      .select({ maxDate: sql<string>`MAX(${anthropicUsageMetrics.date})` })
+      .from(anthropicUsageMetrics);
 
-    const startingAt = monthStart.toISOString().replace(/\.\d+Z$/, "Z");
-    const endingAt = tomorrow.toISOString().replace(/\.\d+Z$/, "Z");
+    const { startingAt, endingAt } = computeSyncWindow(oldestLatest[0]?.maxDate ?? null);
 
     // Fetch all org usage in one call
     const response = await fetchAnthropicUsage(startingAt, endingAt);
@@ -440,84 +463,96 @@ export async function syncSingleUser(userId: number): Promise<{ syncedDays: numb
     .set({ lastSyncStartedAt: new Date(), lastSyncError: null })
     .where(eq(anthropicSyncStatus.userId, userId));
 
-  // Resolve API key ID if not cached
-  if (!syncStatus.resolvedApiKeyId) {
-    const [assignment] = await db
-      .select({
-        apiKeyEncrypted: licenseAssignments.apiKeyEncrypted,
-      })
-      .from(licenseAssignments)
-      .innerJoin(aiTools, eq(licenseAssignments.toolId, aiTools.id))
-      .where(
-        and(
-          eq(licenseAssignments.userId, userId),
-          eq(licenseAssignments.status, "active"),
-          isNotNull(licenseAssignments.apiKeyEncrypted),
-          anthropicToolFilter
+  try {
+    // Resolve API key ID if not cached
+    if (!syncStatus.resolvedApiKeyId) {
+      const [assignment] = await db
+        .select({
+          apiKeyEncrypted: licenseAssignments.apiKeyEncrypted,
+        })
+        .from(licenseAssignments)
+        .innerJoin(aiTools, eq(licenseAssignments.toolId, aiTools.id))
+        .where(
+          and(
+            eq(licenseAssignments.userId, userId),
+            eq(licenseAssignments.status, "active"),
+            isNotNull(licenseAssignments.apiKeyEncrypted),
+            anthropicToolFilter
+          )
         )
-      )
-      .limit(1);
+        .limit(1);
 
-    if (!assignment?.apiKeyEncrypted) {
-      throw new Error("No API key configured for this user");
+      if (!assignment?.apiKeyEncrypted) {
+        throw new Error("No API key configured for this user");
+      }
+
+      const decrypted = await decryptApiKey(assignment.apiKeyEncrypted);
+      const orgKeys = await fetchOrgApiKeys();
+      const apiKeyId = resolveApiKeyId(decrypted, orgKeys);
+      if (!apiKeyId) {
+        throw new Error("Could not resolve API key ID from org keys");
+      }
+
+      await db
+        .update(anthropicSyncStatus)
+        .set({ resolvedApiKeyId: apiKeyId })
+        .where(eq(anthropicSyncStatus.userId, userId));
+
+      syncStatus = { ...syncStatus, resolvedApiKeyId: apiKeyId };
     }
 
-    const decrypted = await decryptApiKey(assignment.apiKeyEncrypted);
-    const orgKeys = await fetchOrgApiKeys();
-    const apiKeyId = resolveApiKeyId(decrypted, orgKeys);
-    if (!apiKeyId) {
-      throw new Error("Could not resolve API key ID from org keys");
+    // Determine start date
+    const latestRow = await db.query.anthropicUsageMetrics.findFirst({
+      where: eq(anthropicUsageMetrics.userId, userId),
+      orderBy: desc(anthropicUsageMetrics.date),
+    });
+
+    const { startingAt, endingAt } = computeSyncWindow(latestRow?.date ?? null);
+
+    // Fetch filtered by this user's API key
+    const response = await fetchAnthropicUsage(startingAt, endingAt, [syncStatus.resolvedApiKeyId!]);
+
+    // Collect all rows for batch upsert
+    const pendingRows: NonNullable<ReturnType<typeof prepareUsageRow>>[] = [];
+    let syncedDays = 0;
+    let latestDate: string | null = null;
+
+    for (const bucket of response.data) {
+      const bucketDate = bucket.starting_at.split("T")[0];
+
+      for (const result of bucket.results) {
+        const row = prepareUsageRow(userId, bucketDate, result);
+        if (row) pendingRows.push(row);
+      }
+
+      syncedDays++;
+      if (!latestDate || bucketDate > latestDate) {
+        latestDate = bucketDate;
+      }
     }
+
+    // Batch upsert all collected rows
+    await batchUpsertUsageRows(pendingRows);
 
     await db
       .update(anthropicSyncStatus)
-      .set({ resolvedApiKeyId: apiKeyId })
+      .set({
+        lastSyncCompletedAt: new Date(),
+        lastSyncError: null,
+        syncedDays,
+      })
       .where(eq(anthropicSyncStatus.userId, userId));
 
-    syncStatus = { ...syncStatus, resolvedApiKeyId: apiKeyId };
+    return { syncedDays, latestDate };
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    await db
+      .update(anthropicSyncStatus)
+      .set({
+        lastSyncError: errorMsg.slice(0, 500),
+        lastSyncCompletedAt: new Date(),
+      })
+      .where(eq(anthropicSyncStatus.userId, userId));
+    throw err;
   }
-
-  // Determine start date
-  const latestRow = await db.query.anthropicUsageMetrics.findFirst({
-    where: eq(anthropicUsageMetrics.userId, userId),
-    orderBy: desc(anthropicUsageMetrics.date),
-  });
-
-  const { startingAt, endingAt } = computeSyncWindow(latestRow?.date ?? null);
-
-  // Fetch filtered by this user's API key
-  const response = await fetchAnthropicUsage(startingAt, endingAt, [syncStatus.resolvedApiKeyId!]);
-
-  // Collect all rows for batch upsert
-  const pendingRows: NonNullable<ReturnType<typeof prepareUsageRow>>[] = [];
-  let syncedDays = 0;
-  let latestDate: string | null = null;
-
-  for (const bucket of response.data) {
-    const bucketDate = bucket.starting_at.split("T")[0];
-
-    for (const result of bucket.results) {
-      const row = prepareUsageRow(userId, bucketDate, result);
-      if (row) pendingRows.push(row);
-    }
-
-    syncedDays++;
-    if (!latestDate || bucketDate > latestDate) {
-      latestDate = bucketDate;
-    }
-  }
-
-  // Batch upsert all collected rows
-  await batchUpsertUsageRows(pendingRows);
-
-  await db
-    .update(anthropicSyncStatus)
-    .set({
-      lastSyncCompletedAt: new Date(),
-      lastSyncError: null,
-      syncedDays,
-    })
-    .where(eq(anthropicSyncStatus.userId, userId));
-
-  return { syncedDays, latestDate };
 }

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -190,7 +190,7 @@ function computeSyncWindow(latestDateStr: string | null): { startingAt: string; 
   if (latestDateStr) {
     startDate = new Date(latestDateStr);
     startDate.setUTCHours(0, 0, 0, 0);
-    startDate.setUTCDate(startDate.getUTCDate() + 1);
+    startDate.setUTCDate(startDate.getUTCDate() - 1);
   } else {
     startDate = new Date(now);
     startDate.setUTCDate(startDate.getUTCDate() - 31);
@@ -292,7 +292,8 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
         return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync already in progress" }] };
       }
       // Stale lock (> 5 min) — allow new sync
-    } else if (nowMs - startedMs < 60 * 1000) {
+    } else if (recentSync.lastSyncCompletedAt &&
+               nowMs - recentSync.lastSyncCompletedAt.getTime() < 60 * 1000) {
       // Completed less than 60 seconds ago — skip
       return { syncedUsers: 0, skippedUsers: 0, errors: [{ userId: 0, error: "Sync completed recently" }] };
     }
@@ -353,20 +354,22 @@ export async function runAnthropicSync(): Promise<SyncSummary> {
         .where(eq(anthropicSyncStatus.userId, userId));
     }
 
-    // Mark completion on ALL sync status rows (including lock row and users without data)
+    // Mark completion on lock row
     await db
       .update(anthropicSyncStatus)
-      .set({ lastSyncCompletedAt: new Date(), lastSyncError: null });
+      .set({ lastSyncCompletedAt: new Date(), lastSyncError: null })
+      .where(eq(anthropicSyncStatus.userId, LOCK_USER_ID));
 
     summary.syncedUsers = usersWithData.size;
     summary.skippedUsers = new Set(apiKeyToUser.values()).size - usersWithData.size;
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
     console.error("Anthropic sync failed:", errorMsg);
-    // Set error on all sync status rows (including lock row userId=0)
+    // Set error on lock row only
     await db
       .update(anthropicSyncStatus)
-      .set({ lastSyncError: errorMsg.slice(0, 500) });
+      .set({ lastSyncError: errorMsg.slice(0, 500) })
+      .where(eq(anthropicSyncStatus.userId, LOCK_USER_ID));
     summary.errors.push({ userId: 0, error: errorMsg });
   }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -472,6 +472,7 @@ export const anthropicUsageMetrics = pgTable(
     ),
     index("anthropic_usage_metrics_user_date_idx").on(table.userId, table.date),
     index("anthropic_usage_metrics_date_idx").on(table.date),
+    index("anthropic_usage_metrics_pricing_resolved_idx").on(table.pricingResolved),
   ]
 );
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -481,9 +481,8 @@ export const anthropicSyncStatus = pgTable(
   "anthropic_sync_status",
   {
     id: serial("id").primaryKey(),
-    userId: integer("user_id")
-      .notNull()
-      .references(() => users.id, { onDelete: "cascade" }),
+    // No FK constraint — userId=0 is used as a global lock sentinel row
+    userId: integer("user_id").notNull(),
     lastSyncStartedAt: timestamp("last_sync_started_at"),
     lastSyncCompletedAt: timestamp("last_sync_completed_at"),
     lastSyncError: varchar("last_sync_error", { length: 500 }),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -4,6 +4,7 @@ import {
   varchar,
   text,
   integer,
+  bigint,
   boolean,
   timestamp,
   date,
@@ -434,6 +435,63 @@ export const copilotBillingSnapshots = pgTable(
   ]
 );
 
+// Anthropic Usage Metrics (daily token usage per user per model)
+export const anthropicUsageMetrics = pgTable(
+  "anthropic_usage_metrics",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    date: date("date").notNull(),
+    model: varchar("model", { length: 100 }).notNull(),
+    uncachedInputTokens: bigint("uncached_input_tokens", { mode: "number" })
+      .notNull()
+      .default(0),
+    cacheReadInputTokens: bigint("cache_read_input_tokens", { mode: "number" })
+      .notNull()
+      .default(0),
+    cacheCreationInputTokens: bigint("cache_creation_input_tokens", {
+      mode: "number",
+    })
+      .notNull()
+      .default(0),
+    outputTokens: bigint("output_tokens", { mode: "number" })
+      .notNull()
+      .default(0),
+    computedCostCents: integer("computed_cost_cents").notNull().default(0),
+    pricingResolved: boolean("pricing_resolved").notNull().default(true),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("anthropic_usage_metrics_user_date_model_idx").on(
+      table.userId,
+      table.date,
+      table.model
+    ),
+    index("anthropic_usage_metrics_user_date_idx").on(table.userId, table.date),
+    index("anthropic_usage_metrics_date_idx").on(table.date),
+  ]
+);
+
+// Anthropic Sync Status (per-user sync tracking + cached API key ID)
+export const anthropicSyncStatus = pgTable(
+  "anthropic_sync_status",
+  {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    lastSyncStartedAt: timestamp("last_sync_started_at"),
+    lastSyncCompletedAt: timestamp("last_sync_completed_at"),
+    lastSyncError: varchar("last_sync_error", { length: 500 }),
+    syncedDays: integer("synced_days").notNull().default(0),
+    resolvedApiKeyId: varchar("resolved_api_key_id", { length: 100 }),
+  },
+  (table) => [uniqueIndex("anthropic_sync_status_user_id_idx").on(table.userId)]
+);
+
 // Relations
 export const usersRelations = relations(users, ({ many, one }) => ({
   licenseAssignments: many(licenseAssignments),
@@ -443,6 +501,11 @@ export const usersRelations = relations(users, ({ many, one }) => ({
   githubProfile: one(githubProfiles, {
     fields: [users.id],
     references: [githubProfiles.userId],
+  }),
+  anthropicUsageMetrics: many(anthropicUsageMetrics),
+  anthropicSyncStatus: one(anthropicSyncStatus, {
+    fields: [users.id],
+    references: [anthropicSyncStatus.userId],
   }),
 }));
 
@@ -580,6 +643,26 @@ export const copilotBillingSnapshotsRelations = relations(
     connection: one(githubConnections, {
       fields: [copilotBillingSnapshots.connectionId],
       references: [githubConnections.id],
+    }),
+  })
+);
+
+export const anthropicUsageMetricsRelations = relations(
+  anthropicUsageMetrics,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [anthropicUsageMetrics.userId],
+      references: [users.id],
+    }),
+  })
+);
+
+export const anthropicSyncStatusRelations = relations(
+  anthropicSyncStatus,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [anthropicSyncStatus.userId],
+      references: [users.id],
     }),
   })
 );

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -47,7 +47,7 @@ export function getChangedUserFields(
 
 export function getCurrentMonth(): string {
   const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
 export function formatDate(date: Date | string | null): string {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -45,6 +45,11 @@ export function getChangedUserFields(
   return changed;
 }
 
+export function getCurrentMonth(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+}
+
 export function formatDate(date: Date | string | null): string {
   if (!date) return "—";
   const d = typeof date === "string" ? new Date(date) : date;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -380,3 +380,45 @@ export interface CopilotAnalyticsData {
     utilizationRate: number;
   }>;
 }
+
+// Anthropic Usage Types (016-claude-api-costs)
+export type DailyModelCost = {
+  model: string;
+  costCents: number;
+  inputTokens: number;
+  outputTokens: number;
+};
+
+export type DailyBreakdown = {
+  date: string;
+  models: DailyModelCost[];
+  totalCents: number;
+};
+
+export type CostData = {
+  available: boolean;
+  error?: string;
+  monthlyTotalCents: number;
+  dailyBreakdown: DailyBreakdown[];
+  latestDataDate: string | null;
+  hasUnresolvedPricing: boolean;
+};
+
+export type ProfileData = {
+  user: {
+    id: number;
+    name: string;
+    email: string;
+    role: "admin" | "viewer";
+    circle: string | null;
+    profile: "boost" | "maxed" | "indie" | null;
+  };
+  assignments: {
+    id: number;
+    toolName: string;
+    tierName: string;
+    assignedAt: Date;
+    status: "active" | "inactive";
+  }[];
+  costData: CostData;
+};


### PR DESCRIPTION
## Summary

- Add self-service **profile page** (`/profile`) where authenticated users view their personal info, assigned AI tools/licenses, and Claude API cost tracking
- **Stacked bar chart** showing daily costs by model with month picker for historical browsing
- **Cron-based sync** (`POST /api/anthropic/sync`) fetches all org usage from Anthropic Admin API in a single pass, maps results to users via cached API key resolution
- **Admin cost view** on user detail page with manual sync button
- **Sidebar user dropdown** with "My Profile" and "Sign Out" options
- Persistent usage history in `anthropic_usage_metrics` table (follows `copilot_usage_metrics` pattern)
- Prefix-based model pricing with unresolved-pricing detection and admin recalculation action

### New files (14)
- `src/lib/anthropic-sync.ts` — sync orchestrator (global + single-user)
- `src/lib/anthropic-pricing.ts` — prefix-based model pricing lookup
- `src/lib/anthropic-keys.ts` — API key ID resolution via Admin API
- `src/actions/anthropic-usage.ts` — server actions (cost data, profile, sync, recalculate)
- `src/app/api/anthropic/sync/route.ts` — cron endpoint (CRON_SECRET auth)
- `src/app/profile/page.tsx` + `profile-client.tsx` — profile page
- `src/components/profile/` — profile-header, profile-assignments, cost-tracking-section, month-picker, admin-cost-section
- `src/components/cost-chart.tsx` — Recharts stacked bar chart

### Modified files (5)
- `src/lib/db/schema.ts` — 2 new tables + relations
- `src/components/app-sidebar.tsx` — user dropdown menu
- `src/app/users/[id]/page.tsx` + `user-detail-client.tsx` — admin cost view
- `src/types/index.ts` — new types
- `src/lib/utils.ts` — getCurrentMonth utility

### Schema changes
- `anthropic_usage_metrics` — daily token usage per user/model (bigint tokens, computed cost, pricing flag)
- `anthropic_sync_status` — per-user sync tracking with cached API key ID resolution

## Test plan

- [ ] Run `pnpm db:generate && pnpm db:migrate` to apply schema changes
- [ ] Set `ANTHROPIC_ADMIN_API_KEY` environment variable
- [ ] Configure external cron to call `POST /api/anthropic/sync` hourly with `Authorization: Bearer <CRON_SECRET>`
- [ ] Verify sync populates `anthropic_usage_metrics` for users with Claude API keys
- [ ] Log in as user → sidebar dropdown → "My Profile" → verify profile page loads with info, assignments, and cost data
- [ ] Switch months via month picker → verify data updates
- [ ] Log in as admin → navigate to user detail → verify Claude API Costs section appears with sync button
- [ ] Verify empty states: no API key configured, no usage data for selected month

🤖 Generated with [Claude Code](https://claude.com/claude-code)