### PR TITLE
feat(pricing): add Claude Opus 4.7 to model pricing table

### DIFF
--- a/src/lib/anthropic-pricing.ts
+++ b/src/lib/anthropic-pricing.ts
@@ -29,7 +29,7 @@ export const MODEL_PRICING: ModelPricing[] = [
     cacheReadPerMToken: 1.5,
     cacheWritePerMToken: 18.75,
   },
-  // Opus 4.5 / 4.6 — $5/$25
+  // Opus 4.5 / 4.6 / 4.7 — $5/$25
   {
     prefix: "claude-opus-4-5",
     inputPerMToken: 5,
@@ -39,6 +39,13 @@ export const MODEL_PRICING: ModelPricing[] = [
   },
   {
     prefix: "claude-opus-4-6",
+    inputPerMToken: 5,
+    outputPerMToken: 25,
+    cacheReadPerMToken: 0.5,
+    cacheWritePerMToken: 6.25,
+  },
+  {
+    prefix: "claude-opus-4-7",
     inputPerMToken: 5,
     outputPerMToken: 25,
     cacheReadPerMToken: 0.5,


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` to the Anthropic pricing table at $5 / $25 per MTok (cache read $0.50, 5m cache write $6.25) — same tier as Opus 4.5/4.6 per [Anthropic's pricing page](https://docs.anthropic.com/en/docs/about-claude/pricing).
- Without this entry, any `claude-opus-4-7-*` usage would fall back to the Opus 4.0/4.1 rate ($15/$75) and overstate costs by 3x.
- The existing prefix-match logic handles date-stamped variants (e.g. `claude-opus-4-7-20260210`) with no further changes; `cost-chart.tsx` already renders the label generically.

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Confirm a sample Opus 4.7 usage row resolves to the new $5/$25 pricing (not the $15/$75 fallback) in the running-costs view