### PR TITLE
fix: exclude cron routes from auth middleware to prevent login redirect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AI Developer Hub Development Guidelines
+﻿# AI Developer Hub Development Guidelines
 
 Auto-generated from all feature plans. Last updated: 2026-03-02
 
@@ -35,6 +35,7 @@ Auto-generated from all feature plans. Last updated: 2026-03-02
 - Neon PostgreSQL (serverless) via @neondatabase/serverless — 1 new table (`invite_tokens`), 1 modified table (`users` + `must_change_password` column), 1 new enum (`invite_token_status`) (017-first-login-experience)
 - TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, shadcn/ui (new-york), TanStack Table 8.21.3, React Hook Form 7.71.2, Zod 4.3.6, cmdk 1.1.1, Sonner (toasts), Lucide React (017-polish-user-ui)
 - Neon PostgreSQL via Drizzle ORM 0.45.1 (no schema changes) (017-polish-user-ui)
+- TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), NextAuth 5.0.0-beta.30, Drizzle ORM 0.45.1 (018-fix-cron-auth)
 
 - **Language**: TypeScript 5.x (strict mode), Node.js LTS
 - **Framework**: Next.js 15 (App Router, Server Components, Server Actions)
@@ -97,11 +98,9 @@ pnpm lighthouse        # Lighthouse CI
 - Server Components by default — `"use client"` only when client interactivity needed
 
 ## Recent Changes
+- 018-fix-cron-auth: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), NextAuth 5.0.0-beta.30, Drizzle ORM 0.45.1
 - 015-github-billing: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, next-auth 5.0.0-beta.30, Zod 4.3.6, Sonner (toasts), Lucide React
 - 017-first-login-experience: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, NextAuth 5.0.0-beta.30, Drizzle ORM 0.45.1, bcryptjs 3.0.3, Zod 4.3.6, React Hook Form 7.71.2, shadcn/ui (new-york), Sonner (toasts), Lucide React. **NEW**: resend, @react-email/components
-- 017-polish-user-ui: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, shadcn/ui (new-york), TanStack Table 8.21.3, React Hook Form 7.71.2, Zod 4.3.6, cmdk 1.1.1, Sonner (toasts), Lucide React
-- 016-claude-api-costs: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, NextAuth 5.0.0-beta.30, Recharts 2.15.4, shadcn/ui (new-york), Zod 4.3.6, Sonner (toasts), Lucide React
-- 015-github-member-sync: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, shadcn/ui (new-york), cmdk 1.1.1, string-similarity (NEW)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/018-fix-cron-auth/checklists/requirements.md
+++ b/specs/018-fix-cron-auth/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Reliable Cron Job Authentication & Coverage
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All checklist items pass. Spec is ready for `/speckit.plan`.

--- a/specs/018-fix-cron-auth/contracts/cron-endpoints.md
+++ b/specs/018-fix-cron-auth/contracts/cron-endpoints.md
@@ -1,0 +1,98 @@
+# API Contracts: Cron Endpoints
+
+**Feature**: 018-fix-cron-auth
+**Date**: 2026-03-20
+
+These endpoints are machine-to-machine routes invoked by the scheduler. They are NOT accessible to browser users and are excluded from the user auth middleware.
+
+---
+
+## Authentication
+
+All cron endpoints require:
+```
+Authorization: Bearer {CRON_SECRET}
+```
+
+Missing or incorrect token → `401 Unauthorized`
+
+---
+
+## GET /api/copilot/sync
+
+Triggers a GitHub Copilot billing data sync.
+
+**Schedule**: Daily at 06:00 UTC
+
+**Request**:
+```
+GET /api/copilot/sync
+Authorization: Bearer {CRON_SECRET}
+```
+
+**Response — 200 OK** (sync completed):
+```json
+{
+  "success": true,
+  "syncEventId": 42,
+  "billingLinked": 12,
+  "billingSkipped": 3
+}
+```
+
+**Response — 401 Unauthorized** (invalid/missing secret):
+```json
+{ "success": false, "error": "Unauthorized" }
+```
+
+**Response — 404 Not Found** (no active Copilot connection):
+```json
+{ "success": false, "error": "No active connection with Copilot sync enabled" }
+```
+
+**Response — 409 Conflict** (sync already in progress):
+```json
+{ "success": false, "error": "Sync already in progress" }
+```
+
+---
+
+## GET /api/anthropic/sync
+
+Triggers an Anthropic (Claude) API usage metrics sync.
+
+**Schedule**: Every 10 minutes
+
+**Request**:
+```
+GET /api/anthropic/sync
+Authorization: Bearer {CRON_SECRET}
+```
+
+**Response — 200 OK** (sync completed):
+```json
+{
+  "success": true,
+  "recordsSynced": 150,
+  "from": "2026-03-19T00:00:00Z",
+  "to": "2026-03-20T00:00:00Z"
+}
+```
+
+**Response — 401 Unauthorized** (invalid/missing secret):
+```json
+{ "success": false, "error": "Unauthorized" }
+```
+
+**Response — 500 Internal Server Error** (upstream failure):
+```json
+{ "success": false, "error": "Error message describing the failure" }
+```
+
+---
+
+## Notes
+
+- Both endpoints also accept `POST` (Vercel Cron may use either method; handlers are identical)
+- Stale in-progress Copilot sync records (>10 min old) are automatically cleaned up before a new sync starts
+- Endpoints are safe to call manually with the correct secret for testing

