### PR TITLE
Remove Copilot billing-to-budget auto-link

### DIFF
--- a/src/actions/copilot-data.ts
+++ b/src/actions/copilot-data.ts
@@ -10,11 +10,8 @@ import {
   accessTiers,
   githubSyncEvents,
   githubConnections,
-  billedCosts,
-  budgetPeriods,
-  annualBudgets,
 } from "@/lib/db/schema";
-import { and, sql, desc, asc, gte, lte, eq, or, ilike, isNull, sum, gt, inArray } from "drizzle-orm";
+import { and, sql, desc, asc, gte, lte, eq, or, ilike } from "drizzle-orm";
 import { requireAdmin } from "@/lib/auth-helpers";
 import {
   copilotDateRangeSchema,
@@ -26,7 +23,6 @@ import type {
   CopilotOverviewData,
   CopilotBillingData,
   CopilotAnalyticsData,
-  BillingSyncConflict,
 } from "@/types";
 
 async function getActiveConnection() {
@@ -367,8 +363,6 @@ export async function getCopilotBillingSyncHistory(): Promise<
     completedAt: string | null;
     status: string;
     billingProcessed: number | null;
-    billingLinked: number | null;
-    billingSkipped: number | null;
     errorMessage: string | null;
   }>>
 > {
@@ -389,8 +383,6 @@ export async function getCopilotBillingSyncHistory(): Promise<
       completedAt: githubSyncEvents.completedAt,
       status: githubSyncEvents.status,
       billingProcessed: githubSyncEvents.billingProcessed,
-      billingLinked: githubSyncEvents.billingLinked,
-      billingSkipped: githubSyncEvents.billingSkipped,
       errorMessage: githubSyncEvents.errorMessage,
     })
     .from(githubSyncEvents)
@@ -406,67 +398,9 @@ export async function getCopilotBillingSyncHistory(): Promise<
       completedAt: row.completedAt?.toISOString() ?? null,
       status: row.status,
       billingProcessed: row.billingProcessed,
-      billingLinked: row.billingLinked,
-      billingSkipped: row.billingSkipped,
       errorMessage: row.errorMessage,
     })),
   };
