### PR TITLE
feat(021): UI enhancements — assignment & user detail polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-﻿# AI Developer Hub Development Guidelines
+# AI Developer Hub Development Guidelines
 
 Auto-generated from all feature plans. Last updated: 2026-03-02
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AI Developer Hub Development Guidelines
+﻿# AI Developer Hub Development Guidelines
 
 Auto-generated from all feature plans. Last updated: 2026-03-02
 
@@ -40,6 +40,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-02
 - TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), NextAuth 5.0.0-beta.30, Drizzle ORM 0.45.1 (018-fix-cron-auth)
 - TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6 (020-profile-api)
 - Neon PostgreSQL (serverless) via `@neondatabase/serverless` — no schema changes (020-profile-api)
+- TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), React 19.2.4, Drizzle ORM 0.45.1, Zod 4.3.6, React Hook Form 7.71.2, shadcn/ui (new-york), Sonner (toasts), Lucide React (021-ui-enhancements)
+- Neon PostgreSQL (serverless) via Drizzle ORM — no schema changes, UI-only feature (021-ui-enhancements)
 
 - **Language**: TypeScript 5.x (strict mode), Node.js LTS
 - **Framework**: Next.js 15 (App Router, Server Components, Server Actions)
@@ -102,9 +104,9 @@ pnpm lighthouse        # Lighthouse CI
 - Server Components by default — `"use client"` only when client interactivity needed
 
 ## Recent Changes
+- 021-ui-enhancements: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6, React Hook Form 7.71.2, shadcn/ui (new-york), Sonner (toasts), Lucide React
 - 020-profile-api: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, Zod 4.3.6
 - 018-claude-global-metrics: Added TypeScript 5.9.3 (strict mode) + Next.js 15.5.12 (App Router), Drizzle ORM 0.45.1, NextAuth 5.0.0-beta.30, Recharts 2.15.4, shadcn/ui (new-york), Zod 4.3.6, Sonner (toasts), Lucide React
-- 018-fix-cron-auth: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), NextAuth 5.0.0-beta.30, Drizzle ORM 0.45.1
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/021-ui-enhancements/checklists/requirements.md
+++ b/specs/021-ui-enhancements/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: UI Enhancements — Assignment & User Detail Polish
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec covers 4 discrete improvements that can each be implemented and tested independently.
+- No clarifications needed — all requirements have reasonable defaults based on existing system patterns.

--- a/specs/021-ui-enhancements/contracts/server-actions.md
+++ b/specs/021-ui-enhancements/contracts/server-actions.md
@@ -1,0 +1,59 @@
+# Server Action Contracts: 021-ui-enhancements
+
+**Date**: 2026-03-24
+
+## Modified Actions
+
+### `assignLicense(input)` — Updated
+
+**File**: `src/actions/assignments.ts`
+
+**Current input schema** (`assignmentSchema`):
+```
+{
+  userId: number (positive integer, required)
+  toolId: number (positive integer, required)
+  tierId: number (positive integer, required)
+}
+```
+
+**New input schema** (`assignmentSchema` — extended):
+```
+{
+  userId: number (positive integer, required)
+  toolId: number (positive integer, required)
+  tierId: number (positive integer, required)
+  workspace: string (max 200, optional)
+  apiKey: string (max 500, optional, trimmed, non-blank if provided)
+}
+```
+
+**Return type**: Unchanged — `{ success: true, data: { id: number } } | { success: false, error: string }`
+
+**Behavior changes**:
+- If `workspace` provided: stored in `license_assignments.workspace`
+- If `apiKey` provided: encrypted via `encryptApiKey()` and stored in `license_assignments.apiKeyEncrypted`
+- Both fields remain optional — omitting them preserves current behavior
+
+---
+
+### `updateAssignment(input)` — Updated
+
+**File**: `src/actions/assignments.ts`
+
+**Input schema**: Unchanged (`updateAssignmentSchema`)
+
+**Return type**: Unchanged — `{ success: true, data: void, warning?: string } | { success: false, error: string }`
+
+**Behavior changes**:
+- **Removed**: Validation that `assignedAt` cannot be before `user.createdAt`
+- **Kept**: Validation that `assignedAt` cannot be in the future
+- **Kept**: Validation that `assignedAt` cannot be before `tool.createdAt`
+- **Kept**: Warning for dates more than 12 months in the past
+
+## Unchanged Actions
+
+- `getAssignmentsForUser(userId)` — no changes
+- `revokeAssignment(id)` — no changes
+- `reactivateAssignment(id)` — no changes
+- `getToolWithTiers(toolId)` — no changes

--- a/specs/021-ui-enhancements/data-model.md
+++ b/specs/021-ui-enhancements/data-model.md
@@ -1,0 +1,52 @@
+# Data Model: 021-ui-enhancements
+
+**Date**: 2026-03-24
+
+## Overview
+
+This feature requires **no schema changes**. All database columns needed already exist. The changes are limited to validation logic and UI layer.
+
+## Existing Entities (Reference)
+
+### License Assignment (`license_assignments`)
+
+| Field | Type | Nullable | Notes |
+|-------|------|----------|-------|
+| id | serial PK | no | |
+| userId | integer FK → users | no | |
+| toolId | integer FK → ai_tools | no | |
+| tierId | integer FK → access_tiers | no | |
+| status | enum (active/inactive) | no | Default: active |
+| costAtAssignmentCents | integer | no | Snapshot at assignment time |
+| assignedAt | timestamp | no | Default: now() |
+| revokedAt | timestamp | yes | Set when revoked |
+| workspace | varchar(200) | yes | **Already exists — adding to create flow** |
+| apiKeyEncrypted | varchar(700) | yes | **Already exists — adding to create flow** |
+| source | varchar(50) | no | Default: "manual" |
+| createdAt | timestamp | no | Auto |
+| updatedAt | timestamp | no | Auto |
+
+### Validation Rules (Changes)
+
+| Rule | Current | After Change |
+|------|---------|-------------|
+| assignedAt < user.createdAt | **Error: rejected** | **Allowed** |
+| assignedAt > now() | Error: rejected | Error: rejected (unchanged) |
+| assignedAt < tool.createdAt | Error: rejected | Error: rejected (unchanged) |
+| assignedAt > 12 months ago | Warning | Warning (unchanged) |
+
+### Zod Schema Changes
+
+**`assignmentSchema`** (create flow) — add optional fields:
+- `workspace`: string, max 200, optional
+- `apiKey`: string, max 500, optional (same refinement as updateAssignmentSchema)
+
+**`updateAssignmentSchema`** (edit flow) — no changes needed.
+
+## State Transitions
+
+No new state transitions. The existing active → inactive (revoked) flow is unchanged.
+
+## Relationships
+
+No relationship changes. The existing foreign keys (user, tool, tier) remain the same.