--- a/specs/018-fix-cron-auth/data-model.md
+++ b/specs/018-fix-cron-auth/data-model.md
@@ -1,0 +1,42 @@
+# Data Model: Reliable Cron Job Authentication & Coverage
+
+**Feature**: 018-fix-cron-auth
+**Date**: 2026-03-20
+
+## Schema Changes
+
+**None required.**
+
+This feature is a middleware configuration fix. No database schema changes, no new tables, no new columns.
+
+## Existing Entities (Referenced, Not Modified)
+
+### GithubSyncEvents
+
+Tracks the state of each Copilot sync run. Already handles duplicate prevention and stale record cleanup. No changes needed.
+
+| Field | Purpose |
+|-------|---------|
+| `id` | Primary key |
+| `connection_id` | Foreign key to githubConnections |
+| `status` | `in_progress` / `completed` / `failed` |
+| `sync_type` | `copilot` |
+| `started_at` | Used for stale-record cleanup (>10 min threshold) |
+| `completed_at` | Set when sync finishes |
+| `error_message` | Set when sync fails |
+
+### GithubConnections
+
+Source of truth for active GitHub integrations. Cron reads this to determine whether Copilot sync is enabled. No changes needed.
+
+### AnthropicUsageMetrics / AnthropicSyncStatus
+
+Stores Anthropic API usage records and sync history. No changes needed.
+
+## Environment Configuration (Non-Schema)
+
+| Variable | Purpose | Where Set |
+|----------|---------|-----------|
+| `CRON_SECRET` | Bearer token for authenticating cron endpoint calls | Vercel project env + `.env.local` for dev |
+
+The `CRON_SECRET` is already documented in `.env.local.example`. No new env vars are introduced.

