### PR TITLE
fix(users): prevent prefilled workspace/API key in assign license dialog

### DIFF
--- a/src/app/users/[id]/user-detail-client.tsx
+++ b/src/app/users/[id]/user-detail-client.tsx
@@ -469,6 +469,12 @@ export function UserDetailClient({
               size="sm"
               variant="outline"
               onClick={async () => {
+                setSelectedToolId("");
+                setSelectedTierId("");
+                setAvailableTiers([]);
+                setAssignWorkspace("");
+                setAssignApiKey("");
+                setShowAssignApiKey(false);
                 setAssignDialogOpen(true);
                 if (tools.length === 0) {
                   setLoadingTools(true);
@@ -628,6 +634,7 @@ export function UserDetailClient({
               <Input
                 placeholder="e.g. team-alpha"
                 maxLength={200}
+                autoComplete="off"
                 value={assignWorkspace}
                 onChange={(e) => setAssignWorkspace(e.target.value)}
               />
@@ -639,6 +646,7 @@ export function UserDetailClient({
                   type={showAssignApiKey ? "text" : "password"}
                   placeholder="Enter API key"
                   maxLength={500}
+                  autoComplete="new-password"
                   value={assignApiKey}
                   onChange={(e) => setAssignApiKey(e.target.value)}
                 />

--- a/src/app/users/[id]/user-detail-client.tsx
+++ b/src/app/users/[id]/user-detail-client.tsx
@@ -160,6 +160,20 @@ export function UserDetailClient({
     }
   }
 
+  function resetAssignDialogState() {
+    setSelectedToolId("");
+    setSelectedTierId("");
+    setAvailableTiers([]);
+    setAssignWorkspace("");
+    setAssignApiKey("");
+    setShowAssignApiKey(false);
+  }
+
+  function closeAssignDialog() {
+    resetAssignDialogState();
+    setAssignDialogOpen(false);
+  }
+
   async function handleToolChange(toolId: string) {
     setSelectedToolId(toolId);
     setSelectedTierId("");
@@ -184,12 +198,7 @@ export function UserDetailClient({
     setAssigning(false);
     if (result.success) {
       toast.success("License assigned");
-      setAssignDialogOpen(false);
-      setSelectedToolId("");
-      setSelectedTierId("");
-      setAssignWorkspace("");
-      setAssignApiKey("");
-      setShowAssignApiKey(false);
+      closeAssignDialog();
       router.refresh();
     } else {
       toast.error(result.error);
@@ -469,12 +478,7 @@ export function UserDetailClient({
               size="sm"
               variant="outline"
               onClick={async () => {
-                setSelectedToolId("");
-                setSelectedTierId("");
-                setAvailableTiers([]);
-                setAssignWorkspace("");
-                setAssignApiKey("");
-                setShowAssignApiKey(false);
+                resetAssignDialogState();
                 setAssignDialogOpen(true);
                 if (tools.length === 0) {
                   setLoadingTools(true);
@@ -581,14 +585,8 @@ export function UserDetailClient({
 
       {/* Assign License Dialog */}
       <Dialog open={assignDialogOpen} onOpenChange={(open) => {
+        if (!open) resetAssignDialogState();
         setAssignDialogOpen(open);
-        if (!open) {
-          setSelectedToolId("");
-          setSelectedTierId("");
-          setAssignWorkspace("");
-          setAssignApiKey("");
-          setShowAssignApiKey(false);
-        }
       }}>
         <DialogContent>
           <DialogHeader>
@@ -671,7 +669,7 @@ export function UserDetailClient({
           <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => setAssignDialogOpen(false)}
+              onClick={closeAssignDialog}
             >
               Cancel
             </Button>


### PR DESCRIPTION
## Summary
- Reset dialog state (`selectedToolId`, `selectedTierId`, `availableTiers`, `assignWorkspace`, `assignApiKey`, `showAssignApiKey`) when the **Assign License** button is clicked, not only on close. This stops stale values from leaking across Cancel, failed submit, or ESC-dismiss paths on `/users/[id]`.
- Add `autoComplete="off"` to the Workspace input and `autoComplete="new-password"` to the API Key input (matching the pattern already used in `setup-password-form.tsx`) to block browser form-history and password-manager autofill.

## Why
An admin clicking **Assign License** a second time would see the previous license's workspace / API key still populated, risking the wrong credential being saved against the wrong license.

## Test plan
- [ ] `pnpm typecheck` and `pnpm lint` pass
- [ ] As admin on `/users/[id]`, open Assign License, enter values, click **Cancel**, reopen → both fields empty
- [ ] Trigger a failed assignment, reopen → both fields empty
- [ ] Hard-reload, open Assign License → browser / password manager no longer offers to autofill the API Key field
- [ ] Happy path still assigns a license with the entered workspace/API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)