-}
-
-async function findBillingSyncConflicts(
-  connectionId: number
-): Promise<BillingSyncConflict[]> {
-  // Single query: JOIN unlinked snapshots → budget periods → manual billed costs
-  const rows = await db
-    .select({
-      billingMonth: copilotBillingSnapshots.billingMonth,
-      snapshotAmountCents: copilotBillingSnapshots.totalCostCents,
-      manualEntryAmountCents: billedCosts.amountCents,
-      manualEntryDescription: billedCosts.description,
-      periodLabel: budgetPeriods.periodLabel,
-    })
-    .from(copilotBillingSnapshots)
-    .innerJoin(
-      budgetPeriods,
-      and(
-        lte(budgetPeriods.startDate, copilotBillingSnapshots.billingMonth),
-        gt(budgetPeriods.endDate, copilotBillingSnapshots.billingMonth)
-      )
-    )
-    .innerJoin(annualBudgets, and(
-      eq(budgetPeriods.budgetId, annualBudgets.id),
-      eq(annualBudgets.status, "active")
-    ))
-    .innerJoin(
-      billedCosts,
-      and(
-        eq(billedCosts.periodId, budgetPeriods.id),
-        sql`${billedCosts.invoiceDate}::text LIKE substring(${copilotBillingSnapshots.billingMonth}::text from 1 for 7) || '%'`,
-        sql`(${billedCosts.vendorReference} IS NULL OR ${billedCosts.vendorReference} NOT LIKE 'github-billing-%')`,
-        sql`${billedCosts.description} ILIKE '%copilot%'`
-      )
-    )
-    .where(
-      and(
-        eq(copilotBillingSnapshots.connectionId, connectionId),
-        isNull(copilotBillingSnapshots.linkedBilledCostId)
-      )
-    );
-
-  return rows;
-}
-
-export async function getBillingSyncConflicts(): Promise<ActionResult<BillingSyncConflict[]>> {
-  const admin = await requireAdmin();
-  if (!admin) return { success: false, error: "Unauthorized" };
-
-  const connection = await getActiveConnection();
-  if (!connection) {
-    return { success: true, data: [] };
-  }
-
-  const conflicts = await findBillingSyncConflicts(connection.id);
-  return { success: true, data: conflicts };
 }
 
 export async function getCopilotBilling(
@@ -497,7 +431,7 @@ export async function getCopilotBilling(
   if (since) conditions.push(gte(copilotBillingSnapshots.billingMonth, since));
   if (until) conditions.push(lte(copilotBillingSnapshots.billingMonth, until));
 
-  // Query billing snapshots with LEFT JOIN to billedCosts and budgetPeriods
+  // Query billing snapshots
   const snapshots = await db
     .select({
       id: copilotBillingSnapshots.id,
@@ -507,52 +441,10 @@ export async function getCopilotBilling(
       activeSeats: copilotBillingSnapshots.activeSeats,
       seatCostCents: copilotBillingSnapshots.seatCostCents,
       totalCostCents: copilotBillingSnapshots.totalCostCents,
-      linkedBilledCostId: copilotBillingSnapshots.linkedBilledCostId,
-      periodLabel: budgetPeriods.periodLabel,
-      periodId: billedCosts.periodId,
-      periodPlannedAmountCents: budgetPeriods.plannedAmountCents,
     })
     .from(copilotBillingSnapshots)
-    .leftJoin(
-      billedCosts,
-      eq(copilotBillingSnapshots.linkedBilledCostId, billedCosts.id)
-    )
-    .leftJoin(budgetPeriods, eq(billedCosts.periodId, budgetPeriods.id))
     .where(and(...conditions))
     .orderBy(asc(copilotBillingSnapshots.billingMonth));
-
-  // For linked snapshots, compute period utilization (sum of period billedCosts / plannedAmountCents)
-  const periodIds = new Set<number>();
-  for (const s of snapshots) {
-    if (s.periodId !== null) {
-      periodIds.add(s.periodId);
-    }
-  }
-
-  const periodUtilizationMap = new Map<number, number>();
-  if (periodIds.size > 0) {
-    const periodIdArray = Array.from(periodIds);
-    const periodSums = await db
-      .select({
-        periodId: billedCosts.periodId,
-        totalBilledCents: sum(billedCosts.amountCents),
-      })
-      .from(billedCosts)
-      .where(inArray(billedCosts.periodId, periodIdArray))
-      .groupBy(billedCosts.periodId);
-
-    for (const ps of periodSums) {
-      const totalBilled = Number(ps.totalBilledCents ?? 0);
-      periodUtilizationMap.set(ps.periodId, totalBilled);
-    }
-  }
-
-  // Get conflicts for unlinked snapshots (to determine "conflict" vs "unlinked" status)
-  const conflicts = await findBillingSyncConflicts(connection.id);
-  const conflictMonths = new Set<string>();
-  for (const c of conflicts) {
-    conflictMonths.add(c.billingMonth);
-  }
 
   // Current month = latest snapshot
   const latestSnapshot = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
@@ -569,36 +461,15 @@ export async function getCopilotBilling(
       ? Math.round(latestSnapshot.totalCostCents / latestSnapshot.activeSeats)
       : 0;
 
-  // Build trends with budget context
-  const trends = snapshots.map((s) => {
-    let linkStatus: "linked" | "unlinked" | "conflict" = "unlinked";
-    if (s.linkedBilledCostId !== null) {
-      linkStatus = "linked";
-    } else if (conflictMonths.has(s.billingMonth)) {
-      linkStatus = "conflict";
-    }
-
-    let linkedPeriodUtilization: number | null = null;
-    if (s.periodId !== null && s.periodPlannedAmountCents !== null && s.periodPlannedAmountCents > 0) {
-      const totalBilled = periodUtilizationMap.get(s.periodId) ?? 0;
-      linkedPeriodUtilization = Math.round(
-        (totalBilled / s.periodPlannedAmountCents) * 100
-      );
-    }
-
-    return {
-      month: s.billingMonth,
-      totalCostCents: s.totalCostCents,
-      totalSeats: s.totalSeats,
-      activeSeats: s.activeSeats,
-      costPerActiveUserCents:
-        s.activeSeats > 0 ? Math.round(s.totalCostCents / s.activeSeats) : 0,
-      linkedBilledCostId: s.linkedBilledCostId,
-      linkedPeriodLabel: s.periodLabel ?? null,
-      linkedPeriodUtilization,
-      linkStatus,
-    };
-  });
+  // Build trends
+  const trends = snapshots.map((s) => ({
+    month: s.billingMonth,
+    totalCostCents: s.totalCostCents,
+    totalSeats: s.totalSeats,
+    activeSeats: s.activeSeats,
+    costPerActiveUserCents:
+      s.activeSeats > 0 ? Math.round(s.totalCostCents / s.activeSeats) : 0,
+  }));
 
   return {
     success: true,

--- a/src/actions/copilot.ts
+++ b/src/actions/copilot.ts
@@ -8,7 +8,7 @@ import {
   copilotBillingSnapshots,
   licenseAssignments,
 } from "@/lib/db/schema";
-import { eq, and, sql, desc, count, ne, isNotNull } from "drizzle-orm";
+import { eq, and, sql, desc, count, ne } from "drizzle-orm";
 import { requireAdmin } from "@/lib/auth-helpers";
 import { decryptApiKey } from "@/lib/crypto";
 import { validateCopilotScopes } from "@/lib/copilot-api";
@@ -146,13 +146,13 @@ export async function getCopilotSyncStatus(): Promise<
         lastSyncStatus: null,
         nextScheduledSync: null,
         dataRange: null,
-        recordCounts: { metrics: 0, billing: 0, seats: 0, linkedBillingMonths: 0 },
+        recordCounts: { metrics: 0, billing: 0, seats: 0 },
       },
     };
   }
 
   // Run all independent queries in parallel
-  const [lastSync, [dateRange], [metricsCount], [billingCount], [seatsCount], [linkedBillingCount]] =
+  const [lastSync, [dateRange], [metricsCount], [billingCount], [seatsCount]] =
     await Promise.all([
       db.query.githubSyncEvents.findFirst({
         where: and(
@@ -181,15 +181,6 @@ export async function getCopilotSyncStatus(): Promise<
         .select({ value: count() })
         .from(licenseAssignments)
         .where(eq(licenseAssignments.source, "copilot-sync")),
-      db
-        .select({ value: count() })
-        .from(copilotBillingSnapshots)
-        .where(
-          and(
-            eq(copilotBillingSnapshots.connectionId, connection.id),
-            isNotNull(copilotBillingSnapshots.linkedBilledCostId)
-          )
-        ),
     ]);
 
   const dataRange =
@@ -216,7 +207,6 @@ export async function getCopilotSyncStatus(): Promise<
         metrics: metricsCount?.value ?? 0,
         billing: billingCount?.value ?? 0,
         seats: seatsCount?.value ?? 0,
-        linkedBillingMonths: linkedBillingCount?.value ?? 0,
       },
     },
   };

--- a/src/app/copilot/billing/page.tsx
+++ b/src/app/copilot/billing/page.tsx
@@ -2,13 +2,6 @@ import { getCopilotBilling } from "@/actions/copilot-data";
 import { BillingTrendChart } from "@/components/copilot/billing-trend-chart";
 import { CostUtilizationChart } from "@/components/copilot/cost-utilization-chart";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import {
   Table,
   TableBody,
@@ -90,8 +83,7 @@ export default async function CopilotBillingPage() {
             <CardTitle className="text-sm font-medium">Monthly Billing Details</CardTitle>
           </CardHeader>
           <CardContent>
-            <TooltipProvider>
-              <Table>
+            <Table>
                 <TableHeader>
                   <TableRow>
                     <TableHead>Month</TableHead>
@@ -99,8 +91,6 @@ export default async function CopilotBillingPage() {
                     <TableHead className="text-right">Seats</TableHead>
                     <TableHead className="text-right">Active</TableHead>
                     <TableHead className="text-right">Cost / User</TableHead>
-                    <TableHead>Budget Period</TableHead>
-                    <TableHead>Status</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -125,62 +115,10 @@ export default async function CopilotBillingPage() {
                       <TableCell className="text-right text-sm">
                         {formatCurrency(trend.costPerActiveUserCents)}
                       </TableCell>
-                      <TableCell className="text-sm">
-                        {trend.linkedPeriodLabel ? (
-                          <span>
-                            {trend.linkedPeriodLabel}
-                            {trend.linkedPeriodUtilization !== null && (
-                              <span className="ml-1 text-xs text-muted-foreground">
-                                ({trend.linkedPeriodUtilization}%)
-                              </span>
-                            )}
-                          </span>
-                        ) : (
-                          <span className="text-muted-foreground">-</span>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        {trend.linkStatus === "linked" && (
-                          <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 hover:bg-green-100">
-                            Linked
-                          </Badge>
-                        )}
-                        {trend.linkStatus === "unlinked" && (
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <Badge
-                                variant="secondary"
-                                className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 hover:bg-yellow-100"
-                              >
-                                Unlinked
-                              </Badge>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>No matching budget period</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        )}
-                        {trend.linkStatus === "conflict" && (
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <Badge
-                                variant="destructive"
-                                className="bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200 hover:bg-red-100"
-                              >
-                                Conflict
-                              </Badge>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>A manual cost entry already exists for this period</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        )}
-                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
               </Table>
-            </TooltipProvider>
           </CardContent>
         </Card>
       )}

--- a/src/lib/budget-utils.ts
+++ b/src/lib/budget-utils.ts
@@ -60,16 +60,6 @@ export async function findPeriodForDate(
   return rows[0] ?? null;
 }
 
-/**
- * Build a vendor reference string for Copilot billing sync.
- * Format: github-billing-copilot-YYYY-MM
- */
-export function buildCopilotVendorRef(billingMonth: string): string {
-  const date = new Date(billingMonth);
-  const yyyy = date.getUTCFullYear();
-  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
-  return `github-billing-copilot-${yyyy}-${mm}`;
-}
 
 /** Return type for getRunningCostsForPeriod */
 export interface RunningCostsResult {

--- a/src/lib/copilot-sync.ts
+++ b/src/lib/copilot-sync.ts
@@ -8,7 +8,6 @@ import {
   githubSyncEvents,
   copilotUsageMetrics,
   copilotBillingSnapshots,
-  billedCosts,
 } from "@/lib/db/schema";
 import {
   fetchCopilotBilling,
@@ -16,10 +15,7 @@ import {
   fetchCopilotMetrics,
 } from "@/lib/copilot-api";
 import { decryptApiKey } from "@/lib/crypto";
-import { findActivePeriodForDate, buildCopilotVendorRef } from "@/lib/budget-utils";
-import { recordCreation, recordUpdate } from "@/actions/history";
-import { eq, and, desc, sql, inArray } from "drizzle-orm";
-import type { BillingLinkResult } from "@/types";
+import { eq, and, desc } from "drizzle-orm";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,8 +29,6 @@ interface SyncConnection {
 interface BillingSyncResult {
   seatsProcessed: number;
   billingProcessed: number;
-  billingLinkResult: BillingLinkResult | null;
-  billingLinkError: string | null;
 }
 
 interface SeatSyncResult {
@@ -51,8 +45,7 @@ interface MetricsSyncResult {
 
 export async function syncBillingData(
   connection: SyncConnection,
-  token: string,
-  adminUserId: number
+  token: string
 ): Promise<BillingSyncResult> {
   const billingResponse = await fetchCopilotBilling(
     token,
@@ -150,219 +143,10 @@ export async function syncBillingData(
       },
     });
 
-  // Sync billing data to budget periods
-  let billingLinkResult: BillingLinkResult | null = null;
-  let billingLinkError: string | null = null;
-  try {
-    billingLinkResult = await syncBillingToBudget(connection.id, adminUserId);
-  } catch (err) {
-    console.error("Billing-to-budget linking failed:", err);
-    billingLinkError = `Billing-to-budget linking failed: ${err instanceof Error ? err.message : String(err)}`;
-  }
-
   return {
     seatsProcessed: billing.seat_breakdown.total,
     billingProcessed: 1,
-    billingLinkResult,
-    billingLinkError,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Function 1b: syncBillingToBudget
-// ---------------------------------------------------------------------------
-
-async function syncBillingToBudget(
-  connectionId: number,
-  adminUserId: number
-): Promise<BillingLinkResult> {
-  const result: BillingLinkResult = { linked: 0, skipped: 0, conflicts: [] };
-
-  // Fetch up to 12 months of billing snapshots for this connection
-  const snapshots = await db
-    .select()
-    .from(copilotBillingSnapshots)
-    .where(eq(copilotBillingSnapshots.connectionId, connectionId))
-    .orderBy(desc(copilotBillingSnapshots.billingMonth))
-    .limit(12);
-
-  if (snapshots.length === 0) return result;
-
-  // Batch-prefetch: find budget periods for all snapshot months in one query
-  const periodMap = new Map<string, { id: number; periodLabel: string }>();
-  for (const snapshot of snapshots) {
-    const period = await findActivePeriodForDate(snapshot.billingMonth);
-    if (period) {
-      periodMap.set(snapshot.billingMonth, period);
-    }
-  }
-
-  // Batch-prefetch: get all existing billed costs for matched period IDs
-  const periodIds = [...new Set([...periodMap.values()].map((p) => p.id))];
-
-  // Also collect already-linked billed cost IDs from snapshots
-  const linkedCostIds = snapshots
-    .map((s) => s.linkedBilledCostId)
-    .filter((id): id is number => id !== null);
-
-  const existingCostsByRef = new Map<string, typeof billedCostsRows[number]>();
-  const existingCostsById = new Map<number, typeof billedCostsRows[number]>();
-  const manualCopilotCostsByPeriodMonth = new Map<string, typeof billedCostsRows[number]>();
-
-  const billedCostsRows = periodIds.length > 0
-    ? await db
-        .select()
-        .from(billedCosts)
-        .where(inArray(billedCosts.periodId, periodIds))
-    : [];
-
-  // If there are linked cost IDs not covered by periodIds, fetch those too
-  const fetchedCostIds = new Set(billedCostsRows.map((c) => c.id));
-  const missingLinkedIds = linkedCostIds.filter((id) => !fetchedCostIds.has(id));
-  if (missingLinkedIds.length > 0) {
-    const extraCosts = await db
-      .select()
-      .from(billedCosts)
-      .where(inArray(billedCosts.id, missingLinkedIds));
-    billedCostsRows.push(...extraCosts);
-  }
-
-  for (const cost of billedCostsRows) {
-    // Index by ID for linked-snapshot lookups
-    existingCostsById.set(cost.id, cost);
-    // Index by "periodId:vendorRef" for vendor-ref lookups
-    if (cost.vendorReference) {
-      existingCostsByRef.set(`${cost.periodId}:${cost.vendorReference}`, cost);
-    }
-    // Index potential manual Copilot entries for conflict detection:
-    // only entries without a github-billing vendor ref AND with a Copilot-related description
-    if (
-      (!cost.vendorReference || !cost.vendorReference.startsWith("github-billing-")) &&
-      cost.description &&
-      /copilot/i.test(cost.description)
-    ) {
-      const invoiceMonth = String(cost.invoiceDate ?? "").substring(0, 7);
-      if (invoiceMonth) {
-        const key = `${cost.periodId}:${invoiceMonth}`;
-        if (!manualCopilotCostsByPeriodMonth.has(key)) {
-          manualCopilotCostsByPeriodMonth.set(key, cost);
-        }
-      }
-    }
-  }
-
-  for (const snapshot of snapshots) {
-    const vendorRef = buildCopilotVendorRef(snapshot.billingMonth);
-
-    // (a) Find matching budget period from prefetched map
-    const period = periodMap.get(snapshot.billingMonth);
-    if (!period) {
-      result.skipped++;
-      result.conflicts.push({
-        billingMonth: snapshot.billingMonth,
-        reason: "no_matching_period",
-      });
-      continue;
-    }
-
-    // (b) If snapshot is already linked to a billed cost, update it directly
-    if (snapshot.linkedBilledCostId !== null) {
-      const linked = existingCostsById.get(snapshot.linkedBilledCostId);
-      if (linked) {
-        const description = `GitHub Copilot — ${snapshot.billingMonth.substring(0, 7)}`;
-        await db
-          .update(billedCosts)
-          .set({
-            amountCents: snapshot.totalCostCents,
-            description,
-            vendorReference: vendorRef,
-            updatedAt: new Date(),
-          })
-          .where(eq(billedCosts.id, linked.id));
-
-        await recordUpdate("billed_cost", linked.id, adminUserId, {
-          amountCents: { old: linked.amountCents, new: snapshot.totalCostCents },
-        });
-
-        result.linked++;
-        continue;
-      }
-      // Linked cost was deleted — clear stale link and fall through to create/match
-      await db
-        .update(copilotBillingSnapshots)
-        .set({ linkedBilledCostId: null, updatedAt: new Date() })
-        .where(eq(copilotBillingSnapshots.id, snapshot.id));
-    }
-
-    // (c) Check for existing billed cost with matching vendor reference
-    const existing = existingCostsByRef.get(`${period.id}:${vendorRef}`);
-
-    if (existing) {
-      // (d) UPDATE existing entry
-      const description = `GitHub Copilot — ${snapshot.billingMonth.substring(0, 7)}`;
-      await db
-        .update(billedCosts)
-        .set({
-          amountCents: snapshot.totalCostCents,
-          description,
-          updatedAt: new Date(),
-        })
-        .where(eq(billedCosts.id, existing.id));
-
-      await recordUpdate("billed_cost", existing.id, adminUserId, {
-        amountCents: { old: existing.amountCents, new: snapshot.totalCostCents },
-      });
-
-      // Update snapshot link
-      await db
-        .update(copilotBillingSnapshots)
-        .set({ linkedBilledCostId: existing.id, updatedAt: new Date() })
-        .where(eq(copilotBillingSnapshots.id, snapshot.id));
-
-      result.linked++;
-      continue;
-    }
-
-    // (e) Check for manual Copilot conflict (only entries with Copilot-related description)
-    const billingMonthPrefix = snapshot.billingMonth.substring(0, 7); // YYYY-MM
-    const manualConflict = manualCopilotCostsByPeriodMonth.get(`${period.id}:${billingMonthPrefix}`);
-
-    if (manualConflict) {
-      // (f) Skip — manual Copilot entry conflict
-      result.skipped++;
-      result.conflicts.push({
-        billingMonth: snapshot.billingMonth,
-        reason: "manual_entry_exists",
-        existingDescription: manualConflict.description,
-      });
-      continue;
-    }
-
-    // (g) INSERT new billed cost
-    const description = `GitHub Copilot — ${snapshot.billingMonth.substring(0, 7)}`;
-    const [created] = await db
-      .insert(billedCosts)
-      .values({
-        periodId: period.id,
-        amountCents: snapshot.totalCostCents,
-        invoiceDate: snapshot.billingMonth,
-        description,
-        vendorReference: vendorRef,
-      })
-      .returning({ id: billedCosts.id });
-
-    await recordCreation("billed_cost", created.id, adminUserId);
-
-    // Update snapshot link
-    await db
-      .update(copilotBillingSnapshots)
-      .set({ linkedBilledCostId: created.id, updatedAt: new Date() })
-      .where(eq(copilotBillingSnapshots.id, snapshot.id));
-
-    result.linked++;
-  }
-
-  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -733,7 +517,7 @@ export async function runCopilotSync(
 
   // Sync billing data
   try {
-    billingResult = await syncBillingData(syncConnection, token, syncEvent?.triggeredBy ?? connection.connectedBy);
+    billingResult = await syncBillingData(syncConnection, token);
   } catch (err) {
     errors.push(
       `Billing sync failed: ${err instanceof Error ? err.message : String(err)}`
@@ -772,13 +556,7 @@ export async function runCopilotSync(
     finalStatus = "failed";
   }
 
-  // Surface billing-to-budget linking errors alongside other sync errors
-  if (billingResult?.billingLinkError) {
-    errors.push(billingResult.billingLinkError);
-  }
-
   // Update sync event
-  const linkResult = billingResult?.billingLinkResult;
   await db
     .update(githubSyncEvents)
     .set({
@@ -786,8 +564,6 @@ export async function runCopilotSync(
       seatsProcessed: seatResult?.seatsProcessed ?? null,
       metricsProcessed: metricsResult?.metricsProcessed ?? null,
       billingProcessed: billingResult?.billingProcessed ?? null,
-      billingLinked: linkResult?.linked ?? null,
-      billingSkipped: linkResult?.skipped ?? null,
       completedAt: new Date(),
       errorMessage: errors.length > 0 ? errors.join("; ") : null,
     })

--- a/src/lib/db/migrations/0014_giant_santa_claus.sql
+++ b/src/lib/db/migrations/0014_giant_santa_claus.sql
@@ -1,0 +1,38 @@
+CREATE TABLE "anthropic_org_config" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"billing_budget_limit_cents" integer,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"updated_by" integer,
+	CONSTRAINT "anthropic_org_config_id_check" CHECK ("anthropic_org_config"."id" = 1)
+);
+--> statement-breakpoint
+CREATE TABLE "anthropic_workspace_limits" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"workspace_id" varchar(100),
+	"limit_cents" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "copilot_billing_snapshots" DROP CONSTRAINT "copilot_billing_snapshots_linked_billed_cost_id_billed_costs_id_fk";
+--> statement-breakpoint
+DROP INDEX "anthropic_workspace_costs_ws_date_idx";--> statement-breakpoint
+DROP INDEX "anthropic_workspace_costs_null_ws_date_idx";--> statement-breakpoint
+DROP INDEX "copilot_billing_snapshots_linked_cost_idx";--> statement-breakpoint
+DROP INDEX "anthropic_workspaces_workspace_id_idx";--> statement-breakpoint
+ALTER TABLE "anthropic_workspaces" ALTER COLUMN "name" SET DATA TYPE varchar(200);--> statement-breakpoint
+ALTER TABLE "anthropic_sync_status" ADD COLUMN "workspace_sync_completed_at" timestamp;--> statement-breakpoint
+ALTER TABLE "anthropic_workspaces" ADD COLUMN "display_color" varchar(20);--> statement-breakpoint
+ALTER TABLE "anthropic_workspaces" ADD COLUMN "archived_at" timestamp;--> statement-breakpoint
+ALTER TABLE "anthropic_workspaces" ADD COLUMN "anthropic_created_at" timestamp;--> statement-breakpoint
+ALTER TABLE "anthropic_org_config" ADD CONSTRAINT "anthropic_org_config_updated_by_users_id_fk" FOREIGN KEY ("updated_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "anthropic_workspace_limits_workspace_id_idx" ON "anthropic_workspace_limits" USING btree ("workspace_id") WHERE "anthropic_workspace_limits"."workspace_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "anthropic_workspace_limits_default_idx" ON "anthropic_workspace_limits" USING btree ((1)) WHERE "anthropic_workspace_limits"."workspace_id" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "anthropic_workspace_costs_workspace_date_idx" ON "anthropic_workspace_costs" USING btree ("workspace_id","date") WHERE "anthropic_workspace_costs"."workspace_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "anthropic_workspace_costs_default_date_idx" ON "anthropic_workspace_costs" USING btree ("date") WHERE "anthropic_workspace_costs"."workspace_id" IS NULL;--> statement-breakpoint
+CREATE INDEX "anthropic_workspace_costs_workspace_id_idx" ON "anthropic_workspace_costs" USING btree ("workspace_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "anthropic_workspaces_is_default_idx" ON "anthropic_workspaces" USING btree ("is_default") WHERE "anthropic_workspaces"."is_default" = true;--> statement-breakpoint
+CREATE INDEX "anthropic_workspaces_archived_idx" ON "anthropic_workspaces" USING btree ("is_archived");--> statement-breakpoint
+CREATE UNIQUE INDEX "anthropic_workspaces_workspace_id_idx" ON "anthropic_workspaces" USING btree ("workspace_id") WHERE "anthropic_workspaces"."workspace_id" IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "copilot_billing_snapshots" DROP COLUMN "linked_billed_cost_id";--> statement-breakpoint
+ALTER TABLE "anthropic_workspace_costs" ADD CONSTRAINT "anthropic_workspace_costs_cost_cents_check" CHECK ("anthropic_workspace_costs"."cost_cents" >= 0);

--- a/src/lib/db/migrations/meta/0014_snapshot.json
+++ b/src/lib/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,3249 @@
+{
+  "id": "c6ed2159-0ae3-40fe-ba25-740d9a580d9a",
+  "prevId": "7356fd4a-93e4-4e17-89db-61b7baea53f6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_tiers": {
+      "name": "access_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_cost_cents": {
+          "name": "monthly_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_tiers_tool_id_idx": {
+          "name": "access_tiers_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_tiers_tool_name_idx": {
+          "name": "access_tiers_tool_name_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_tiers_tool_id_ai_tools_id_fk": {
+          "name": "access_tiers_tool_id_ai_tools_id_fk",
+          "tableFrom": "access_tiers",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tools": {
+      "name": "ai_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_licenses": {
+          "name": "max_licenses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tool_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_tools_name_idx": {
+          "name": "ai_tools_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_vendor_idx": {
+          "name": "ai_tools_vendor_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.annual_budgets": {
+      "name": "annual_budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fiscal_year": {
+          "name": "fiscal_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_cents": {
+          "name": "total_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "budget_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annual_budgets_fiscal_year_idx": {
+          "name": "annual_budgets_fiscal_year_idx",
+          "columns": [
+            {
+              "expression": "fiscal_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annual_budgets_status_idx": {
+          "name": "annual_budgets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_org_config": {
+      "name": "anthropic_org_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "billing_budget_limit_cents": {
+          "name": "billing_budget_limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anthropic_org_config_updated_by_users_id_fk": {
+          "name": "anthropic_org_config_updated_by_users_id_fk",
+          "tableFrom": "anthropic_org_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_org_config_id_check": {
+          "name": "anthropic_org_config_id_check",
+          "value": "\"anthropic_org_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_sync_status": {
+      "name": "anthropic_sync_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_days": {
+          "name": "synced_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_api_key_id": {
+          "name": "resolved_api_key_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sync_completed_at": {
+          "name": "workspace_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "anthropic_sync_status_user_id_idx": {
+          "name": "anthropic_sync_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_usage_metrics": {
+      "name": "anthropic_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncached_input_tokens": {
+          "name": "uncached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_cost_cents": {
+          "name": "computed_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pricing_resolved": {
+          "name": "pricing_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_usage_metrics_user_date_model_idx": {
+          "name": "anthropic_usage_metrics_user_date_model_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_user_date_idx": {
+          "name": "anthropic_usage_metrics_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_date_idx": {
+          "name": "anthropic_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_pricing_resolved_idx": {
+          "name": "anthropic_usage_metrics_pricing_resolved_idx",
+          "columns": [
+            {
+              "expression": "pricing_resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anthropic_usage_metrics_user_id_users_id_fk": {
+          "name": "anthropic_usage_metrics_user_id_users_id_fk",
+          "tableFrom": "anthropic_usage_metrics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_costs": {
+      "name": "anthropic_workspace_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_costs_workspace_date_idx": {
+          "name": "anthropic_workspace_costs_workspace_date_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_default_date_idx": {
+          "name": "anthropic_workspace_costs_default_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_date_idx": {
+          "name": "anthropic_workspace_costs_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_workspace_id_idx": {
+          "name": "anthropic_workspace_costs_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_workspace_costs_cost_cents_check": {
+          "name": "anthropic_workspace_costs_cost_cents_check",
+          "value": "\"anthropic_workspace_costs\".\"cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_limits": {
+      "name": "anthropic_workspace_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_cents": {
+          "name": "limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_limits_workspace_id_idx": {
+          "name": "anthropic_workspace_limits_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_limits_default_idx": {
+          "name": "anthropic_workspace_limits_default_idx",
+          "columns": [
+            {
+              "expression": "(1)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspaces": {
+      "name": "anthropic_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_color": {
+          "name": "display_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_created_at": {
+          "name": "anthropic_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspaces_workspace_id_idx": {
+          "name": "anthropic_workspaces_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspaces\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspaces_is_default_idx": {
+          "name": "anthropic_workspaces_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspaces\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspaces_archived_idx": {
+          "name": "anthropic_workspaces_archived_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assignment_comments": {
+      "name": "assignment_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assignment_comments_assignment_id_idx": {
+          "name": "assignment_comments_assignment_id_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_comments_author_id_idx": {
+          "name": "assignment_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_comments_created_at_idx": {
+          "name": "assignment_comments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assignment_comments_assignment_id_license_assignments_id_fk": {
+          "name": "assignment_comments_assignment_id_license_assignments_id_fk",
+          "tableFrom": "assignment_comments",
+          "tableTo": "license_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_comments_author_id_users_id_fk": {
+          "name": "assignment_comments_author_id_users_id_fk",
+          "tableFrom": "assignment_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billed_costs": {
+      "name": "billed_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor_reference": {
+          "name": "vendor_reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billed_costs_period_id_idx": {
+          "name": "billed_costs_period_id_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billed_costs_invoice_date_idx": {
+          "name": "billed_costs_invoice_date_idx",
+          "columns": [
+            {
+              "expression": "invoice_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billed_costs_period_id_budget_periods_id_fk": {
+          "name": "billed_costs_period_id_budget_periods_id_fk",
+          "tableFrom": "billed_costs",
+          "tableTo": "budget_periods",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_periods": {
+      "name": "budget_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_amount_cents": {
+          "name": "planned_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_periods_budget_id_idx": {
+          "name": "budget_periods_budget_id_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_periods_budget_period_idx": {
+          "name": "budget_periods_budget_period_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_periods_budget_id_annual_budgets_id_fk": {
+          "name": "budget_periods_budget_id_annual_budgets_id_fk",
+          "tableFrom": "budget_periods",
+          "tableTo": "annual_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_history": {
+      "name": "change_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "change_history_entity_idx": {
+          "name": "change_history_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_history_changed_by_idx": {
+          "name": "change_history_changed_by_idx",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_history_created_at_idx": {
+          "name": "change_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_history_changed_by_users_id_fk": {
+          "name": "change_history_changed_by_users_id_fk",
+          "tableFrom": "change_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_billing_snapshots": {
+      "name": "copilot_billing_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_month": {
+          "name": "billing_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seats": {
+          "name": "total_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_seats": {
+          "name": "active_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_cost_cents": {
+          "name": "seat_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost_cents": {
+          "name": "total_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_billing_snapshots_connection_month_idx": {
+          "name": "copilot_billing_snapshots_connection_month_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_billing_snapshots_connection_id_github_connections_id_fk": {
+          "name": "copilot_billing_snapshots_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_billing_snapshots",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_usage_metrics": {
+      "name": "copilot_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_engaged_users": {
+          "name": "total_engaged_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_suggestions": {
+          "name": "total_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_acceptances": {
+          "name": "total_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_suggested": {
+          "name": "total_lines_suggested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_accepted": {
+          "name": "total_lines_accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_chat_turns": {
+          "name": "total_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_chat_acceptances": {
+          "name": "total_chat_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_dotcom_chat_turns": {
+          "name": "total_dotcom_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pr_summaries": {
+          "name": "total_pr_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_breakdown": {
+          "name": "language_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_breakdown": {
+          "name": "editor_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_usage_metrics_connection_date_idx": {
+          "name": "copilot_usage_metrics_connection_date_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_usage_metrics_date_idx": {
+          "name": "copilot_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_usage_metrics_connection_id_github_connections_id_fk": {
+          "name": "copilot_usage_metrics_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_usage_metrics",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_login": {
+          "name": "org_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_avatar_url": {
+          "name": "org_avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_scopes_csv": {
+          "name": "token_scopes_csv",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_sync_enabled": {
+          "name": "copilot_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "copilot_sync_schedule": {
+          "name": "copilot_sync_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        }
+      },
+      "indexes": {
+        "github_connections_status_idx": {
+          "name": "github_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_connections_connected_by_users_id_fk": {
+          "name": "github_connections_connected_by_users_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_profiles": {
+      "name": "github_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_profiles_user_id_idx": {
+          "name": "github_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_profiles_github_id_idx": {
+          "name": "github_profiles_github_id_idx",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_profiles_github_login_idx": {
+          "name": "github_profiles_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_profiles_user_id_users_id_fk": {
+          "name": "github_profiles_user_id_users_id_fk",
+          "tableFrom": "github_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sync_events": {
+      "name": "github_sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_members": {
+          "name": "total_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manually_matched_count": {
+          "name": "manually_matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "copilot_sync_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "seats_processed": {
+          "name": "seats_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_processed": {
+          "name": "metrics_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_processed": {
+          "name": "billing_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_linked": {
+          "name": "billing_linked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_skipped": {
+          "name": "billing_skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_sync_events_connection_id_idx": {
+          "name": "github_sync_events_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_sync_events_triggered_by_idx": {
+          "name": "github_sync_events_triggered_by_idx",
+          "columns": [
+            {
+              "expression": "triggered_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sync_events_connection_id_github_connections_id_fk": {
+          "name": "github_sync_events_connection_id_github_connections_id_fk",
+          "tableFrom": "github_sync_events",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_sync_events_triggered_by_users_id_fk": {
+          "name": "github_sync_events_triggered_by_users_id_fk",
+          "tableFrom": "github_sync_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_tokens": {
+      "name": "invite_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_token_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_tokens_token_hash_idx": {
+          "name": "invite_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_tokens_user_id_idx": {
+          "name": "invite_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_tokens_active_user_idx": {
+          "name": "invite_tokens_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_tokens\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_tokens_user_id_users_id_fk": {
+          "name": "invite_tokens_user_id_users_id_fk",
+          "tableFrom": "invite_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_billed_cost_id": {
+          "name": "linked_billed_cost_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_created_at_idx": {
+          "name": "invoices_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_linked_billed_cost_id_idx": {
+          "name": "invoices_linked_billed_cost_id_idx",
+          "columns": [
+            {
+              "expression": "linked_billed_cost_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_billed_cost_id_billed_costs_id_fk": {
+          "name": "invoices_linked_billed_cost_id_billed_costs_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "billed_costs",
+          "columnsFrom": [
+            "linked_billed_cost_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invoices_uploaded_by_users_id_fk": {
+          "name": "invoices_uploaded_by_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_assignments": {
+      "name": "license_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_at_assignment_cents": {
+          "name": "cost_at_assignment_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace": {
+          "name": "workspace",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "license_assignments_user_id_idx": {
+          "name": "license_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_tool_id_idx": {
+          "name": "license_assignments_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_tier_id_idx": {
+          "name": "license_assignments_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_status_idx": {
+          "name": "license_assignments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_active_lookup_idx": {
+          "name": "license_assignments_active_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_assignments_user_id_users_id_fk": {
+          "name": "license_assignments_user_id_users_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_assignments_tool_id_ai_tools_id_fk": {
+          "name": "license_assignments_tool_id_ai_tools_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_assignments_tier_id_access_tiers_id_fk": {
+          "name": "license_assignments_tier_id_access_tiers_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "access_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_events": {
+      "name": "sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "sync_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "backfill_start_date": {
+          "name": "backfill_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sync_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_events_source_type_idx": {
+          "name": "sync_events_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_outcome_idx": {
+          "name": "sync_events_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_started_at_idx": {
+          "name": "sync_events_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_source_started_idx": {
+          "name": "sync_events_source_started_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_events_triggered_by_users_id_fk": {
+          "name": "sync_events_triggered_by_users_id_fk",
+          "tableFrom": "sync_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_sources": {
+      "name": "sync_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cron_schedule": {
+          "name": "cron_schedule",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_sources_source_type_idx": {
+          "name": "sync_sources_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circle": {
+          "name": "circle",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"theme\":\"system\"}'::jsonb"
+        },
+        "profile": {
+          "name": "profile",
+          "type": "user_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_circle_idx": {
+          "name": "users_circle_idx",
+          "columns": [
+            {
+              "expression": "circle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_status_idx": {
+          "name": "users_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.budget_status": {
+      "name": "budget_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.change_type": {
+      "name": "change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "deleted",
+        "status_change"
+      ]
+    },
+    "public.copilot_sync_type": {
+      "name": "copilot_sync_type",
+      "schema": "public",
+      "values": [
+        "members",
+        "copilot"
+      ]
+    },
+    "public.github_connection_status": {
+      "name": "github_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disconnected"
+      ]
+    },
+    "public.github_sync_status": {
+      "name": "github_sync_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.invite_token_status": {
+      "name": "invite_token_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "consumed",
+        "invalidated"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "quarterly"
+      ]
+    },
+    "public.sync_operation_type": {
+      "name": "sync_operation_type",
+      "schema": "public",
+      "values": [
+        "regular",
+        "backfill"
+      ]
+    },
+    "public.sync_outcome": {
+      "name": "sync_outcome",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "success",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.sync_source_type": {
+      "name": "sync_source_type",
+      "schema": "public",
+      "values": [
+        "github_copilot_billing",
+        "anthropic_api_usage",
+        "anthropic_team_invoices",
+        "github_members",
+        "invoice_period_matching",
+        "anthropic_api_costs"
+      ]
+    },
+    "public.tool_status": {
+      "name": "tool_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "public",
+      "values": [
+        "boost",
+        "maxed",
+        "indie"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "viewer"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1774617761000,
       "tag": "0013_add_anthropic_workspace_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1774523819181,
+      "tag": "0014_giant_santa_claus",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -485,10 +485,6 @@ export const copilotBillingSnapshots = pgTable(
     activeSeats: integer("active_seats").notNull(),
     seatCostCents: integer("seat_cost_cents").notNull(),
     totalCostCents: integer("total_cost_cents").notNull(),
-    linkedBilledCostId: integer("linked_billed_cost_id").references(
-      () => billedCosts.id,
-      { onDelete: "set null" }
-    ),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
@@ -496,9 +492,6 @@ export const copilotBillingSnapshots = pgTable(
     uniqueIndex("copilot_billing_snapshots_connection_month_idx").on(
       table.connectionId,
       table.billingMonth
-    ),
-    index("copilot_billing_snapshots_linked_cost_idx").on(
-      table.linkedBilledCostId
     ),
   ]
 );
@@ -851,10 +844,6 @@ export const copilotBillingSnapshotsRelations = relations(
     connection: one(githubConnections, {
       fields: [copilotBillingSnapshots.connectionId],
       references: [githubConnections.id],
-    }),
-    linkedBilledCost: one(billedCosts, {
-      fields: [copilotBillingSnapshots.linkedBilledCostId],
-      references: [billedCosts.id],
     }),
   })
 );

--- a/src/lib/sync/sources/github-copilot.ts
+++ b/src/lib/sync/sources/github-copilot.ts
@@ -3,7 +3,6 @@ import { db } from "@/lib/db";
 import {
   githubConnections,
   copilotBillingSnapshots,
-  billedCosts,
 } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { syncBillingData, syncSeatAssignments, syncUsageMetrics } from "@/lib/copilot-sync";
@@ -62,20 +61,14 @@ export async function run(
       };
 
       const errors: string[] = [];
-      const adminUserId = triggeredBy ?? connection.connectedBy;
 
       // Sync billing data
       try {
         const billingResult = await syncBillingData(
           syncConnection,
-          token,
-          adminUserId
+          token
         );
-        counts.createdCount += billingResult.billingLinkResult?.linked ?? 0;
-        counts.skippedCount += billingResult.billingLinkResult?.skipped ?? 0;
-        if (billingResult.billingLinkError) {
-          errors.push(billingResult.billingLinkError);
-        }
+        counts.createdCount += billingResult.billingProcessed;
       } catch (err) {
         errors.push(
           `Billing sync failed: ${err instanceof Error ? err.message : String(err)}`

--- a/src/lib/sync/sources/github-copilot.ts
+++ b/src/lib/sync/sources/github-copilot.ts
@@ -2,7 +2,6 @@ import { withSyncLock, type SyncCounts } from "@/lib/sync/framework";
 import { db } from "@/lib/db";
 import {
   githubConnections,
-  copilotBillingSnapshots,
 } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { syncBillingData, syncSeatAssignments, syncUsageMetrics } from "@/lib/copilot-sync";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -283,24 +283,6 @@ export interface SyncPreview {
   rateLimitRemaining: number;
 }
 
-// Billing sync types
-export interface BillingLinkResult {
-  linked: number;
-  skipped: number;
-  conflicts: Array<{
-    billingMonth: string;
-    reason: "manual_entry_exists" | "no_matching_period";
-    existingDescription?: string;
-  }>;
-}
-
-export interface BillingSyncConflict {
-  billingMonth: string;
-  snapshotAmountCents: number;
-  manualEntryAmountCents: number;
-  manualEntryDescription: string;
-  periodLabel: string;
-}
 
 // GitHub member sync — manual matching types
 export type PendingResolution =
@@ -346,7 +328,6 @@ export type CopilotSyncStatus = {
     metrics: number;
     billing: number;
     seats: number;
-    linkedBillingMonths: number;
   };
 };
 
@@ -405,10 +386,6 @@ export interface CopilotBillingData {
     totalSeats: number;
     activeSeats: number;
     costPerActiveUserCents: number;
-    linkedBilledCostId: number | null;
-    linkedPeriodLabel: string | null;
-    linkedPeriodUtilization: number | null;
-    linkStatus: "linked" | "unlinked" | "conflict";
   }>;
 }
 


### PR DESCRIPTION
## Summary
- Removed `syncBillingToBudget()` and all budget-linking logic from the Copilot billing sync — costs will flow through the invoice ingestion API instead
- Dropped `linked_billed_cost_id` column, index, and relation from `copilot_billing_snapshots` (migration included)
- Deleted `BillingLinkResult`, `BillingSyncConflict` types, `findBillingSyncConflicts()`, `getBillingSyncConflicts()`, `buildCopilotVendorRef()`
- Removed Budget Period and Status columns from the Copilot billing UI
- Cleaned up dead `adminUserId` parameter and redundant null field writes

## Migration note
Migration `0014_giant_santa_claus.sql` includes accumulated Drizzle schema drift (Anthropic workspace tables/indexes) that was previously applied via `db:push` without generating migrations. These changes already exist in the production DB — the migration catches up the Drizzle snapshot so future `db:generate` runs produce clean diffs. The Copilot-specific changes are on lines 17, 21, and 37 (FK drop, index drop, column drop).

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (zero warnings)
- [x] `pnpm build` succeeds
- [ ] Verify Copilot sync still stores snapshots, seats, and usage metrics
- [ ] Verify Copilot billing page renders without Budget Period / Status columns
- [ ] Run migration against staging DB and verify column drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)