--- a/specs/018-fix-cron-auth/plan.md
+++ b/specs/018-fix-cron-auth/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: Reliable Cron Job Authentication & Coverage
+
+**Branch**: `018-fix-cron-auth` | **Date**: 2026-03-20 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/018-fix-cron-auth/spec.md`
+
+## Summary
+
+Cron jobs are silently failing because the Next.js auth middleware intercepts scheduled invocations and redirects them to `/login` before the route handler's secret token validation can run. The fix is a single-line change to the middleware matcher to exclude cron routes from user auth interception. Both cron routes (`/api/copilot/sync`, `/api/anthropic/sync`) already have correct handler-level token validation via `requireCronSecret()`. No schema changes or new routes are required.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3 (strict mode), Node.js LTS
+**Primary Dependencies**: Next.js 15.5.12 (App Router), NextAuth 5.0.0-beta.30, Drizzle ORM 0.45.1
+**Storage**: Neon PostgreSQL (serverless) — no schema changes
+**Testing**: Vitest (unit/integration), Playwright (e2e)
+**Target Platform**: Vercel (serverless functions + Vercel Cron Jobs)
+**Project Type**: Web application (Next.js App Router)
+**Performance Goals**: Cron endpoints respond within 30 seconds; middleware exclusion adds zero latency overhead
+**Constraints**: Must not break existing user session auth for any other routes; no new dependencies
+**Scale/Scope**: 2 cron routes affected; 1 middleware file changed
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Type-Safe Code Quality | ✅ Pass | Middleware matcher change is a string literal; no type risk |
+| II. UX Consistency | ✅ N/A | No user-facing UI changes |
+| III. Performance Budgets | ✅ Pass | Matcher exclusion reduces (not increases) middleware overhead |
+| IV. Accessibility-First | ✅ N/A | No UI changes |
+| V. Simplicity & Maintainability | ✅ Pass | Single-line fix; explicit route names over opaque wildcards |
+
+**Gate result**: PASS — no violations. Complexity Tracking table not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-fix-cron-auth/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — root cause analysis, decisions
+├── data-model.md        # Phase 1 output — no schema changes
+├── quickstart.md        # Phase 1 output — testing & verification guide
+├── contracts/
+│   └── cron-endpoints.md # Phase 1 output — API contracts for both cron routes
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (affected files only)
+
+```text
+src/
+└── middleware.ts         # CHANGE: add cron routes to matcher exclusion
+
+# No other files change
+# vercel.json — no change (both cron paths already registered)
+# src/lib/auth-helpers.ts — no change (requireCronSecret is correct)
+# src/app/api/copilot/sync/route.ts — no change
+# src/app/api/anthropic/sync/route.ts — no change
+```
+
+**Structure Decision**: Single Next.js project. Only the middleware matcher string is modified. All other existing files remain unchanged.
+
+## Phase 0: Research Findings
+
+See [research.md](research.md) for full details. Summary:
+
+| Unknown | Resolution |
+|---------|-----------|
+| Why are cron jobs redirected to login? | Middleware matcher includes cron routes; no user session → redirect |
+| How does Vercel Cron authenticate? | `Authorization: Bearer {CRON_SECRET}` header on every invocation |
+| Best fix strategy? | Add cron routes to matcher negative lookahead (not conditional logic) |
+| Are any cron routes missing from vercel.json? | No — both sync endpoints are already registered |
+| Does `requireCronSecret` need changes? | No — implementation is correct; it's never reached due to redirect |
+
+## Phase 1: Design
+
+### Middleware Fix
+
+The entire implementation is this change to `src/middleware.ts`:
+
+```typescript
+// Current (broken)
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico|api/auth).*)"],
+};
+
+// Fixed
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico|api/auth|api/copilot/sync|api/anthropic/sync).*)"],
+};
+```
+
+**Why this works:**
+- Requests to `/api/copilot/sync` and `/api/anthropic/sync` will no longer trigger the middleware
+- Vercel Cron invocations pass directly to the route handler
+- `requireCronSecret()` in each handler validates the `Authorization: Bearer {CRON_SECRET}` header
+- Unauthorized requests (no token or wrong token) receive `401 Unauthorized` — not a redirect
+
+### Security Posture
+
+Excluding cron routes from user auth middleware does NOT weaken security:
+- Handler-level `requireCronSecret()` remains the gate for these endpoints
+- A request without a valid `CRON_SECRET` still receives 401
+- No other routes are affected
+
+### Vercel Configuration
+
+`vercel.json` requires no changes. Both cron paths are already registered:
+
+```json
+{
+  "crons": [
+    { "path": "/api/copilot/sync",    "schedule": "0 6 * * *"    },
+    { "path": "/api/anthropic/sync",  "schedule": "*/10 * * * *" }
+  ]
+}
+```
+
+### Environment Variables
+
+`CRON_SECRET` must be set in Vercel project environment settings. No new variables needed.
+
+## Implementation Steps
+
+1. Edit `src/middleware.ts`: add `api/copilot/sync|api/anthropic/sync` to the matcher negative lookahead
+2. Verify `CRON_SECRET` is set in Vercel environment settings (or add it if missing)
+3. Deploy and confirm cron endpoints return 200 (not 302) in Vercel Cron logs
+
+**Estimated code change**: 1 line in 1 file.

--- a/specs/018-fix-cron-auth/quickstart.md
+++ b/specs/018-fix-cron-auth/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: Cron Job Auth Fix
+
+**Feature**: 018-fix-cron-auth
+**Date**: 2026-03-20
+
+## The Problem
+
+Vercel Cron Jobs fire as unauthenticated HTTP requests. The Next.js auth middleware sees no user session and redirects to `/login` before the cron route handler can validate the `CRON_SECRET` token.
+
+## The Fix (1 line)
+
+Edit `src/middleware.ts` — add `api/copilot/sync` and `api/anthropic/sync` to the negative lookahead in the matcher:
+
+```typescript
+// Before
+matcher: ["/((?!_next/static|_next/image|favicon\\.ico|api/auth).*)"]
+
+// After
+matcher: ["/((?!_next/static|_next/image|favicon\\.ico|api/auth|api/copilot/sync|api/anthropic/sync).*)"]
+```
+
+## Environment Setup
+
+Ensure `CRON_SECRET` is set in:
+1. **Vercel project environment variables** (required for production cron invocations)
+2. **`.env.local`** (for local testing)
+
+Generate a value:
+```bash
+openssl rand -base64 32
+```
+
+## Testing Locally
+
+After applying the middleware fix, verify a cron endpoint works:
+
+```bash
+# Should return 200 with sync results (not a 302 redirect)
+curl -X GET http://localhost:3000/api/copilot/sync \
+  -H "Authorization: Bearer YOUR_CRON_SECRET"
+
+# Should return 401 (not a 302 redirect)
+curl -X GET http://localhost:3000/api/copilot/sync
+
+# Should return 401 (not a 302 redirect)
+curl -X GET http://localhost:3000/api/anthropic/sync
+```
+
+## Verifying in Production
+
+After deployment:
+1. Check Vercel dashboard → Cron Jobs tab for execution history
+2. Look for 200 status codes (previously would show 302 redirects)
+3. Check runtime logs for sync summaries
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/middleware.ts` | Add cron routes to matcher exclusion |
+
+No other files require modification.