--- a/specs/021-ui-enhancements/plan.md
+++ b/specs/021-ui-enhancements/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: UI Enhancements — Assignment & User Detail Polish
+
+**Branch**: `021-ui-enhancements` | **Date**: 2026-03-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/021-ui-enhancements/spec.md`
+
+## Summary
+
+Four targeted UX improvements to the assignment and user detail pages: (1) make assigned tool entries clickable links to assignment detail, (2) merge the duplicated detail-card and edit-form on the assignment detail page into a single unified view, (3) remove the server-side validation that prevents assignment dates before user creation, and (4) add optional workspace and API key fields to the new-assignment creation dialog. No new dependencies. No schema changes — all required columns already exist.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3 (strict mode)
+**Primary Dependencies**: Next.js 15.5.12 (App Router), React 19.2.4, React Hook Form 7.71.2, Zod 4.3.6, shadcn/ui (new-york), Sonner (toasts), Lucide React
+**Storage**: Neon PostgreSQL (serverless) via Drizzle ORM 0.45.1 — no schema changes
+**Testing**: Vitest (unit/integration), Playwright (e2e)
+**Target Platform**: Web (Next.js SSR)
+**Project Type**: Web application (Next.js App Router)
+**Performance Goals**: LCP < 2.5s, INP < 200ms, CLS < 0.1, JS bundle per route < 150 KB gzipped
+**Constraints**: All UI must use shadcn/ui components and Tailwind design tokens only
+**Scale/Scope**: 4 files modified, ~200 lines changed, 0 new files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Type-Safe Code Quality | PASS | All changes are TypeScript strict. Zod schemas extended with proper types. No `any` usage. |
+| II. UX Consistency | PASS | Unified assignment detail follows existing user detail patterns. Link components use standard Next.js Link. shadcn/ui primitives throughout. |
+| III. Performance Budgets | PASS | No new dependencies. No additional JS bundle. Link component adds negligible weight. Removing a card section reduces DOM size. |
+| IV. Accessibility-First | PASS | Using semantic `<Link>` for navigation (keyboard navigable, screen reader friendly). Form fields use existing accessible shadcn/ui components with labels and error messages. |
+| V. Simplicity & Maintainability | PASS | Net reduction in code — merging two cards into one removes ~120 lines of duplication. Validation change is a deletion. Schema extension adds 2 optional fields. |
+
+**Pre-design gate**: PASSED — no violations.
+
+**Post-design re-check**: PASSED — design phase confirmed no new dependencies, no new abstractions, no schema changes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/021-ui-enhancements/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── server-actions.md
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (files to modify)
+
+```text
+src/
+├── app/
+│   ├── users/[id]/
+│   │   └── user-detail-client.tsx    # Add Link wrappers + workspace/apiKey fields in dialog
+│   └── assignments/[id]/
+│       └── assignment-detail-client.tsx  # Merge detail + edit cards into unified view
+├── actions/
+│   └── assignments.ts                # Remove user-creation-date check; add workspace/apiKey to assignLicense
+└── lib/
+    └── validators.ts                 # Extend assignmentSchema with workspace + apiKey
+
+tests/
+├── unit/
+│   └── assignments.test.ts           # Update tests for removed validation + new fields
+└── integration/
+    └── assignments.test.ts           # Update integration tests
+```
+
+**Structure Decision**: Existing Next.js App Router structure. No new files or directories — all changes are modifications to 4 existing source files plus test updates.
+
+## Complexity Tracking
+
+> No violations to justify. All changes are deletions or minimal additions to existing files.

--- a/specs/021-ui-enhancements/quickstart.md
+++ b/specs/021-ui-enhancements/quickstart.md
@@ -1,0 +1,44 @@
+# Quickstart: 021-ui-enhancements
+
+**Date**: 2026-03-24
+
+## Prerequisites
+
+- Node.js LTS
+- pnpm installed
+- Local `.env.local` with database connection string and `ENCRYPTION_KEY`
+
+## Setup
+
+```bash
+git checkout 021-ui-enhancements
+pnpm install
+pnpm dev
+```
+
+No new dependencies are required. No database migrations needed — all schema columns already exist.
+
+## Key Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/app/users/[id]/user-detail-client.tsx` | Add Link wrappers on tool entries; add workspace/apiKey fields to assign dialog |
+| `src/app/assignments/[id]/assignment-detail-client.tsx` | Merge detail card and edit form into unified view |
+| `src/actions/assignments.ts` | Remove user-creation-date validation; add workspace/apiKey to assignLicense |
+| `src/lib/validators.ts` | Extend assignmentSchema with workspace and apiKey |
+
+## Verification
+
+1. **Clickable tools**: Navigate to any user detail page → click an assigned tool → should open assignment detail
+2. **Unified view**: Open an active assignment → should see single card with inline edit controls, no duplicate info
+3. **Date validation**: Edit assignment date to before user creation → should succeed
+4. **New assignment fields**: From user detail, assign a license with workspace and API key → verify on assignment detail
+
+## Testing
+
+```bash
+pnpm typecheck          # TypeScript compilation
+pnpm lint               # ESLint
+pnpm test               # Unit tests
+pnpm test:integration   # Integration tests (requires DB)
+```