--- a/specs/018-fix-cron-auth/research.md
+++ b/specs/018-fix-cron-auth/research.md
@@ -1,0 +1,131 @@
+# Research: Reliable Cron Job Authentication & Coverage
+
+**Feature**: 018-fix-cron-auth
+**Date**: 2026-03-20
+**Status**: Complete — all unknowns resolved
+
+---
+
+## Decision 1: Root Cause of Auth Redirect
+
+**Decision**: The Next.js middleware matcher does not exclude cron routes, so every request to `/api/copilot/sync` and `/api/anthropic/sync` runs through the auth middleware, which redirects unauthenticated requests (including Vercel Cron invocations) to `/login` before the route handler's `requireCronSecret()` check ever executes.
+
+**Evidence — current middleware matcher:**
+```typescript
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico|api/auth).*)"],
+};
+```
+Only `/api/auth/**` is excluded. Cron routes are not excluded.
+
+**Evidence — redirect logic in middleware:**
+```typescript
+if (!req.auth && !isPublicPath(pathname)) {
+  const callbackUrl = encodeURIComponent(pathname + search);
+  return NextResponse.redirect(
+    new URL(`/login?callbackUrl=${callbackUrl}`, req.url)
+  );
+}
+```
+Vercel Cron invocations carry no user session, so `req.auth` is `null` → redirect fires.
+
+**Alternatives considered:**
+- Conditional logic inside middleware to check for CRON_SECRET: rejected — middleware still executes, adds complexity, mixes concerns (cron auth belongs in the handler)
+- Moving `requireCronSecret` into middleware: rejected — tightly couples machine-to-machine auth to the user auth middleware
+
+**Rationale**: Exclude cron routes from the middleware matcher. This is the standard Next.js approach for machine-to-machine API routes: they bypass the user session middleware entirely and rely on their own handler-level token validation (`requireCronSecret`).
+
+---
+
+## Decision 2: Middleware Fix Strategy
+
+**Decision**: Update the middleware matcher's negative lookahead to exclude `/api/copilot/sync` and `/api/anthropic/sync`.
+
+**Exact change:**
+```typescript
+// Before
+matcher: ["/((?!_next/static|_next/image|favicon\\.ico|api/auth).*)"]
+
+// After
+matcher: ["/((?!_next/static|_next/image|favicon\\.ico|api/auth|api/copilot/sync|api/anthropic/sync).*)"]
+```
+
+**Why explicit paths over a wildcard pattern (e.g., `api/.*/sync`):**
+- Wildcard patterns are ambiguous and could accidentally exclude future admin routes
+- Explicit paths are self-documenting and reviewable
+- No performance cost difference for static strings in regex negative lookahead
+
+**Alternatives considered:**
+- `api/.*sync` wildcard: rejected — too broad, catches unintended routes
+- `api/cron/` namespace (restructuring routes): rejected — unnecessary breaking change
+
+---
+
+## Decision 3: Vercel Cron Authentication Protocol
+
+**Decision**: Confirmed — Vercel Cron Jobs automatically inject `Authorization: Bearer {CRON_SECRET}` on every scheduled invocation when `CRON_SECRET` is set in the Vercel project environment.
+
+**Existing `requireCronSecret` implementation is correct:**
+```typescript
+export function requireCronSecret(request: NextRequest): NextResponse | null {
+  const authHeader = request.headers.get("authorization");
+  const expectedToken = process.env.CRON_SECRET;
+  if (!expectedToken || authHeader !== `Bearer ${expectedToken}`) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+```
+
+No changes needed to route handlers or the auth helper — both cron routes already call `requireCronSecret` on GET and POST.
+
+---
+
+## Decision 4: Missing Cron Jobs Audit
+
+**Decision**: No new cron routes need to be created. The two sync endpoints that exist (`/api/copilot/sync`, `/api/anthropic/sync`) are both already registered in `vercel.json`. No other sync endpoints exist in the codebase.
+
+**Full API route inventory:**
+```
+src/app/api/
+├── anthropic/sync/route.ts     ← cron route ✅ in vercel.json
+├── auth/[...nextauth]/route.ts ← auth handler (excluded from middleware)
+├── copilot/sync/route.ts       ← cron route ✅ in vercel.json
+├── export/assignments/route.ts ← admin route (requireAdmin)
+├── export/users/route.ts       ← admin route (requireAdmin)
+└── invoices/
+    ├── [id]/pdf/route.ts       ← admin route (requireAdmin)
+    ├── bulk-upload/route.ts    ← admin route (requireAdmin)
+    └── upload-url/route.ts     ← admin route (requireAdmin)
+```
+
+**GitHub billing/member sync**: Triggered manually via Server Actions and UI buttons — not cron-automated. No missing registration issue.
+
+**What User Story 4 means in practice**: Adding the cron routes to the middleware exclusion list is itself the "fix" that makes them reliably registered. No new route files are needed.
+
+---
+
+## Decision 5: CRON_SECRET Environment Variable
+
+**Decision**: `CRON_SECRET` must be set in Vercel project environment settings (not just `.env.local`) for cron invocations to be authenticated. Local development testing can use `.env.local`.
+
+**Generation command** (already documented in `.env.local.example`):
+```bash
+openssl rand -base64 32
+```
+
+**No code change needed** — the env var reference is already correct in `auth-helpers.ts`.
+
+---
+
+## Summary: Scope of Changes Required
+
+| Change | File | Type |
+|--------|------|------|
+| Add cron routes to middleware matcher exclusion | `src/middleware.ts` | 1-line fix |
+| Verify `CRON_SECRET` is set in Vercel env | Vercel dashboard | Config |
+| No new routes needed | — | None |
+| No schema changes needed | — | None |
+| No handler changes needed | — | None |
+
+**Total implementation scope**: 1 line of code change + environment variable verification. The root cause is purely a middleware configuration gap.

--- a/specs/018-fix-cron-auth/spec.md
+++ b/specs/018-fix-cron-auth/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: Reliable Cron Job Authentication & Coverage
+
+**Feature Branch**: `018-fix-cron-auth`
+**Created**: 2026-03-20
+**Status**: Draft
+**Input**: User description: "The cron jobs should work reliably and missing ones should be added. The existing cron jobs are getting redirected to the login page, which makes them not work. They need to have a way to get passed the auth."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Cron Jobs Bypass Auth Redirect (Priority: P1)
+
+As the system operator, automated scheduled jobs must execute their sync logic without being intercepted by the user authentication layer and redirected to the login page.
+
+**Why this priority**: Without this fix, all scheduled data syncs are silently failing. No billing data, no usage metrics — the entire automated pipeline is broken. This is the root cause.
+
+**Independent Test**: Can be fully tested by triggering a cron endpoint with the correct secret key and verifying it returns sync results (not a redirect to the login page), delivering confirmed automated data collection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cron job is scheduled and the correct secret is provided, **When** the job fires at its scheduled time, **Then** the job completes successfully and returns a 200 response with sync results.
+2. **Given** the user authentication middleware is active, **When** a cron endpoint is called with a valid secret, **Then** the request is NOT redirected to the login page.
+3. **Given** a cron endpoint is called WITHOUT a valid secret, **When** the request arrives, **Then** the system returns a 401 Unauthorized response (not a redirect).
+
+---
+
+### User Story 2 - GitHub Copilot Sync Runs on Schedule (Priority: P2)
+
+As the system operator, the GitHub Copilot billing sync should run daily without manual intervention, pulling the latest seat usage and billing data into the system.
+
+**Why this priority**: Accurate Copilot billing data depends on this scheduled sync. Without it, administrators see stale or missing cost data.
+
+**Independent Test**: Can be fully tested by triggering the Copilot sync endpoint with the correct secret and confirming billing data is updated in the system.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Copilot sync is triggered (scheduled or manual), **When** valid GitHub credentials are configured, **Then** the sync fetches the latest billing data and stores it successfully.
+2. **Given** a sync is already in progress, **When** a second sync attempt arrives, **Then** the system rejects the duplicate and returns an appropriate conflict response.
+3. **Given** a stale in-progress sync older than 10 minutes exists, **When** a new sync attempt arrives, **Then** the stale record is cleaned up and the new sync proceeds.
+
+---
+
+### User Story 3 - Anthropic API Usage Sync Runs on Schedule (Priority: P2)
+
+As the system operator, the Anthropic (Claude) API usage metrics should sync every 10 minutes without manual intervention, keeping cost dashboards current.
+
+**Why this priority**: Near-real-time Claude API cost tracking requires frequent automated syncs. Without it, cost dashboards are perpetually stale.
+
+**Independent Test**: Can be fully tested by triggering the Anthropic sync endpoint with the correct secret and confirming usage metrics are updated.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Anthropic sync is triggered on schedule, **When** valid API credentials are configured, **Then** the sync fetches the latest usage metrics and stores them successfully.
+2. **Given** the sync endpoint is called, **When** it completes, **Then** a summary of records synced is returned.
+3. **Given** the sync fails due to an upstream error, **When** the error occurs, **Then** the system logs the failure and returns an appropriate error response without crashing.
+
+---
+
+### User Story 4 - Missing Cron Jobs Are Added (Priority: P3)
+
+As the system operator, any scheduled operations that exist in code but are not registered in the scheduling configuration should be added so they run automatically.
+
+**Why this priority**: A discrepancy between what is configured to run and what should run creates silent gaps in data collection. This story ensures the scheduled job list is complete.
+
+**Independent Test**: Can be fully tested by auditing the list of sync-capable endpoints against the scheduled job configuration and confirming all are registered.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sync endpoint exists in the system, **When** the scheduled job configuration is reviewed, **Then** all sync endpoints appear in the configuration with appropriate schedules.
+2. **Given** a new sync job is added to the configuration, **When** its scheduled time arrives, **Then** it executes and bypasses authentication correctly.
+
+---
+
+### Edge Cases
+
+- What happens when the secret key is missing from the environment entirely? The system should fail safely (treat as unauthorized) without exposing error details.
+- What happens when a cron job is triggered manually (e.g., via curl) with a valid secret? It should behave identically to the scheduled invocation.
+- What happens when two cron schedules overlap or run concurrently? Each job should handle concurrency independently without interference.
+- What happens when the upstream data source (GitHub API, Anthropic API) is unreachable? The job should fail with a logged error and return a 500 response without entering an inconsistent state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The authentication middleware MUST allow requests to cron job endpoints to pass through without redirecting to the login page, provided the request carries a valid secret token.
+- **FR-002**: Cron endpoints MUST validate the incoming secret token and return a 401 Unauthorized response (not a redirect) when the token is absent or incorrect.
+- **FR-003**: The GitHub Copilot billing sync MUST run on its defined daily schedule and complete without requiring a logged-in user session.
+- **FR-004**: The Anthropic API usage sync MUST run on its defined frequent schedule and complete without requiring a logged-in user session.
+- **FR-005**: All sync endpoints that exist in the system MUST be registered in the scheduled job configuration with an appropriate execution frequency.
+- **FR-006**: Cron jobs MUST be idempotent — running the same job multiple times within a short window MUST NOT produce duplicate data or corrupt existing records.
+- **FR-007**: When a cron job fails, the system MUST return a structured error response and log enough detail to diagnose the failure without exposing sensitive credentials.
+- **FR-008**: Stale or stuck in-progress sync records MUST be automatically cleaned up before a new sync attempt begins.
+
+### Key Entities
+
+- **Cron Secret**: A shared secret token known to the scheduling platform and the application; used to authenticate automated job requests without a user session.
+- **Sync Job**: A scheduled automated task that fetches data from an external source and persists it in the application's data store.
+- **Sync Status Record**: A record tracking the current state of a sync operation (in-progress, completed, failed) used to prevent duplicate concurrent runs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All configured cron jobs complete successfully on every scheduled execution (0% redirect-to-login failures after fix is deployed).
+- **SC-002**: Cron endpoints respond with a structured JSON result within 30 seconds for normal sync operations.
+- **SC-003**: No cron endpoint can be invoked without a valid secret — 100% of unauthorized requests receive a 401 response.
+- **SC-004**: All sync-capable endpoints are represented in the scheduled job configuration — 0 unregistered sync endpoints remain after this feature ships.
+- **SC-005**: Duplicate sync prevention works correctly — concurrent invocations result in at most 1 active sync per job type.
+
+## Assumptions
+
+- The scheduling platform (Vercel Cron) sends a `Authorization: Bearer {secret}` header with every cron invocation when `CRON_SECRET` is configured in the environment.
+- The application already has a working secret validation helper; the issue is the authentication middleware intercepting requests before the handler can check the secret.
+- Middleware exclusion of cron routes is sufficient to resolve the redirect issue — no additional session-based auth is needed for these machine-to-machine endpoints.
+- "Missing cron jobs" refers to sync endpoints that exist in code but are not listed in the scheduler configuration, not entirely new features to be built.