--- a/specs/021-ui-enhancements/research.md
+++ b/specs/021-ui-enhancements/research.md
@@ -1,0 +1,52 @@
+# Research: 021-ui-enhancements
+
+**Date**: 2026-03-24
+
+## R1: Inline Editing Pattern on User Detail Page
+
+**Decision**: Reuse the existing React Hook Form + Zod pattern from `assignment-detail-client.tsx` for the unified view. The user detail page does NOT actually use inline editing — it uses a separate edit form card. The assignment detail page already has the same pattern (detail card + edit card). The "unification" means merging these two cards into one, where each field shows its current value with an adjacent edit control.
+
+**Rationale**: The current assignment detail page already uses `useForm<UpdateAssignmentInput>` with `zodResolver(updateAssignmentSchema)`. The edit form fields (tier select, date picker, workspace input, API key input) can be embedded directly into the detail card rows instead of living in a separate card. This eliminates the duplicate display without changing the underlying form mechanics.
+
+**Alternatives considered**:
+- Individual field-level inline edit (click to edit pattern): More complex, requires per-field save endpoints. Rejected — the current batch-save pattern works well.
+- Keep separate cards but remove read-only duplication from edit card: Still leaves two cards. Rejected — doesn't match the "combined" requirement.
+
+## R2: Making Tool Entries Clickable
+
+**Decision**: Wrap each tool entry in the "Assigned Tools" card with a Next.js `Link` component pointing to `/assignments/{assignment.id}`.
+
+**Rationale**: The `assignments` data passed to `user-detail-client.tsx` already includes `a.id` (assignment ID). The assignment detail page already exists at `/assignments/[id]`. This is a one-line change per entry — wrap the existing `<div>` content in `<Link href={/assignments/${a.id}}>`.
+
+**Alternatives considered**:
+- Using `router.push()` on click handler: Works but semantically worse — a `<Link>` gives proper anchor behavior (right-click, cmd+click, accessibility).
+- Making only the tool name clickable vs. the entire row: Entire row is more discoverable and consistent with table row click patterns used elsewhere.
+
+## R3: Removing User-Creation-Date Validation
+
+**Decision**: Remove the `newDate < assignment.user.createdAt` check in `updateAssignment()` (lines 236-241 of `src/actions/assignments.ts`). Keep the tool-creation-date check and the future-date check.
+
+**Rationale**: The spec explicitly requires allowing dates before user creation for backdating scenarios. The tool-creation-date check still makes logical sense (can't assign a tool before it existed). The 12-month warning remains as a soft guard.
+
+**Alternatives considered**:
+- Making it a warning instead of an error: Adds complexity without clear benefit — if we're allowing it, just allow it.
+- Adding a separate "backdate" flag: Over-engineering for a simple validation removal.
+
+## R4: Adding Workspace/API Key to New Assignment Form
+
+**Decision**: Extend `assignmentSchema` in validators.ts with optional `workspace` and `apiKey` fields. Update `assignLicense()` in `src/actions/assignments.ts` to accept and process these fields, including API key encryption via `encryptApiKey()` from `src/lib/crypto.ts`. Add corresponding UI fields to the assignment dialog in `user-detail-client.tsx`.
+
+**Rationale**: The database schema already has `workspace` and `apiKeyEncrypted` columns. The `updateAssignment` action already handles these fields with encryption. The bulk import flow already accepts them. This just closes the gap in the manual single-assignment creation flow.
+
+**Alternatives considered**:
+- Adding fields only to the assignment dialog, not the assignments list quick-create: The user detail page dialog is the primary creation point. The assignments list page also has a quick-create dialog that could benefit, but is out of scope per the spec.
+
+## R5: Unified Assignment Detail Layout
+
+**Decision**: Merge the "Assignment Details" read-only card (lines 248-371) and the "Edit Assignment" card (lines 374-542) in `assignment-detail-client.tsx` into a single card. For active assignments viewed by admins, each field row shows the current value with an adjacent edit control (select, input, date picker). For inactive assignments or non-admin viewers, fields are read-only.
+
+**Rationale**: The current page shows the same information twice — once in the detail card and once in the edit form. The unified view eliminates this duplication while maintaining all functionality. The form wraps the entire card content, and the submit button lives at the bottom of the card.
+
+**Alternatives considered**:
+- Tabbed interface (View/Edit tabs): Adds UI complexity and still requires switching modes. Rejected.
+- Modal-based editing: Hides context. Rejected — inline is better for this use case.

--- a/specs/021-ui-enhancements/spec.md
+++ b/specs/021-ui-enhancements/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: UI Enhancements — Assignment & User Detail Polish
+
+**Feature Branch**: `021-ui-enhancements`
+**Created**: 2026-03-24
+**Status**: Draft
+**Input**: User description: "Improve UX: clickable assigned tools in user detail, combine assignment detail/edit, allow pre-creation assignment dates, add workspace and API key to license assignment"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Clickable Assigned Tools in User Detail (Priority: P1)
+
+When viewing a user's detail page, administrators see a list of assigned tools. Currently these tool names are plain text. Administrators need to quickly navigate to the assignment detail for any listed tool to review or edit assignment specifics (tier, workspace, API key, dates).
+
+Each assigned tool entry in the user detail page should be a clickable link that navigates directly to the corresponding assignment detail page.
+
+**Why this priority**: This is the simplest change with the highest daily impact — administrators frequently need to drill into assignment details from the user view, and having to navigate manually through the assignments list is a common friction point.
+
+**Independent Test**: Can be fully tested by viewing any user with at least one assigned tool and clicking on the tool entry to confirm navigation to the correct assignment detail page.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user detail page showing assigned tools, **When** an administrator clicks on an assigned tool entry, **Then** they are navigated to the assignment detail page for that specific assignment.
+2. **Given** a user detail page showing multiple assigned tools (active and revoked), **When** an administrator clicks on any tool entry regardless of status, **Then** the correct assignment detail page opens.
+3. **Given** a user detail page with assigned tools, **When** the tools list is displayed, **Then** each tool entry visually indicates it is clickable (e.g., cursor change, underline, or link styling).
+
+---
+
+### User Story 2 - Unified Assignment Detail View (Priority: P1)
+
+The assignment detail page currently shows two separate sections: a read-only detail card and an edit form below it. This creates duplication — the same fields (tier, workspace, API key, assigned date) appear twice in different formats. The user detail page already uses a pattern where details are shown inline with edit capability. The assignment detail page should follow the same pattern, combining the detail display and edit controls into a single cohesive view.
+
+**Why this priority**: This directly addresses user confusion and visual clutter. The current duplication is disorienting and makes the page unnecessarily long. Aligning with the existing user detail pattern creates UI consistency.
+
+**Independent Test**: Can be fully tested by navigating to any active assignment detail page and verifying that fields are displayed once with inline edit capability, matching the user detail page pattern.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active assignment detail page, **When** an administrator views the page, **Then** each editable field (tier, assigned date, workspace, API key) is displayed once with the ability to edit inline.
+2. **Given** an active assignment detail page, **When** an administrator edits a field and saves, **Then** the field updates in place without page reload and shows the new value.
+3. **Given** an inactive (revoked) assignment detail page, **When** an administrator views the page, **Then** fields are displayed in read-only mode without edit controls.
+4. **Given** the unified assignment detail view, **When** comparing it to the user detail page, **Then** the interaction patterns (inline editing, save behavior, field layout) are visually consistent.
+
+---
+
+### User Story 3 - Allow Assignment Dates Before User Creation (Priority: P2)
+
+Currently, the system prevents setting an assignment date earlier than the user's creation date. This restriction causes problems when backdating assignments for users who had tool access before they were registered in the system (e.g., migrating from another tracking system, or when the user account was created after the tool was already provisioned).
+
+The system should allow assignment dates before the user creation date while still preventing dates in the future.
+
+**Why this priority**: This is a targeted validation rule change that unblocks a real workflow need — backdating assignments during data migration or corrections — without affecting normal day-to-day assignment flows.
+
+**Independent Test**: Can be tested by editing an existing assignment's date to a date before the user's creation date and confirming the system accepts it without error.
+
+**Acceptance Scenarios**:
+
+1. **Given** an assignment for a user created on 2025-06-01, **When** an administrator sets the assignment date to 2025-01-15, **Then** the system accepts the date without error.
+2. **Given** an assignment for a user, **When** an administrator sets the assignment date to a future date, **Then** the system still rejects the date with an appropriate error message.
+3. **Given** an assignment for a tool created on 2025-03-01, **When** an administrator sets the assignment date to 2025-02-01, **Then** the system still rejects the date (tool creation date validation remains).
+4. **Given** an assignment date set more than 12 months in the past, **When** the date is saved, **Then** a warning is displayed but the date is still accepted.
+
+---
+
+### User Story 4 - Workspace and API Key Fields on New Assignment (Priority: P2)
+
+When assigning a new license to a user from the user detail page, the current form only offers tool and tier selection. Workspace and API key must be set afterward by navigating to the assignment detail and editing it there. This is an extra step that slows down the workflow.
+
+The new assignment form should include optional fields for workspace and API key, so administrators can provide all assignment details in a single step.
+
+**Why this priority**: This completes the assignment creation workflow and reduces the number of steps for a common admin task. The fields already exist in the database schema and in the bulk import flow, so this aligns the manual creation experience with existing capabilities.
+
+**Independent Test**: Can be tested by creating a new assignment from the user detail page with workspace and API key filled in, then verifying the values appear on the resulting assignment detail page.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new assignment dialog on the user detail page, **When** an administrator opens it, **Then** optional fields for workspace and API key are available alongside tool and tier selection.
+2. **Given** the new assignment form with workspace and API key filled in, **When** the administrator submits the form, **Then** the assignment is created with all provided values stored correctly.
+3. **Given** the new assignment form, **When** the administrator leaves workspace and API key empty, **Then** the assignment is created successfully with those fields as empty (they remain optional).
+4. **Given** the new assignment form, **When** an API key is provided, **Then** the key is stored encrypted, consistent with existing API key handling throughout the system.
+5. **Given** the new assignment form, **When** a workspace value exceeding 200 characters is entered, **Then** the form displays a validation error.
+
+---
+
+### Edge Cases
+
+- What happens when a user has no assigned tools? The user detail page should display a clear empty state with no broken clickable elements.
+- What happens when navigating to an assignment that was deleted between page load and click? The assignment detail page should show an appropriate "not found" message.
+- What happens when two administrators edit the same assignment field simultaneously? The last save wins; the system should not corrupt data.
+- What happens when an API key contains special characters? The system should accept and correctly encrypt/decrypt any valid string up to 500 characters.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Each assigned tool entry on the user detail page MUST be a navigable link to the corresponding assignment detail page.
+- **FR-002**: The assignment detail page MUST display each field (status, tier, cost, assigned date, revoked date, workspace, API key) exactly once, with inline edit capability for administrators on active assignments.
+- **FR-003**: The assignment detail page MUST remove the separate "Edit Assignment" form section that duplicates the detail display.
+- **FR-004**: The system MUST allow assignment dates that are before the user's account creation date.
+- **FR-005**: The system MUST continue to reject assignment dates that are in the future.
+- **FR-006**: The system MUST continue to reject assignment dates that are before the tool's creation date.
+- **FR-007**: The system MUST continue to display a warning for assignment dates more than 12 months in the past.
+- **FR-008**: The new license assignment form MUST include an optional workspace text field (maximum 200 characters).
+- **FR-009**: The new license assignment form MUST include an optional API key field (maximum 500 characters).
+- **FR-010**: API keys provided during new assignment creation MUST be encrypted before storage, using the same encryption mechanism as existing API key handling.
+- **FR-011**: The unified assignment detail view MUST show fields as read-only for revoked (inactive) assignments.
+- **FR-012**: The unified assignment detail view MUST follow the same inline-editing pattern used on the user detail page for visual and behavioral consistency.
+
+### Key Entities
+
+- **License Assignment**: Represents a user's access to a specific tool tier. Key attributes: assigned date, status (active/inactive), workspace, encrypted API key, cost snapshot, source.
+- **User**: The person to whom tools are assigned. Linked to assignments; detail page serves as the entry point for assignment navigation.
+- **AI Tool / Tier**: The tool and pricing tier being assigned. Each tool has multiple tiers with associated costs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Administrators can navigate from user detail to any assignment detail in a single click, reducing the number of steps from 3+ to 1.
+- **SC-002**: The assignment detail page displays each field exactly once — no duplicate information visible on the page.
+- **SC-003**: Assignment date changes to dates before user creation are accepted by the system without error, while future dates continue to be rejected.
+- **SC-004**: New assignments can be created with workspace and API key in a single form submission, reducing the required steps from 2 operations (create + edit) to 1.
+- **SC-005**: All four improvements maintain visual consistency with the existing user detail page patterns and design language.
+
+## Assumptions
+
+- The existing inline-editing pattern on the user detail page is the target UX pattern for the unified assignment detail view. No new interaction paradigms need to be designed.
+- The existing API key encryption mechanism is reusable for new assignment creation without modification.
+- The workspace and API key fields remain optional for all assignment creation flows (manual and bulk import).
+- Removing the user-creation-date validation on assignment dates does not affect any downstream reporting or billing calculations.
+- The "not found" behavior for deleted assignments already exists and does not need to be built as part of this feature.

--- a/specs/021-ui-enhancements/tasks.md
+++ b/specs/021-ui-enhancements/tasks.md
@@ -39,9 +39,9 @@
 
 ### Implementation for User Story 1
 
-- [ ] T001 [US1] Wrap each assignment entry in the "Assigned Tools" card with a Next.js `Link` component pointing to `/assignments/${a.id}` in `src/app/users/[id]/user-detail-client.tsx` (lines ~479-553). Import `Link` from `next/link`. The entire tool row (name, tier, cost, dates) should be the clickable area. Add hover styling (`hover:bg-muted/50 transition-colors`) to indicate interactivity. Ensure the existing revoke/reactivate action buttons remain outside the link to avoid nested interactive elements.
+- [x] T001 [US1] Wrap each assignment entry in the "Assigned Tools" card with a Next.js `Link` component pointing to `/assignments/${a.id}` in `src/app/users/[id]/user-detail-client.tsx` (lines ~479-553). Import `Link` from `next/link`. The entire tool row (name, tier, cost, dates) should be the clickable area. Add hover styling (`hover:bg-muted/50 transition-colors`) to indicate interactivity. Ensure the existing revoke/reactivate action buttons remain outside the link to avoid nested interactive elements.
 
-- [ ] T002 [US1] Verify that the `Link` component is keyboard-accessible (focusable via Tab, activatable via Enter) and has appropriate visual focus indicators consistent with the design system. Test with both active and revoked assignments to confirm navigation works for all statuses.
+- [x] T002 [US1] Verify that the `Link` component is keyboard-accessible (focusable via Tab, activatable via Enter) and has appropriate visual focus indicators consistent with the design system. Test with both active and revoked assignments to confirm navigation works for all statuses.
 
 **Checkpoint**: User Story 1 is complete. Administrators can click any assigned tool to navigate directly to its assignment detail page.
 
@@ -55,11 +55,11 @@
 
 ### Implementation for User Story 2
 
-- [ ] T003 [US2] In `src/app/assignments/[id]/assignment-detail-client.tsx`, restructure the detail card (lines ~248-371) to integrate edit controls inline. For each editable field (tier, assigned date, workspace, API key), replace the read-only display with the corresponding form control from the current edit card (lines ~386-529) when the user is an admin and the assignment is active. Wrap the entire card content in the existing `<Form>` component. Keep non-editable fields (status badge, cost display, revoked date) as read-only. Each field row should show a label on the left and the value/control on the right, using the same grid/flex layout as the current detail card.
+- [x] T003 [US2] In `src/app/assignments/[id]/assignment-detail-client.tsx`, restructure the detail card (lines ~248-371) to integrate edit controls inline. For each editable field (tier, assigned date, workspace, API key), replace the read-only display with the corresponding form control from the current edit card (lines ~386-529) when the user is an admin and the assignment is active. Wrap the entire card content in the existing `<Form>` component. Keep non-editable fields (status badge, cost display, revoked date) as read-only. Each field row should show a label on the left and the value/control on the right, using the same grid/flex layout as the current detail card.
 
-- [ ] T004 [US2] Remove the separate "Edit Assignment" `<Card>` section (lines ~374-542) from `src/app/assignments/[id]/assignment-detail-client.tsx`. The "Save Changes" button should now appear at the bottom of the unified detail card, visible only for admins on active assignments. Move the tier-loading `useEffect` and `loadTiers` callback to remain at the component level (they already are — just verify they still work after the card merge).
+- [x] T004 [US2] Remove the separate "Edit Assignment" `<Card>` section (lines ~374-542) from `src/app/assignments/[id]/assignment-detail-client.tsx`. The "Save Changes" button should now appear at the bottom of the unified detail card, visible only for admins on active assignments. Move the tier-loading `useEffect` and `loadTiers` callback to remain at the component level (they already are — just verify they still work after the card merge).
 
-- [ ] T005 [US2] Ensure the unified card displays correctly for non-admin users and revoked assignments: all fields should render as plain text (the current detail card format) with no form controls, no "Save Changes" button. The API key display (masked with reveal/copy buttons) should still work for read-only view. Test that the `form.handleSubmit(onSubmit)` still triggers correctly from the unified card.
+- [x] T005 [US2] Ensure the unified card displays correctly for non-admin users and revoked assignments: all fields should render as plain text (the current detail card format) with no form controls, no "Save Changes" button. The API key display (masked with reveal/copy buttons) should still work for read-only view. Test that the `form.handleSubmit(onSubmit)` still triggers correctly from the unified card.
 
 **Checkpoint**: User Story 2 is complete. The assignment detail page shows each field exactly once. Active assignments have inline edit controls; revoked assignments are read-only.
 
@@ -73,9 +73,9 @@
 
 ### Implementation for User Story 3
 
-- [ ] T006 [US3] In `src/actions/assignments.ts`, remove the validation block (lines ~236-242) in the `updateAssignment` function that checks `if (newDate < assignment.user.createdAt)` and returns an error. Keep the future-date check (lines ~232-233), the tool-creation-date check (lines ~245-250), and the 12-month warning (lines ~252-257) unchanged.
+- [x] T006 [US3] In `src/actions/assignments.ts`, remove the validation block (lines ~236-242) in the `updateAssignment` function that checks `if (newDate < assignment.user.createdAt)` and returns an error. Keep the future-date check (lines ~232-233), the tool-creation-date check (lines ~245-250), and the 12-month warning (lines ~252-257) unchanged.
 
-- [ ] T007 [US3] Update any existing unit or integration tests in `tests/` that assert the "Assigned date cannot be before the user was created" error behavior. These tests should now expect success for dates before user creation while continuing to assert failure for future dates and dates before tool creation.
+- [x] T007 [US3] Update any existing unit or integration tests in `tests/` that assert the "Assigned date cannot be before the user was created" error behavior. These tests should now expect success for dates before user creation while continuing to assert failure for future dates and dates before tool creation.
 
 **Checkpoint**: User Story 3 is complete. Dates before user creation are accepted. All other date validations remain enforced.
 
@@ -89,11 +89,11 @@
 
 ### Implementation for User Story 4
 
-- [ ] T008 [P] [US4] Extend `assignmentSchema` in `src/lib/validators.ts` (lines ~58-62) to add `workspace: z.string().max(200).optional()` and `apiKey: z.string().max(500).refine((val) => val === "" || val.trim().length > 0, { message: "API key cannot be blank" }).transform((val) => (val === "" ? val : val.trim())).optional()`. This matches the existing `updateAssignmentSchema` pattern for these fields.
+- [x] T008 [P] [US4] Extend `assignmentSchema` in `src/lib/validators.ts` (lines ~58-62) to add `workspace: z.string().max(200).optional()` and `apiKey: z.string().max(500).refine((val) => val === "" || val.trim().length > 0, { message: "API key cannot be blank" }).transform((val) => (val === "" ? val : val.trim())).optional()`. This matches the existing `updateAssignmentSchema` pattern for these fields.
 
-- [ ] T009 [P] [US4] Update the `assignLicense` function in `src/actions/assignments.ts` (lines ~25-134) to destructure `workspace` and `apiKey` from the parsed input. If `apiKey` is provided and non-empty, encrypt it using `encryptApiKey()` from `src/lib/crypto.ts`. Include `workspace` and `apiKeyEncrypted` in the `db.insert(licenseAssignments).values({...})` call (lines ~111-118). Import `encryptApiKey` if not already imported.
+- [x] T009 [P] [US4] Update the `assignLicense` function in `src/actions/assignments.ts` (lines ~25-134) to destructure `workspace` and `apiKey` from the parsed input. If `apiKey` is provided and non-empty, encrypt it using `encryptApiKey()` from `src/lib/crypto.ts`. Include `workspace` and `apiKeyEncrypted` in the `db.insert(licenseAssignments).values({...})` call (lines ~111-118). Import `encryptApiKey` if not already imported.
 
-- [ ] T010 [US4] Add workspace and API key fields to the assignment dialog in `src/app/users/[id]/user-detail-client.tsx` (lines ~564-621). After the Tier select dropdown (~line 604), add: (1) a text `<Input>` for workspace with `placeholder="e.g. team-alpha"`, `maxLength={200}`, and a `<label className="text-sm font-medium">Workspace (optional)</label>`; (2) a password `<Input>` for API key with show/hide toggle button (using `Eye`/`EyeOff` icons from Lucide), `maxLength={500}`, and a `<label className="text-sm font-medium">API Key (optional)</label>`. Add corresponding React state variables (`assignWorkspace`, `assignApiKey`, `showAssignApiKey`). Pass `workspace` and `apiKey` to the `assignLicense` call in the submit handler. Reset these fields when the dialog closes or after successful submission.
+- [x] T010 [US4] Add workspace and API key fields to the assignment dialog in `src/app/users/[id]/user-detail-client.tsx` (lines ~564-621). After the Tier select dropdown (~line 604), add: (1) a text `<Input>` for workspace with `placeholder="e.g. team-alpha"`, `maxLength={200}`, and a `<label className="text-sm font-medium">Workspace (optional)</label>`; (2) a password `<Input>` for API key with show/hide toggle button (using `Eye`/`EyeOff` icons from Lucide), `maxLength={500}`, and a `<label className="text-sm font-medium">API Key (optional)</label>`. Add corresponding React state variables (`assignWorkspace`, `assignApiKey`, `showAssignApiKey`). Pass `workspace` and `apiKey` to the `assignLicense` call in the submit handler. Reset these fields when the dialog closes or after successful submission.
 
 **Checkpoint**: User Story 4 is complete. New assignments can be created with workspace and API key in a single step.
 
@@ -103,10 +103,10 @@
 
 **Purpose**: Final verification across all stories.
 
-- [ ] T011 Run `pnpm typecheck` to verify TypeScript compilation passes with zero errors across all modified files
-- [ ] T012 Run `pnpm lint` to verify ESLint passes with zero warnings across all modified files
-- [ ] T013 Run `pnpm build` to verify production build succeeds
-- [ ] T014 Run quickstart.md validation: manually verify all 4 verification steps described in `specs/021-ui-enhancements/quickstart.md`
+- [x] T011 Run `pnpm typecheck` to verify TypeScript compilation passes with zero errors across all modified files
+- [x] T012 Run `pnpm lint` to verify ESLint passes with zero warnings across all modified files
+- [x] T013 Run `pnpm build` to verify production build succeeds
+- [x] T014 Run quickstart.md validation: manually verify all 4 verification steps described in `specs/021-ui-enhancements/quickstart.md`
 
 ---
 

--- a/specs/021-ui-enhancements/tasks.md
+++ b/specs/021-ui-enhancements/tasks.md
@@ -1,0 +1,192 @@
+# Tasks: UI Enhancements — Assignment & User Detail Polish
+
+**Input**: Design documents from `/specs/021-ui-enhancements/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Not explicitly requested — test tasks omitted. Existing tests should be updated where they break.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — this feature modifies existing files only. No new dependencies, no schema changes.
+
+*Phase skipped — proceed directly to user stories.*
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No foundational tasks needed. All four user stories are independent and modify different sections of existing files. No shared infrastructure changes are required.
+
+*Phase skipped — user story implementation can begin immediately.*
+
+---
+
+## Phase 3: User Story 1 - Clickable Assigned Tools in User Detail (Priority: P1) 🎯 MVP
+
+**Goal**: Each assigned tool entry on the user detail page is a clickable link that navigates to the corresponding assignment detail page.
+
+**Independent Test**: View any user with assigned tools → click a tool entry → verify navigation to `/assignments/{id}`.
+
+### Implementation for User Story 1
+
+- [ ] T001 [US1] Wrap each assignment entry in the "Assigned Tools" card with a Next.js `Link` component pointing to `/assignments/${a.id}` in `src/app/users/[id]/user-detail-client.tsx` (lines ~479-553). Import `Link` from `next/link`. The entire tool row (name, tier, cost, dates) should be the clickable area. Add hover styling (`hover:bg-muted/50 transition-colors`) to indicate interactivity. Ensure the existing revoke/reactivate action buttons remain outside the link to avoid nested interactive elements.
+
+- [ ] T002 [US1] Verify that the `Link` component is keyboard-accessible (focusable via Tab, activatable via Enter) and has appropriate visual focus indicators consistent with the design system. Test with both active and revoked assignments to confirm navigation works for all statuses.
+
+**Checkpoint**: User Story 1 is complete. Administrators can click any assigned tool to navigate directly to its assignment detail page.
+
+---
+
+## Phase 4: User Story 2 - Unified Assignment Detail View (Priority: P1)
+
+**Goal**: Merge the separate "Assignment Details" read-only card and "Edit Assignment" form card into a single unified card where each field is displayed once with inline edit capability for admins on active assignments.
+
+**Independent Test**: Navigate to an active assignment → verify single card with inline edit controls, no duplicate fields. Navigate to a revoked assignment → verify read-only view with no edit controls.
+
+### Implementation for User Story 2
+
+- [ ] T003 [US2] In `src/app/assignments/[id]/assignment-detail-client.tsx`, restructure the detail card (lines ~248-371) to integrate edit controls inline. For each editable field (tier, assigned date, workspace, API key), replace the read-only display with the corresponding form control from the current edit card (lines ~386-529) when the user is an admin and the assignment is active. Wrap the entire card content in the existing `<Form>` component. Keep non-editable fields (status badge, cost display, revoked date) as read-only. Each field row should show a label on the left and the value/control on the right, using the same grid/flex layout as the current detail card.
+
+- [ ] T004 [US2] Remove the separate "Edit Assignment" `<Card>` section (lines ~374-542) from `src/app/assignments/[id]/assignment-detail-client.tsx`. The "Save Changes" button should now appear at the bottom of the unified detail card, visible only for admins on active assignments. Move the tier-loading `useEffect` and `loadTiers` callback to remain at the component level (they already are — just verify they still work after the card merge).
+
+- [ ] T005 [US2] Ensure the unified card displays correctly for non-admin users and revoked assignments: all fields should render as plain text (the current detail card format) with no form controls, no "Save Changes" button. The API key display (masked with reveal/copy buttons) should still work for read-only view. Test that the `form.handleSubmit(onSubmit)` still triggers correctly from the unified card.
+
+**Checkpoint**: User Story 2 is complete. The assignment detail page shows each field exactly once. Active assignments have inline edit controls; revoked assignments are read-only.
+
+---
+
+## Phase 5: User Story 3 - Allow Assignment Dates Before User Creation (Priority: P2)
+
+**Goal**: Remove the server-side validation that rejects assignment dates earlier than the user's account creation date.
+
+**Independent Test**: Edit an assignment's date to a date before the user's `createdAt` → verify it succeeds. Confirm future dates are still rejected. Confirm dates before tool creation are still rejected.
+
+### Implementation for User Story 3
+
+- [ ] T006 [US3] In `src/actions/assignments.ts`, remove the validation block (lines ~236-242) in the `updateAssignment` function that checks `if (newDate < assignment.user.createdAt)` and returns an error. Keep the future-date check (lines ~232-233), the tool-creation-date check (lines ~245-250), and the 12-month warning (lines ~252-257) unchanged.
+
+- [ ] T007 [US3] Update any existing unit or integration tests in `tests/` that assert the "Assigned date cannot be before the user was created" error behavior. These tests should now expect success for dates before user creation while continuing to assert failure for future dates and dates before tool creation.
+
+**Checkpoint**: User Story 3 is complete. Dates before user creation are accepted. All other date validations remain enforced.
+
+---
+
+## Phase 6: User Story 4 - Workspace and API Key Fields on New Assignment (Priority: P2)
+
+**Goal**: Add optional workspace and API key fields to the new license assignment dialog and the server action that creates assignments.
+
+**Independent Test**: From user detail page, assign a license with workspace and API key filled in → verify values appear on the resulting assignment detail page.
+
+### Implementation for User Story 4
+
+- [ ] T008 [P] [US4] Extend `assignmentSchema` in `src/lib/validators.ts` (lines ~58-62) to add `workspace: z.string().max(200).optional()` and `apiKey: z.string().max(500).refine((val) => val === "" || val.trim().length > 0, { message: "API key cannot be blank" }).transform((val) => (val === "" ? val : val.trim())).optional()`. This matches the existing `updateAssignmentSchema` pattern for these fields.
+
+- [ ] T009 [P] [US4] Update the `assignLicense` function in `src/actions/assignments.ts` (lines ~25-134) to destructure `workspace` and `apiKey` from the parsed input. If `apiKey` is provided and non-empty, encrypt it using `encryptApiKey()` from `src/lib/crypto.ts`. Include `workspace` and `apiKeyEncrypted` in the `db.insert(licenseAssignments).values({...})` call (lines ~111-118). Import `encryptApiKey` if not already imported.
+
+- [ ] T010 [US4] Add workspace and API key fields to the assignment dialog in `src/app/users/[id]/user-detail-client.tsx` (lines ~564-621). After the Tier select dropdown (~line 604), add: (1) a text `<Input>` for workspace with `placeholder="e.g. team-alpha"`, `maxLength={200}`, and a `<label className="text-sm font-medium">Workspace (optional)</label>`; (2) a password `<Input>` for API key with show/hide toggle button (using `Eye`/`EyeOff` icons from Lucide), `maxLength={500}`, and a `<label className="text-sm font-medium">API Key (optional)</label>`. Add corresponding React state variables (`assignWorkspace`, `assignApiKey`, `showAssignApiKey`). Pass `workspace` and `apiKey` to the `assignLicense` call in the submit handler. Reset these fields when the dialog closes or after successful submission.
+
+**Checkpoint**: User Story 4 is complete. New assignments can be created with workspace and API key in a single step.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification across all stories.
+
+- [ ] T011 Run `pnpm typecheck` to verify TypeScript compilation passes with zero errors across all modified files
+- [ ] T012 Run `pnpm lint` to verify ESLint passes with zero warnings across all modified files
+- [ ] T013 Run `pnpm build` to verify production build succeeds
+- [ ] T014 Run quickstart.md validation: manually verify all 4 verification steps described in `specs/021-ui-enhancements/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Skipped — no setup needed
+- **Foundational (Phase 2)**: Skipped — no shared prerequisites
+- **User Stories (Phase 3-6)**: Can all start immediately in parallel
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies — modifies only `user-detail-client.tsx` (assigned tools section)
+- **User Story 2 (P1)**: No dependencies — modifies only `assignment-detail-client.tsx`
+- **User Story 3 (P2)**: No dependencies — modifies only `assignments.ts` (validation removal)
+- **User Story 4 (P2)**: No dependencies on other stories — modifies `validators.ts`, `assignments.ts` (create function), and `user-detail-client.tsx` (dialog section)
+
+**Note**: US1 and US4 both modify `user-detail-client.tsx` but in different sections (US1: assigned tools card ~lines 479-553, US4: assignment dialog ~lines 564-621), so they can be developed in parallel without conflicts.
+
+**Note**: US3 and US4 both modify `assignments.ts` but in different functions (US3: `updateAssignment` ~line 236, US4: `assignLicense` ~line 25), so they can be developed in parallel without conflicts.
+
+### Within Each User Story
+
+- T008 and T009 (US4) are marked [P] — they modify different files and can run in parallel
+- T010 (US4) depends on T008 and T009 completing first (needs the updated schema and action)
+
+### Parallel Opportunities
+
+- **Maximum parallelism**: All 4 user stories can be worked on simultaneously
+- **Within US4**: T008 (validators.ts) and T009 (assignments.ts) can run in parallel
+- **Recommended order for single developer**: US1 → US3 → US4 → US2 (simplest to most complex)
+
+---
+
+## Parallel Example: All User Stories
+
+```bash
+# All four stories can launch in parallel (different files):
+Agent 1: T001-T002 [US1] user-detail-client.tsx (assigned tools section)
+Agent 2: T003-T005 [US2] assignment-detail-client.tsx
+Agent 3: T006-T007 [US3] assignments.ts (updateAssignment)
+Agent 4: T008-T010 [US4] validators.ts + assignments.ts (assignLicense) + user-detail-client.tsx (dialog)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete T001-T002: Clickable tool entries
+2. **STOP and VALIDATE**: Click any assigned tool → navigates to assignment detail
+3. Deploy/demo if ready — immediate value with minimal risk
+
+### Incremental Delivery
+
+1. US1 (Clickable tools) → Test → Deploy — single click navigation ✓
+2. US3 (Date validation) → Test → Deploy — backdate assignments ✓
+3. US4 (Workspace/API key) → Test → Deploy — complete assignment creation ✓
+4. US2 (Unified view) → Test → Deploy — clean, deduplicated UI ✓
+5. Polish (T011-T014) → Final validation
+
+### Parallel Team Strategy
+
+With multiple developers:
+1. No shared setup — start all stories immediately
+2. Developer A: US1 + US3 (quick wins, ~30 min each)
+3. Developer B: US2 (largest change, ~1-2 hours)
+4. Developer C: US4 (moderate, ~45 min)
+5. All merge and run polish phase together
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- No new files created — all modifications to existing code
+- Net code reduction expected (US2 removes ~120 lines of duplication)
+- Commit after each user story completion for clean git history

--- a/src/actions/assignments.ts
+++ b/src/actions/assignments.ts
@@ -88,6 +88,9 @@ export async function assignLicense(
     }
   }
 
+  // Encrypt API key if provided (before transaction to avoid holding connection during crypto)
+  const apiKeyEncrypted = apiKey && apiKey !== "" ? await encryptApiKey(apiKey) : null;
+
   const now = new Date();
   let newAssignmentId: number;
 
@@ -104,9 +107,6 @@ export async function assignLicense(
           eq(licenseAssignments.status, "active")
         )
       );
-
-    // Encrypt API key if provided
-    const apiKeyEncrypted = apiKey && apiKey !== "" ? await encryptApiKey(apiKey) : null;
 
     // Create new assignment with cost snapshot (FR-020)
     const [newAssignment] = await tx

--- a/src/actions/assignments.ts
+++ b/src/actions/assignments.ts
@@ -33,7 +33,7 @@ export async function assignLicense(
     return { success: false, error: "Validation failed" };
   }
 
-  const { userId, toolId, tierId } = parsed.data;
+  const { userId, toolId, tierId, workspace, apiKey } = parsed.data;
 
   // Validate user exists and is active
   const user = await db.query.users.findFirst({
@@ -105,6 +105,9 @@ export async function assignLicense(
         )
       );
 
+    // Encrypt API key if provided
+    const apiKeyEncrypted = apiKey && apiKey !== "" ? await encryptApiKey(apiKey) : null;
+
     // Create new assignment with cost snapshot (FR-020)
     const [newAssignment] = await tx
       .insert(licenseAssignments)
@@ -115,6 +118,8 @@ export async function assignLicense(
         costAtAssignmentCents: tier.monthlyCostCents,
         status: "active",
         assignedAt: now,
+        workspace: workspace ?? null,
+        apiKeyEncrypted,
       })
       .returning({ id: licenseAssignments.id });
 
@@ -231,14 +236,6 @@ export async function updateAssignment(
       // Validate not in the future
       if (newDate > new Date()) {
         return { success: false, error: "Assigned date cannot be in the future" };
-      }
-
-      // Validate not before user.createdAt
-      if (newDate < assignment.user.createdAt) {
-        return {
-          success: false,
-          error: "Assigned date cannot be before the user was created",
-        };
       }
 
       // Validate not before tool.createdAt

--- a/src/app/assignments/[id]/assignment-detail-client.tsx
+++ b/src/app/assignments/[id]/assignment-detail-client.tsx
@@ -138,12 +138,15 @@ export function AssignmentDetailClient({
   }, [isAdmin, assignment.status, loadTiers]);
 
   async function onSubmit(data: UpdateAssignmentInput) {
+    const dirtyFields = form.formState.dirtyFields;
     const payload: UpdateAssignmentInput = {
       id: data.id,
       tierId: data.tierId,
       assignedAt: data.assignedAt,
       workspace: data.workspace,
-      apiKey: data.apiKey,
+      // Only include apiKey when the field was explicitly touched to avoid
+      // unintended clearing of existing keys (empty string = clear)
+      apiKey: dirtyFields.apiKey ? data.apiKey : undefined,
     };
 
     const result = await updateAssignment(payload);

--- a/src/app/assignments/[id]/assignment-detail-client.tsx
+++ b/src/app/assignments/[id]/assignment-detail-client.tsx
@@ -244,7 +244,7 @@ export function AssignmentDetailClient({
         </p>
       </div>
 
-      {/* Detail Card */}
+      {/* Unified Assignment Details Card */}
       <Card>
         <CardHeader>
           <CardTitle>Assignment Details</CardTitle>
@@ -252,281 +252,242 @@ export function AssignmentDetailClient({
             License assignment information and configuration
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid gap-4 sm:grid-cols-2">
-            {/* Status */}
-            <div className="space-y-1">
-              <p className="text-sm font-medium text-muted-foreground">
-                Status
-              </p>
-              <Badge
-                variant={
-                  assignment.status === "active" ? "default" : "secondary"
-                }
-              >
-                {assignment.status === "active" ? "Active" : "Inactive"}
-              </Badge>
-            </div>
-
-            {/* Tier */}
-            <div className="space-y-1">
-              <p className="text-sm font-medium text-muted-foreground">Tier</p>
-              <p className="text-sm">{assignment.tier.name}</p>
-            </div>
-
-            {/* Cost */}
-            <div className="space-y-1">
-              <p className="text-sm font-medium text-muted-foreground">
-                Cost per Month
-              </p>
-              <p className="text-sm">
-                {formatCurrency(assignment.costAtAssignmentCents)}
-              </p>
-            </div>
-
-            {/* Assigned date */}
-            <div className="space-y-1">
-              <p className="text-sm font-medium text-muted-foreground">
-                Assigned Date
-              </p>
-              <p className="text-sm">
-                {assignment.assignedAt
-                  ? format(new Date(assignment.assignedAt), "PPP")
-                  : "\u2014"}
-              </p>
-            </div>
-
-            {/* Revoked date (only if inactive) */}
-            {assignment.revokedAt && (
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-muted-foreground">
-                  Revoked Date
-                </p>
-                <p className="text-sm">
-                  {format(new Date(assignment.revokedAt), "PPP")}
-                </p>
-              </div>
-            )}
-
-            {/* Workspace */}
-            <div className="space-y-1">
-              <p className="text-sm font-medium text-muted-foreground">
-                Workspace
-              </p>
-              <p className="text-sm">
-                {assignment.workspace || "\u2014"}
-              </p>
-            </div>
-          </div>
-
-          {/* API Key display section */}
-          {assignment.hasApiKey && (
-            <>
-              <Separator />
-              <div className="space-y-2">
-                <p className="text-sm font-medium text-muted-foreground">
-                  API Key
-                </p>
-                <div className="flex items-center gap-2">
-                  <code className="flex-1 rounded-md border bg-muted px-3 py-2 text-sm font-mono">
-                    {displayedKey}
-                  </code>
-                  {isAdmin && (
-                    <>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={handleRevealApiKey}
-                        disabled={revealing}
-                        title={revealedKey ? "Hide API key" : "Reveal API key"}
-                      >
-                        {revealedKey ? (
-                          <EyeOff className="size-4" />
-                        ) : (
-                          <Eye className="size-4" />
-                        )}
-                        <span className="sr-only">
-                          {revealedKey ? "Hide" : "Reveal"} API key
-                        </span>
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={handleCopyApiKey}
-                        disabled={!revealedKey}
-                        title="Copy API key"
-                      >
-                        <Copy className="size-4" />
-                        <span className="sr-only">Copy API key</span>
-                      </Button>
-                    </>
-                  )}
-                </div>
-              </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Edit Assignment Card — admin only, active assignments */}
-      {isAdmin && assignment.status === "active" && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Edit Assignment</CardTitle>
-          </CardHeader>
-          <CardContent>
+        <CardContent>
+          {isAdmin && assignment.status === "active" ? (
             <Form {...form}>
               <form
                 onSubmit={form.handleSubmit(onSubmit)}
                 className="space-y-4"
               >
-                {/* Tier */}
-                <FormField
-                  control={form.control}
-                  name="tierId"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Tier</FormLabel>
-                      <Select
-                        value={String(field.value)}
-                        onValueChange={(val) => field.onChange(Number(val))}
-                        disabled={loadingTiers || tiers.length === 0}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue
-                              placeholder={
-                                loadingTiers ? "Loading tiers..." : "Select tier"
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {/* Status */}
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Status
+                    </p>
+                    <Badge variant="default">Active</Badge>
+                  </div>
+
+                  {/* Tier (editable) */}
+                  <FormField
+                    control={form.control}
+                    name="tierId"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-sm font-medium text-muted-foreground">
+                          Tier
+                        </FormLabel>
+                        <Select
+                          value={String(field.value)}
+                          onValueChange={(val) => field.onChange(Number(val))}
+                          disabled={loadingTiers || tiers.length === 0}
+                        >
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue
+                                placeholder={
+                                  loadingTiers
+                                    ? "Loading tiers..."
+                                    : "Select tier"
+                                }
+                              />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {tiers.map((t) => (
+                              <SelectItem key={t.id} value={String(t.id)}>
+                                {t.name} &mdash;{" "}
+                                {formatCurrency(t.monthlyCostCents)}/mo
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Cost (read-only) */}
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Cost per Month
+                    </p>
+                    <p className="text-sm">
+                      {formatCurrency(assignment.costAtAssignmentCents)}
+                    </p>
+                  </div>
+
+                  {/* Assigned Date (editable) */}
+                  <FormField
+                    control={form.control}
+                    name="assignedAt"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-col">
+                        <FormLabel className="text-sm font-medium text-muted-foreground">
+                          Assigned Date
+                        </FormLabel>
+                        <Popover
+                          open={datePickerOpen}
+                          onOpenChange={setDatePickerOpen}
+                        >
+                          <PopoverTrigger asChild>
+                            <FormControl>
+                              <Button
+                                variant="outline"
+                                className={cn(
+                                  "w-full justify-start text-left font-normal",
+                                  !field.value && "text-muted-foreground"
+                                )}
+                              >
+                                <CalendarIcon className="mr-2 size-4" />
+                                {field.value
+                                  ? format(parseISO(field.value), "PPP")
+                                  : "Pick a date"}
+                              </Button>
+                            </FormControl>
+                          </PopoverTrigger>
+                          <PopoverContent
+                            className="w-auto p-0"
+                            align="start"
+                          >
+                            <Calendar
+                              mode="single"
+                              captionLayout="dropdown"
+                              selected={
+                                field.value
+                                  ? parseISO(field.value)
+                                  : undefined
+                              }
+                              onSelect={(date) => {
+                                if (date) {
+                                  field.onChange(formatDateOnly(date));
+                                }
+                                setDatePickerOpen(false);
+                              }}
+                              disabled={(date) => date > new Date()}
+                              defaultMonth={
+                                field.value
+                                  ? parseISO(field.value)
+                                  : undefined
                               }
                             />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {tiers.map((t) => (
-                            <SelectItem key={t.id} value={String(t.id)}>
-                              {t.name} &mdash;{" "}
-                              {formatCurrency(t.monthlyCostCents)}/mo
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                          </PopoverContent>
+                        </Popover>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
 
-                {/* Assigned Date */}
-                <FormField
-                  control={form.control}
-                  name="assignedAt"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-col">
-                      <FormLabel>Assigned Date</FormLabel>
-                      <Popover
-                        open={datePickerOpen}
-                        onOpenChange={setDatePickerOpen}
-                      >
-                        <PopoverTrigger asChild>
-                          <FormControl>
-                            <Button
-                              variant="outline"
-                              className={cn(
-                                "w-full justify-start text-left font-normal",
-                                !field.value && "text-muted-foreground"
-                              )}
-                            >
-                              <CalendarIcon className="mr-2 size-4" />
-                              {field.value
-                                ? format(parseISO(field.value), "PPP")
-                                : "Pick a date"}
-                            </Button>
-                          </FormControl>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calendar
-                            mode="single"
-                            captionLayout="dropdown"
-                            selected={
-                              field.value ? parseISO(field.value) : undefined
-                            }
-                            onSelect={(date) => {
-                              if (date) {
-                                field.onChange(formatDateOnly(date));
-                              }
-                              setDatePickerOpen(false);
-                            }}
-                            disabled={(date) => date > new Date()}
-                            defaultMonth={
-                              field.value ? parseISO(field.value) : undefined
-                            }
-                          />
-                        </PopoverContent>
-                      </Popover>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                {/* Workspace */}
-                <FormField
-                  control={form.control}
-                  name="workspace"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Workspace</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder="e.g. team-alpha"
-                          maxLength={200}
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                {/* API Key */}
-                <FormField
-                  control={form.control}
-                  name="apiKey"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>API Key</FormLabel>
-                      <div className="flex gap-2">
+                  {/* Workspace (editable) */}
+                  <FormField
+                    control={form.control}
+                    name="workspace"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-sm font-medium text-muted-foreground">
+                          Workspace
+                        </FormLabel>
                         <FormControl>
                           <Input
-                            type={showApiKey ? "text" : "password"}
-                            placeholder={
-                              assignment.hasApiKey
-                                ? "Enter new key to replace existing"
-                                : "Enter API key"
-                            }
+                            placeholder="e.g. team-alpha"
+                            maxLength={200}
                             {...field}
                           />
                         </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {/* API Key (editable) */}
+                <Separator />
+                <div className="space-y-2">
+                  {assignment.hasApiKey && (
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium text-muted-foreground">
+                        Current API Key
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <code className="flex-1 rounded-md border bg-muted px-3 py-2 text-sm font-mono">
+                          {displayedKey}
+                        </code>
                         <Button
                           type="button"
                           variant="ghost"
                           size="icon"
-                          onClick={() => setShowApiKey(!showApiKey)}
+                          onClick={handleRevealApiKey}
+                          disabled={revealing}
+                          title={
+                            revealedKey ? "Hide API key" : "Reveal API key"
+                          }
                         >
-                          {showApiKey ? (
+                          {revealedKey ? (
                             <EyeOff className="size-4" />
                           ) : (
                             <Eye className="size-4" />
                           )}
                           <span className="sr-only">
-                            {showApiKey ? "Hide" : "Show"} API key input
+                            {revealedKey ? "Hide" : "Reveal"} API key
                           </span>
                         </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={handleCopyApiKey}
+                          disabled={!revealedKey}
+                          title="Copy API key"
+                        >
+                          <Copy className="size-4" />
+                          <span className="sr-only">Copy API key</span>
+                        </Button>
                       </div>
-                      <FormMessage />
-                    </FormItem>
+                    </div>
                   )}
-                />
+                  <FormField
+                    control={form.control}
+                    name="apiKey"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {assignment.hasApiKey
+                            ? "Replace API Key"
+                            : "API Key"}
+                        </FormLabel>
+                        <div className="flex gap-2">
+                          <FormControl>
+                            <Input
+                              type={showApiKey ? "text" : "password"}
+                              placeholder={
+                                assignment.hasApiKey
+                                  ? "Enter new key to replace existing"
+                                  : "Enter API key"
+                              }
+                              {...field}
+                            />
+                          </FormControl>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setShowApiKey(!showApiKey)}
+                          >
+                            {showApiKey ? (
+                              <EyeOff className="size-4" />
+                            ) : (
+                              <Eye className="size-4" />
+                            )}
+                            <span className="sr-only">
+                              {showApiKey ? "Hide" : "Show"} API key input
+                            </span>
+                          </Button>
+                        </div>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
 
                 <Button
                   type="submit"
@@ -538,9 +499,132 @@ export function AssignmentDetailClient({
                 </Button>
               </form>
             </Form>
-          </CardContent>
-        </Card>
-      )}
+          ) : (
+            <div className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                {/* Status */}
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-muted-foreground">
+                    Status
+                  </p>
+                  <Badge
+                    variant={
+                      assignment.status === "active" ? "default" : "secondary"
+                    }
+                  >
+                    {assignment.status === "active" ? "Active" : "Inactive"}
+                  </Badge>
+                </div>
+
+                {/* Tier */}
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-muted-foreground">
+                    Tier
+                  </p>
+                  <p className="text-sm">{assignment.tier.name}</p>
+                </div>
+
+                {/* Cost */}
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-muted-foreground">
+                    Cost per Month
+                  </p>
+                  <p className="text-sm">
+                    {formatCurrency(assignment.costAtAssignmentCents)}
+                  </p>
+                </div>
+
+                {/* Assigned date */}
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-muted-foreground">
+                    Assigned Date
+                  </p>
+                  <p className="text-sm">
+                    {assignment.assignedAt
+                      ? format(new Date(assignment.assignedAt), "PPP")
+                      : "\u2014"}
+                  </p>
+                </div>
+
+                {/* Revoked date (only if inactive) */}
+                {assignment.revokedAt && (
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">
+                      Revoked Date
+                    </p>
+                    <p className="text-sm">
+                      {format(new Date(assignment.revokedAt), "PPP")}
+                    </p>
+                  </div>
+                )}
+
+                {/* Workspace */}
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-muted-foreground">
+                    Workspace
+                  </p>
+                  <p className="text-sm">
+                    {assignment.workspace || "\u2014"}
+                  </p>
+                </div>
+              </div>
+
+              {/* API Key display section */}
+              {assignment.hasApiKey && (
+                <>
+                  <Separator />
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-muted-foreground">
+                      API Key
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 rounded-md border bg-muted px-3 py-2 text-sm font-mono">
+                        {displayedKey}
+                      </code>
+                      {isAdmin && (
+                        <>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={handleRevealApiKey}
+                            disabled={revealing}
+                            title={
+                              revealedKey
+                                ? "Hide API key"
+                                : "Reveal API key"
+                            }
+                          >
+                            {revealedKey ? (
+                              <EyeOff className="size-4" />
+                            ) : (
+                              <Eye className="size-4" />
+                            )}
+                            <span className="sr-only">
+                              {revealedKey ? "Hide" : "Reveal"} API key
+                            </span>
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={handleCopyApiKey}
+                            disabled={!revealedKey}
+                            title="Copy API key"
+                          >
+                            <Copy className="size-4" />
+                            <span className="sr-only">Copy API key</span>
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Comments Section */}
       <Card>

--- a/src/app/users/[id]/user-detail-client.tsx
+++ b/src/app/users/[id]/user-detail-client.tsx
@@ -13,7 +13,8 @@ import { getTools, getToolWithTiers } from "@/actions/tools";
 import { formatCurrency, formatDate } from "@/lib/utils";
 import type { User, ChangeHistoryRecord, CostData, AiTool, AccessTier } from "@/types";
 import { AdminCostSection } from "@/components/profile/admin-cost-section";
-import { Github, ExternalLink, BookOpen, KeyRound, Plus, RotateCcw } from "lucide-react";
+import { Github, ExternalLink, BookOpen, KeyRound, Plus, RotateCcw, Eye, EyeOff } from "lucide-react";
+import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -111,6 +112,9 @@ export function UserDetailClient({
   const [availableTiers, setAvailableTiers] = useState<AccessTier[]>([]);
   const [assigning, setAssigning] = useState(false);
   const [reactivatingId, setReactivatingId] = useState<number | null>(null);
+  const [assignWorkspace, setAssignWorkspace] = useState("");
+  const [assignApiKey, setAssignApiKey] = useState("");
+  const [showAssignApiKey, setShowAssignApiKey] = useState(false);
 
   const form = useForm<EditUserInput>({
     resolver: zodResolver(editUserSchema),
@@ -174,6 +178,8 @@ export function UserDetailClient({
       userId: user.id,
       toolId: Number(selectedToolId),
       tierId: Number(selectedTierId),
+      workspace: assignWorkspace || undefined,
+      apiKey: assignApiKey || undefined,
     });
     setAssigning(false);
     if (result.success) {
@@ -181,6 +187,9 @@ export function UserDetailClient({
       setAssignDialogOpen(false);
       setSelectedToolId("");
       setSelectedTierId("");
+      setAssignWorkspace("");
+      setAssignApiKey("");
+      setShowAssignApiKey(false);
       router.refresh();
     } else {
       toast.error(result.error);
@@ -481,7 +490,10 @@ export function UserDetailClient({
                   key={a.id}
                   className="flex items-center justify-between rounded-lg border p-3"
                 >
-                  <div>
+                  <Link
+                    href={`/assignments/${a.id}`}
+                    className="flex-1 hover:bg-muted/50 -m-1 p-1 rounded transition-colors"
+                  >
                     <p className="font-medium">{a.tool.name}</p>
                     <p className="text-sm text-muted-foreground">
                       {a.tier.name} &bull;{" "}
@@ -491,7 +503,7 @@ export function UserDetailClient({
                       Assigned {formatDate(a.assignedAt)}
                       {a.revokedAt && ` — Revoked ${formatDate(a.revokedAt)}`}
                     </p>
-                  </div>
+                  </Link>
                   <div className="flex items-center gap-2">
                     <Badge
                       variant={
@@ -601,6 +613,42 @@ export function UserDetailClient({
                   ))}
                 </SelectContent>
               </Select>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Workspace (optional)</label>
+              <Input
+                placeholder="e.g. team-alpha"
+                maxLength={200}
+                value={assignWorkspace}
+                onChange={(e) => setAssignWorkspace(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">API Key (optional)</label>
+              <div className="flex gap-2">
+                <Input
+                  type={showAssignApiKey ? "text" : "password"}
+                  placeholder="Enter API key"
+                  maxLength={500}
+                  value={assignApiKey}
+                  onChange={(e) => setAssignApiKey(e.target.value)}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setShowAssignApiKey(!showAssignApiKey)}
+                >
+                  {showAssignApiKey ? (
+                    <EyeOff className="size-4" />
+                  ) : (
+                    <Eye className="size-4" />
+                  )}
+                  <span className="sr-only">
+                    {showAssignApiKey ? "Hide" : "Show"} API key
+                  </span>
+                </Button>
+              </div>
             </div>
           </div>
           <DialogFooter>

--- a/src/app/users/[id]/user-detail-client.tsx
+++ b/src/app/users/[id]/user-detail-client.tsx
@@ -574,7 +574,16 @@ export function UserDetailClient({
       </Card>
 
       {/* Assign License Dialog */}
-      <Dialog open={assignDialogOpen} onOpenChange={setAssignDialogOpen}>
+      <Dialog open={assignDialogOpen} onOpenChange={(open) => {
+        setAssignDialogOpen(open);
+        if (!open) {
+          setSelectedToolId("");
+          setSelectedTierId("");
+          setAssignWorkspace("");
+          setAssignApiKey("");
+          setShowAssignApiKey(false);
+        }
+      }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Assign License to {user.name}</DialogTitle>

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -98,7 +98,7 @@ export const bulkImportAssignmentRowSchema = z.object({
   tool: z.string().min(1).max(255),
   tier: z.string().min(1).max(100),
   workspace: z.string().max(200).optional(),
-  apiKey: z.string().max(500).optional(),
+  apiKey: apiKeyField,
   assignedAt: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD format")

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -54,18 +54,21 @@ export const bulkImportUserSchema = z.object({
   profile: z.enum(["boost", "maxed", "indie"]).optional(),
 });
 
+// Shared API key field validation
+const apiKeyField = z
+  .string()
+  .max(500)
+  .refine((val) => val === "" || val.trim().length > 0, { message: "API key cannot be blank" })
+  .transform((val) => (val === "" ? val : val.trim()))
+  .optional();
+
 // Assignment
 export const assignmentSchema = z.object({
   userId: z.number().int().positive(),
   toolId: z.number().int().positive(),
   tierId: z.number().int().positive(),
   workspace: z.string().max(200).optional(),
-  apiKey: z
-    .string()
-    .max(500)
-    .refine((val) => val === "" || val.trim().length > 0, { message: "API key cannot be blank" })
-    .transform((val) => (val === "" ? val : val.trim()))
-    .optional(),
+  apiKey: apiKeyField,
 });
 
 // Budget
@@ -113,12 +116,7 @@ export const updateAssignmentSchema = z.object({
   tierId: z.number().int().positive().optional(),
   assignedAt: z.string().optional(),
   workspace: z.string().max(200).optional(),
-  apiKey: z
-    .string()
-    .max(500)
-    .refine((val) => val === "" || val.trim().length > 0, { message: "API key cannot be blank" })
-    .transform((val) => (val === "" ? val : val.trim()))
-    .optional(),
+  apiKey: apiKeyField,
 });
 
 // Assignment comment

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -59,6 +59,13 @@ export const assignmentSchema = z.object({
   userId: z.number().int().positive(),
   toolId: z.number().int().positive(),
   tierId: z.number().int().positive(),
+  workspace: z.string().max(200).optional(),
+  apiKey: z
+    .string()
+    .max(500)
+    .refine((val) => val === "" || val.trim().length > 0, { message: "API key cannot be blank" })
+    .transform((val) => (val === "" ? val : val.trim()))
+    .optional(),
 });
 
 // Budget


### PR DESCRIPTION
## Summary

- **Clickable assigned tools**: Tool entries on user detail page now link directly to assignment detail (`/assignments/{id}`)
- **Unified assignment detail**: Merged duplicate detail card and edit form into a single card with inline edit controls for admins
- **Relaxed date validation**: Assignment dates before user creation are now allowed (tool creation date check remains)
- **Workspace & API key on new assignment**: Added optional workspace and API key fields to the license assignment dialog

## Test plan

- [ ] Navigate to user detail → verify tool entries are clickable links to assignment detail
- [ ] Open active assignment detail → verify single card with inline edit controls, no duplicate fields
- [ ] Open revoked assignment detail → verify read-only view with no edit controls
- [ ] Edit assignment date to before user creation → verify it succeeds
- [ ] Edit assignment date to future → verify it's rejected
- [ ] Create new assignment with workspace and API key → verify values appear on assignment detail
- [ ] Create new assignment without workspace/API key → verify it still works (optional fields)
- [ ] Run `pnpm typecheck` and `pnpm lint` → verify zero errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)