--- a/specs/018-fix-cron-auth/tasks.md
+++ b/specs/018-fix-cron-auth/tasks.md
@@ -1,0 +1,187 @@
+# Tasks: Reliable Cron Job Authentication & Coverage
+
+**Input**: Design documents from `/specs/018-fix-cron-auth/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: Not requested — no test tasks generated.
+
+**Organization**: Tasks grouped by user story. This is a minimal-scope fix (1 line of code change) with verification tasks per story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+- No test tasks — spec did not request TDD
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm environment is ready before making changes
+
+- [x] T001 Verify `CRON_SECRET` is set in `.env.local` for local testing (generate with `openssl rand -base64 32` if missing; document value matches Vercel env)
+- [x] T002 [P] Read `src/middleware.ts` to confirm exact current matcher string before editing
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The single code change that unblocks ALL user stories — must complete before any story can be verified
+
+**⚠️ CRITICAL**: All user story verification depends on this fix being deployed
+
+- [x] T003 Edit `src/middleware.ts`: add `api/copilot/sync|api/anthropic/sync` to the matcher negative lookahead so the updated matcher reads `/((?!_next/static|_next/image|favicon\\.ico|api/auth|api/copilot/sync|api/anthropic/sync).*)`
+
+**Checkpoint**: Middleware fix applied — user story verification can now begin
+
+---
+
+## Phase 3: User Story 1 - Cron Jobs Bypass Auth Redirect (Priority: P1) 🎯 MVP
+
+**Goal**: Cron endpoints pass through the middleware and respond to requests based on the `CRON_SECRET` token alone — no user session required.
+
+**Independent Test**: Trigger `GET /api/copilot/sync` without a token → 401 (not a 302 redirect). Trigger with valid token → 200 with sync results.
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Run `pnpm typecheck` to confirm the middleware edit introduced no TypeScript errors
+- [x] T005 [US1] Run `pnpm lint` to confirm zero ESLint warnings after the middleware change
+- [x] T006 [P] [US1] Start dev server (`pnpm dev`) and verify `GET http://localhost:3000/api/copilot/sync` without `Authorization` header returns `401 {"success":false,"error":"Unauthorized"}` (not a 302 redirect to `/login`)
+- [x] T007 [P] [US1] Verify `GET http://localhost:3000/api/anthropic/sync` without `Authorization` header returns `401 {"success":false,"error":"Unauthorized"}` (not a 302 redirect)
+- [x] T008 [US1] Verify `GET http://localhost:3000/api/copilot/sync` with `Authorization: Bearer {CRON_SECRET}` returns `200` with a JSON body (sync result or 404 if no connection configured — either is correct; the point is no redirect)
+- [x] T009 [US1] Verify `GET http://localhost:3000/api/anthropic/sync` with `Authorization: Bearer {CRON_SECRET}` returns `200` or `500` with a JSON body — NOT a redirect
+
+**Checkpoint**: User Story 1 is fully functional. Cron endpoints no longer redirect. MVP is complete at this point.
+
+---
+
+## Phase 4: User Story 2 - GitHub Copilot Sync Runs on Schedule (Priority: P2)
+
+**Goal**: The daily Copilot billing sync runs end-to-end without a user session and returns billing metrics.
+
+**Independent Test**: Trigger `GET /api/copilot/sync` with valid secret and a configured GitHub connection → 200 with `billingLinked` and `billingSkipped` counts.
+
+### Implementation for User Story 2
+
+- [x] T010 [US2] Confirm `vercel.json` cron entry for `/api/copilot/sync` has schedule `0 6 * * *` (daily at 06:00 UTC) — no change needed if already correct
+- [ ] T011 [US2] Confirm `CRON_SECRET` environment variable is set in the Vercel project dashboard (Settings → Environment Variables) — required for Vercel to inject the auth header on scheduled invocations
+- [ ] T012 [US2] Trigger `GET /api/copilot/sync` with `Authorization: Bearer {CRON_SECRET}` in the deployed environment and confirm response is `200` with `{"success":true,"syncEventId":...}` — verifies the full production path works
+
+**Checkpoint**: Copilot daily sync is confirmed working end-to-end in production.
+
+---
+
+## Phase 5: User Story 3 - Anthropic API Usage Sync Runs on Schedule (Priority: P2)
+
+**Goal**: The every-10-minute Anthropic usage sync runs end-to-end without a user session and returns a sync summary.
+
+**Independent Test**: Trigger `GET /api/anthropic/sync` with valid secret → 200 with sync summary (records count, date range).
+
+### Implementation for User Story 3
+
+- [x] T013 [US3] Confirm `vercel.json` cron entry for `/api/anthropic/sync` has schedule `*/10 * * * *` (every 10 minutes) — no change needed if already correct
+- [ ] T014 [US3] Trigger `GET /api/anthropic/sync` with `Authorization: Bearer {CRON_SECRET}` in the deployed environment and confirm response is `200` with `{"success":true,...}` — verifies the full production path works
+
+**Checkpoint**: Anthropic sync is confirmed working end-to-end in production.
+
+---
+
+## Phase 6: User Story 4 - Missing Cron Jobs Are Added (Priority: P3)
+
+**Goal**: Every sync endpoint that exists in the codebase appears in the scheduled job configuration. No silent gaps.
+
+**Independent Test**: Enumerate all `route.ts` files under `src/app/api/` and confirm every sync route (`requireCronSecret`) is listed in `vercel.json` crons.
+
+### Implementation for User Story 4
+
+- [x] T015 [US4] Audit `src/app/api/` directory: list every route file that calls `requireCronSecret` and cross-reference with `vercel.json` cron paths to identify any gaps
+- [x] T016 [US4] If T015 finds unregistered sync routes: add the missing `{ "path": "...", "schedule": "..." }` entries to `vercel.json`; if no gaps found, document the audit result as a comment in `vercel.json` or this tasks file
+
+**Checkpoint**: Cron configuration is complete and audited. All sync endpoints are scheduled.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation across all stories before merge
+
+- [x] T017 [P] Run `pnpm build` to confirm production build succeeds with no errors after all changes
+- [ ] T018 [P] Check Vercel Cron Jobs dashboard after next scheduled run to confirm both cron jobs show `200` status (not `302`) in execution history
+- [x] T019 Verify that protected user-facing routes (e.g., `/dashboard`) still require login — confirm the middleware fix did NOT accidentally open other routes
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately; T001 and T002 run in parallel
+- **Foundational (Phase 2)**: Depends on Phase 1 — T003 is the single blocking change
+- **User Stories (Phases 3–6)**: All depend on T003 (middleware fix) being complete
+  - US1 verification (Phase 3) can begin immediately after T003
+  - US2 and US3 (Phases 4–5) require a deployed environment; can run in parallel after Phase 3
+  - US4 audit (Phase 6) is independent and can run in parallel with Phases 4–5
+- **Polish (Phase 7)**: Depends on all user story phases being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends only on T003 — no other story dependencies
+- **US2 (P2)**: Depends on US1 passing; requires Vercel deployment
+- **US3 (P2)**: Depends on US1 passing; requires Vercel deployment; parallel with US2
+- **US4 (P3)**: Independent of US1-3; can be done any time after T003
+
+### Parallel Opportunities
+
+- T001 and T002 (Phase 1) run in parallel
+- T006 and T007 (Phase 3 dev verification) run in parallel after dev server starts
+- T010–T012 (US2) and T013–T014 (US3) run in parallel after Phase 3
+- T015–T016 (US4) runs in parallel with Phases 4–5
+- T017 and T018 (Polish) run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After T003 (middleware fix) and dev server started:
+# Run both verification checks simultaneously:
+Task: "Verify /api/copilot/sync without token returns 401" (T006)
+Task: "Verify /api/anthropic/sync without token returns 401" (T007)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (verify env)
+2. Complete Phase 2: Apply middleware fix (T003 — 1 line)
+3. Complete Phase 3: Verify US1 with curl/dev server
+4. **STOP and VALIDATE**: Both cron endpoints return 401 (no token) / 200 (valid token) — no redirects
+5. Deploy — this alone fixes the production failure
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → Middleware fixed
+2. Phase 3 → US1 verified locally (MVP!)
+3. Phase 4 + 5 (parallel) → Production cron execution confirmed
+4. Phase 6 → Coverage audit complete
+5. Phase 7 → Final polish and build gate
+
+### Parallel Team Strategy
+
+With two developers after Phase 2:
+- Developer A: Phase 3 (US1 local verification) → Phase 4 (US2 production)
+- Developer B: Phase 6 (US4 audit) → Phase 5 (US3 production)
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent actions with no blocking dependencies
+- [Story] label maps each task to its user story for traceability
+- The entire code change is T003 (1 line in `src/middleware.ts`)
+- All remaining tasks are verification, configuration, and validation
+- No schema changes, no new routes, no new dependencies
+- Commit after T003; all remaining tasks are verification only until T016 (if gaps found in audit)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,5 +18,7 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon\\.ico|api/auth).*)"],
+  matcher: [
+    "/((?!_next/static|_next/image|favicon\\.ico|api/auth|api/copilot/sync|api/anthropic/sync).*)",
+  ],
 };


### PR DESCRIPTION
## Summary

- Cron job routes (`/api/copilot/sync`, `/api/anthropic/sync`) were being intercepted by the NextAuth middleware, which redirected them to `/login` because Vercel Cron invocations carry no user session
- The `requireCronSecret()` handler-level validation was never reached because the middleware fired first
- Fix: add both routes to the middleware matcher's negative lookahead so they bypass user auth and reach their handlers directly

## Root Cause

```
// Before: cron routes matched by middleware → redirect to /login
matcher: ["/((?!_next/static|_next/image|favicon\.ico|api/auth).*)"]

// After: cron routes excluded → reach handler → requireCronSecret() validates token
matcher: ["/((?!_next/static|_next/image|favicon\.ico|api/auth|api/copilot/sync|api/anthropic/sync).*)"]
```

## Changes

- `src/middleware.ts` — 1-line matcher update (the only code change)
- `specs/018-fix-cron-auth/` — feature spec, plan, research, contracts, tasks

## Verification

- `pnpm typecheck` — zero errors ✅
- `pnpm lint` — zero warnings ✅  
- `pnpm build` — production build succeeds ✅
- Coverage audit: both cron routes are in `vercel.json`; no missing registrations ✅
- Protected user routes still require login (only the two explicit cron paths are excluded) ✅

## Post-deployment

- Confirm `CRON_SECRET` is set in Vercel project environment settings
- Check Vercel Cron Jobs dashboard to confirm 200 responses after next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)