### PR TITLE
feat(claude): Claude Console redesign (spec 026)

### DIFF
--- a/.claude/skills/neon-worktree-branch/SKILL.md
+++ b/.claude/skills/neon-worktree-branch/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: neon-worktree-branch
+description: This skill should be used when working inside a git worktree (path contains `.claude/worktrees/` or `worktrees/`) and about to apply schema changes, run migrations (`pnpm db:push`, `pnpm db:migrate`, `drizzle-kit push`, `prisma migrate`), or perform destructive data operations against a Neon Postgres database. Also triggers when the user asks to "branch the database", "create a database branch", "isolate the DB for this worktree", "fork the DB", or troubleshoots accidentally writing to production data from a worktree. Creates an isolated Neon branch, swaps the worktree's `DATABASE_URL` (and `DATABASE_URL_UNPOOLED`) to point at it, and cleans up when the worktree is merged or abandoned. **Safety guarantee**: the skill refuses to run migrations until the worktree's DB is verifiably on a `wt/*` branch (never the default / production branch), and refuses to delete the default branch under any circumstances.
+---
+
+# Neon database branch for a git worktree
+
+Create a copy-on-write Neon branch so schema changes and migrations in a worktree don't touch the production / shared database. Neon branches are instant and free; the only durable side effect is a row in the project's branch list until cleanup.
+
+## Safety rails (mandatory — never relax)
+
+These rules are non-negotiable. They prevent this skill — and any migration command run while this skill is loaded — from touching production data.
+
+1. **Never migrate while pointed at the default branch.** Before any `pnpm db:push` / `pnpm db:migrate` / `drizzle-kit push` / `prisma migrate` runs from a worktree, the skill MUST verify the active `DATABASE_URL` host resolves to a Neon branch whose name starts with `wt/` AND whose id is NOT the default branch id from `describe_project`. If either check fails, **abort with a hard error**. Do not "try anyway", do not auto-create a branch on the fly without going through the full skill flow with user confirmation.
+2. **Never delete the default branch.** `delete_branch` MUST only be called when ALL of these hold: (a) the branch name starts with `wt/`, (b) the branch id is NOT equal to the default branch id from `describe_project`, (c) the user has confirmed deletion of that specific branch name in this session. If any check fails, refuse and surface the reason to the user.
+3. **Never edit `.env.local` outside a worktree.** The path passed to Edit MUST contain `worktrees/` (or `.claude/worktrees/`). Reject any swap that would write to the main repo's `.env.local`.
+4. **Never restore production credentials into a worktree without explicit user instruction.** After branch deletion, do NOT auto-rewrite `DATABASE_URL` back to the production URL. Leave the worktree in a broken-DB state (or delete it entirely) — that's safer than silently re-pointing at production where the next casual command could write.
+5. **Never run a migration command yourself unless the user just asked for it in this turn.** Schema files changing in a Diff is NOT permission to run `db:push`. The skill creates a safe environment; the user pulls the trigger.
+6. **No fallback path that talks to the DB directly.** If the Neon MCP is not connected, stop and tell the user. Do not invent an alternative via `neonctl`, raw HTTP, or `psql` to "make it work" — those bypass these safety rails.
+7. **Mask connection strings in all output.** Never print the password component to the user; always mask as `postgresql://<role>:***@<host>/<db>?sslmode=require`. This is a habit, not just a privacy rule — it prevents a copy-paste of a production URL into a misclick.
+
+Each substantive section below has an explicit verification step that enforces one of these rails. Do not skip them, even when the user is in a hurry.
+
+## When to trigger
+
+- The current working directory contains `worktrees/` or `.claude/worktrees/` **and** the user is about to run `pnpm db:push`, `pnpm db:migrate`, `pnpm db:generate` with intent to apply, `drizzle-kit push`, or any direct migration / DDL.
+- The user explicitly asks to branch / fork / isolate the database for this worktree.
+- The agent (or user) realizes a destructive operation just ran (or is about to run) against the *shared* `DATABASE_URL` that was copied from the main checkout into the worktree's `.env.local`.
+
+If the user is in the main repo checkout (not a worktree), do not silently branch — surface the risk and ask first. The skill assumes worktree isolation is the goal.
+
+## Required tools
+
+The Neon MCP server must be connected. The relevant deferred tools are:
+
+- `mcp__plugin_neon_neon__list_projects`
+- `mcp__plugin_neon_neon__describe_project`
+- `mcp__plugin_neon_neon__create_branch`
+- `mcp__plugin_neon_neon__get_connection_string`
+- `mcp__plugin_neon_neon__describe_branch`
+- `mcp__plugin_neon_neon__delete_branch`
+
+Load schemas via `ToolSearch` with `query: "select:mcp__plugin_neon_neon__list_projects,mcp__plugin_neon_neon__create_branch,mcp__plugin_neon_neon__get_connection_string,mcp__plugin_neon_neon__delete_branch,mcp__plugin_neon_neon__describe_project"` before invoking.
+
+If the Neon MCP is not available, **stop**. Do not attempt a workaround via `neonctl` or raw HTTP — explain to the user that the Neon MCP server is required for this skill and that they can connect it via the Vercel/Neon integration in Claude Code.
+
+## Identify project + parent branch (pre-flight)
+
+1. **Read the worktree's `.env.local`** with the Read tool. Confirm a `DATABASE_URL=postgresql://...neon.tech/...` is present. Extract the host substring — Neon project IDs appear in the host as `ep-<adjective>-<noun>-<id>` or as part of the project subdomain. Do **not** print the full URL back to the user.
+2. Call `list_projects` to find the candidate project. Match against the host. If multiple projects could match, ask the user which one.
+3. Call `describe_project` for the chosen project. Note:
+   - The **default branch ID** (parent for the new branch — usually `production` or `main`).
+   - Existing branches whose name collides with the worktree (handle below).
+
+## Choose a branch name
+
+Use the **worktree directory name**, not the git branch (multiple worktrees may share a git branch, and git branch names can contain slashes that Neon doesn't allow):
+
+```
+wt/<worktree-dir-name>
+```
+
+For this project family, examples: `wt/claude-dashboard`, `wt/copilot-billing-fix`.
+
+If a branch with that name already exists in `describe_project`'s output, **do not auto-recreate it**. Ask the user whether to reuse the existing branch (just refresh the `DATABASE_URL`) or delete + recreate (destroys whatever state was in it).
+
+## Create the branch
+
+Call `create_branch` with:
+- `project_id`: the matched project's id
+- `branch_name`: the chosen `wt/<dir>` name
+- `parent_id`: the default branch id from `describe_project` (so the new branch forks from current production state, not from a stale earlier branch)
+
+The call returns the new branch's id and the auto-provisioned compute endpoint. If the response is missing a compute endpoint, call `list_branch_computes` to confirm one was created (Neon usually auto-creates a read-write compute for new branches; if not, surface to the user).
+
+## Pull the connection strings
+
+Neon issues two URLs per branch — pooled (for serverless / `@neondatabase/serverless`) and unpooled (for direct migrations). Most Next.js projects use the pooled URL at runtime and the unpooled URL for `drizzle-kit` migrations.
+
+Call `get_connection_string` **twice** (or once and check the response shape):
+1. `pooled: true` → assign to `DATABASE_URL`
+2. `pooled: false` → assign to `DATABASE_URL_UNPOOLED`
+
+Use the database name from the original `DATABASE_URL` (typically `neondb` for Neon defaults). Use the role from the original URL (typically `neondb_owner`).
+
+**Never print the full connection string** to the user output. When confirming the swap, mask the password: `postgresql://neondb_owner:***@ep-...-pooler.eu-central-1.aws.neon.tech/neondb?sslmode=require`.
+
+## Swap the worktree's `.env.local`
+
+Use the Edit tool — **not** Write — so existing comments and unrelated env vars are preserved.
+
+1. **Path check (Rail #3)** — confirm the file path passed to Edit contains `worktrees/` or `.claude/worktrees/`. If not, abort: this skill must never edit the main checkout's `.env.local`.
+2. Replace the line starting with `DATABASE_URL=` with the new pooled URL.
+3. Replace the line starting with `DATABASE_URL_UNPOOLED=` with the new unpooled URL. If that key doesn't exist yet, add it on a new line immediately after `DATABASE_URL`.
+4. Leave every other line untouched.
+
+### Post-swap verification (mandatory — enforces Rail #1)
+
+Immediately after the edit, **re-Read** the worktree's `.env.local` and verify all of the following before declaring success:
+
+1. `DATABASE_URL` exists and its host substring contains the new branch's host fragment returned by `get_connection_string`.
+2. `DATABASE_URL`'s host does NOT match the default branch's host from `describe_project`. (Defensive: if `get_connection_string` ever returned the wrong URL, this catches it.)
+3. The branch id encoded in the host corresponds to the `wt/<dir>` branch you just created — cross-reference against `describe_branch` or the response from `create_branch`.
+
+If any of these fail, **revert the Edit** by writing the original `DATABASE_URL` value back and tell the user: "Branch swap failed verification — worktree is still on the original DB. Do not run migrations until this is resolved." Then stop. Do not retry silently.
+
+When verification passes, confirm with the user in plaintext (masked URL only): "Worktree DATABASE_URL now points at Neon branch `wt/<dir>` (parent: `production`). Restart any running dev servers."
+
+## Restart the dev server
+
+If a `pnpm dev` is already running in the background (check via Bash output files or running processes), the new env vars won't be picked up. Kill the running process and start a new one. The user should not have to do this manually if you started the dev server yourself.
+
+## Apply migrations against the branch
+
+### Pre-flight gate (mandatory — enforces Rail #1 + Rail #5)
+
+Before running ANY migration command, run this in-context check. Even if you "know" the swap succeeded.
+
+1. Re-Read the worktree's `.env.local` (do not trust memory of what was written earlier; the user may have edited it).
+2. Extract the host of `DATABASE_URL`. Compare against the default branch host from `describe_project` (cached from the create-branch step, or re-fetched).
+3. Verify the host belongs to a branch whose name starts with `wt/`. If `describe_project` doesn't surface branch-name-to-host mapping directly, call `describe_branch` for the suspected branch id and confirm name and id.
+
+If the host matches the default branch host, or the branch name does not start with `wt/`, **abort**. Tell the user: "Refusing to run migrations — worktree appears to still be pointing at the production / default Neon branch. Run the `neon-worktree-branch` skill from scratch." Do not run migrations.
+
+### Confirm user intent (Rail #5)
+
+Migration commands change schema and can drop data. They must be triggered by an explicit in-turn user request ("run db:push", "apply the migration", "let's migrate") — not by the agent observing that `src/lib/db/schema.ts` changed. If the user has not explicitly asked, do not run them yourself. Surface the diff and the suggested command instead.
+
+### Run
+
+When the gate passes AND the user has explicitly asked:
+
+```
+pnpm db:push        # for Drizzle schema sync (dev)
+pnpm db:generate    # to author migration files (safe — no DB writes)
+pnpm db:migrate     # to apply migrations against the branch
+```
+
+These will hit the Neon branch via the swapped URL. Confirm with a cheap query immediately after the first migration:
+
+```
+psql "$DATABASE_URL_UNPOOLED" -c "select current_database(), current_user, now(), inet_server_addr();"
+```
+
+Or via the project's own DB connection helper if `psql` isn't installed. The point is to confirm "schema landed on the branch, not on production" before doing any real work. The result's host fingerprint should still match the `wt/*` branch.
+
+## When the worktree is merged or abandoned
+
+After the worktree's git branch is merged into `main` (or the worktree is discarded), the Neon branch can be deleted. This is the only path in this skill that calls a destructive Neon API; it gets the strictest gates.
+
+### Pre-delete checks (mandatory — enforces Rail #2)
+
+All of the following MUST be true before calling `delete_branch`:
+
+1. **Explicit user request in this turn.** The user has said "delete the Neon branch", "drop the branch", "worktree is done — clean up", or similar — in this session, not a stale earlier intent. Never auto-prune on session start.
+2. **Name starts with `wt/`.** Re-fetch the branch via `describe_branch` and verify `name.startsWith("wt/")`. Refuse to delete branches with any other name pattern — they were not created by this skill.
+3. **ID is NOT the default branch id.** From `describe_project`, get the default branch id. The branch you intend to delete must not equal it. (Belt-and-braces: Neon's own API also rejects deleting the protected/default branch, but do not rely on that.)
+4. **Name matches what the user named.** Echo the exact branch name back to the user ("Delete Neon branch `wt/claude-dashboard`? This is irreversible.") and wait for an unambiguous yes. Do not pattern-match "ok"/"yeah" mid-other-conversation; require a clear confirmation tied specifically to the branch name.
+5. **No active connection from the dev server.** If a `pnpm dev` is still running against the branch URL, it will start erroring as soon as the branch goes away. Stop the dev server first or warn the user.
+
+If any check fails, refuse and surface the reason. Do not "try the delete anyway" hoping the Neon API will reject it.
+
+### Delete
+
+When all checks pass:
+
+1. Call `delete_branch` with the matched project id and branch id.
+2. Confirm success by listing branches (`describe_project` again) and verifying the branch is gone.
+3. **Do NOT restore production credentials into the worktree's `.env.local`** (Rail #4). Leave it with the stale branch URL (or empty), which will cause an obvious connection-refused error if anything tries to use the DB from the worktree afterward — that is the desired behavior, since the worktree is being torn down. If the user explicitly asks to re-point the worktree at production, treat it as a separate, explicit request and warn them clearly first.
+
+Do **not** auto-delete the branch on every cleanup — only when the user explicitly says the worktree is done.
+
+## Caveats and known gotchas
+
+- **`.env.local` is gitignored.** The branched `DATABASE_URL` does not travel with the worktree. If a colleague pulls the same worktree branch, they will still be on the shared `DATABASE_URL` until they run this skill themselves.
+- **Don't reuse branches across worktrees.** If two worktrees share a Neon branch, schema changes in one will surprise the other. Name the branch after the worktree dir, always.
+- **Drizzle `db:push` is dev-only.** It applies the current TS schema directly to the DB without producing a migration file. That's fine for branch isolation but means the change must still be captured via `db:generate` + committed before merging back to main. Confirm with the user which mode they want for the worktree.
+- **Neon free tier branch limits.** Free Neon projects cap branches per project. If `create_branch` fails with a quota error, prompt the user to delete stale `wt/*` branches from older worktrees rather than auto-pruning.
+- **Don't branch from a non-default parent unless asked.** Forking from another `wt/*` branch (a fork of a fork) is supported by Neon but rarely what the user wants — it propagates schema state from one worktree into another. Default to the production branch.
+- **Pooled vs unpooled for serverless.** `@neondatabase/serverless` works with both, but the pooled URL is required when you exceed simple per-request connection counts. Drizzle migrations need the unpooled URL because pgbouncer doesn't support some statements migrations issue. Always provide both.
+
+## Quick mode (state already good)
+
+If the user asks "are we on a branched DB?" or "am I safe to migrate?", check current state in one Read + one MCP call:
+
+1. Read the worktree's `.env.local`, extract the host portion of `DATABASE_URL`.
+2. Call `describe_project` and compare the host substring against branch ids in the response.
+
+Outcomes:
+- Host matches a `wt/<dir>` branch → "Yes, on branch `wt/<dir>` — safe to migrate."
+- Host matches the default branch → "**No — still on production. Refusing to run migrations from this worktree until the full skill has branched the DB.**"
+- Host doesn't match any known Neon branch → "Worktree env points at an unknown database. Refusing to run migrations until the user confirms what this database is and that it is safe to write to."
+
+In the latter two cases, do NOT silently proceed. Do NOT attempt a "best-effort" branch creation without going through the full skill flow with user confirmation.
+
+## Out of scope (and explicitly refused)
+
+- **Branching Neon for the main repo checkout (not a worktree).** Default to refusing. The skill's safety model assumes the worktree pattern. If the user explicitly insists on branching for a migration spike in main, surface the risk clearly: future `pnpm db:push` runs from main will keep hitting the branch until they restore the env — which is an easy way to forget and silently corrupt prod schema. Strongly prefer asking them to create a worktree first.
+- **Promoting a branch to production.** Neon supports this via the console but this skill MUST NOT do it. That's a deploy-time decision with downtime/migration-replay implications; it belongs in a release process, not in a worktree cleanup.
+- **Editing the production branch directly.** No write path in this skill targets the default branch. If the user asks the skill to "apply this migration to prod", refuse and direct them to the actual deploy process.
+- **Non-Neon Postgres (Supabase, RDS, self-hosted).** The branching MCP tools don't exist for these; the skill does not apply. Suggest a separate `.env.local` with a manually provisioned dev DB, or `pg_dump`/`pg_restore` into a local Postgres for isolation. Do NOT attempt to simulate branching by copying schema with raw `psql` against an unknown URL — that's exactly the path that ends in writing to production.
+- **Any path that bypasses the rails above.** If the user asks for an "exception just this once", the answer is no. The rails exist because the cost of being wrong (production schema corruption, dropped data) is asymmetric with the cost of asking the user to slow down for 30 seconds. If they truly need to talk to production, they should do it from the main checkout, with an explicit one-off command they typed themselves — not via this skill.

--- a/scripts/backfill-anthropic-workspace-costs.ts
+++ b/scripts/backfill-anthropic-workspace-costs.ts
@@ -1,0 +1,42 @@
+/**
+ * One-off backfill for per-day workspace costs after fixing the sync bug.
+ *
+ * Usage:
+ *   pnpm tsx --env-file=.env.local scripts/backfill-anthropic-workspace-costs.ts [YYYY-MM-DD]
+ *
+ * Default start date is 6 months back (matches the dashboard's sparkline range).
+ */
+
+import { run } from "../src/lib/sync/sources/anthropic-workspace";
+
+async function main() {
+  const arg = process.argv[2];
+  let startDate: Date;
+
+  if (arg) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(arg)) {
+      console.error(`Invalid date: ${arg} (expected YYYY-MM-DD)`);
+      process.exit(1);
+    }
+    startDate = new Date(`${arg}T00:00:00Z`);
+  } else {
+    const now = new Date();
+    startDate = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 5, 1)
+    );
+  }
+
+  console.log(
+    `Backfilling anthropic_workspace_costs from ${startDate.toISOString().slice(0, 10)}…`
+  );
+
+  const result = await run(undefined, { backfillStartDate: startDate });
+  console.log("Result:", result);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/backfill-anthropic-workspace-mapping.ts
+++ b/scripts/backfill-anthropic-workspace-mapping.ts
@@ -1,0 +1,74 @@
+/**
+ * One-off backfill for anthropic_sync_status.resolved_workspace_id.
+ *
+ * Background:
+ *   The `resolved_workspace_id` column was added (spec 026 / migration 0018)
+ *   after most users were already resolved via spec 016. The ongoing
+ *   `resolveAllMappings()` in src/lib/anthropic-sync.ts only re-resolves
+ *   users that lack a `resolvedApiKeyId` (or whose key has changed), so
+ *   pre-existing rows kept `resolved_workspace_id = NULL` forever — which
+ *   broke the per-workspace user/model breakdowns on the drill-down.
+ *
+ *   This script re-queries Anthropic's `/v1/organizations/api_keys`
+ *   endpoint once and updates `resolved_workspace_id` for every row that
+ *   already has a `resolved_api_key_id`. Idempotent — safe to re-run.
+ *
+ * Usage:
+ *   pnpm tsx --env-file=.env.local scripts/backfill-anthropic-workspace-mapping.ts
+ */
+
+import { eq, isNotNull } from "drizzle-orm";
+import { db } from "../src/lib/db";
+import { anthropicSyncStatus } from "../src/lib/db/schema";
+import { fetchOrgApiKeys } from "../src/lib/anthropic-keys";
+
+async function main() {
+  console.log("Fetching all org API keys from Anthropic…");
+  const orgKeys = await fetchOrgApiKeys();
+  console.log(`  Got ${orgKeys.length} active keys.`);
+
+  const byId = new Map<string, string | null>();
+  for (const k of orgKeys) byId.set(k.id, k.workspace_id ?? null);
+
+  const rows = await db.query.anthropicSyncStatus.findMany({
+    where: isNotNull(anthropicSyncStatus.resolvedApiKeyId),
+  });
+  console.log(`Found ${rows.length} sync_status rows with a resolved api_key_id.`);
+
+  let updated = 0;
+  let missingFromOrg = 0;
+  let unchanged = 0;
+  for (const row of rows) {
+    if (!row.resolvedApiKeyId) continue;
+    if (!byId.has(row.resolvedApiKeyId)) {
+      missingFromOrg++;
+      continue;
+    }
+    const wsId = byId.get(row.resolvedApiKeyId) ?? null;
+    if (wsId === row.resolvedWorkspaceId) {
+      unchanged++;
+      continue;
+    }
+    await db
+      .update(anthropicSyncStatus)
+      .set({ resolvedWorkspaceId: wsId })
+      .where(eq(anthropicSyncStatus.userId, row.userId));
+    updated++;
+  }
+
+  console.log(
+    `Done. Updated: ${updated}, unchanged: ${unchanged}, missing from org listing: ${missingFromOrg}.`
+  );
+  if (missingFromOrg > 0) {
+    console.warn(
+      "  (Rows tagged 'missing from org listing' have an api_key_id that Anthropic no longer returns — the key was deleted or rotated. These rows keep their current resolved_workspace_id.)"
+    );
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/specs/026-claude-page-redesign/data-model.md
+++ b/specs/026-claude-page-redesign/data-model.md
@@ -1,0 +1,77 @@
+# Spec 026 · Data model
+
+Schema analysis and decisions for the `/claude` page redesign. Only Phase 3 introduces a schema change; Phases 1 + 2 are pure UI / aggregation over existing tables.
+
+## No schema changes (Phases 1 + 2)
+
+Phase 1 (header + sync pill + global metrics) and Phase 2 (workspace cards + drill-in) read from tables that already exist:
+
+- `anthropic_workspace_costs` — daily cost per workspace
+- `anthropic_workspaces` — workspace metadata
+- `anthropic_workspace_limits` — admin-configured caps
+- `anthropic_org_config` — org-wide billing budget
+- `anthropic_sync_status` — sync state (existing column `workspace_sync_completed_at`)
+- `sync_events` — used by the sync status pill
+
+No new tables, no new columns, no migrations required for Phases 1 + 2.
+
+## User → workspace mapping (Phase 3 decision)
+
+Phase 3 needs to render "top users in this workspace" inside the workspace drill-in, but the existing schema has no direct user→workspace relationship. Anthropic's usage report is keyed by user; the cost report is keyed by workspace; nothing bridges the two.
+
+Three potential bridges were evaluated:
+
+1. **`license_assignments.workspace` text column** — already exists (`src/lib/db/schema.ts:222`) but is a free-form admin-entered string, not tied to Anthropic's workspace IDs. Rejected as brittle — admins type "Marketing" while Anthropic returns `wrkspc_01ABC...`.
+2. **Anthropic's `workspace_id` on each API key** — Anthropic's `/v1/organizations/api_keys` response includes `workspace_id` on every key. The codebase already calls this endpoint via `fetchOrgApiKeys()` (`src/lib/anthropic-keys.ts:20-56`), but the Zod schema `orgApiKeySchema` (lines 5-11) only captures `id, name, partial_key_hint, status, type` — `workspace_id` is parsed away. **Chosen path.**
+3. **Add `workspace_id` directly to `anthropic_usage_metrics`** — denormalized, fast queries, but requires backfilling the large per-user-day-model table on every workspace move. Rejected as too expensive for the marginal query-speed gain.
+
+## Chosen approach
+
+- Extend `orgApiKeySchema` in `src/lib/anthropic-keys.ts` to capture `workspace_id: z.string().nullable()`. Anthropic returns `null` for keys in the org's default workspace; that null is meaningful and must be preserved (not coerced to a string).
+- Add one nullable column to `anthropic_sync_status`:
+  ```sql
+  ALTER TABLE anthropic_sync_status
+    ADD COLUMN resolved_workspace_id varchar(100);
+  ```
+- Update `resolveAllMappings()` in `src/lib/anthropic-sync.ts:143-221`: when persisting the resolved `api_key_id`, also persist the `workspace_id` from the matching entry in the `orgKeys` array. Same row, same upsert — no extra round-trip.
+- Phase 3 queries join `anthropic_usage_metrics.user_id → anthropic_sync_status.user_id → resolved_workspace_id`.
+
+## Reference query
+
+The canonical Phase 3 "top users in a workspace" query:
+
+```sql
+SELECT u.id, u.email, u.name, SUM(m.computed_cost_cents) AS cents
+FROM anthropic_usage_metrics m
+JOIN anthropic_sync_status s ON s.user_id = m.user_id
+JOIN users u                  ON u.id      = m.user_id
+WHERE s.resolved_workspace_id IS NOT DISTINCT FROM $1   -- $1 = NULL for default workspace
+  AND m.date BETWEEN $2 AND $3
+GROUP BY u.id, u.email, u.name
+ORDER BY cents DESC
+LIMIT 10;
+```
+
+`IS NOT DISTINCT FROM` handles the default-workspace null sentinel cleanly — a plain `=` would silently drop every user assigned to the default workspace.
+
+## Caveats (must be surfaced in UI)
+
+- **Per-user totals do not sum to workspace totals.** Per-user data comes from Anthropic's usage report endpoint; workspace cost data comes from the cost report endpoint. Different rounding rules, different aggregation windows. The two will not reconcile exactly. The UI must show both as separate signals — do NOT add a footnote saying "if numbers differ, X is correct"; surface both and let the admin compare.
+
+- **Mid-month workspace moves.** `resolved_workspace_id` reflects the user's *current* API key's workspace. If an admin moves a user's API key to a different workspace mid-month, historical usage rows in `anthropic_usage_metrics` will be retroactively attributed to the new workspace (because the join goes through the current `anthropic_sync_status` row, not a historical record). This is acceptable but must be documented in the UI footnote on the workspace drill-in.
+
+## Backfill
+
+No backfill of historical data is needed:
+
+- The new `resolved_workspace_id` column will populate naturally on the next sync run for every active user — the sync runs hourly.
+- Historical `anthropic_usage_metrics` rows do NOT need backfilling. They're attributed via the live join at query time, not a denormalized column.
+- Users with revoked / disabled API keys won't get a `workspace_id` resolved; their rows will be excluded from per-workspace queries. Acceptable — they can't be in any workspace anyway.
+
+## Out of scope
+
+This data-model.md does NOT cover:
+
+- Schema for the workspace-level *cost* data (already exists from spec 018).
+- Anthropic credit balance (still not exposed by the Anthropic API).
+- Per-tool generalization. This is Claude/Anthropic-specific; if GitHub Copilot ever needs per-workspace user attribution, it would need a parallel mapping built on Copilot's own org/team primitives.

--- a/specs/026-claude-page-redesign/data-model.md
+++ b/specs/026-claude-page-redesign/data-model.md
@@ -6,7 +6,7 @@ Schema analysis and decisions for the `/claude` page redesign. Only Phase 3 intr
 
 Phase 1 (header + sync pill + global metrics) and Phase 2 (workspace cards + drill-in) read from tables that already exist:
 
-- `anthropic_workspace_costs` — daily cost per workspace
+- `anthropic_workspace_costs` — daily cost per workspace (one row per `(workspace_id, YYYY-MM-DD)`; see "Per-day storage fix" below)
 - `anthropic_workspaces` — workspace metadata
 - `anthropic_workspace_limits` — admin-configured caps
 - `anthropic_org_config` — org-wide billing budget
@@ -14,6 +14,15 @@ Phase 1 (header + sync pill + global metrics) and Phase 2 (workspace cards + dri
 - `sync_events` — used by the sync status pill
 
 No new tables, no new columns, no migrations required for Phases 1 + 2.
+
+### Per-day storage fix (post-implementation)
+
+Although the schema for `anthropic_workspace_costs` has always declared a daily grain, the cost sync was originally writing one row per workspace per month (keyed to `YYYY-MM-01`). The 12-month and pacing visualizations exposed this immediately. Fixed in commit `e1428aa` (and refactored to batched upserts in `616c88c`):
+
+- `/v1/organizations/cost_report` is now requested with `bucket_width=1d`.
+- A pure `aggregateDailyCosts(buckets)` helper keys by `(workspace_id, YYYY-MM-DD)` derived from `bucket.starting_at` and sums the multiple per-cost-type rows Anthropic returns inside a single bucket.
+- Upserts are batched into one statement per partial-index bucket (named workspaces / default workspace) — two round-trips per sync regardless of date range.
+- Backfill of historical rows requires `scripts/backfill-anthropic-workspace-costs.ts` (TRUNCATE + re-fetch).
 
 ## User → workspace mapping (Phase 3 decision)
 
@@ -62,11 +71,12 @@ LIMIT 10;
 
 ## Backfill
 
-No backfill of historical data is needed:
+The Phase 3 mapping was originally planned without a backfill — but two backfill scripts shipped after live data exposed gaps. Both are idempotent and safe to re-run.
 
-- The new `resolved_workspace_id` column will populate naturally on the next sync run for every active user — the sync runs hourly.
-- Historical `anthropic_usage_metrics` rows do NOT need backfilling. They're attributed via the live join at query time, not a denormalized column.
-- Users with revoked / disabled API keys won't get a `workspace_id` resolved; their rows will be excluded from per-workspace queries. Acceptable — they can't be in any workspace anyway.
+- `scripts/backfill-anthropic-workspace-costs.ts` — one-off after the per-day storage fix. Operators should TRUNCATE `anthropic_workspace_costs` and run this to re-fetch historical months with `bucket_width=1d`. New syncs already write per-day rows, so no further intervention is required.
+- `scripts/backfill-anthropic-workspace-mapping.ts` — retro-populates `resolved_workspace_id` for users whose `anthropic_sync_status` row already had a `resolved_api_key_id` from spec 016 *before* migration 0018 added the column. `resolveAllMappings()` only re-resolves users whose mapping is missing or whose key changed, so existing rows would otherwise keep `resolved_workspace_id = NULL` forever. The script queries `/v1/organizations/api_keys` once, builds an `api_key_id → workspace_id` map, and updates every row in place.
+- Historical `anthropic_usage_metrics` rows still do NOT need backfilling — they're attributed via the live join at query time, not a denormalized column.
+- Users with revoked / disabled API keys still won't get a `workspace_id` resolved; their rows will be excluded from per-workspace queries.
 
 ## Out of scope
 

--- a/specs/026-claude-page-redesign/mockup.html
+++ b/specs/026-claude-page-redesign/mockup.html
@@ -1,0 +1,931 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Claude API Spending — redesign mock</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0a0a0a;
+        --panel: #121212;
+        --panel-2: #181818;
+        --border: #262626;
+        --border-2: #2e2e2e;
+        --text: #fafafa;
+        --muted: #a1a1aa;
+        --muted-2: #71717a;
+        --primary: #d4f057;
+        --primary-ink: #0a0a0a;
+        --success: #4ade80;
+        --warn: #facc15;
+        --danger: #f87171;
+        --ring: #d4f057;
+      }
+      html, body { background: var(--bg); color: var(--text); }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+      .tabular { font-variant-numeric: tabular-nums; }
+      .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; }
+      .card-2 { background: var(--panel-2); border: 1px solid var(--border); border-radius: 12px; }
+      .pill { display: inline-flex; align-items: center; gap: 6px; padding: 2px 10px; border-radius: 999px; font-size: 12px; font-weight: 500; line-height: 1.6; }
+      .pill .dot { width: 6px; height: 6px; border-radius: 999px; }
+      .legend-swatch { width: 10px; height: 10px; border-radius: 2px; display: inline-block; vertical-align: middle; margin-right: 6px; }
+      .row:hover { background: rgba(255,255,255,0.02); }
+      .progress { height: 6px; border-radius: 999px; background: #262626; overflow: hidden; }
+      .progress > div { height: 100%; border-radius: 999px; }
+      .btn { display: inline-flex; align-items: center; gap: 6px; height: 32px; padding: 0 12px; border-radius: 8px; font-size: 13px; font-weight: 500; border: 1px solid var(--border-2); background: transparent; color: var(--text); cursor: pointer; }
+      .btn:hover { background: #1f1f1f; }
+      .btn-primary { background: var(--primary); color: var(--primary-ink); border-color: var(--primary); }
+      .btn-primary:hover { background: #c9e94a; }
+      .btn-ghost { border-color: transparent; color: var(--muted); }
+      .select { display: inline-flex; align-items: center; justify-content: space-between; gap: 8px; height: 36px; padding: 0 12px; border-radius: 8px; border: 1px solid var(--border-2); background: #141414; color: var(--text); font-size: 13px; }
+      .select svg { color: var(--muted); }
+      .kpi-tile { padding: 16px 18px; border-radius: 12px; border: 1px solid var(--border); background: var(--panel); }
+      .kpi-label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+      .kpi-value { font-size: 28px; font-weight: 600; }
+      .kpi-sub { font-size: 12px; color: var(--muted); }
+      .chip { font-size: 11px; padding: 2px 8px; border-radius: 999px; background: #1f1f1f; color: var(--muted); border: 1px solid var(--border-2); }
+      .ws-row { display: grid; grid-template-columns: minmax(0,1.3fr) 1fr 96px minmax(200px,1.2fr) auto; gap: 20px; align-items: center; padding: 14px 0; }
+      .ws-row.simple { grid-template-columns: minmax(0,1.3fr) 1fr 1fr auto; }
+      .sparkline { display: block; }
+      .sparkline-label { font-size: 10px; color: var(--muted-2); text-align: center; margin-top: 2px; letter-spacing: 0.02em; }
+      .mover-chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 8px; font-size: 12px; background: #181818; border: 1px solid var(--border-2); color: var(--text); }
+      .mover-chip .arrow { color: var(--danger); font-weight: 600; }
+      .ws-name { font-weight: 500; }
+      .ws-spend { font-size: 18px; font-weight: 600; font-variant-numeric: tabular-nums; }
+      .ws-limit { font-size: 13px; color: var(--muted); }
+      .ws-over { color: var(--danger); }
+      .ws-warn { color: var(--warn); }
+      .divider { border-top: 1px solid var(--border); }
+      .skel { background: linear-gradient(90deg, transparent, rgba(255,255,255,0.04), transparent); }
+      .tooltip { position: absolute; background: #0a0a0a; border: 1px solid var(--border-2); border-radius: 8px; padding: 8px 10px; font-size: 12px; pointer-events: none; box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
+      details > summary { list-style: none; cursor: pointer; }
+      details > summary::-webkit-details-marker { display: none; }
+    </style>
+  </head>
+  <body class="min-h-screen">
+    <div class="flex min-h-screen">
+      <!-- Sidebar -->
+      <aside class="w-56 shrink-0 border-r border-[var(--border)] bg-[var(--panel)] p-4 hidden lg:block">
+        <h2 class="text-sm font-semibold mb-4">AI Developer Hub</h2>
+        <div class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] mb-2">Navigation</div>
+        <nav class="text-sm space-y-1">
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded text-[var(--muted)] hover:bg-white/5">Dashboard</a>
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded text-[var(--muted)] hover:bg-white/5">Tools</a>
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded text-[var(--muted)] hover:bg-white/5">Users</a>
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded text-[var(--muted)] hover:bg-white/5">Assignments</a>
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded text-[var(--muted)] hover:bg-white/5">Budget</a>
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded text-[var(--muted)] hover:bg-white/5">Reports</a>
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded text-[var(--muted)] hover:bg-white/5">Copilot</a>
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded bg-white/5 text-white font-medium">Claude</a>
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded text-[var(--muted)] hover:bg-white/5">Invoices</a>
+          <a class="flex items-center gap-2 px-2 py-1.5 rounded text-[var(--muted)] hover:bg-white/5">Settings</a>
+        </nav>
+      </aside>
+
+      <!-- Main -->
+      <main class="flex-1 min-w-0">
+        <div class="mx-auto max-w-[1200px] px-6 py-5 space-y-6">
+
+          <!-- Budget alert (kept) -->
+          <div class="card border-[#3a1212] bg-[#1a0a0a] px-4 py-3 flex items-start gap-3">
+            <span class="mt-0.5 text-[var(--danger)]" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v4M12 17h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/></svg>
+            </span>
+            <div class="flex-1 text-sm">
+              <p class="font-semibold text-[var(--danger)]">Budget Alert</p>
+              <p class="text-[var(--text)]/90"><span class="font-medium">Automations</span> is at <span class="font-semibold">105%</span> of monthly budget — limit exceeded.</p>
+            </div>
+            <button class="btn btn-ghost" aria-label="Dismiss alert">×</button>
+          </div>
+
+          <!-- Header with renamed title (P7) + sync status pill (P5) -->
+          <div class="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <h1 class="text-2xl font-bold tracking-tight">Claude API Spending</h1>
+              <p class="text-[var(--muted)] text-sm">Org-wide usage, budgets, and Anthropic sync status</p>
+            </div>
+            <div class="flex items-center gap-3">
+              <span class="pill" style="background:#0f1d12; color:#86efac; border:1px solid #14532d">
+                <span class="dot" style="background:#22c55e"></span>
+                Synced 3m ago · next in 57m
+              </span>
+              <button class="btn btn-primary">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"/><path d="M20.49 15A9 9 0 0 1 5.64 18.36L1 14"/></svg>
+                Trigger Sync
+              </button>
+            </div>
+          </div>
+
+          <!-- Controls row -->
+          <div class="flex flex-wrap items-center gap-2">
+            <button class="select w-[160px]">
+              <span class="flex items-center gap-2"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg> May 2026</span>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+            <button class="select w-[220px]">
+              <span class="flex items-center gap-2"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg> All workspaces</span>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+            <div class="ml-auto flex items-center gap-2 text-sm text-[var(--muted)]">
+              <button class="btn btn-ghost">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                Export CSV
+              </button>
+            </div>
+          </div>
+
+          <!-- KPI strip (P1: total + MoM delta + run-rate) -->
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="kpi-tile">
+              <div class="kpi-label">Total org spend — May 2026</div>
+              <div class="kpi-value tabular">$1,820.40</div>
+              <div class="kpi-sub mt-1 flex items-center gap-1">
+                <span class="text-[var(--success)]">▲ 12%</span> vs Apr ($1,621.40)
+              </div>
+            </div>
+            <div class="kpi-tile">
+              <div class="kpi-label">Projected month-end</div>
+              <div class="kpi-value tabular">$3,640<span class="text-[var(--muted)] text-base font-normal">.80</span></div>
+              <div class="kpi-sub mt-1"><span class="text-[var(--danger)]">104%</span> of $3,500 budget · linear pace from day 15</div>
+            </div>
+            <div class="kpi-tile">
+              <div class="kpi-label">Workspaces over 80%</div>
+              <div class="kpi-value tabular">1 <span class="text-[var(--muted)] text-base font-normal">/ 13</span></div>
+              <div class="kpi-sub mt-1"><span class="text-[var(--danger)]">Automations</span> · 105% of $50 limit</div>
+            </div>
+          </div>
+
+          <!-- Chart card: stacked by workspace -->
+          <div class="card p-5">
+            <div class="flex items-center justify-between mb-4 gap-4 flex-wrap">
+              <div>
+                <h3 class="text-sm font-medium">Daily spend by workspace</h3>
+                <p class="text-xs text-[var(--muted)]">Stacked · top 6 workspaces + Other</p>
+              </div>
+              <div class="flex flex-wrap gap-3 text-xs text-[var(--muted)]">
+                <span><span class="legend-swatch" style="background:#d4f057"></span>boost-starter-5</span>
+                <span><span class="legend-swatch" style="background:#86efac"></span>boost-starter-1</span>
+                <span><span class="legend-swatch" style="background:#67e8f9"></span>boost-starter-2</span>
+                <span><span class="legend-swatch" style="background:#93c5fd"></span>boost-starter-3</span>
+                <span><span class="legend-swatch" style="background:#c4b5fd"></span>boost-expert-1</span>
+                <span><span class="legend-swatch" style="background:#f9a8d4"></span>Automations</span>
+                <span><span class="legend-swatch" style="background:#52525b"></span>Other</span>
+              </div>
+            </div>
+
+            <!-- Chart: pure SVG, stacked bars over 15 days with synthetic data totaling ~$1,820.40 -->
+            <div class="relative">
+              <svg viewBox="0 0 1100 280" preserveAspectRatio="none" class="w-full h-[300px]" role="img" aria-label="Daily spend by workspace">
+                <!-- Y axis lines -->
+                <g stroke="#262626" stroke-width="1">
+                  <line x1="50" y1="20"  x2="1080" y2="20"  stroke-dasharray="3 3"/>
+                  <line x1="50" y1="80"  x2="1080" y2="80"  stroke-dasharray="3 3"/>
+                  <line x1="50" y1="140" x2="1080" y2="140" stroke-dasharray="3 3"/>
+                  <line x1="50" y1="200" x2="1080" y2="200" stroke-dasharray="3 3"/>
+                  <line x1="50" y1="240" x2="1080" y2="240"/>
+                </g>
+                <!-- Y labels (max $200/day) -->
+                <g fill="#71717a" font-size="11" font-family="ui-sans-serif">
+                  <text x="44" y="24"  text-anchor="end">$200</text>
+                  <text x="44" y="84"  text-anchor="end">$150</text>
+                  <text x="44" y="144" text-anchor="end">$100</text>
+                  <text x="44" y="204" text-anchor="end">$50</text>
+                  <text x="44" y="244" text-anchor="end">$0</text>
+                </g>
+                <!--
+                  X scale: 15 days, bar width 50, gap 18, starting at 60
+                  Y scale: $200/day = 220px (240 - 20)
+                -->
+                <g font-family="ui-sans-serif" font-size="11" fill="#71717a">
+                  <!-- Each <g> = one day, stacked bottom-up: starter-5, starter-1, starter-2, starter-3, expert-1, automations, other -->
+                  <!-- day 1 -->
+                  <g transform="translate(60,0)">
+                    <rect x="0" y="124" width="50" height="116" fill="#d4f057"/>
+                    <rect x="0" y="84"  width="50" height="40"  fill="#86efac"/>
+                    <rect x="0" y="60"  width="50" height="24"  fill="#67e8f9"/>
+                    <rect x="0" y="44"  width="50" height="16"  fill="#93c5fd"/>
+                    <rect x="0" y="32"  width="50" height="12"  fill="#c4b5fd"/>
+                    <rect x="0" y="26"  width="50" height="6"   fill="#f9a8d4"/>
+                    <rect x="0" y="20"  width="50" height="6"   fill="#52525b"/>
+                    <text x="25" y="258" text-anchor="middle">May 1</text>
+                  </g>
+                  <!-- day 2 -->
+                  <g transform="translate(128,0)">
+                    <rect x="0" y="146" width="50" height="94"  fill="#d4f057"/>
+                    <rect x="0" y="118" width="50" height="28"  fill="#86efac"/>
+                    <rect x="0" y="100" width="50" height="18"  fill="#67e8f9"/>
+                    <rect x="0" y="86"  width="50" height="14"  fill="#93c5fd"/>
+                    <rect x="0" y="72"  width="50" height="14"  fill="#c4b5fd"/>
+                    <rect x="0" y="64"  width="50" height="8"   fill="#f9a8d4"/>
+                    <rect x="0" y="58"  width="50" height="6"   fill="#52525b"/>
+                  </g>
+                  <g transform="translate(196,0)">
+                    <rect x="0" y="160" width="50" height="80"  fill="#d4f057"/>
+                    <rect x="0" y="132" width="50" height="28"  fill="#86efac"/>
+                    <rect x="0" y="116" width="50" height="16"  fill="#67e8f9"/>
+                    <rect x="0" y="100" width="50" height="16"  fill="#93c5fd"/>
+                    <rect x="0" y="84"  width="50" height="16"  fill="#c4b5fd"/>
+                    <rect x="0" y="76"  width="50" height="8"   fill="#f9a8d4"/>
+                    <rect x="0" y="70"  width="50" height="6"   fill="#52525b"/>
+                  </g>
+                  <g transform="translate(264,0)">
+                    <rect x="0" y="116" width="50" height="124" fill="#d4f057"/>
+                    <rect x="0" y="78"  width="50" height="38"  fill="#86efac"/>
+                    <rect x="0" y="56"  width="50" height="22"  fill="#67e8f9"/>
+                    <rect x="0" y="40"  width="50" height="16"  fill="#93c5fd"/>
+                    <rect x="0" y="24"  width="50" height="16"  fill="#c4b5fd"/>
+                    <rect x="0" y="16"  width="50" height="8"   fill="#f9a8d4"/>
+                    <rect x="0" y="10"  width="50" height="6"   fill="#52525b"/>
+                  </g>
+                  <g transform="translate(332,0)">
+                    <rect x="0" y="150" width="50" height="90"  fill="#d4f057"/>
+                    <rect x="0" y="124" width="50" height="26"  fill="#86efac"/>
+                    <rect x="0" y="106" width="50" height="18"  fill="#67e8f9"/>
+                    <rect x="0" y="92"  width="50" height="14"  fill="#93c5fd"/>
+                    <rect x="0" y="78"  width="50" height="14"  fill="#c4b5fd"/>
+                    <rect x="0" y="70"  width="50" height="8"   fill="#f9a8d4"/>
+                    <rect x="0" y="64"  width="50" height="6"   fill="#52525b"/>
+                    <text x="25" y="258" text-anchor="middle">May 5</text>
+                  </g>
+                  <g transform="translate(400,0)">
+                    <rect x="0" y="180" width="50" height="60"  fill="#d4f057"/>
+                    <rect x="0" y="160" width="50" height="20"  fill="#86efac"/>
+                    <rect x="0" y="148" width="50" height="12"  fill="#67e8f9"/>
+                    <rect x="0" y="136" width="50" height="12"  fill="#93c5fd"/>
+                    <rect x="0" y="124" width="50" height="12"  fill="#c4b5fd"/>
+                    <rect x="0" y="118" width="50" height="6"   fill="#f9a8d4"/>
+                    <rect x="0" y="114" width="50" height="4"   fill="#52525b"/>
+                  </g>
+                  <g transform="translate(468,0)">
+                    <rect x="0" y="186" width="50" height="54"  fill="#d4f057"/>
+                    <rect x="0" y="168" width="50" height="18"  fill="#86efac"/>
+                    <rect x="0" y="156" width="50" height="12"  fill="#67e8f9"/>
+                    <rect x="0" y="144" width="50" height="12"  fill="#93c5fd"/>
+                    <rect x="0" y="132" width="50" height="12"  fill="#c4b5fd"/>
+                    <rect x="0" y="126" width="50" height="6"   fill="#f9a8d4"/>
+                    <rect x="0" y="122" width="50" height="4"   fill="#52525b"/>
+                  </g>
+                  <g transform="translate(536,0)">
+                    <rect x="0" y="130" width="50" height="110" fill="#d4f057"/>
+                    <rect x="0" y="96"  width="50" height="34"  fill="#86efac"/>
+                    <rect x="0" y="76"  width="50" height="20"  fill="#67e8f9"/>
+                    <rect x="0" y="60"  width="50" height="16"  fill="#93c5fd"/>
+                    <rect x="0" y="46"  width="50" height="14"  fill="#c4b5fd"/>
+                    <rect x="0" y="38"  width="50" height="8"   fill="#f9a8d4"/>
+                    <rect x="0" y="32"  width="50" height="6"   fill="#52525b"/>
+                  </g>
+                  <g transform="translate(604,0)">
+                    <rect x="0" y="142" width="50" height="98"  fill="#d4f057"/>
+                    <rect x="0" y="112" width="50" height="30"  fill="#86efac"/>
+                    <rect x="0" y="92"  width="50" height="20"  fill="#67e8f9"/>
+                    <rect x="0" y="78"  width="50" height="14"  fill="#93c5fd"/>
+                    <rect x="0" y="62"  width="50" height="16"  fill="#c4b5fd"/>
+                    <rect x="0" y="54"  width="50" height="8"   fill="#f9a8d4"/>
+                    <rect x="0" y="48"  width="50" height="6"   fill="#52525b"/>
+                    <text x="25" y="258" text-anchor="middle">May 10</text>
+                  </g>
+                  <g transform="translate(672,0)">
+                    <rect x="0" y="156" width="50" height="84"  fill="#d4f057"/>
+                    <rect x="0" y="128" width="50" height="28"  fill="#86efac"/>
+                    <rect x="0" y="112" width="50" height="16"  fill="#67e8f9"/>
+                    <rect x="0" y="98"  width="50" height="14"  fill="#93c5fd"/>
+                    <rect x="0" y="86"  width="50" height="12"  fill="#c4b5fd"/>
+                    <rect x="0" y="78"  width="50" height="8"   fill="#f9a8d4"/>
+                    <rect x="0" y="72"  width="50" height="6"   fill="#52525b"/>
+                  </g>
+                  <g transform="translate(740,0)">
+                    <rect x="0" y="168" width="50" height="72"  fill="#d4f057"/>
+                    <rect x="0" y="142" width="50" height="26"  fill="#86efac"/>
+                    <rect x="0" y="126" width="50" height="16"  fill="#67e8f9"/>
+                    <rect x="0" y="114" width="50" height="12"  fill="#93c5fd"/>
+                    <rect x="0" y="100" width="50" height="14"  fill="#c4b5fd"/>
+                    <rect x="0" y="92"  width="50" height="8"   fill="#f9a8d4"/>
+                    <rect x="0" y="86"  width="50" height="6"   fill="#52525b"/>
+                  </g>
+                  <g transform="translate(808,0)">
+                    <rect x="0" y="120" width="50" height="120" fill="#d4f057"/>
+                    <rect x="0" y="82"  width="50" height="38"  fill="#86efac"/>
+                    <rect x="0" y="60"  width="50" height="22"  fill="#67e8f9"/>
+                    <rect x="0" y="44"  width="50" height="16"  fill="#93c5fd"/>
+                    <rect x="0" y="28"  width="50" height="16"  fill="#c4b5fd"/>
+                    <rect x="0" y="20"  width="50" height="8"   fill="#f9a8d4"/>
+                    <rect x="0" y="14"  width="50" height="6"   fill="#52525b"/>
+                  </g>
+                  <g transform="translate(876,0)">
+                    <rect x="0" y="100" width="50" height="140" fill="#d4f057"/>
+                    <rect x="0" y="66"  width="50" height="34"  fill="#86efac"/>
+                    <rect x="0" y="44"  width="50" height="22"  fill="#67e8f9"/>
+                    <rect x="0" y="28"  width="50" height="16"  fill="#93c5fd"/>
+                    <rect x="0" y="12"  width="50" height="16"  fill="#c4b5fd"/>
+                    <rect x="0" y="4"   width="50" height="8"   fill="#f9a8d4"/>
+                  </g>
+                  <g transform="translate(944,0)">
+                    <rect x="0" y="92"  width="50" height="148" fill="#d4f057"/>
+                    <rect x="0" y="58"  width="50" height="34"  fill="#86efac"/>
+                    <rect x="0" y="36"  width="50" height="22"  fill="#67e8f9"/>
+                    <rect x="0" y="20"  width="50" height="16"  fill="#93c5fd"/>
+                    <rect x="0" y="4"   width="50" height="16"  fill="#c4b5fd"/>
+                  </g>
+                  <g transform="translate(1012,0)">
+                    <rect x="0" y="106" width="50" height="134" fill="#d4f057"/>
+                    <rect x="0" y="74"  width="50" height="32"  fill="#86efac"/>
+                    <rect x="0" y="52"  width="50" height="22"  fill="#67e8f9"/>
+                    <rect x="0" y="36"  width="50" height="16"  fill="#93c5fd"/>
+                    <rect x="0" y="20"  width="50" height="16"  fill="#c4b5fd"/>
+                    <text x="25" y="258" text-anchor="middle">May 15</text>
+                  </g>
+                </g>
+
+                <!-- Run-rate forecast: dashed line from end of bars to projected total at day 31 -->
+                <g>
+                  <line x1="1062" y1="20" x2="1080" y2="20" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4 3"/>
+                  <text x="1075" y="14" text-anchor="end" font-size="10" fill="#f87171" font-family="ui-sans-serif">budget cap</text>
+                </g>
+              </svg>
+            </div>
+          </div>
+
+          <!-- Historical trend card (NEW) -->
+          <section aria-label="Historical trend">
+            <div class="card p-5 space-y-5">
+              <div class="flex items-start justify-between gap-4 flex-wrap">
+                <div>
+                  <h3 class="text-sm font-medium">Historical trend</h3>
+                  <p class="text-xs text-[var(--muted)]">Last 12 months · monthly totals and pacing vs. prior months</p>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-xs text-[var(--muted)] mr-1">Top movers (6mo):</span>
+                  <span class="mover-chip"><span class="arrow">▲</span><span class="font-medium">Automations</span><span class="text-[var(--muted)]">$8 → $41 · +413%</span></span>
+                  <span class="mover-chip"><span class="arrow">▲</span><span class="font-medium">boost-starter-5</span><span class="text-[var(--muted)]">$160 → $400 · +150%</span></span>
+                  <span class="mover-chip"><span class="arrow">▲</span><span class="font-medium">boost-starter-3</span><span class="text-[var(--muted)]">$85 → $180 · +112%</span></span>
+                </div>
+              </div>
+
+              <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <!-- LEFT: 12-month bar chart -->
+                <div>
+                  <div class="flex items-center justify-between mb-2">
+                    <h4 class="text-xs uppercase tracking-wider text-[var(--muted-2)]">Monthly totals</h4>
+                    <span class="text-xs text-[var(--muted)]">Jun 2025 → May 2026 (projected)</span>
+                  </div>
+                  <svg viewBox="0 0 540 260" class="w-full h-[240px]" role="img" aria-label="12-month spend bar chart">
+                    <!-- grid -->
+                    <g stroke="#262626" stroke-dasharray="3 3"><line x1="40" y1="20"  x2="530" y2="20"/><line x1="40" y1="70"  x2="530" y2="70"/><line x1="40" y1="120" x2="530" y2="120"/><line x1="40" y1="170" x2="530" y2="170"/></g>
+                    <line x1="40" y1="220" x2="530" y2="220" stroke="#262626"/>
+                    <!-- y labels (max $4k) -->
+                    <g fill="#71717a" font-size="10" font-family="ui-sans-serif">
+                      <text x="36" y="23"  text-anchor="end">$4k</text>
+                      <text x="36" y="73"  text-anchor="end">$3k</text>
+                      <text x="36" y="123" text-anchor="end">$2k</text>
+                      <text x="36" y="173" text-anchor="end">$1k</text>
+                      <text x="36" y="223" text-anchor="end">$0</text>
+                    </g>
+                    <!-- budget cap line ($3,500 → y=45) -->
+                    <g>
+                      <line x1="40" y1="45" x2="530" y2="45" stroke="#f87171" stroke-width="1" stroke-dasharray="4 3"/>
+                      <text x="528" y="40" text-anchor="end" font-size="10" fill="#f87171">budget cap $3,500</text>
+                    </g>
+                    <!-- bars (width 28, gap 12, start x=50) -->
+                    <g>
+                      <!-- Jun $820 -->   <rect x="50"  y="179" width="28" height="41" fill="#3f3f46" rx="2"/>
+                      <!-- Jul $940 -->   <rect x="90"  y="173" width="28" height="47" fill="#3f3f46" rx="2"/>
+                      <!-- Aug $1050 -->  <rect x="130" y="167" width="28" height="53" fill="#3f3f46" rx="2"/>
+                      <!-- Sep $1180 -->  <rect x="170" y="161" width="28" height="59" fill="#3f3f46" rx="2"/>
+                      <!-- Oct $1310 -->  <rect x="210" y="154" width="28" height="66" fill="#52525b" rx="2"/>
+                      <!-- Nov $1240 -->  <rect x="250" y="158" width="28" height="62" fill="#52525b" rx="2"/>
+                      <!-- Dec $980 -->   <rect x="290" y="171" width="28" height="49" fill="#52525b" rx="2"/>
+                      <!-- Jan $1420 -->  <rect x="330" y="149" width="28" height="71" fill="#71717a" rx="2"/>
+                      <!-- Feb $1490 -->  <rect x="370" y="145" width="28" height="75" fill="#71717a" rx="2"/>
+                      <!-- Mar $1560 -->  <rect x="410" y="142" width="28" height="78" fill="#71717a" rx="2"/>
+                      <!-- Apr $1621 -->  <rect x="450" y="139" width="28" height="81" fill="#a1a1aa" rx="2"/>
+                      <!-- May actual $1820 -->     <rect x="490" y="129" width="28" height="91" fill="#d4f057" rx="2"/>
+                      <!-- May projected (top) +$1821 -->  <rect x="490" y="38"  width="28" height="91" fill="#d4f057" fill-opacity="0.28" rx="2" stroke="#d4f057" stroke-dasharray="3 3" stroke-width="1"/>
+                    </g>
+                    <!-- x labels -->
+                    <g fill="#71717a" font-size="10" font-family="ui-sans-serif" text-anchor="middle">
+                      <text x="64"  y="238">Jun</text>
+                      <text x="104" y="238">Jul</text>
+                      <text x="144" y="238">Aug</text>
+                      <text x="184" y="238">Sep</text>
+                      <text x="224" y="238">Oct</text>
+                      <text x="264" y="238">Nov</text>
+                      <text x="304" y="238">Dec</text>
+                      <text x="344" y="238">Jan</text>
+                      <text x="384" y="238">Feb</text>
+                      <text x="424" y="238">Mar</text>
+                      <text x="464" y="238">Apr</text>
+                      <text x="504" y="238" fill="#d4f057" font-weight="600">May</text>
+                    </g>
+                    <!-- annotation: this month -->
+                    <g font-family="ui-sans-serif">
+                      <text x="504" y="124" font-size="9" fill="#d4f057" text-anchor="middle">$1,820</text>
+                      <text x="504" y="32"  font-size="9" fill="#d4f057" text-anchor="middle" font-weight="600">$3,641</text>
+                    </g>
+                  </svg>
+                  <div class="flex items-center gap-4 text-xs text-[var(--muted)] mt-1 pl-10">
+                    <span class="inline-flex items-center gap-1.5"><span class="legend-swatch" style="background:#d4f057"></span>this month</span>
+                    <span class="inline-flex items-center gap-1.5"><span class="legend-swatch" style="background:#d4f057;opacity:0.4"></span>projected</span>
+                    <span class="inline-flex items-center gap-1.5"><span class="legend-swatch" style="background:#a1a1aa"></span>prior month</span>
+                    <span class="inline-flex items-center gap-1.5"><span class="legend-swatch" style="background:#3f3f46"></span>older</span>
+                  </div>
+                </div>
+
+                <!-- RIGHT: cumulative pacing chart -->
+                <div>
+                  <div class="flex items-center justify-between mb-2">
+                    <h4 class="text-xs uppercase tracking-wider text-[var(--muted-2)]">Cumulative pacing</h4>
+                    <span class="text-xs text-[var(--muted)]">By day-of-month · this month vs. prior 3</span>
+                  </div>
+                  <svg viewBox="0 0 540 260" class="w-full h-[240px]" role="img" aria-label="Cumulative spend by day-of-month, current vs prior 3 months">
+                    <!-- grid -->
+                    <g stroke="#262626" stroke-dasharray="3 3"><line x1="40" y1="20"  x2="510" y2="20"/><line x1="40" y1="70"  x2="510" y2="70"/><line x1="40" y1="120" x2="510" y2="120"/><line x1="40" y1="170" x2="510" y2="170"/></g>
+                    <line x1="40" y1="220" x2="510" y2="220" stroke="#262626"/>
+                    <!-- y labels (max $4k) -->
+                    <g fill="#71717a" font-size="10" font-family="ui-sans-serif">
+                      <text x="36" y="23"  text-anchor="end">$4k</text>
+                      <text x="36" y="73"  text-anchor="end">$3k</text>
+                      <text x="36" y="123" text-anchor="end">$2k</text>
+                      <text x="36" y="173" text-anchor="end">$1k</text>
+                      <text x="36" y="223" text-anchor="end">$0</text>
+                    </g>
+                    <!-- budget cap -->
+                    <g>
+                      <line x1="40" y1="45" x2="510" y2="45" stroke="#f87171" stroke-width="1" stroke-dasharray="4 3"/>
+                      <text x="508" y="40" text-anchor="end" font-size="10" fill="#f87171">budget cap</text>
+                    </g>
+                    <!-- February ($1,490 at day 28) -->
+                    <polyline fill="none" stroke="#52525b" stroke-width="1.5"
+                      points="40,219 100,210 160,200 220,190 280,178 340,165 400,151 460,139" />
+                    <!-- March ($1,560 at day 31) -->
+                    <polyline fill="none" stroke="#71717a" stroke-width="1.5"
+                      points="40,217 100,208 175,194 250,181 325,168 400,155 490,142" />
+                    <!-- April ($1,621 at day 30) -->
+                    <polyline fill="none" stroke="#a1a1aa" stroke-width="1.5"
+                      points="40,218 100,207 175,194 250,180 325,166 400,152 475,139" />
+                    <!-- This month — solid through day 15 -->
+                    <polyline fill="none" stroke="#d4f057" stroke-width="2.5"
+                      points="40,213 70,202 100,190 130,179 175,161 205,149 250,129" />
+                    <!-- This month — dashed projection day 15 → 31 -->
+                    <polyline fill="none" stroke="#d4f057" stroke-width="2" stroke-dasharray="5 3" opacity="0.85"
+                      points="250,129 325,100 400,70 490,38" />
+                    <!-- Day 15 marker -->
+                    <line x1="250" y1="20" x2="250" y2="220" stroke="#3f3f46" stroke-dasharray="2 3"/>
+                    <text x="250" y="16" font-size="10" fill="#71717a" font-family="ui-sans-serif" text-anchor="middle">today</text>
+                    <circle cx="250" cy="129" r="3.5" fill="#d4f057"/>
+                    <!-- x axis labels -->
+                    <g fill="#71717a" font-size="10" font-family="ui-sans-serif" text-anchor="middle">
+                      <text x="40"  y="238">1</text>
+                      <text x="100" y="238">5</text>
+                      <text x="175" y="238">10</text>
+                      <text x="250" y="238">15</text>
+                      <text x="325" y="238">20</text>
+                      <text x="400" y="238">25</text>
+                      <text x="490" y="238">31</text>
+                    </g>
+                  </svg>
+                  <div class="flex items-center gap-4 text-xs text-[var(--muted)] mt-1 pl-10 flex-wrap">
+                    <span class="inline-flex items-center gap-1.5"><span style="display:inline-block;width:12px;height:2px;background:#d4f057;border-radius:2px"></span>May 2026</span>
+                    <span class="inline-flex items-center gap-1.5"><span style="display:inline-block;width:12px;height:2px;background:#a1a1aa;border-radius:2px"></span>Apr</span>
+                    <span class="inline-flex items-center gap-1.5"><span style="display:inline-block;width:12px;height:2px;background:#71717a;border-radius:2px"></span>Mar</span>
+                    <span class="inline-flex items-center gap-1.5"><span style="display:inline-block;width:12px;height:2px;background:#52525b;border-radius:2px"></span>Feb</span>
+                    <span class="ml-auto text-[var(--text)]">Day 15: tracking <span class="font-medium" style="color:#facc15">+125% vs Apr</span> at same day</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <!-- Organization Billing — single full-width card (P3 option A) -->
+          <section aria-label="Organization billing">
+            <h2 class="text-lg font-semibold mb-3">Organization Billing</h2>
+            <div class="card p-5">
+              <div class="flex flex-wrap items-start justify-between gap-6">
+                <div class="min-w-[260px]">
+                  <p class="text-sm text-[var(--muted)]">Monthly billing budget</p>
+                  <p class="text-2xl font-semibold tabular mt-1">$1,820.40 <span class="text-base text-[var(--muted)] font-normal">/ $3,500.00</span></p>
+                  <div class="mt-3 w-[340px] max-w-full">
+                    <div class="progress"><div style="width:52%; background:#d4f057"></div></div>
+                    <p class="text-xs text-[var(--muted)] mt-1">52% used · 16 days left in May</p>
+                  </div>
+                </div>
+                <div class="min-w-[200px]">
+                  <p class="text-sm text-[var(--muted)]">Projected month-end</p>
+                  <p class="text-2xl font-semibold tabular mt-1 ws-over">$3,640.80</p>
+                  <p class="text-xs text-[var(--muted)] mt-3">104% of budget · over by $140.80</p>
+                </div>
+                <div class="flex items-center gap-2">
+                  <button class="btn">Edit budget</button>
+                </div>
+              </div>
+              <p class="text-xs text-[var(--muted)] mt-4">
+                Credit balance isn't exposed by the Anthropic API —
+                <a href="https://console.anthropic.com" class="underline underline-offset-4 hover:text-white">view in Anthropic Console ↗</a>.
+              </p>
+            </div>
+          </section>
+
+          <!-- Workspace Budgets — re-sorted by utilization (P2) + hide-zero toggle -->
+          <section aria-label="Workspace budgets">
+            <div class="flex items-center justify-between mb-3 gap-4 flex-wrap">
+              <h2 class="text-lg font-semibold">Workspace Budgets</h2>
+              <div class="flex items-center gap-4">
+                <label class="flex items-center gap-2 text-sm text-[var(--muted)] cursor-pointer">
+                  <input type="checkbox" checked class="rounded border-[var(--border-2)] bg-transparent text-[var(--primary)]" />
+                  Hide $0 + no limit
+                </label>
+                <div class="flex items-center gap-1 text-xs text-[var(--muted)]">
+                  Sort:
+                  <button class="chip" style="background:#1f1f1f; color:#fafafa; border-color:var(--border-2)">Utilization</button>
+                  <button class="chip">Spend</button>
+                  <button class="chip">Name</button>
+                </div>
+              </div>
+            </div>
+
+            <div class="card divide-y divide-[var(--border)] px-5">
+
+              <!-- Row: Automations (over) -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2">
+                    <span class="ws-name">Automations</span>
+                    <span class="pill" style="background:#2a0a0a; color:#fca5a5; border:1px solid #7f1d1d">
+                      <span class="dot" style="background:#f87171"></span> over budget
+                    </span>
+                  </div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_at1234… · 4 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend ws-over">$52.49</div>
+                  <p class="text-xs text-[var(--muted)]">limit $50.00 · over by $2.49</p>
+                </div>
+                <div class="sparkline" title="Nov $8 → Apr $41 · +413%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="19.4" width="12" height="4.6"  fill="#f87171" rx="1.5"/>
+                    <rect x="16" y="17.0" width="12" height="7.0"  fill="#f87171" rx="1.5"/>
+                    <rect x="30" y="13.5" width="12" height="10.5" fill="#f87171" rx="1.5"/>
+                    <rect x="44" y="10.0" width="12" height="14.0" fill="#f87171" rx="1.5"/>
+                    <rect x="58" y="5.3"  width="12" height="18.7" fill="#f87171" rx="1.5"/>
+                    <rect x="72" y="0"    width="12" height="24"   fill="#f87171" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label"><span style="color:#f87171">▲ 6mo</span></div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:100%; background:#f87171"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1"><span class="ws-over font-medium">105%</span> · projected $105 month-end</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- boost-expert-1 -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2"><span class="ws-name">boost-expert-1</span></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_be0001… · 8 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$125.64</div>
+                  <p class="text-xs text-[var(--muted)]">limit $200.00</p>
+                </div>
+                <div class="sparkline" title="Nov $88 → Apr $118 · +34%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="6.1" width="12" height="17.9" fill="#86efac" rx="1.5"/>
+                    <rect x="16" y="4.6" width="12" height="19.3" fill="#86efac" rx="1.5"/>
+                    <rect x="30" y="3.2" width="12" height="20.7" fill="#86efac" rx="1.5"/>
+                    <rect x="44" y="2.0" width="12" height="21.9" fill="#86efac" rx="1.5"/>
+                    <rect x="58" y="0.6" width="12" height="23.4" fill="#86efac" rx="1.5"/>
+                    <rect x="72" y="0"   width="12" height="24"   fill="#86efac" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label">+34% 6mo</div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:63%; background:#d4f057"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">63% · on pace $251 (126%)</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- boost-starter-1 -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2"><span class="ws-name">boost-starter-1</span></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_bs0001… · 12 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$370.72</div>
+                  <p class="text-xs text-[var(--muted)]">limit $600.00</p>
+                </div>
+                <div class="sparkline" title="Nov $200 → Apr $360 · +80%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="10.7" width="12" height="13.3" fill="#86efac" rx="1.5"/>
+                    <rect x="16" y="8.7"  width="12" height="15.3" fill="#86efac" rx="1.5"/>
+                    <rect x="30" y="5.3"  width="12" height="18.7" fill="#86efac" rx="1.5"/>
+                    <rect x="44" y="3.3"  width="12" height="20.7" fill="#86efac" rx="1.5"/>
+                    <rect x="58" y="1.3"  width="12" height="22.7" fill="#86efac" rx="1.5"/>
+                    <rect x="72" y="0"    width="12" height="24"   fill="#86efac" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label">+80% 6mo</div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:62%; background:#d4f057"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">62% · on pace $741 (124%)</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- boost-starter-5 -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2"><span class="ws-name">boost-starter-5</span></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_bs0005… · 9 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$415.47</div>
+                  <p class="text-xs text-[var(--muted)]">limit $700.00</p>
+                </div>
+                <div class="sparkline" title="Nov $160 → Apr $400 · +150%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="14.4" width="12" height="9.6"  fill="#facc15" rx="1.5"/>
+                    <rect x="16" y="12.0" width="12" height="12.0" fill="#facc15" rx="1.5"/>
+                    <rect x="30" y="8.4"  width="12" height="15.6" fill="#facc15" rx="1.5"/>
+                    <rect x="44" y="5.4"  width="12" height="18.6" fill="#facc15" rx="1.5"/>
+                    <rect x="58" y="2.4"  width="12" height="21.6" fill="#facc15" rx="1.5"/>
+                    <rect x="72" y="0"    width="12" height="24"   fill="#facc15" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label"><span style="color:#facc15">▲ 150% 6mo</span></div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:59%; background:#d4f057"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">59% · on pace $830 (119%)</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- boost-starter-7 -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2"><span class="ws-name">boost-starter-7</span></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_bs0007… · 3 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$103.41</div>
+                  <p class="text-xs text-[var(--muted)]">limit $200.00</p>
+                </div>
+                <div class="sparkline" title="Nov $50 → Apr $95 · +90%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="11.4" width="12" height="12.6" fill="#86efac" rx="1.5"/>
+                    <rect x="16" y="8.8"  width="12" height="15.2" fill="#86efac" rx="1.5"/>
+                    <rect x="30" y="4.9"  width="12" height="19.1" fill="#86efac" rx="1.5"/>
+                    <rect x="44" y="2.9"  width="12" height="21.1" fill="#86efac" rx="1.5"/>
+                    <rect x="58" y="1.3"  width="12" height="22.7" fill="#86efac" rx="1.5"/>
+                    <rect x="72" y="0"    width="12" height="24"   fill="#86efac" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label">+90% 6mo</div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:52%; background:#d4f057"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">52% · on pace $207 (103%)</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- boost-starter-6 -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2"><span class="ws-name">boost-starter-6</span></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_bs0006… · 5 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$187.02</div>
+                  <p class="text-xs text-[var(--muted)]">limit $450.00</p>
+                </div>
+                <div class="sparkline" title="Nov $90 → Apr $175 · +94%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="11.6" width="12" height="12.4" fill="#86efac" rx="1.5"/>
+                    <rect x="16" y="9.6"  width="12" height="14.4" fill="#86efac" rx="1.5"/>
+                    <rect x="30" y="6.1"  width="12" height="17.9" fill="#86efac" rx="1.5"/>
+                    <rect x="44" y="4.1"  width="12" height="19.9" fill="#86efac" rx="1.5"/>
+                    <rect x="58" y="2.1"  width="12" height="21.9" fill="#86efac" rx="1.5"/>
+                    <rect x="72" y="0"    width="12" height="24"   fill="#86efac" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label">+94% 6mo</div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:42%; background:#d4f057"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">42% · on pace $374 (83%)</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- boost-starter-2 -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2"><span class="ws-name">boost-starter-2</span></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_bs0002… · 11 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$208.88</div>
+                  <p class="text-xs text-[var(--muted)]">limit $600.00</p>
+                </div>
+                <div class="sparkline" title="Nov $110 → Apr $200 · +82%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="10.8" width="12" height="13.2" fill="#86efac" rx="1.5"/>
+                    <rect x="16" y="8.4"  width="12" height="15.6" fill="#86efac" rx="1.5"/>
+                    <rect x="30" y="4.8"  width="12" height="19.2" fill="#86efac" rx="1.5"/>
+                    <rect x="44" y="3.0"  width="12" height="21.0" fill="#86efac" rx="1.5"/>
+                    <rect x="58" y="1.4"  width="12" height="22.6" fill="#86efac" rx="1.5"/>
+                    <rect x="72" y="0"    width="12" height="24"   fill="#86efac" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label">+82% 6mo</div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:35%; background:#d4f057"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">35% · on pace $418 (70%)</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- boost-starter-3 -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2"><span class="ws-name">boost-starter-3</span></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_bs0003… · 7 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$190.62</div>
+                  <p class="text-xs text-[var(--muted)]">limit $550.00</p>
+                </div>
+                <div class="sparkline" title="Nov $85 → Apr $180 · +112%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="12.7" width="12" height="11.3" fill="#facc15" rx="1.5"/>
+                    <rect x="16" y="11.0" width="12" height="13.0" fill="#facc15" rx="1.5"/>
+                    <rect x="30" y="7.3"  width="12" height="16.7" fill="#facc15" rx="1.5"/>
+                    <rect x="44" y="5.1"  width="12" height="18.9" fill="#facc15" rx="1.5"/>
+                    <rect x="58" y="2.0"  width="12" height="22.0" fill="#facc15" rx="1.5"/>
+                    <rect x="72" y="0"    width="12" height="24"   fill="#facc15" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label"><span style="color:#facc15">▲ 112% 6mo</span></div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:35%; background:#d4f057"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">35% · on pace $381 (69%)</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- boost-starter-4 -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2"><span class="ws-name">boost-starter-4</span></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_bs0004… · 6 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$125.82</div>
+                  <p class="text-xs text-[var(--muted)]">limit $450.00</p>
+                </div>
+                <div class="sparkline" title="Nov $60 → Apr $122 · +103%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="12.2" width="12" height="11.8" fill="#facc15" rx="1.5"/>
+                    <rect x="16" y="9.3"  width="12" height="14.7" fill="#facc15" rx="1.5"/>
+                    <rect x="30" y="5.3"  width="12" height="18.7" fill="#facc15" rx="1.5"/>
+                    <rect x="44" y="3.4"  width="12" height="20.6" fill="#facc15" rx="1.5"/>
+                    <rect x="58" y="1.4"  width="12" height="22.6" fill="#facc15" rx="1.5"/>
+                    <rect x="72" y="0"    width="12" height="24"   fill="#facc15" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label"><span style="color:#facc15">▲ 103% 6mo</span></div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:28%; background:#d4f057"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">28% · on pace $252 (56%)</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- boost-starter-8 -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2"><span class="ws-name">boost-starter-8</span></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">ws_bs0008… · 2 users</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$39.52</div>
+                  <p class="text-xs text-[var(--muted)]">limit $300.00</p>
+                </div>
+                <div class="sparkline" title="Nov $18 → Apr $70 · +289%">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="17.8" width="12" height="6.2"  fill="#facc15" rx="1.5"/>
+                    <rect x="16" y="15.4" width="12" height="8.6"  fill="#facc15" rx="1.5"/>
+                    <rect x="30" y="12.0" width="12" height="12.0" fill="#facc15" rx="1.5"/>
+                    <rect x="44" y="9.6"  width="12" height="14.4" fill="#facc15" rx="1.5"/>
+                    <rect x="58" y="5.1"  width="12" height="18.9" fill="#facc15" rx="1.5"/>
+                    <rect x="72" y="0"    width="12" height="24"   fill="#facc15" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label"><span style="color:#facc15">▲ 6mo</span></div>
+                </div>
+                <div>
+                  <div class="progress"><div style="width:13%; background:#d4f057"></div></div>
+                  <p class="text-xs text-[var(--muted)] mt-1">13% · on pace $79 (26%)</p>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Edit</button>
+                  <button class="btn btn-ghost" title="View workspace">↗</button>
+                </div>
+              </div>
+
+              <!-- Default Workspace (has spend but no limit) -->
+              <div class="ws-row row">
+                <div>
+                  <div class="flex items-center gap-2">
+                    <span class="ws-name">Default Workspace</span>
+                    <span class="chip">Default</span>
+                  </div>
+                  <p class="text-xs text-[var(--muted)] mt-1">— · 1 user</p>
+                </div>
+                <div>
+                  <div class="ws-spend">$0.81</div>
+                  <p class="text-xs text-[var(--muted)]">no limit configured</p>
+                </div>
+                <div class="sparkline" title="Stable, near-zero usage">
+                  <svg viewBox="0 0 86 24" width="86" height="24" aria-hidden="true">
+                    <rect x="2"  y="20" width="12" height="4" fill="#52525b" rx="1.5"/>
+                    <rect x="16" y="21" width="12" height="3" fill="#52525b" rx="1.5"/>
+                    <rect x="30" y="20" width="12" height="4" fill="#52525b" rx="1.5"/>
+                    <rect x="44" y="22" width="12" height="2" fill="#52525b" rx="1.5"/>
+                    <rect x="58" y="21" width="12" height="3" fill="#52525b" rx="1.5"/>
+                    <rect x="72" y="22" width="12" height="2" fill="#52525b" rx="1.5"/>
+                  </svg>
+                  <div class="sparkline-label">flat</div>
+                </div>
+                <div></div>
+                <div class="flex items-center gap-1">
+                  <button class="btn">Set limit</button>
+                </div>
+              </div>
+
+            </div>
+
+            <details class="mt-3">
+              <summary class="text-sm text-[var(--muted)] hover:text-white inline-flex items-center gap-1">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+                Show 3 hidden workspaces ($0, no limit)
+              </summary>
+              <div class="card divide-y divide-[var(--border)] px-5 mt-2 opacity-70">
+                <div class="ws-row row">
+                  <div><span class="ws-name">boost-expert-2</span></div>
+                  <div><div class="ws-spend">$0.00</div><p class="text-xs text-[var(--muted)]">no limit</p></div>
+                  <div></div>
+                  <div><button class="btn">Set limit</button></div>
+                </div>
+                <div class="ws-row row">
+                  <div><span class="ws-name">boost-expert-3</span></div>
+                  <div><div class="ws-spend">$0.00</div><p class="text-xs text-[var(--muted)]">no limit</p></div>
+                  <div></div>
+                  <div><button class="btn">Set limit</button></div>
+                </div>
+                <div class="ws-row row">
+                  <div><span class="ws-name">boost-starter-9</span></div>
+                  <div><div class="ws-spend">$0.00</div><p class="text-xs text-[var(--muted)]">no limit</p></div>
+                  <div></div>
+                  <div><button class="btn">Set limit</button></div>
+                </div>
+              </div>
+            </details>
+          </section>
+
+          <p class="text-xs text-[var(--muted)] pt-2 pb-8">
+            Mockup · uses real workspace names + month-to-date values from your dev DB on 2026-05-15. Daily values in the chart are synthesized for visualization.
+          </p>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/specs/026-claude-page-redesign/plan.html
+++ b/specs/026-claude-page-redesign/plan.html
@@ -80,7 +80,7 @@
       <header class="mb-10 pb-6 border-b border-[var(--border)]">
         <div class="flex flex-wrap items-center gap-3 mb-3 text-xs">
           <span class="chip">Spec 026</span>
-          <span class="chip info">Status · Draft</span>
+          <span class="chip info">Status · Ready for implementation</span>
           <span class="chip">Created 2026-05-15</span>
           <span class="chip">Owner · tobias.studer@unic.com</span>
           <span class="chip success">3 phases · 1 PR</span>

--- a/specs/026-claude-page-redesign/plan.html
+++ b/specs/026-claude-page-redesign/plan.html
@@ -1,0 +1,983 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Spec 026 — Claude API Spending redesign · Implementation plan</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0a0a0a;
+        --panel: #121212;
+        --panel-2: #181818;
+        --border: #262626;
+        --border-2: #2e2e2e;
+        --text: #fafafa;
+        --muted: #a1a1aa;
+        --muted-2: #71717a;
+        --primary: #d4f057;
+        --primary-ink: #0a0a0a;
+        --success: #4ade80;
+        --warn: #facc15;
+        --danger: #f87171;
+        --info: #67e8f9;
+      }
+      html, body { background: var(--bg); color: var(--text); }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.55; }
+      code, pre, .mono { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; }
+      h1, h2, h3, h4 { letter-spacing: -0.01em; }
+      .container { max-width: 1080px; margin: 0 auto; padding: 32px 24px; }
+      .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; }
+      .card-2 { background: var(--panel-2); border: 1px solid var(--border); border-radius: 12px; }
+      .pill { display: inline-flex; align-items: center; gap: 6px; padding: 2px 10px; border-radius: 999px; font-size: 12px; font-weight: 500; }
+      .pill .dot { width: 6px; height: 6px; border-radius: 999px; }
+      .chip { display: inline-flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 6px; font-size: 11px; background: #181818; border: 1px solid var(--border-2); color: var(--muted); }
+      .chip.warn { color: #facc15; border-color: #5a4607; background: #1c1407; }
+      .chip.danger { color: #fca5a5; border-color: #7f1d1d; background: #2a0a0a; }
+      .chip.info { color: #67e8f9; border-color: #155e75; background: #082f3a; }
+      .chip.success { color: #86efac; border-color: #14532d; background: #0a1c10; }
+      .kbd { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 11px; padding: 1px 6px; border-radius: 4px; background: #181818; border: 1px solid var(--border-2); }
+      a.link { color: #d4f057; text-decoration: underline; text-underline-offset: 4px; }
+      a.link:hover { color: #c9e94a; }
+      .grid-cols-fit { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+      table.spec-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+      table.spec-table th, table.spec-table td { padding: 8px 10px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+      table.spec-table th { color: var(--muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+      table.spec-table tbody tr:hover { background: rgba(255,255,255,0.02); }
+      .toc a { color: var(--muted); }
+      .toc a:hover { color: var(--text); }
+      .phase-pill { padding: 4px 10px; border-radius: 8px; font-size: 12px; font-weight: 600; }
+      .phase-1 { background: #0a1c10; color: #86efac; border: 1px solid #14532d; }
+      .phase-2 { background: #082f3a; color: #67e8f9; border: 1px solid #155e75; }
+      .phase-3 { background: #2a1607; color: #fcd34d; border: 1px solid #78350f; }
+      .anchor { scroll-margin-top: 24px; }
+      .file-path { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px; color: #67e8f9; }
+      .ac-list { padding-left: 22px; }
+      .ac-list li { margin: 6px 0; }
+      .ac-list li::marker { color: #4ade80; }
+      .risk-list li::marker { color: #f87171; }
+      .legend-swatch { width: 10px; height: 10px; border-radius: 2px; display: inline-block; vertical-align: middle; margin-right: 6px; }
+      details.code-detail summary { cursor: pointer; color: var(--muted); font-size: 12px; }
+      details.code-detail summary:hover { color: var(--text); }
+      pre.code { background: #060606; border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; overflow-x: auto; font-size: 12px; line-height: 1.5; color: #e4e4e7; }
+      pre.code .k { color: #c084fc; }
+      pre.code .s { color: #86efac; }
+      pre.code .n { color: #fcd34d; }
+      pre.code .c { color: #71717a; font-style: italic; }
+      pre.code .t { color: #67e8f9; }
+      .callout { border-left: 3px solid var(--primary); background: rgba(212, 240, 87, 0.04); padding: 12px 14px; border-radius: 0 8px 8px 0; }
+      .callout.warn { border-color: #facc15; background: rgba(250, 204, 21, 0.04); }
+      .callout.danger { border-color: #f87171; background: rgba(248, 113, 113, 0.04); }
+      .callout.info { border-color: #67e8f9; background: rgba(103, 232, 249, 0.04); }
+      .viz { background: #0d0d0d; border: 1px solid var(--border); border-radius: 10px; padding: 14px; }
+      .viz-label { font-size: 11px; color: var(--muted-2); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+
+      <header class="mb-10 pb-6 border-b border-[var(--border)]">
+        <div class="flex flex-wrap items-center gap-3 mb-3 text-xs">
+          <span class="chip">Spec 026</span>
+          <span class="chip info">Status · Draft</span>
+          <span class="chip">Created 2026-05-15</span>
+          <span class="chip">Owner · tobias.studer@unic.com</span>
+          <span class="chip success">3 phases · 1 PR</span>
+        </div>
+        <h1 class="text-3xl font-bold tracking-tight">Claude API Spending — page redesign</h1>
+        <p class="text-[var(--muted)] mt-2 max-w-3xl">
+          Reorient <code class="mono text-[var(--text)]">/claude</code> around three operational questions: <em>are we over budget anywhere right now? where is the run-rate going? which workspace is growing fastest?</em>
+          The redesign ships in three phases, keeps the existing schema (no migrations in Phases 1 & 2), and reuses the hourly Anthropic Admin API sync from spec 018.
+        </p>
+        <div class="mt-4 flex flex-wrap gap-2 text-xs">
+          <a class="chip info" href="spec.md">spec.md ↗</a>
+          <a class="chip info" href="tasks.md">tasks.md ↗</a>
+          <a class="chip info" href="mockup.html">mockup.html (interactive) ↗</a>
+        </div>
+      </header>
+
+      <!-- TOC -->
+      <nav class="card p-5 mb-10 toc">
+        <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-3">Contents</p>
+        <ol class="text-sm space-y-1.5 list-decimal pl-5">
+          <li><a href="#context">Context</a></li>
+          <li><a href="#before-after">Before / after at a glance</a></li>
+          <li><a href="#phase-1">Phase 1 — Visual reset + KPI strip</a></li>
+          <li><a href="#phase-2">Phase 2 — Historical trend + sparklines</a></li>
+          <li><a href="#phase-3">Phase 3 — Workspace drill-through</a></li>
+          <li><a href="#cross">Cross-cutting concerns &amp; shared helpers</a></li>
+          <li><a href="#test-strategy">Test strategy</a></li>
+          <li><a href="#rollout">Rollout &amp; risk register</a></li>
+        </ol>
+      </nav>
+
+      <!-- ====================== CONTEXT ====================== -->
+      <section id="context" class="anchor mb-12">
+        <h2 class="text-xl font-semibold mb-3">1. Context</h2>
+        <div class="prose prose-invert max-w-none text-[15px]">
+          <p>
+            <code class="mono">/claude</code> is admin-only (admin role gate; non-admins redirect to <code class="mono">/</code>).
+            It aggregates Anthropic API cost data synced hourly from the Anthropic Admin API into the <code class="mono">anthropic_workspace_costs</code> table
+            (per-workspace, per-date rows; see spec 018).
+            Org billing budget lives in <code class="mono">anthropic_org_config</code>; workspace-level monthly caps in <code class="mono">anthropic_workspace_limits</code>;
+            workspace metadata in <code class="mono">anthropic_workspaces</code>. Sync state is tracked by the <code class="mono">userId = 0</code> sentinel row (per <code class="mono">LOCK_USER_ID</code> in <code class="mono">src/lib/anthropic-sync.ts:23</code>) in
+            <code class="mono">anthropicSyncStatus.workspaceSyncCompletedAt</code>.
+          </p>
+          <p>
+            The current page surfaces a grand total, a single-series daily bar chart, an org billing card paired with a "Credit Balance" placeholder
+            (the Anthropic API does not expose credit balance), and a workspace list sorted alphabetically. Inspected live on 2026-05-15 with 13 real workspaces,
+            the layout buries the operational signal: "Automations" is at <strong class="text-[var(--danger)]">105% of its $50 cap</strong> and has grown
+            <strong class="text-[var(--danger)]">+413% over six months</strong>, but neither fact is visible without scanning every row or computing it mentally.
+          </p>
+        </div>
+      </section>
+
+      <!-- ====================== BEFORE/AFTER ====================== -->
+      <section id="before-after" class="anchor mb-12">
+        <h2 class="text-xl font-semibold mb-3">2. Before / after at a glance</h2>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <!-- BEFORE -->
+          <div class="viz">
+            <p class="viz-label">Before · current /claude page</p>
+            <svg viewBox="0 0 500 320" class="w-full h-auto">
+              <rect x="0" y="0" width="500" height="320" fill="#0d0d0d"/>
+              <!-- alert -->
+              <rect x="10" y="10" width="480" height="22" rx="4" fill="#2a0a0a" stroke="#7f1d1d"/>
+              <text x="20" y="25" font-size="10" fill="#fca5a5" font-family="ui-sans-serif">⚠ Budget Alert: Automations is at 105%</text>
+              <!-- header -->
+              <text x="10" y="55" font-size="16" font-weight="700" fill="#fafafa" font-family="ui-sans-serif">Claude Console</text>
+              <text x="10" y="70" font-size="10" fill="#71717a" font-family="ui-sans-serif">Org-wide Claude API usage and spending</text>
+              <rect x="400" y="44" width="80" height="22" rx="4" fill="#d4f057"/>
+              <text x="440" y="59" font-size="10" font-weight="600" fill="#0a0a0a" text-anchor="middle" font-family="ui-sans-serif">Trigger Sync</text>
+              <!-- controls -->
+              <rect x="10" y="85" width="80" height="22" rx="4" fill="#141414" stroke="#2e2e2e"/>
+              <text x="50" y="100" font-size="9" fill="#fafafa" text-anchor="middle" font-family="ui-sans-serif">May 2026</text>
+              <rect x="96" y="85" width="110" height="22" rx="4" fill="#141414" stroke="#2e2e2e"/>
+              <text x="151" y="100" font-size="9" fill="#fafafa" text-anchor="middle" font-family="ui-sans-serif">All workspaces</text>
+              <text x="215" y="100" font-size="9" fill="#71717a" font-family="ui-sans-serif">Last synced 3 min ago</text>
+              <!-- single big total -->
+              <text x="10" y="135" font-size="9" fill="#71717a" font-family="ui-sans-serif">Total org spend — May 2026</text>
+              <text x="10" y="160" font-size="22" font-weight="700" fill="#fafafa" font-family="ui-sans-serif">$1,820.40</text>
+              <!-- wall of green chart -->
+              <rect x="10" y="175" width="480" height="60" rx="4" fill="#d4f057"/>
+              <text x="250" y="208" font-size="10" fill="#0a0a0a" text-anchor="middle" font-family="ui-sans-serif" font-weight="600">single bar · only May 1 has data</text>
+              <!-- 2 col org billing -->
+              <rect x="10" y="245" width="232" height="32" rx="4" fill="#121212" stroke="#262626"/>
+              <text x="20" y="263" font-size="10" fill="#fafafa" font-family="ui-sans-serif">Monthly Billing Budget</text>
+              <text x="20" y="274" font-size="9" fill="#71717a" font-family="ui-sans-serif">$1,820 / $3,500 · 52%</text>
+              <rect x="248" y="245" width="242" height="32" rx="4" fill="#121212" stroke="#262626"/>
+              <text x="258" y="263" font-size="10" fill="#71717a" font-family="ui-sans-serif">Credit Balance · not exposed by API</text>
+              <text x="258" y="274" font-size="9" fill="#71717a" font-family="ui-sans-serif">→ View in Anthropic Console</text>
+              <!-- workspace list (small) -->
+              <text x="10" y="295" font-size="10" fill="#fafafa" font-family="ui-sans-serif">Workspace Budgets · alphabetical · 13 rows · $0 rows mixed in</text>
+              <text x="10" y="310" font-size="9" fill="#71717a" font-family="ui-sans-serif">over-budget workspace is buried at row 4</text>
+            </svg>
+          </div>
+          <!-- AFTER -->
+          <div class="viz">
+            <p class="viz-label">After · redesigned /claude page (Phases 1+2)</p>
+            <svg viewBox="0 0 500 320" class="w-full h-auto">
+              <rect x="0" y="0" width="500" height="320" fill="#0d0d0d"/>
+              <!-- alert -->
+              <rect x="10" y="10" width="480" height="22" rx="4" fill="#2a0a0a" stroke="#7f1d1d"/>
+              <text x="20" y="25" font-size="10" fill="#fca5a5" font-family="ui-sans-serif">⚠ Budget Alert: Automations is at 105%</text>
+              <!-- header -->
+              <text x="10" y="55" font-size="16" font-weight="700" fill="#fafafa" font-family="ui-sans-serif">Claude API Spending</text>
+              <text x="10" y="70" font-size="10" fill="#71717a" font-family="ui-sans-serif">Org-wide usage, budgets, and sync status</text>
+              <!-- sync pill -->
+              <rect x="335" y="48" width="90" height="18" rx="9" fill="#0a1c10" stroke="#14532d"/>
+              <circle cx="345" cy="57" r="3" fill="#22c55e"/>
+              <text x="350" y="60" font-size="9" fill="#86efac" font-family="ui-sans-serif">Synced 3m ago</text>
+              <rect x="430" y="44" width="60" height="22" rx="4" fill="#d4f057"/>
+              <text x="460" y="59" font-size="10" font-weight="600" fill="#0a0a0a" text-anchor="middle" font-family="ui-sans-serif">Sync</text>
+              <!-- KPI strip 4 tiles -->
+              <g font-family="ui-sans-serif">
+                <rect x="10" y="80" width="115" height="44" rx="6" fill="#121212" stroke="#262626"/>
+                <text x="18" y="92" font-size="7" fill="#71717a">TOTAL · MAY</text>
+                <text x="18" y="108" font-size="13" font-weight="700" fill="#fafafa">$1,820.40</text>
+                <text x="18" y="120" font-size="7" fill="#86efac">▲ 12% vs Apr</text>
+
+                <rect x="129" y="80" width="115" height="44" rx="6" fill="#121212" stroke="#262626"/>
+                <text x="137" y="92" font-size="7" fill="#71717a">PROJECTED</text>
+                <text x="137" y="108" font-size="13" font-weight="700" fill="#fafafa">$3,640</text>
+                <text x="137" y="120" font-size="7" fill="#f87171">104% of $3,500 budget</text>
+
+                <rect x="248" y="80" width="115" height="44" rx="6" fill="#121212" stroke="#262626"/>
+                <text x="256" y="92" font-size="7" fill="#71717a">OVER 80%</text>
+                <text x="256" y="108" font-size="13" font-weight="700" fill="#fafafa">1 <tspan font-size="9" fill="#71717a">/ 13</tspan></text>
+                <text x="256" y="120" font-size="7" fill="#f87171">Automations · 105%</text>
+
+                <rect x="367" y="80" width="123" height="44" rx="6" fill="#121212" stroke="#262626"/>
+                <text x="375" y="92" font-size="7" fill="#71717a">MoM DELTA</text>
+                <text x="375" y="108" font-size="13" font-weight="700" fill="#fafafa">+$199</text>
+                <text x="375" y="120" font-size="7" fill="#86efac">+12% vs Apr</text>
+              </g>
+              <!-- stacked daily chart -->
+              <rect x="10" y="130" width="480" height="56" rx="4" fill="#121212" stroke="#262626"/>
+              <g>
+                <rect x="20" y="160" width="20" height="22" fill="#d4f057"/><rect x="20" y="152" width="20" height="8" fill="#86efac"/><rect x="20" y="146" width="20" height="6" fill="#67e8f9"/>
+                <rect x="48" y="155" width="20" height="27" fill="#d4f057"/><rect x="48" y="146" width="20" height="9" fill="#86efac"/><rect x="48" y="140" width="20" height="6" fill="#67e8f9"/>
+                <rect x="76" y="158" width="20" height="24" fill="#d4f057"/><rect x="76" y="150" width="20" height="8" fill="#86efac"/><rect x="76" y="144" width="20" height="6" fill="#67e8f9"/>
+                <rect x="104" y="152" width="20" height="30" fill="#d4f057"/><rect x="104" y="142" width="20" height="10" fill="#86efac"/><rect x="104" y="136" width="20" height="6" fill="#67e8f9"/>
+                <rect x="132" y="156" width="20" height="26" fill="#d4f057"/><rect x="132" y="146" width="20" height="10" fill="#86efac"/><rect x="132" y="140" width="20" height="6" fill="#67e8f9"/>
+                <rect x="160" y="148" width="20" height="34" fill="#d4f057"/><rect x="160" y="140" width="20" height="8" fill="#86efac"/><rect x="160" y="134" width="20" height="6" fill="#67e8f9"/>
+                <rect x="188" y="146" width="20" height="36" fill="#d4f057"/><rect x="188" y="138" width="20" height="8" fill="#86efac"/><rect x="188" y="132" width="20" height="6" fill="#67e8f9"/>
+              </g>
+              <text x="250" y="146" font-size="8" fill="#71717a" font-family="ui-sans-serif">stacked by workspace</text>
+              <!-- historical trend mini -->
+              <rect x="10" y="192" width="232" height="40" rx="4" fill="#121212" stroke="#262626"/>
+              <text x="20" y="205" font-size="8" fill="#71717a" font-family="ui-sans-serif">12-MONTH TREND</text>
+              <g>
+                <rect x="22" y="222" width="14" height="6" fill="#3f3f46"/>
+                <rect x="38" y="220" width="14" height="8" fill="#3f3f46"/>
+                <rect x="54" y="216" width="14" height="12" fill="#52525b"/>
+                <rect x="70" y="218" width="14" height="10" fill="#52525b"/>
+                <rect x="86" y="222" width="14" height="6" fill="#52525b"/>
+                <rect x="102" y="214" width="14" height="14" fill="#71717a"/>
+                <rect x="118" y="212" width="14" height="16" fill="#71717a"/>
+                <rect x="134" y="210" width="14" height="18" fill="#71717a"/>
+                <rect x="150" y="208" width="14" height="20" fill="#a1a1aa"/>
+                <rect x="166" y="204" width="14" height="24" fill="#d4f057"/>
+                <rect x="182" y="195" width="14" height="9" fill="#d4f057" opacity="0.3"/>
+              </g>
+              <line x1="14" y1="200" x2="200" y2="200" stroke="#f87171" stroke-dasharray="2 2" stroke-width="0.5"/>
+              <rect x="248" y="192" width="242" height="40" rx="4" fill="#121212" stroke="#262626"/>
+              <text x="258" y="205" font-size="8" fill="#71717a" font-family="ui-sans-serif">CUMULATIVE PACING</text>
+              <polyline points="260,224 280,222 300,218 320,213 340,208 360,204 380,200" stroke="#a1a1aa" stroke-width="1" fill="none"/>
+              <polyline points="260,224 270,221 285,215 300,210 315,206 325,204" stroke="#d4f057" stroke-width="1.5" fill="none"/>
+              <text x="380" y="220" font-size="7" fill="#facc15" font-family="ui-sans-serif">+125% pace</text>
+              <!-- ws list reordered + sparklines -->
+              <text x="10" y="248" font-size="10" fill="#fafafa" font-family="ui-sans-serif">Workspace Budgets · sorted by utilization · sparklines · hide $0</text>
+              <g font-family="ui-sans-serif">
+                <text x="10" y="265" font-size="9" fill="#fca5a5">▶ Automations · $52.49 · 105% · 📈</text>
+                <text x="10" y="280" font-size="9" fill="#fafafa">boost-expert-1 · $125.64 · 63% · ▁▂▃▅▆▇</text>
+                <text x="10" y="295" font-size="9" fill="#fafafa">boost-starter-1 · $370.72 · 62% · ▁▂▃▄▆▇</text>
+                <text x="10" y="310" font-size="9" fill="#71717a">3 more · $0 rows collapsed</text>
+              </g>
+            </svg>
+          </div>
+        </div>
+
+        <p class="text-xs text-[var(--muted)] mt-3">
+          The redesign reuses the same data — only the layout, sort order, and a handful of new aggregations change.
+          Live mockup with real workspace names: <a class="link" href="mockup.html">mockup.html</a>.
+        </p>
+      </section>
+
+      <!-- ====================== PHASE 1 ====================== -->
+      <section id="phase-1" class="anchor mb-12">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="phase-pill phase-1">Phase 1 · Commit 1</span>
+          <h2 class="text-xl font-semibold">Visual reset + KPI strip</h2>
+        </div>
+        <p class="text-[var(--muted)] mb-5 max-w-3xl">
+          Rename, sync pill, 4-tile KPI strip, daily chart stacked by workspace, full-width Monthly Billing Budget card,
+          and workspace list re-sorted with a "Hide $0 + no limit" toggle. Standalone-shippable.
+        </p>
+
+        <!-- Goal + stories -->
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
+          <div class="card p-4">
+            <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Goal</p>
+            <p class="text-sm">An admin can spot over-budget workspaces and the projected month-end position within <strong>five seconds</strong> of landing on the page.</p>
+          </div>
+          <div class="card p-4">
+            <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Effort</p>
+            <p class="text-sm">~30–40 hours · 4 new components · 3 new server actions · 1 shared util · 0 schema changes.</p>
+          </div>
+          <div class="card p-4">
+            <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Standalone value</p>
+            <p class="text-sm">Ships independently. Subsequent phases are additive.</p>
+          </div>
+        </div>
+
+        <!-- User stories -->
+        <h3 class="text-base font-semibold mt-6 mb-2">User stories</h3>
+        <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+          <li>As an admin, I want a single glance to tell me total MTD, MoM change, projected month-end, and how many workspaces are over 80%, so I can triage without scrolling.</li>
+          <li>As an admin, I want the daily chart segmented by workspace so I can see which workspace drove a given day's spike.</li>
+          <li>As an admin, I want noisy zero-cost workspaces hidden by default so the workspace list shows what actually matters.</li>
+        </ul>
+
+        <!-- Files to change -->
+        <h3 class="text-base font-semibold mt-6 mb-2">Files to change</h3>
+        <table class="spec-table">
+          <thead><tr><th>Path</th><th>Change</th></tr></thead>
+          <tbody>
+            <tr><td class="file-path">src/app/claude/page.tsx</td><td>Rename title (L21, L55); add new parallel queries; remove Credit Balance section.</td></tr>
+            <tr><td class="file-path">src/components/claude/global-metrics-client.tsx</td><td>Render <code class="mono">&lt;KpiStrip&gt;</code> + <code class="mono">&lt;SyncStatusPill&gt;</code>. Switch chart from single-series to stacked.</td></tr>
+            <tr><td class="file-path">src/components/claude/workspace-budget-list.tsx</td><td>Apply new sort, add "Hide $0 + no limit" toggle, restructure row layout (spend big, limit small).</td></tr>
+            <tr><td class="file-path">src/components/claude/org-credits-panel.tsx</td><td>Rename to <code class="mono">OrgBillingBudgetCard</code>. Drop the dead Credit Balance card; promote to full width; add Projected column.</td></tr>
+            <tr><td class="file-path">src/components/claude/kpi-strip.tsx</td><td><strong>NEW</strong> · 4 tiles.</td></tr>
+            <tr><td class="file-path">src/components/claude/sync-status-pill.tsx</td><td><strong>NEW</strong> · green/amber/grey pill.</td></tr>
+            <tr><td class="file-path">src/actions/anthropic-global.ts</td><td>New: <code class="mono">getDashboardKpis</code>, <code class="mono">getDailyTotalsByWorkspace</code>, <code class="mono">getSyncStatus</code>. Update <code class="mono">_getWorkspaceList</code> sort.</td></tr>
+            <tr><td class="file-path">src/components/app-sidebar.tsx</td><td>Sidebar label rename.</td></tr>
+            <tr><td class="file-path">src/lib/utils.ts</td><td>New shared util <code class="mono">projectMonthEnd</code>.</td></tr>
+            <tr><td class="file-path">src/types/index.ts</td><td>Export <code class="mono">DashboardKpis</code>, <code class="mono">DailyStackedRow</code>, <code class="mono">SyncStatus</code>.</td></tr>
+          </tbody>
+        </table>
+
+        <!-- New queries / signatures -->
+        <h3 class="text-base font-semibold mt-6 mb-2">New server actions &amp; types</h3>
+        <pre class="code mono"><span class="c">// src/actions/anthropic-global.ts — additions</span>
+<span class="k">async function</span> <span class="t">getDashboardKpis</span>(month?: <span class="t">string</span>): <span class="t">Promise</span>&lt;DashboardKpis&gt;
+<span class="k">async function</span> <span class="t">getDailyTotalsByWorkspace</span>(month?: <span class="t">string</span>): <span class="t">Promise</span>&lt;DailyStackedRow[]&gt;
+<span class="k">async function</span> <span class="t">getSyncStatus</span>(): <span class="t">Promise</span>&lt;SyncStatus&gt;
+
+<span class="c">// All admin-gated. All wrapped in unstable_cache with tag "anthropic-workspace-costs"</span>
+<span class="c">// (existing cron-triggered revalidateTag already invalidates them — no new wiring).</span>
+
+<span class="c">// src/types/index.ts — additions</span>
+<span class="k">export type</span> <span class="t">DashboardKpis</span> = {
+  totalCents: <span class="t">number</span>;
+  momDeltaCents: <span class="t">number</span>;
+  momDeltaPct: <span class="t">number</span> | <span class="k">null</span>;   <span class="c">// null when prior month &lt; $1</span>
+  projectedMonthEndCents: <span class="t">number</span>;
+  workspacesOverEightyCount: <span class="t">number</span>;
+  workspacesWithLimitCount: <span class="t">number</span>;
+};
+
+<span class="k">export type</span> <span class="t">DailyStackedRow</span> = {
+  date: <span class="t">string</span>;                       <span class="c">// 'YYYY-MM-DD'</span>
+  perWorkspace: <span class="t">Record</span>&lt;<span class="t">string</span>, <span class="t">number</span>&gt;; <span class="c">// workspaceId|"default" -> cents</span>
+  total: <span class="t">number</span>;
+};
+
+<span class="k">export type</span> <span class="t">SyncStatus</span> = {
+  lastSyncedAt: <span class="t">Date</span> | <span class="k">null</span>;
+  ageMinutes: <span class="t">number</span> | <span class="k">null</span>;
+  isStale: <span class="t">boolean</span>;                    <span class="c">// age &gt; 70 minutes</span>
+};
+
+<span class="c">// src/lib/utils.ts — shared util</span>
+<span class="k">export function</span> <span class="t">projectMonthEnd</span>(
+  mtdCents: <span class="t">number</span>,
+  daysElapsed: <span class="t">number</span>,
+  daysInMonth: <span class="t">number</span>,
+): <span class="t">number</span> {
+  <span class="k">if</span> (daysElapsed === <span class="n">0</span>) <span class="k">return</span> <span class="n">0</span>;
+  <span class="k">return</span> <span class="t">Math</span>.round((mtdCents / daysElapsed) * daysInMonth);
+}</pre>
+
+        <!-- Data flow -->
+        <h3 class="text-base font-semibold mt-6 mb-2">Data flow</h3>
+        <p class="text-sm text-[var(--text)]/90 max-w-3xl">
+          <code class="mono">page.tsx</code> (Server Component) calls
+          <code class="mono">getGlobalCostDashboard</code>, <code class="mono">getWorkspaceList</code>, <code class="mono">getOrgConfig</code>,
+          <code class="mono">getDashboardKpis</code>, and <code class="mono">getSyncStatus</code> in parallel via <code class="mono">Promise.all</code>.
+          All five reuse the <code class="mono">"anthropic-workspace-costs"</code> cache tag.
+          Plain JSON is passed to <code class="mono">&lt;GlobalMetricsClient&gt;</code>; the client component owns workspace/month filter state and re-fetches via <code class="mono">useTransition</code> on month change.
+          The "Hide $0 + no limit" toggle is pure client-side filtering over the <code class="mono">workspaces</code> prop, with the preference persisted in
+          <code class="mono">localStorage</code> at key <code class="mono">claude-hide-zero-workspaces</code>.
+        </p>
+
+        <!-- Layout viz -->
+        <h3 class="text-base font-semibold mt-6 mb-2">Layout</h3>
+        <div class="viz">
+          <p class="viz-label">Phase 1 wireframe (real proportions)</p>
+          <svg viewBox="0 0 1000 480" class="w-full h-auto">
+            <rect x="0" y="0" width="1000" height="480" fill="#0a0a0a"/>
+            <!-- alert -->
+            <rect x="20" y="20" width="960" height="32" rx="6" fill="#1a0a0a" stroke="#3a1212"/>
+            <text x="35" y="40" font-size="12" fill="#fca5a5" font-family="ui-sans-serif" font-weight="600">⚠ Budget Alert · Automations is at 105% of monthly budget</text>
+            <!-- header row -->
+            <text x="20" y="80" font-size="22" font-weight="700" fill="#fafafa" font-family="ui-sans-serif">Claude API Spending</text>
+            <text x="20" y="98" font-size="11" fill="#71717a" font-family="ui-sans-serif">Org-wide usage, budgets, and Anthropic sync status</text>
+            <rect x="780" y="70" width="120" height="22" rx="11" fill="#0a1c10" stroke="#14532d"/>
+            <circle cx="795" cy="81" r="3.5" fill="#22c55e"/>
+            <text x="803" y="84" font-size="11" fill="#86efac" font-family="ui-sans-serif">Synced 3m ago</text>
+            <rect x="908" y="68" width="72" height="26" rx="6" fill="#d4f057"/>
+            <text x="944" y="85" font-size="11" font-weight="600" fill="#0a0a0a" text-anchor="middle" font-family="ui-sans-serif">Sync</text>
+
+            <!-- KPI strip -->
+            <g font-family="ui-sans-serif">
+              <rect x="20" y="120" width="234" height="76" rx="8" fill="#121212" stroke="#262626"/>
+              <text x="34" y="138" font-size="9" fill="#71717a">TOTAL ORG SPEND — MAY 2026</text>
+              <text x="34" y="166" font-size="22" font-weight="700" fill="#fafafa">$1,820.40</text>
+              <text x="34" y="186" font-size="10" fill="#86efac">▲ 12% vs Apr ($1,621.40)</text>
+
+              <rect x="262" y="120" width="234" height="76" rx="8" fill="#121212" stroke="#262626"/>
+              <text x="276" y="138" font-size="9" fill="#71717a">PROJECTED MONTH-END</text>
+              <text x="276" y="166" font-size="22" font-weight="700" fill="#fafafa">$3,640.80</text>
+              <text x="276" y="186" font-size="10" fill="#f87171">104% of $3,500 budget</text>
+
+              <rect x="504" y="120" width="234" height="76" rx="8" fill="#121212" stroke="#262626"/>
+              <text x="518" y="138" font-size="9" fill="#71717a">WORKSPACES OVER 80%</text>
+              <text x="518" y="166" font-size="22" font-weight="700" fill="#fafafa">1 <tspan font-size="14" fill="#71717a">/ 13</tspan></text>
+              <text x="518" y="186" font-size="10" fill="#f87171">Automations · 105% of $50 limit</text>
+
+              <rect x="746" y="120" width="234" height="76" rx="8" fill="#121212" stroke="#262626"/>
+              <text x="760" y="138" font-size="9" fill="#71717a">MoM DELTA</text>
+              <text x="760" y="166" font-size="22" font-weight="700" fill="#fafafa">+$199</text>
+              <text x="760" y="186" font-size="10" fill="#86efac">+12% (vs Apr)</text>
+            </g>
+
+            <!-- stacked chart -->
+            <rect x="20" y="216" width="960" height="160" rx="8" fill="#121212" stroke="#262626"/>
+            <text x="34" y="234" font-size="11" fill="#fafafa" font-family="ui-sans-serif" font-weight="500">Daily spend by workspace</text>
+            <text x="34" y="248" font-size="10" fill="#71717a" font-family="ui-sans-serif">Stacked · top 8 workspaces + Other</text>
+            <g>
+              <!-- 15 stacked bars -->
+              <g transform="translate(50,260)">
+                <g><rect x="0"   y="60" width="50" height="40" fill="#d4f057"/><rect x="0"   y="40" width="50" height="20" fill="#86efac"/><rect x="0"   y="28" width="50" height="12" fill="#67e8f9"/><rect x="0"   y="20" width="50" height="8"  fill="#93c5fd"/><rect x="0"   y="14" width="50" height="6"  fill="#c4b5fd"/><rect x="0"   y="11" width="50" height="3"  fill="#f9a8d4"/></g>
+                <g transform="translate(62,0)"><rect y="64" width="50" height="36" fill="#d4f057"/><rect y="44" width="50" height="20" fill="#86efac"/><rect y="30" width="50" height="14" fill="#67e8f9"/><rect y="22" width="50" height="8"  fill="#93c5fd"/><rect y="14" width="50" height="8"  fill="#c4b5fd"/><rect y="11" width="50" height="3"  fill="#f9a8d4"/></g>
+                <g transform="translate(124,0)"><rect y="66" width="50" height="34" fill="#d4f057"/><rect y="48" width="50" height="18" fill="#86efac"/><rect y="34" width="50" height="14" fill="#67e8f9"/><rect y="26" width="50" height="8"  fill="#93c5fd"/><rect y="18" width="50" height="8"  fill="#c4b5fd"/><rect y="14" width="50" height="4"  fill="#f9a8d4"/></g>
+                <g transform="translate(186,0)"><rect y="52" width="50" height="48" fill="#d4f057"/><rect y="32" width="50" height="20" fill="#86efac"/><rect y="18" width="50" height="14" fill="#67e8f9"/><rect y="10" width="50" height="8"  fill="#93c5fd"/><rect y="3"  width="50" height="7"  fill="#c4b5fd"/></g>
+                <g transform="translate(248,0)"><rect y="62" width="50" height="38" fill="#d4f057"/><rect y="44" width="50" height="18" fill="#86efac"/><rect y="30" width="50" height="14" fill="#67e8f9"/><rect y="22" width="50" height="8"  fill="#93c5fd"/><rect y="14" width="50" height="8"  fill="#c4b5fd"/></g>
+                <g transform="translate(310,0)"><rect y="70" width="50" height="30" fill="#d4f057"/><rect y="54" width="50" height="16" fill="#86efac"/><rect y="42" width="50" height="12" fill="#67e8f9"/><rect y="34" width="50" height="8"  fill="#93c5fd"/><rect y="28" width="50" height="6"  fill="#c4b5fd"/></g>
+                <g transform="translate(372,0)"><rect y="72" width="50" height="28" fill="#d4f057"/><rect y="56" width="50" height="16" fill="#86efac"/><rect y="44" width="50" height="12" fill="#67e8f9"/><rect y="36" width="50" height="8"  fill="#93c5fd"/><rect y="30" width="50" height="6"  fill="#c4b5fd"/></g>
+                <g transform="translate(434,0)"><rect y="54" width="50" height="46" fill="#d4f057"/><rect y="32" width="50" height="22" fill="#86efac"/><rect y="18" width="50" height="14" fill="#67e8f9"/><rect y="10" width="50" height="8"  fill="#93c5fd"/><rect y="2"  width="50" height="8"  fill="#c4b5fd"/></g>
+                <g transform="translate(496,0)"><rect y="58" width="50" height="42" fill="#d4f057"/><rect y="38" width="50" height="20" fill="#86efac"/><rect y="24" width="50" height="14" fill="#67e8f9"/><rect y="16" width="50" height="8"  fill="#93c5fd"/><rect y="10" width="50" height="6"  fill="#c4b5fd"/></g>
+                <g transform="translate(558,0)"><rect y="66" width="50" height="34" fill="#d4f057"/><rect y="48" width="50" height="18" fill="#86efac"/><rect y="34" width="50" height="14" fill="#67e8f9"/><rect y="26" width="50" height="8"  fill="#93c5fd"/><rect y="20" width="50" height="6"  fill="#c4b5fd"/></g>
+                <g transform="translate(620,0)"><rect y="70" width="50" height="30" fill="#d4f057"/><rect y="54" width="50" height="16" fill="#86efac"/><rect y="42" width="50" height="12" fill="#67e8f9"/><rect y="34" width="50" height="8"  fill="#93c5fd"/><rect y="28" width="50" height="6"  fill="#c4b5fd"/></g>
+                <g transform="translate(682,0)"><rect y="50" width="50" height="50" fill="#d4f057"/><rect y="30" width="50" height="20" fill="#86efac"/><rect y="16" width="50" height="14" fill="#67e8f9"/><rect y="8"  width="50" height="8"  fill="#93c5fd"/><rect y="2"  width="50" height="6"  fill="#c4b5fd"/></g>
+                <g transform="translate(744,0)"><rect y="40" width="50" height="60" fill="#d4f057"/><rect y="20" width="50" height="20" fill="#86efac"/><rect y="6"  width="50" height="14" fill="#67e8f9"/><rect y="0"  width="50" height="6"  fill="#93c5fd"/></g>
+                <g transform="translate(806,0)"><rect y="36" width="50" height="64" fill="#d4f057"/><rect y="16" width="50" height="20" fill="#86efac"/><rect y="2"  width="50" height="14" fill="#67e8f9"/></g>
+                <g transform="translate(868,0)"><rect y="48" width="50" height="52" fill="#d4f057"/><rect y="28" width="50" height="20" fill="#86efac"/><rect y="14" width="50" height="14" fill="#67e8f9"/><rect y="6"  width="50" height="8"  fill="#93c5fd"/></g>
+              </g>
+            </g>
+            <!-- Workspace list (preview) -->
+            <rect x="20" y="392" width="960" height="74" rx="8" fill="#121212" stroke="#262626"/>
+            <text x="34" y="412" font-size="11" fill="#fafafa" font-family="ui-sans-serif" font-weight="500">Workspace Budgets · sorted by utilization · "Hide $0" toggle ON</text>
+            <text x="34" y="430" font-size="10" fill="#fca5a5" font-family="ui-sans-serif">▶ Automations · $52.49 · over budget</text>
+            <rect x="180" y="423" width="50" height="6" fill="#f87171" rx="3"/>
+            <text x="250" y="430" font-size="10" fill="#fafafa" font-family="ui-sans-serif">boost-expert-1 · $125.64 · 63%</text>
+            <rect x="380" y="423" width="32" height="6" fill="#d4f057" rx="3"/>
+            <text x="440" y="430" font-size="10" fill="#fafafa" font-family="ui-sans-serif">boost-starter-1 · $370.72 · 62%</text>
+            <text x="34" y="450" font-size="10" fill="#71717a" font-family="ui-sans-serif">... 8 more rows · 3 hidden ($0, no limit)</text>
+          </svg>
+        </div>
+
+        <!-- UX details -->
+        <h3 class="text-base font-semibold mt-6 mb-2">UX details &amp; edge cases</h3>
+        <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+          <li><strong>KPI tile 3 (projected)</strong>: if <code class="mono">projectedMonthEndCents &gt; orgBudget</code>, the tile gets a red ring + warning icon.</li>
+          <li><strong>KPI tile 4 (over 80%)</strong>: warning palette when count &gt; 0; lists the most-over workspace name underneath.</li>
+          <li><strong>Stacked chart</strong>: with more than 8 workspaces, the legend collapses to "Top 8 + Other". <strong>Top-8 rule</strong> (decided in spec review): rank by <code class="mono">SUM(cost_cents)</code> for the selected period — re-computed per render based on the month being viewed; ties broken by workspace name ASC. Tooltip shows per-workspace breakdown for the hovered day. Color comes from <code class="mono">anthropic_workspaces.displayColor</code> (verified present, varchar(20)) with a deterministic palette fallback keyed by workspace ID so the same workspace always gets the same color across renders.</li>
+          <li><strong>Workspace sort</strong>: (1) over 100% first, (2) over 80% next, (3) with-limit by utilization DESC, (4) no-limit by spend DESC, (5) $0+no-limit last.</li>
+          <li><strong>Hide $0 toggle</strong>: default ON, persisted via localStorage. A "Show N hidden workspaces" disclosure expands the collapsed rows.</li>
+          <li><strong>Empty data</strong>: existing empty state from spec 018 still renders; the KPI strip shows "$0" and the MoM tile shows "—".</li>
+          <li><strong>Single workspace</strong>: stacked chart degrades cleanly to one series. Legend hides "Other".</li>
+          <li><strong>Prior month $0</strong>: MoM delta tile renders "—" with caption "no spend last month" (avoids divide-by-zero nonsense).</li>
+          <li><strong>Stale sync (&gt;70 min)</strong>: amber pill. KPIs still render from the cached data.</li>
+        </ul>
+
+        <!-- Risks -->
+        <h3 class="text-base font-semibold mt-6 mb-2">Risks</h3>
+        <ul class="text-sm space-y-1.5 list-disc pl-5 risk-list text-[var(--text)]/90">
+          <li>MoM percent unstable when prior month is near-zero. Mitigation: render <code class="mono">null</code> from the action, "—" in the UI when prior &lt; $1.</li>
+          <li>Linear extrapolation for projected month-end can mislead on lumpy workloads. Acceptable for Phase 1; Phase 2 pacing chart provides better visual baseline.</li>
+          <li>13+ workspace stack would produce an unreadable legend. Mitigation: top-8 + Other rollup is enforced server-side.</li>
+        </ul>
+
+        <!-- Acceptance criteria -->
+        <h3 class="text-base font-semibold mt-6 mb-2">Acceptance criteria</h3>
+        <ul class="text-sm space-y-1.5 ac-list">
+          <li>Page title and sidebar nav read "Claude API Spending".</li>
+          <li>KPI strip renders four tiles in the order: Total MTD · MoM delta · Projected month-end · Over-80% count.</li>
+          <li>When any workspace exceeds 80% of its limit, the Over-80% tile renders in the warning palette and the workspace appears at the top of the list.</li>
+          <li>Daily chart renders one stacked bar per day with one segment per workspace; hovering a bar shows a per-workspace tooltip.</li>
+          <li>"Hide $0 + no limit" toggle is checked by default; toggling persists across reloads via localStorage.</li>
+          <li>The Credit Balance card no longer appears; the Monthly Billing Budget card spans the full content width.</li>
+          <li>Sync pill shows green ≤ 70 min, amber &gt; 70 min, grey when never synced.</li>
+        </ul>
+      </section>
+
+      <!-- ====================== PHASE 2 ====================== -->
+      <section id="phase-2" class="anchor mb-12">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="phase-pill phase-2">Phase 2 · Commit 2</span>
+          <h2 class="text-xl font-semibold">Historical trend card + per-workspace sparklines</h2>
+        </div>
+        <p class="text-[var(--muted)] mb-5 max-w-3xl">
+          Add a Historical Trend card with 12-month bars, cumulative pacing, and Top Movers chips.
+          Add a 6-month sparkline column to the workspace list so growth is visible inline.
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
+          <div class="card p-4">
+            <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Goal</p>
+            <p class="text-sm">Answer "are we tracking high <em>this month</em>?" before month-end, and "which workspace is the runaway?" without drilling in.</p>
+          </div>
+          <div class="card p-4">
+            <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Effort</p>
+            <p class="text-sm">~25–35 hours · 5 new components · 4 new server actions · 0 schema changes.</p>
+          </div>
+          <div class="card p-4">
+            <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Depends on</p>
+            <p class="text-sm">Phase 1 (reuses <code class="mono">projectMonthEnd</code> &amp; KPI plumbing).</p>
+          </div>
+        </div>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">User stories</h3>
+        <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+          <li>As an admin, I want to see 12 months of org spend with the budget line overlaid so I know whether this month's pacing is normal or an outlier.</li>
+          <li>As an admin, I want to see whether we are tracking above or below the same day-of-month in the last three months, so I can intervene mid-month.</li>
+          <li>As an admin, I want a per-workspace sparkline so a fast-growing workspace (Automations: 4.3x in 6 months) is visible without clicking in.</li>
+        </ul>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">Files to change</h3>
+        <table class="spec-table">
+          <thead><tr><th>Path</th><th>Change</th></tr></thead>
+          <tbody>
+            <tr><td class="file-path">src/components/claude/historical-trend-card.tsx</td><td><strong>NEW</strong> · container with segmented control (3 views).</td></tr>
+            <tr><td class="file-path">src/components/claude/twelve-month-bar-chart.tsx</td><td><strong>NEW</strong> · Recharts BarChart + budget cap line.</td></tr>
+            <tr><td class="file-path">src/components/claude/cumulative-pacing-chart.tsx</td><td><strong>NEW</strong> · Recharts LineChart, 4 series.</td></tr>
+            <tr><td class="file-path">src/components/claude/top-movers-chips.tsx</td><td><strong>NEW</strong> · 3 chips, non-interactive until Phase 3.</td></tr>
+            <tr><td class="file-path">src/components/ui/sparkline.tsx</td><td><strong>NEW</strong> · inline-SVG primitive (no Recharts) — reusable on <code class="mono">/profile</code>.</td></tr>
+            <tr><td class="file-path">src/components/claude/workspace-budget-list.tsx</td><td>Add sparkline column between spend and progress bar.</td></tr>
+            <tr><td class="file-path">src/app/claude/page.tsx</td><td>Wire 4 new actions into <code class="mono">Promise.all</code>.</td></tr>
+            <tr><td class="file-path">src/actions/anthropic-global.ts</td><td>New: <code class="mono">getTwelveMonthTotals</code>, <code class="mono">getCumulativePacing</code>, <code class="mono">getTopMovers</code>, <code class="mono">getWorkspaceSparklines</code>.</td></tr>
+          </tbody>
+        </table>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">New server actions</h3>
+        <pre class="code mono"><span class="k">async function</span> <span class="t">getTwelveMonthTotals</span>():
+  <span class="t">Promise</span>&lt;{ month: <span class="t">string</span>; totalCents: <span class="t">number</span>; budgetLimitCents: <span class="t">number</span> | <span class="k">null</span> }[]&gt;
+  <span class="c">// SQL:</span>
+  <span class="c">//   SELECT to_char(date_trunc('month', date), 'YYYY-MM') AS month,</span>
+  <span class="c">//          SUM(cost_cents)::int AS total_cents</span>
+  <span class="c">//   FROM anthropic_workspace_costs</span>
+  <span class="c">//   WHERE date &gt;= current_date - interval '12 months'</span>
+  <span class="c">//   GROUP BY 1 ORDER BY 1;</span>
+  <span class="c">// budgetLimitCents is the *current* org_config value (no history retained — spec 018 convention).</span>
+
+<span class="k">async function</span> <span class="t">getCumulativePacing</span>():
+  <span class="t">Promise</span>&lt;{ dayOfMonth: <span class="t">number</span>; current: <span class="t">number</span>|<span class="k">null</span>;
+              m1: <span class="t">number</span>|<span class="k">null</span>; m2: <span class="t">number</span>|<span class="k">null</span>; m3: <span class="t">number</span>|<span class="k">null</span> }[]&gt;
+  <span class="c">// Window function:</span>
+  <span class="c">//   SUM(cost_cents) OVER (</span>
+  <span class="c">//     PARTITION BY date_trunc('month', date)</span>
+  <span class="c">//     ORDER BY date</span>
+  <span class="c">//   )</span>
+  <span class="c">// then pivot per (dayOfMonth, monthOffset). Pad missing days with null.</span>
+
+<span class="k">async function</span> <span class="t">getTopMovers</span>(): <span class="t">Promise</span>&lt;TopMover[]&gt;
+  <span class="c">// Compare workspace SUM for newest 3 months vs oldest 3 months of last 6.</span>
+  <span class="c">// Filter rows where prior_period_cents &lt; 500 ($5) to suppress noise.</span>
+  <span class="c">// Top 3 by ABS(deltaPct), each tagged direction: 'up' | 'down'.</span>
+
+<span class="k">async function</span> <span class="t">getWorkspaceSparklines</span>():
+  <span class="t">Promise</span>&lt;<span class="t">Record</span>&lt;<span class="t">string</span>, { month: <span class="t">string</span>; totalCents: <span class="t">number</span> }[]&gt;&gt;
+  <span class="c">// Single query: 6 months grouped by (workspace_id, date_trunc('month', date)).</span>
+  <span class="c">// Pivoted server-side to Record&lt;workspaceId | 'default', monthly rows&gt;.</span></pre>
+
+        <!-- Phase 2 viz -->
+        <h3 class="text-base font-semibold mt-6 mb-2">Layout</h3>
+        <div class="viz">
+          <p class="viz-label">Phase 2 — Historical Trend card</p>
+          <svg viewBox="0 0 1000 280" class="w-full h-auto">
+            <rect x="0" y="0" width="1000" height="280" fill="#0a0a0a"/>
+            <rect x="20" y="20" width="960" height="240" rx="8" fill="#121212" stroke="#262626"/>
+            <text x="34" y="42" font-size="12" fill="#fafafa" font-family="ui-sans-serif" font-weight="500">Historical trend</text>
+            <text x="34" y="56" font-size="10" fill="#71717a" font-family="ui-sans-serif">Last 12 months · monthly totals and pacing vs. prior months</text>
+            <!-- top movers chips -->
+            <g font-family="ui-sans-serif">
+              <text x="640" y="42" font-size="10" fill="#71717a" text-anchor="end">Fastest growing (6mo):</text>
+              <rect x="650" y="30" width="100" height="18" rx="4" fill="#181818" stroke="#2e2e2e"/>
+              <text x="700" y="42" font-size="9" fill="#fca5a5" text-anchor="middle">▲ Automations +413%</text>
+              <rect x="758" y="30" width="100" height="18" rx="4" fill="#181818" stroke="#2e2e2e"/>
+              <text x="808" y="42" font-size="9" fill="#fca5a5" text-anchor="middle">▲ boost-starter-5 +150%</text>
+              <rect x="866" y="30" width="110" height="18" rx="4" fill="#181818" stroke="#2e2e2e"/>
+              <text x="921" y="42" font-size="9" fill="#fca5a5" text-anchor="middle">▲ boost-starter-3 +112%</text>
+            </g>
+            <!-- 12-month bar chart -->
+            <g transform="translate(40,80)">
+              <text x="0" y="0" font-size="9" fill="#71717a" font-family="ui-sans-serif">MONTHLY TOTALS</text>
+              <line x1="0" y1="140" x2="430" y2="140" stroke="#262626"/>
+              <line x1="0" y1="55" x2="430" y2="55" stroke="#f87171" stroke-dasharray="3 3" stroke-width="0.8"/>
+              <text x="428" y="50" font-size="8" fill="#f87171" font-family="ui-sans-serif" text-anchor="end">budget cap $3,500</text>
+              <g>
+                <rect x="10"  y="120" width="22" height="20" fill="#3f3f46" rx="2"/>
+                <rect x="40"  y="116" width="22" height="24" fill="#3f3f46" rx="2"/>
+                <rect x="70"  y="113" width="22" height="27" fill="#3f3f46" rx="2"/>
+                <rect x="100" y="110" width="22" height="30" fill="#3f3f46" rx="2"/>
+                <rect x="130" y="106" width="22" height="34" fill="#52525b" rx="2"/>
+                <rect x="160" y="108" width="22" height="32" fill="#52525b" rx="2"/>
+                <rect x="190" y="115" width="22" height="25" fill="#52525b" rx="2"/>
+                <rect x="220" y="104" width="22" height="36" fill="#71717a" rx="2"/>
+                <rect x="250" y="102" width="22" height="38" fill="#71717a" rx="2"/>
+                <rect x="280" y="100" width="22" height="40" fill="#71717a" rx="2"/>
+                <rect x="310" y="98"  width="22" height="42" fill="#a1a1aa" rx="2"/>
+                <rect x="340" y="94"  width="22" height="46" fill="#d4f057" rx="2"/>
+                <rect x="340" y="48"  width="22" height="46" fill="#d4f057" opacity="0.3" stroke="#d4f057" stroke-dasharray="3 3" stroke-width="0.8" rx="2"/>
+              </g>
+              <text x="350" y="90" font-size="8" fill="#d4f057" font-family="ui-sans-serif" text-anchor="middle" font-weight="600">$3,641</text>
+              <g font-family="ui-sans-serif" font-size="8" fill="#71717a" text-anchor="middle">
+                <text x="21"  y="152">Jun</text><text x="51"  y="152">Jul</text><text x="81"  y="152">Aug</text><text x="111" y="152">Sep</text>
+                <text x="141" y="152">Oct</text><text x="171" y="152">Nov</text><text x="201" y="152">Dec</text><text x="231" y="152">Jan</text>
+                <text x="261" y="152">Feb</text><text x="291" y="152">Mar</text><text x="321" y="152">Apr</text>
+                <text x="351" y="152" fill="#d4f057" font-weight="600">May</text>
+              </g>
+            </g>
+            <!-- pacing chart -->
+            <g transform="translate(530,80)">
+              <text x="0" y="0" font-size="9" fill="#71717a" font-family="ui-sans-serif">CUMULATIVE PACING</text>
+              <line x1="0" y1="140" x2="430" y2="140" stroke="#262626"/>
+              <line x1="0" y1="55" x2="430" y2="55" stroke="#f87171" stroke-dasharray="3 3" stroke-width="0.8"/>
+              <!-- Feb -->
+              <polyline fill="none" stroke="#52525b" stroke-width="1.5"
+                points="10,138 70,128 130,118 190,108 250,96 310,84 370,71" />
+              <!-- Mar -->
+              <polyline fill="none" stroke="#71717a" stroke-width="1.5"
+                points="10,136 70,124 150,112 230,98 310,84 390,69" />
+              <!-- Apr -->
+              <polyline fill="none" stroke="#a1a1aa" stroke-width="1.5"
+                points="10,134 70,122 150,108 230,96 310,82 410,67" />
+              <!-- May solid through today -->
+              <polyline fill="none" stroke="#d4f057" stroke-width="2.5"
+                points="10,132 40,124 70,114 130,98 190,84 220,72" />
+              <!-- May dashed projection -->
+              <polyline fill="none" stroke="#d4f057" stroke-width="2" stroke-dasharray="4 3" opacity="0.85"
+                points="220,72 290,55 360,32 420,12" />
+              <line x1="220" y1="10" x2="220" y2="140" stroke="#3f3f46" stroke-dasharray="2 3"/>
+              <text x="220" y="7" font-size="8" fill="#71717a" font-family="ui-sans-serif" text-anchor="middle">today</text>
+              <circle cx="220" cy="72" r="3" fill="#d4f057"/>
+              <text x="225" y="64" font-size="8" fill="#facc15" font-family="ui-sans-serif">+125% vs Apr</text>
+              <g font-family="ui-sans-serif" font-size="8" fill="#71717a" text-anchor="middle">
+                <text x="10" y="152">1</text><text x="70" y="152">5</text><text x="150" y="152">10</text>
+                <text x="220" y="152">15</text><text x="290" y="152">20</text><text x="360" y="152">25</text><text x="420" y="152">31</text>
+              </g>
+            </g>
+          </svg>
+        </div>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">UX details &amp; edge cases</h3>
+        <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+          <li><strong>12-month chart</strong>: bars exceeding the budget cap line get a red top stroke. Tooltip shows total + cap + over/under.</li>
+          <li><strong>Pacing chart</strong>: current month bold; prior 3 months in cool greys. Tooltip locks to closest day-of-month across all series. Current line terminates at <em>today</em>; prior months extend to their actual end.</li>
+          <li><strong>Fastest growing</strong> (label decided in spec review; was "Top Movers"): top 3 by <em>positive</em> % delta only — drops are filtered out. $5 floor on prior period to suppress huge percentages off tiny bases. All chips render with ▲.</li>
+          <li><strong>Sparklines</strong>: 120×32 inline SVG (no Recharts). Hand-rolled <code class="mono">&lt;polyline&gt;</code> avoids 13× component overhead. Workspaces with &lt; 2 months of data render <code class="mono">—</code>.</li>
+          <li><strong>&lt; 12 months of history</strong>: chart only renders months that exist; missing prior-month pacing series simply absent.</li>
+          <li><strong>New workspace mid-month</strong>: sparkline shows partial data with a starting dot.</li>
+        </ul>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">Risks</h3>
+        <ul class="text-sm space-y-1.5 list-disc pl-5 risk-list text-[var(--text)]/90">
+          <li>Cumulative pacing query is the heaviest in this phase. Mitigation: use SQL window functions, not JS reduction.</li>
+          <li>13+ Recharts sparkline instances would hurt render time. Mitigation: hand-rolled inline-SVG primitive in <code class="mono">src/components/ui/sparkline.tsx</code>.</li>
+          <li>Top movers can mislead when prior figure is tiny — already mitigated by the $5 floor.</li>
+        </ul>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">Acceptance criteria</h3>
+        <ul class="text-sm space-y-1.5 ac-list">
+          <li>Historical Trend card renders below the daily chart with three views: 12-month bars · Cumulative pacing · Fastest growing.</li>
+          <li>12-month bar chart shows a horizontal budget cap line and visually marks any month that exceeded it.</li>
+          <li>Cumulative pacing chart shows four series (current + 3 prior); current series terminates at today.</li>
+          <li>"Fastest growing" strip shows up to 3 workspaces by positive % delta (no decliners), filtering out workspaces with &lt; $5 in prior period.</li>
+          <li>Workspace list has a new "Trend" column with a 6-month sparkline per workspace; &lt; 2 data points renders "—".</li>
+          <li>All new queries reuse the existing <code class="mono">"anthropic-workspace-costs"</code> cache tag.</li>
+        </ul>
+      </section>
+
+      <!-- ====================== PHASE 3 ====================== -->
+      <section id="phase-3" class="anchor mb-12">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="phase-pill phase-3">Phase 3 · Commit 3</span>
+          <h2 class="text-xl font-semibold">Workspace drill-through</h2>
+        </div>
+        <p class="text-[var(--muted)] mb-5 max-w-3xl">
+          New route <code class="mono">/claude/workspaces/[workspaceId]</code> showing per-workspace daily chart, top users, and model breakdown.
+          Reachable from workspace rows and Top Movers chips.
+        </p>
+
+        <div class="callout info mb-5">
+  <p class="text-sm"><strong>Schema decision (resolved — no spike needed).</strong> The current <code class="mono">anthropic_usage_metrics</code> table has no workspace attribution. Anthropic's <code class="mono">/v1/organizations/api_keys</code> response includes a <code class="mono">workspace_id</code> per key, but the codebase's Zod schema (<code class="mono">src/lib/anthropic-keys.ts:5-11</code>) discards it.</p>
+  <p class="text-sm mt-2"><strong>Approach</strong>: extend <code class="mono">orgApiKeySchema</code> to capture <code class="mono">workspace_id</code>, then store it alongside <code class="mono">resolvedApiKeyId</code> via a new <code class="mono">resolved_workspace_id</code> column on <code class="mono">anthropic_sync_status</code> (1 row per user — tiny). Phase 3 queries join <code class="mono">anthropic_usage_metrics</code> → <code class="mono">anthropic_sync_status</code> → <code class="mono">resolved_workspace_id</code>. No backfill on the large usage table.</p>
+  <p class="text-sm mt-2">Full analysis and caveats in <a class="link" href="data-model.md">data-model.md</a>.</p>
+</div>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
+          <div class="card p-4">
+            <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Goal</p>
+            <p class="text-sm">When a workspace is over budget or in Top Movers, an admin can click in and immediately see who and what is driving spend.</p>
+          </div>
+          <div class="card p-4">
+            <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Effort</p>
+            <p class="text-sm">~30–50 hours · depends on schema decision · 5 new components · 1 new route · 2–3 new actions.</p>
+          </div>
+          <div class="card p-4">
+            <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Depends on</p>
+            <p class="text-sm">Phase 1 (KPI strip is reused). Phase 2 makes Top Movers chips navigable (small follow-up edit).</p>
+          </div>
+        </div>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">User stories</h3>
+        <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+          <li>As an admin, when I see a workspace alarmingly close to its limit, I want to click into it and see who and what is driving the spend.</li>
+          <li>As an admin, I want to see model mix per workspace (Sonnet vs Opus vs Haiku) so I can suggest cost-saving substitutions.</li>
+          <li>As an admin, I want back-navigation to return me to <code class="mono">/claude</code> with my filter state intact.</li>
+        </ul>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">Files to change</h3>
+        <table class="spec-table">
+          <thead><tr><th>Path</th><th>Change</th></tr></thead>
+          <tbody>
+            <tr><td class="file-path">src/app/claude/workspaces/[workspaceId]/page.tsx</td><td><strong>NEW</strong> Server Component · admin gate · parses <code class="mono">"default"</code> sentinel.</td></tr>
+            <tr><td class="file-path">src/app/claude/workspaces/[workspaceId]/workspace-detail-client.tsx</td><td><strong>NEW</strong> client wrapper.</td></tr>
+            <tr><td class="file-path">src/components/claude/workspace-daily-chart.tsx</td><td><strong>NEW</strong> single-series Recharts BarChart.</td></tr>
+            <tr><td class="file-path">src/components/claude/workspace-top-users.tsx</td><td><strong>NEW</strong> table: User · Requests · Cost · row link to user profile.</td></tr>
+            <tr><td class="file-path">src/components/claude/workspace-model-breakdown.tsx</td><td><strong>NEW</strong> horizontal stacked bar + legend table (model, tokens in/out, cost, %).</td></tr>
+            <tr><td class="file-path">src/components/claude/workspace-budget-list.tsx</td><td>Make each row a <code class="mono">&lt;Link&gt;</code>; wire the drill-through icon from Phase 1.</td></tr>
+            <tr><td class="file-path">src/components/claude/top-movers-chips.tsx</td><td>Make chips navigable to the detail page.</td></tr>
+            <tr><td class="file-path">src/actions/anthropic-global.ts</td><td>New: <code class="mono">getWorkspaceDetail</code>, <code class="mono">getWorkspaceMonths</code>.</td></tr>
+            <tr><td class="file-path">src/lib/anthropic-keys.ts</td><td>Extend <code class="mono">orgApiKeySchema</code> to capture <code class="mono">workspace_id: z.string().nullable()</code> (Anthropic returns null for the default workspace).</td></tr>
+            <tr><td class="file-path">src/lib/anthropic-sync.ts</td><td>In <code class="mono">resolveAllMappings</code> (lines 143-221), persist the resolved <code class="mono">workspace_id</code> into <code class="mono">anthropic_sync_status.resolved_workspace_id</code> alongside the existing <code class="mono">resolvedApiKeyId</code>.</td></tr>
+            <tr><td class="file-path">drizzle/NNNN_anthropic_sync_workspace_id.sql</td><td><strong>NEW</strong> migration · <code class="mono">ALTER TABLE anthropic_sync_status ADD COLUMN resolved_workspace_id varchar(100);</code></td></tr>
+            <tr><td class="file-path">src/lib/db/schema.ts</td><td>Add <code class="mono">resolvedWorkspaceId</code> to the <code class="mono">anthropicSyncStatus</code> Drizzle definition.</td></tr>
+          </tbody>
+        </table>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">New server action</h3>
+        <pre class="code mono"><span class="k">async function</span> <span class="t">getWorkspaceDetail</span>(
+  workspaceId: <span class="t">string</span> | <span class="t">"default"</span>,
+  month?: <span class="t">string</span>,
+): <span class="t">Promise</span>&lt;WorkspaceDetail&gt;
+
+<span class="k">type</span> <span class="t">WorkspaceDetail</span> = {
+  workspace: { id: <span class="t">string</span>|<span class="k">null</span>; name: <span class="t">string</span>; isDefault: <span class="t">boolean</span>; displayColor?: <span class="t">string</span> };
+  currentMonthCents: <span class="t">number</span>;
+  limitCents: <span class="t">number</span> | <span class="k">null</span>;
+  utilizationPct: <span class="t">number</span> | <span class="k">null</span>;
+  dailyTotals: { date: <span class="t">string</span>; costCents: <span class="t">number</span> }[];
+  topUsers: { userId: <span class="t">number</span>; email: <span class="t">string</span>; name: <span class="t">string</span>;
+              costCents: <span class="t">number</span>; requestCount: <span class="t">number</span> }[];
+  modelBreakdown: { modelName: <span class="t">string</span>; tokensIn: <span class="t">number</span>;
+                    tokensOut: <span class="t">number</span>; costCents: <span class="t">number</span>; pctOfWorkspace: <span class="t">number</span> }[];
+};
+<span class="c">// Cache tag: "anthropic-workspace-costs".</span>
+<span class="c">// "default" URL sentinel → null workspaceId in SQL.</span></pre>
+
+        <pre class="code mono"><span class="c">// Phase 3 top-users query (uses the new resolved_workspace_id)</span>
+<span class="c">// SELECT u.id, u.email, u.name, SUM(m.computed_cost_cents) AS cents</span>
+<span class="c">//   FROM anthropic_usage_metrics m</span>
+<span class="c">//   JOIN anthropic_sync_status s ON s.user_id = m.user_id</span>
+<span class="c">//   JOIN users u                   ON u.id      = m.user_id</span>
+<span class="c">//  WHERE s.resolved_workspace_id IS NOT DISTINCT FROM $1   -- NULL = default workspace</span>
+<span class="c">//    AND m.date BETWEEN $2 AND $3</span>
+<span class="c">//  GROUP BY u.id ORDER BY cents DESC LIMIT 10;</span></pre>
+
+        <!-- Phase 3 viz -->
+        <h3 class="text-base font-semibold mt-6 mb-2">Layout</h3>
+        <div class="viz">
+          <p class="viz-label">Phase 3 — <code class="mono">/claude/workspaces/automations</code></p>
+          <svg viewBox="0 0 1000 380" class="w-full h-auto">
+            <rect x="0" y="0" width="1000" height="380" fill="#0a0a0a"/>
+            <!-- breadcrumb -->
+            <g font-family="ui-sans-serif">
+              <text x="20" y="35" font-size="11" fill="#71717a">Claude API Spending</text>
+              <text x="160" y="35" font-size="11" fill="#71717a">/</text>
+              <circle cx="180" cy="31" r="4" fill="#f87171"/>
+              <text x="190" y="35" font-size="14" font-weight="600" fill="#fafafa">Automations</text>
+              <rect x="290" y="22" width="78" height="16" rx="4" fill="#2a0a0a" stroke="#7f1d1d"/>
+              <text x="329" y="33" font-size="9" fill="#fca5a5" text-anchor="middle">over budget</text>
+            </g>
+            <!-- workspace KPI strip -->
+            <g font-family="ui-sans-serif">
+              <rect x="20" y="55" width="234" height="68" rx="8" fill="#121212" stroke="#262626"/>
+              <text x="34" y="72" font-size="9" fill="#71717a">TOTAL · MAY</text>
+              <text x="34" y="96" font-size="20" font-weight="700" fill="#fafafa">$52.49</text>
+              <text x="34" y="114" font-size="9" fill="#86efac">▲ +28% vs Apr</text>
+
+              <rect x="262" y="55" width="234" height="68" rx="8" fill="#121212" stroke="#262626"/>
+              <text x="276" y="72" font-size="9" fill="#71717a">PROJECTED</text>
+              <text x="276" y="96" font-size="20" font-weight="700" fill="#fafafa">$105.00</text>
+              <text x="276" y="114" font-size="9" fill="#f87171">210% of $50 limit</text>
+
+              <rect x="504" y="55" width="234" height="68" rx="8" fill="#121212" stroke="#262626"/>
+              <text x="518" y="72" font-size="9" fill="#71717a">UTILIZATION</text>
+              <text x="518" y="96" font-size="20" font-weight="700" fill="#f87171">105%</text>
+              <text x="518" y="114" font-size="9" fill="#71717a">of $50 monthly limit</text>
+
+              <rect x="746" y="55" width="234" height="68" rx="8" fill="#121212" stroke="#262626"/>
+              <text x="760" y="72" font-size="9" fill="#71717a">REQUESTS · MAY</text>
+              <text x="760" y="96" font-size="20" font-weight="700" fill="#fafafa">3,148</text>
+              <text x="760" y="114" font-size="9" fill="#86efac">4 distinct users</text>
+            </g>
+            <!-- daily chart -->
+            <rect x="20" y="138" width="500" height="160" rx="8" fill="#121212" stroke="#262626"/>
+            <text x="34" y="156" font-size="11" fill="#fafafa" font-family="ui-sans-serif" font-weight="500">Daily spend</text>
+            <g transform="translate(34,170)">
+              <rect x="0"   y="100" width="30" height="20" fill="#f87171"/>
+              <rect x="35"  y="92"  width="30" height="28" fill="#f87171"/>
+              <rect x="70"  y="86"  width="30" height="34" fill="#f87171"/>
+              <rect x="105" y="76"  width="30" height="44" fill="#f87171"/>
+              <rect x="140" y="68"  width="30" height="52" fill="#f87171"/>
+              <rect x="175" y="74"  width="30" height="46" fill="#f87171"/>
+              <rect x="210" y="84"  width="30" height="36" fill="#f87171"/>
+              <rect x="245" y="62"  width="30" height="58" fill="#f87171"/>
+              <rect x="280" y="56"  width="30" height="64" fill="#f87171"/>
+              <rect x="315" y="50"  width="30" height="70" fill="#f87171"/>
+              <rect x="350" y="44"  width="30" height="76" fill="#f87171"/>
+              <rect x="385" y="40"  width="30" height="80" fill="#f87171"/>
+              <rect x="420" y="38"  width="30" height="82" fill="#f87171"/>
+            </g>
+            <!-- top users + model breakdown -->
+            <rect x="540" y="138" width="220" height="160" rx="8" fill="#121212" stroke="#262626"/>
+            <text x="554" y="156" font-size="11" fill="#fafafa" font-family="ui-sans-serif" font-weight="500">Top users this month</text>
+            <g font-family="ui-sans-serif" font-size="10" fill="#fafafa">
+              <text x="554" y="180">alice@unic.com</text><text x="746" y="180" text-anchor="end" fill="#fafafa">$24.10</text>
+              <text x="554" y="200">bob@unic.com</text>  <text x="746" y="200" text-anchor="end" fill="#fafafa">$18.55</text>
+              <text x="554" y="220">carol@unic.com</text><text x="746" y="220" text-anchor="end" fill="#fafafa">$7.41</text>
+              <text x="554" y="240">dan@unic.com</text>  <text x="746" y="240" text-anchor="end" fill="#fafafa">$2.43</text>
+            </g>
+            <rect x="780" y="138" width="200" height="160" rx="8" fill="#121212" stroke="#262626"/>
+            <text x="794" y="156" font-size="11" fill="#fafafa" font-family="ui-sans-serif" font-weight="500">Model breakdown</text>
+            <!-- horizontal stack -->
+            <rect x="794" y="172" width="100" height="16" fill="#c084fc" rx="2"/>
+            <rect x="894" y="172" width="55"  height="16" fill="#67e8f9" rx="2"/>
+            <rect x="949" y="172" width="22"  height="16" fill="#86efac" rx="2"/>
+            <g font-family="ui-sans-serif" font-size="9">
+              <text x="794" y="208" fill="#c084fc">■ Opus · $30.20 (58%)</text>
+              <text x="794" y="226" fill="#67e8f9">■ Sonnet · $16.42 (31%)</text>
+              <text x="794" y="244" fill="#86efac">■ Haiku · $5.87 (11%)</text>
+            </g>
+            <!-- back link -->
+            <text x="20" y="345" font-size="11" fill="#d4f057" font-family="ui-sans-serif">← Back to Claude API Spending</text>
+          </svg>
+        </div>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">UX details &amp; edge cases</h3>
+        <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+          <li><strong>Default workspace</strong>: reachable via <code class="mono">/claude/workspaces/default</code> (URL sentinel for SQL NULL). Page renders "Default Workspace" with no badge.</li>
+          <li><strong>Not found</strong>: unknown workspace ID → <code class="mono">notFound()</code> from Next.js → 404 page.</li>
+          <li><strong>Per-workspace KPI tiles</strong> (decided in spec review): reuse the Phase 1 <code class="mono">&lt;KpiStrip&gt;</code> with workspace-scoped props rendering (1) Total MTD · (2) MoM delta · (3) Projected month-end · (4) <strong>Utilization %</strong> (replaces the org-level "Over 80% count" tile). Mockup screenshot showed a Requests-count tile — that's overridden by this spec decision; the canonical 4 tiles are listed here.</li>
+          <li><strong>No limit set</strong>: 4th KPI tile shows "No limit set" with an inline action to set one (reuses <code class="mono">setWorkspaceLimit</code> from Phase 1).</li>
+          <li><strong>No usage data</strong>: daily chart + top users render empty states; KPI strip still renders ($0).</li>
+          <li><strong>Per-user totals vs workspace total</strong>: the sum of per-user costs in this workspace will <em>not</em> exactly match the headline workspace cost. They come from different Anthropic endpoints (usage report vs cost report) with different rounding. Surface both as separate signals; do not try to reconcile them.</li>
+          <li><strong>Mid-month workspace move</strong>: <code class="mono">resolved_workspace_id</code> reflects the user's <em>current</em> API key's workspace. If a user is moved to a different workspace mid-month, historical usage gets attributed to the new workspace. Footnote in the UI.</li>
+          <li><strong>Back navigation</strong>: breadcrumb uses <code class="mono">next/link</code> to <code class="mono">/claude?workspace={id}</code>; parent <code class="mono">&lt;GlobalMetricsClient&gt;</code> reads the query param on mount.</li>
+        </ul>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">Risks</h3>
+        <ul class="text-sm space-y-1.5 list-disc pl-5 risk-list text-[var(--text)]/90">
+          <li>Per-user → workspace attribution is derived via the Anthropic API key's <code class="mono">workspace_id</code>; reliable because Anthropic enforces 1 key = 1 workspace. The risk is that admin imports might leave stale <code class="mono">resolved_workspace_id</code> values — mitigation: re-resolve on every sync (cheap, sync already calls <code class="mono">fetchOrgApiKeys</code>).</li>
+          <li>The <code class="mono">"default"</code> URL sentinel needs round-trip testing. Mitigation: explicit unit test on the route parser.</li>
+          <li><code class="mono">anthropic_usage_metrics.model</code> column is <code class="mono">NOT NULL</code> per <code class="mono">src/lib/db/schema.ts:534</code> — no nullability mitigation needed (earlier draft worry retracted during spec review).</li>
+        </ul>
+
+        <h3 class="text-base font-semibold mt-6 mb-2">Acceptance criteria</h3>
+        <ul class="text-sm space-y-1.5 ac-list">
+          <li>As admin, navigating to <code class="mono">/claude/workspaces/{id}</code> renders the workspace name, KPI strip, daily chart, top users, and model breakdown.</li>
+          <li>Clicking a workspace row in Phase 1 list navigates here.</li>
+          <li>Clicking a Phase 2 Top Movers chip navigates here.</li>
+          <li>The default workspace is reachable via <code class="mono">/claude/workspaces/default</code> and renders without error.</li>
+          <li>Non-admins are redirected from this route.</li>
+          <li>Breadcrumb back-link pre-selects the workspace in the parent filter.</li>
+        </ul>
+      </section>
+
+      <!-- ====================== CROSS-CUTTING ====================== -->
+      <section id="cross" class="anchor mb-12">
+        <h2 class="text-xl font-semibold mb-3">6. Cross-cutting concerns &amp; shared helpers</h2>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="card p-4">
+            <h4 class="text-sm font-semibold mb-2">Shared helpers (introduced in Phase 1, reused after)</h4>
+            <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+              <li><code class="mono">projectMonthEnd(mtdCents, daysElapsed, daysInMonth)</code> in <code class="file-path">src/lib/utils.ts</code> — reused by org billing card &amp; per-workspace KPI strip.</li>
+              <li><code class="mono">&lt;SyncStatusPill /&gt;</code> — reusable wherever sync status is surfaced.</li>
+              <li><code class="mono">&lt;KpiStrip /&gt;</code> — the same component renders both the org-level (Phase 1) and per-workspace (Phase 3) strips with different prop sets.</li>
+              <li><code class="mono">&lt;Sparkline /&gt;</code> — Phase 2; should also replace any equivalent sparkline on <code class="mono">/profile</code> (existing user view).</li>
+            </ul>
+          </div>
+          <div class="card p-4">
+            <h4 class="text-sm font-semibold mb-2">Cache &amp; sync</h4>
+            <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+              <li>Every new server action wraps in <code class="mono">unstable_cache</code> with tag <code class="mono">"anthropic-workspace-costs"</code>.</li>
+              <li>The existing hourly cron sync (spec 018) already calls <code class="mono">revalidateTag("anthropic-workspace-costs")</code> on completion — no new wiring needed.</li>
+              <li><code class="mono">getSyncStatus()</code> bypasses the cache; it reads the sentinel row directly (sub-millisecond).</li>
+            </ul>
+          </div>
+          <div class="card p-4">
+            <h4 class="text-sm font-semibold mb-2">Authorization</h4>
+            <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+              <li><code class="mono">/claude</code> + all subroutes gated by <code class="mono">session.user.role === "admin"</code>.</li>
+              <li>Phase 3 route guard mirrors the parent page guard (redirect to <code class="mono">/</code> for non-admins).</li>
+              <li>Server actions use <code class="mono">requireAdmin()</code> from <code class="mono">src/lib/auth-helpers.ts</code>; non-admin callers receive an empty payload (existing pattern).</li>
+            </ul>
+          </div>
+          <div class="card p-4">
+            <h4 class="text-sm font-semibold mb-2">Accessibility</h4>
+            <ul class="text-sm space-y-1.5 list-disc pl-5 text-[var(--text)]/90">
+              <li>All charts retain Recharts <code class="mono">accessibilityLayer</code>; sparkline primitive uses <code class="mono">role="img"</code> + <code class="mono">aria-label</code> with a textual summary.</li>
+              <li>KPI tiles use <code class="mono">aria-describedby</code> linking the value to its caption for screen readers.</li>
+              <li>Sync pill uses <code class="mono">aria-live="polite"</code> when the staleness state changes.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== TESTING ====================== -->
+      <section id="test-strategy" class="anchor mb-12">
+        <h2 class="text-xl font-semibold mb-3">7. Test strategy</h2>
+        <table class="spec-table">
+          <thead><tr><th>Layer</th><th>Phase 1</th><th>Phase 2</th><th>Phase 3</th></tr></thead>
+          <tbody>
+            <tr>
+              <td><strong>Unit (Vitest)</strong></td>
+              <td>MoM math (zero/missing prior); projection at days-elapsed 1 / mid / end; over-80% counting; staleness boundary at 70 min.</td>
+              <td>Cumulative pacing math; top-movers ranking + $5 floor; 12-month bucketing across year boundary.</td>
+              <td>Route param parsing inc. <code class="mono">"default"</code> sentinel; model % math sums to 100; top-user tie ordering.</td>
+            </tr>
+            <tr>
+              <td><strong>Integration (Vitest, real DB)</strong></td>
+              <td>Seed 2 months → verify <code class="mono">getDashboardKpis</code> shape end-to-end.</td>
+              <td>Seed 6 months across multiple workspaces → verify <code class="mono">getWorkspaceSparklines</code> &amp; <code class="mono">getTopMovers</code>.</td>
+              <td>Seed workspace + users + models → verify <code class="mono">getWorkspaceDetail</code>.</td>
+            </tr>
+            <tr>
+              <td><strong>E2E (Playwright)</strong></td>
+              <td>Admin lands on <code class="mono">/claude</code>, sees title, 4 KPI tiles, stacked chart, toggle persists across reload, non-admin redirected.</td>
+              <td>Trend card renders, tabs switch views, sparkline column populated.</td>
+              <td>List row click → detail page → breadcrumb back restores filter; non-admin direct-nav redirects; 404 on bad ID.</td>
+            </tr>
+            <tr>
+              <td><strong>Manual smoke</strong></td>
+              <td>Confirm Automations row 1 + tile 4 warning + projected tile red ring with current dev DB.</td>
+              <td>Automations sparkline ramps up; Top Movers contains expected workspaces.</td>
+              <td>Walk <code class="mono">/claude/workspaces/default</code>, real ID, unknown ID.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- ====================== ROLLOUT ====================== -->
+      <section id="rollout" class="anchor mb-12">
+        <h2 class="text-xl font-semibold mb-3">8. Rollout &amp; risk register</h2>
+
+        <div class="card p-5 mb-6">
+  <p class="text-xs uppercase tracking-wider text-[var(--muted-2)] mb-2">Single-PR rollout</p>
+  <p class="text-sm">All 3 phases ship in one PR, organized as 3 sequential commits so review can be staged phase-by-phase:</p>
+  <ol class="text-sm space-y-2 list-decimal pl-5 mt-3">
+    <li><strong>Commit 1 — Phase 1</strong>: visual reset, KPI strip, stacked daily chart, sync pill, full-width billing card, workspace re-sort. Standalone-functional even if commits 2 + 3 are reverted.</li>
+    <li><strong>Commit 2 — Phase 2</strong>: Historical Trend card + sparklines. Includes a perf assertion (cumulative pacing query &lt; 200ms on dev DB).</li>
+    <li><strong>Commit 3 — Phase 3</strong>: schema migration (<code class="mono">resolved_workspace_id</code>) + sync extension + drill-through route. Migration runs first; ships before the UI that depends on it within the same commit so review sees the full vertical slice.</li>
+  </ol>
+  <p class="text-sm mt-3">Gated rollout (feature flag) is not used: the page is admin-only and changes are additive. Internal-admin validation period of 1 week before announcing.</p>
+</div>
+
+        <h3 class="text-base font-semibold mb-2">Risk register</h3>
+        <table class="spec-table">
+          <thead><tr><th>Risk</th><th>Likelihood</th><th>Impact</th><th>Mitigation</th></tr></thead>
+          <tbody>
+            <tr><td>Stale <code class="mono">resolved_workspace_id</code> after admin moves a key between workspaces</td><td>Low</td><td>Medium</td><td>Re-resolve on every sync (already runs every hour); document the mid-month edge case in UI.</td></tr>
+            <tr><td>Per-user totals don't sum to workspace total</td><td>High (by design)</td><td>Low</td><td>Document upfront — separate Anthropic endpoints, different rounding. Surface both signals separately.</td></tr>
+            <tr><td>Cumulative pacing query slow on large dataset</td><td>Low</td><td>Medium</td><td>SQL window function; integration test asserts &lt;200ms.</td></tr>
+            <tr><td>MoM% misleading near zero</td><td>High</td><td>Low</td><td>Return <code class="mono">null</code> below $1 floor; render "—".</td></tr>
+            <tr><td>Stacked chart legend unreadable with 13+ workspaces</td><td>High</td><td>Low</td><td>Top-8 + Other rollup; documented in T112.</td></tr>
+            <tr><td>Top movers misleading off tiny prior base</td><td>Medium</td><td>Low</td><td>$5 floor on prior-period spend.</td></tr>
+            <tr><td>"default" URL sentinel collisions with a real workspace named "default"</td><td>Very Low</td><td>Medium</td><td>Document the reserved name; unit-test the parser.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <footer class="pt-6 mt-12 border-t border-[var(--border)] text-xs text-[var(--muted-2)]">
+        <p>Spec 026 · drafted 2026-05-15 · companion analysis: <code class="mono">C:\Users\stude\.claude\plans\claude-page-analysis.md</code> · companion mockup: <a class="link" href="mockup.html">mockup.html</a></p>
+      </footer>
+
+    </div>
+  </body>
+</html>

--- a/specs/026-claude-page-redesign/spec.md
+++ b/specs/026-claude-page-redesign/spec.md
@@ -1,0 +1,45 @@
+# Spec 026: Claude API Spending page redesign
+
+**Status**: Ready for implementation
+**Created**: 2026-05-15
+**Owner**: tobias.studer@unic.com
+**Replaces / supersedes**: 018-claude-global-metrics (UX layer only; data layer is unchanged)
+
+## Summary
+
+Redesign the admin `/claude` page so it surfaces operational signal (over-budget workspaces, run-rate, growth trends) instead of just current totals. The redesign keeps the existing schema (no migrations in Phases 1 & 2) and reuses the hourly sync established by spec 018.
+
+## Why now
+
+With real data — 13 workspaces, "Automations" at 105% of its $50 cap and 4.3x growth over six months — the current layout buries the operational signal:
+
+- The total dollars-spent number is the largest element, but it is the *least actionable* signal on the page.
+- The daily chart is a single series so it cannot answer "which workspace drove the spike on May 12".
+- The workspace list is sorted alphabetically; the over-budget workspace is buried.
+- The Credit Balance card is a permanent placeholder ("not exposed by the Anthropic API") consuming 50% of the Org Billing row.
+- There is no historical view, no run-rate forecast, no MoM comparison, and no drill-through into a single workspace.
+
+A 5-minute review with the live page made these gaps obvious and they are addressed phase-by-phase below.
+
+## Scope (3 phases delivered in 1 PR)
+
+All three phases ship in a **single pull request**, organized as three sequential commits so review can still be staged phase-by-phase. The user→workspace mapping decision for Phase 3 (see `data-model.md`) is small enough — a single nullable column on `anthropic_sync_status` plus a Zod schema extension — that there's no spike risk justifying separate PRs.
+
+- **Phase 1 (commit 1) — Visual reset + KPI strip.** Rename, KPI tiles, stacked daily chart, full-width billing card, sync pill, workspace list re-sort + Hide $0 toggle.
+- **Phase 2 (commit 2) — Historical detail.** 12-month bar chart, cumulative pacing chart, Top Movers chips, per-row 6-month sparklines.
+- **Phase 3 (commit 3) — Drill-through.** `/claude/workspaces/[id]` with per-workspace daily chart, top users (attributed via Anthropic-provided `workspace_id` on each API key), model breakdown.
+
+## Out of scope
+
+- Anthropic credit balance display (still not exposed by the Anthropic API).
+- Workspace-level alerts beyond the existing site-wide banner.
+- Changes to the per-user `/profile` Claude cost view.
+- Backfill of historical data — relies on what spec 025 already populated.
+
+## Companion artifacts
+
+- `plan.html` — full technical implementation plan with embedded visualizations (this is the primary plan document; open in a browser).
+- `mockup.html` — standalone interactive mockup of the redesigned page.
+- `tasks.md` — ordered execution checklist (single PR; 3 commit groups).
+- `data-model.md` — schema analysis and the user→workspace mapping decision for Phase 3.
+- Background: `C:\Users\stude\.claude\plans\claude-page-analysis.md` (analysis that informed this spec).

--- a/specs/026-claude-page-redesign/spec.md
+++ b/specs/026-claude-page-redesign/spec.md
@@ -25,16 +25,27 @@ A 5-minute review with the live page made these gaps obvious and they are addres
 
 All three phases ship in a **single pull request**, organized as three sequential commits so review can still be staged phase-by-phase. The user→workspace mapping decision for Phase 3 (see `data-model.md`) is small enough — a single nullable column on `anthropic_sync_status` plus a Zod schema extension — that there's no spike risk justifying separate PRs.
 
-- **Phase 1 (commit 1) — Visual reset + KPI strip.** Rename, KPI tiles, stacked daily chart, full-width billing card, sync pill, workspace list re-sort + Hide $0 toggle.
-- **Phase 2 (commit 2) — Historical detail.** 12-month bar chart, cumulative pacing chart, Top Movers chips, per-row 6-month sparklines.
+- **Phase 1 (commit 1) — Visual reset + KPI strip.** Rename, KPI tiles, stacked daily chart, full-width billing card, sync pill, workspace list re-sort + Hide $0 toggle. Sidebar entry was subsequently renamed from "Claude API Spending" to **"Claude Console"** (commit `331da58`).
+- **Phase 2 (commit 2) — Historical detail.** 12-month bar chart, cumulative pacing chart, Top Movers chips, per-row sparklines. Sparkline delta label is **dynamic** (`{N}mo` where N = calendar-month distance between first and last data points), not a fixed "6mo".
 - **Phase 3 (commit 3) — Drill-through.** `/claude/workspaces/[id]` with per-workspace daily chart, top users (attributed via Anthropic-provided `workspace_id` on each API key), model breakdown.
+
+### Post-implementation refinements
+
+Beyond the three phases, several polish commits landed in this PR:
+
+- **Per-day cost storage bug fix** (commits `e1428aa`, `616c88c`) — `anthropic_workspace_costs` previously held month-rolled rows keyed to `YYYY-MM-01` because `/v1/organizations/cost_report` was called without `bucket_width=1d` and the aggregation loop discarded `bucket.starting_at`. Phase 1 / Phase 2 charts implicitly assumed per-day storage; the fix makes that real. Two batched upserts (one per partial-index bucket) replace the original per-row round-trip.
+- **Historical-trend card kept the tabs**, not the side-by-side layout the mockup explored. Rationale: the segmented control reads cleanly at desktop widths, avoided a layout regression on tablet, and the three views are rarely compared simultaneously in practice.
+- **Daily-chart color toggle** — a "Use workspace colors" switch in the daily spend card header flips between the curated theme palette (default) and each workspace's `display_color` from `anthropic_workspaces`. Persisted to `localStorage` (`claude-dashboard:useDbColors`). Default switched to the palette because Anthropic-supplied `display_color` values frequently collide across `boost-starter-*` and `boost-expert-*` families.
+- **Workspace name is a Link** to the drill-through detail page; the chevron drill-icon stays as the original affordance.
+- **Drill-down polish** (commit `743c612`): per-day budget cap reference line on the workspace daily chart, model-breakdown reconciliation footnote mirroring the top-users footnote, default-workspace limit-editor hint, removed duplicate "Over budget" badge under the month picker.
+- **Backfill scripts**: `scripts/backfill-anthropic-workspace-costs.ts` (truncate + re-fetch after the daily-bucket fix) and `scripts/backfill-anthropic-workspace-mapping.ts` (one-off retro-population of `resolved_workspace_id` for users whose mapping existed before migration 0018).
 
 ## Out of scope
 
 - Anthropic credit balance display (still not exposed by the Anthropic API).
 - Workspace-level alerts beyond the existing site-wide banner.
 - Changes to the per-user `/profile` Claude cost view.
-- Backfill of historical data — relies on what spec 025 already populated.
+- Backfill of historical *usage* data — relies on what spec 025 already populated. (Note: a one-off `anthropic_workspace_costs` backfill *did* become necessary because of the per-day storage bug — see "Post-implementation refinements" above.)
 
 ## Companion artifacts
 

--- a/specs/026-claude-page-redesign/tasks.md
+++ b/specs/026-claude-page-redesign/tasks.md
@@ -1,0 +1,99 @@
+# Tasks — Spec 026: Claude page redesign
+
+All three phases ship in **one PR** as three sequential commits. Tasks within a phase are ordered for execution; check off in order.
+
+## Delivery model
+
+All 3 phases ship in a **single pull request**, organized as **3 sequential commits** so review can be staged phase-by-phase. Commits are intentionally ordered so each is independently revertible without breaking the previous: commit 1 leaves the page functional, commit 2 adds the historical card additively, commit 3 adds the new route + small schema migration.
+
+Run `pnpm lint && pnpm typecheck && pnpm test` between each commit, not just at the end.
+
+## Phase 1 — Visual reset + KPI strip (Commit 1)
+
+### Data layer
+- [ ] T101 Extend `getGlobalCostDashboard` return type with `kpis: DashboardKpis` and `dailyStacked: DailyStackedRow[]` in `src/types/index.ts`.
+- [ ] T102 Implement `getDashboardKpis(month?)` server action in `src/actions/anthropic-global.ts`. Cache tag `"anthropic-workspace-costs"`. Includes MoM math (return `null` when prior month < $1) and `projectMonthEnd()`.
+- [ ] T103 Implement `getDailyTotalsByWorkspace(month?)`. Reshape existing `workspaceBreakdown` into per-day stacked rows: top 8 workspaces + `Other`. **Top-8 rule (decided in spec review)**: rank by `SUM(cost_cents)` for the selected period — re-computed per render based on the month being viewed; ties broken by workspace name ASC. Same cache tag.
+- [ ] T104 Implement `getSyncStatus()` reading the `userId = 0` sentinel row from `anthropicSyncStatus` (per `LOCK_USER_ID` in `src/lib/anthropic-sync.ts:23`). Returns `{ lastSyncedAt, ageMinutes, isStale }` with `isStale` = age > 70 minutes.
+- [ ] T105 Add shared util `projectMonthEnd(mtdCents, daysElapsed, daysInMonth)` in `src/lib/utils.ts` + unit tests.
+- [ ] T106 Unit tests: `tests/unit/anthropic-global-kpis.test.ts` — MoM math, projection math, over-80% counting, staleness boundary.
+- [ ] T107 Integration test: seed two months of workspace costs, verify `getDashboardKpis` shape.
+
+### UI layer
+- [ ] T108 Rename header in `src/app/claude/page.tsx` (line 21 metadata, line 55 h1) → "Claude API Spending"; update sidebar nav label in `src/components/app-sidebar.tsx`.
+- [ ] T109 New `SyncStatusPill` component in `src/components/claude/sync-status-pill.tsx`. Green / amber / grey states per `isStale` flag. Anchored to `/settings/sync`.
+- [ ] T110 New `KpiStrip` component (`src/components/claude/kpi-strip.tsx`) — 4 tiles in `md:grid-cols-2 lg:grid-cols-4`. Tile 3 gets red ring + warning icon if `projectedMonthEndCents > orgBudget`. Tile 4 shows over-80% count out of `workspacesWithLimitCount`.
+- [ ] T111 Update `GlobalMetricsClient` to render `KpiStrip` above the chart. Pass through new props.
+- [ ] T112 Convert the daily chart in `global-metrics-client.tsx` from single-series to stacked Bar (`stackId="costs"`, one `<Bar>` per top-8 workspace + `Other`). Legend on top. Tooltip shows per-workspace breakdown.
+- [ ] T113 Refactor `OrgCreditsPanel` → `OrgBillingBudgetCard`: drop the dead Credit Balance card; full-width; add a Projected month-end column. Move credits stub to a footnote link.
+- [ ] T114 Update `WorkspaceBudgetList` sort consumer + add "Hide $0 + no limit" toggle (default on, persisted to `localStorage` key `claude-hide-zero-workspaces`).
+- [ ] T115 Update SQL in `_getWorkspaceList` to sort: over-limit first, over-80% next, with-limit by utilization DESC, no-limit by spend DESC, $0+no-limit last.
+- [ ] T116 Visual restructure of `WorkspaceBudgetRow`: spend big on left, limit small on right; drill-through icon button on hover (no-op until Phase 3 ships).
+
+### Verification
+- [ ] T117 E2E: `tests/e2e/claude-page-phase1.spec.ts` — admin lands on `/claude`, sees new title, 4 KPI tiles, sync pill, stacked chart legend, toggle persists across reload, non-admin gets redirected.
+- [ ] T118 Manual: with the dev DB, confirm "Automations" appears at row 1 (over budget), KPI tile 4 is in warning color, projected tile shows the red ring.
+
+## Phase 2 — Historical trend + sparklines (Commit 2)
+
+### Data layer
+- [ ] T201 New action `getTwelveMonthTotals()` in `anthropic-global.ts`. SQL: `GROUP BY date_trunc('month', date)` for last 12 months. Returns budget cap alongside each row (uses current `anthropic_org_config` value — no history is retained, consistent with spec 018).
+- [ ] T202 New action `getCumulativePacing()` — window function over 4 months: `SUM(cost_cents) OVER (PARTITION BY date_trunc('month', date) ORDER BY date)`. Pivot per `dayOfMonth`. Pad missing days with `null` so Recharts skips them cleanly.
+- [ ] T203 New action `getTopMovers()` — top 3 by **positive** % delta only (newest 3-month vs oldest 3-month windows), with `>= $5` floor on the prior period to filter noise. **Decline / drops are filtered out** (decided in spec review — user-facing label is "Fastest growing"). Internal function/type names may stay as `getTopMovers` / `TopMover` for git history continuity.
+- [ ] T204 New action `getWorkspaceSparklines()` — single query: 6 months of monthly totals grouped by `(workspace_id, month)`, pivoted server-side into `Record<workspaceId, {month, totalCents}[]>`.
+- [ ] T205 New types in `src/types/index.ts`: `TwelveMonthRow`, `PacingRow`, `TopMover`, `WorkspaceSparkline`.
+- [ ] T206 Unit tests: cumulative pacing math, top-movers ranking + floor, 12-month bucketing across year boundaries.
+- [ ] T207 Integration test: seed 6 months across multiple workspaces; verify sparkline shape and top movers ranking.
+
+### UI layer
+- [ ] T208 New `HistoricalTrendCard` container in `src/components/claude/historical-trend-card.tsx` with a 3-way segmented control (Monthly totals / Pacing / **Fastest growing**).
+- [ ] T209 New `TwelveMonthBarChart` (`twelve-month-bar-chart.tsx`) — Recharts BarChart + horizontal dashed budget-cap line; bars exceeding cap get a red top stroke.
+- [ ] T210 New `CumulativePacingChart` (`cumulative-pacing-chart.tsx`) — Recharts LineChart with 4 series. Current month bold; prior 3 in cool greys. Synchronized tooltip across all series.
+- [ ] T211 New `TopMoversChips` (`top-movers-chips.tsx`) — 3 chips with name + ▲ arrow + delta %. Section title is **"Fastest growing (6mo)"** (user-facing label decided in spec review). All chips render with ▲ since the action filters to positive deltas only. Until Phase 3 ships, chips are non-interactive static badges.
+- [ ] T212 New `Sparkline` primitive in `src/components/ui/sparkline.tsx`. Hand-rolled inline SVG `<polyline>` — not Recharts — to avoid 13× instance overhead. Props: `data`, `color?`, `height?`, `width?`. Renders `—` when `data.length < 2`.
+- [ ] T213 Add `<Sparkline>` column to `WorkspaceBudgetRow` (between spend and progress bar). Reuse `displayColor` from `anthropic_workspaces`.
+- [ ] T214 Wire all 4 new actions into `page.tsx` Promise.all and pass into the chart card + workspace list.
+
+### Verification
+- [ ] T215 E2E: navigate to `/claude`, confirm Historical Trend card renders, tabs switch views, sparkline column populated.
+- [ ] T216 Manual: with dev DB confirm Automations sparkline ramps up; Top Movers shows Automations + boost-starter-5 + boost-starter-3.
+
+## Phase 3 — Drill-through (Commit 3)
+
+### Schema migration (small, deterministic — no spike)
+
+- [ ] T301 Add Zod field: extend `orgApiKeySchema` in `src/lib/anthropic-keys.ts` (lines 5-11) to capture `workspace_id: z.string().nullable()`. Anthropic's `/v1/organizations/api_keys` already returns it — codebase currently discards it.
+- [ ] T302 Drizzle migration `drizzle/NNNN_anthropic_sync_workspace_id.sql`: `ALTER TABLE anthropic_sync_status ADD COLUMN resolved_workspace_id varchar(100);`. Generate via `pnpm db:generate` after updating the schema in `src/lib/db/schema.ts`.
+- [ ] T303 Update `src/lib/db/schema.ts`: add `resolvedWorkspaceId: varchar("resolved_workspace_id", { length: 100 })` to the `anthropicSyncStatus` table definition.
+- [ ] T304 Update `resolveAllMappings()` in `src/lib/anthropic-sync.ts` (lines 143-221): when persisting `resolvedApiKeyId`, also persist the corresponding `workspace_id` from the `orgKeys` array into `resolved_workspace_id`. Backfill happens automatically on the next hourly sync — no manual backfill required.
+- [ ] T305 Verify in dev DB: after one sync run, every active user's `anthropic_sync_status` row should have a non-null `resolved_workspace_id` (NULL only for the org's default workspace).
+
+### Data layer
+
+- [ ] T306 New action `getWorkspaceDetail(workspaceId | "default", month?)` in `anthropic-global.ts` returning `{ workspace, currentMonthCents, limitCents, utilizationPct, dailyTotals, topUsers, modelBreakdown }`. Cache tag `"anthropic-workspace-costs"`. Top users query joins `anthropic_usage_metrics` → `anthropic_sync_status.user_id` → `resolved_workspace_id`. Model breakdown aggregates `anthropic_usage_metrics.model` filtered by the same join.
+- [ ] T307 New action `getWorkspaceMonths(workspaceId | "default")` for the per-workspace month picker.
+- [ ] T308 Type additions in `src/types/index.ts`: `WorkspaceDetail`, `WorkspaceUser`, `ModelBreakdownRow`.
+- [ ] T309 Unit + integration tests for `getWorkspaceDetail`, including the `"default"` URL sentinel → null SQL value round-trip.
+
+### UI layer
+
+- [ ] T310 New route `src/app/claude/workspaces/[workspaceId]/page.tsx` (Server Component, admin gate, parses `"default"` sentinel → `null`).
+- [ ] T311 New `WorkspaceDetailClient` (client wrapper) — month picker + KPI strip scoped to this workspace. **Reuses Phase 1 `KpiStrip`** with these 4 tiles (decided in spec review): (1) Total MTD · (2) MoM delta · (3) Projected month-end · (4) **Utilization %** (replaces the org-level "Over 80% count" tile). When `limitCents IS NULL`, tile 4 shows "No limit set" with an inline action calling `setWorkspaceLimit`.
+- [ ] T312 New `WorkspaceDailyChart` — single-series Recharts BarChart.
+- [ ] T313 New `WorkspaceTopUsers` — table with `User | Requests | Cost`; row click opens the user's existing profile cost page in a new tab. Show a footnote that the per-user sum does not reconcile with the workspace total (different Anthropic endpoints).
+- [ ] T314 New `WorkspaceModelBreakdown` — horizontal stacked bar + legend table (model, tokens in/out, cost, % of workspace).
+- [ ] T315 Make `WorkspaceBudgetRow` a `<Link>` to the detail page. Reuse the drill icon added in Phase 1.
+- [ ] T316 Make `TopMoversChips` navigable. Update breadcrumb on detail page to support back-navigation with `?workspace=` query param preserved on `/claude`.
+
+### Verification
+
+- [ ] T317 E2E: `tests/e2e/claude-workspace-detail.spec.ts` — list → row click → detail page renders → breadcrumb back restores filter. Non-admin direct-nav redirects. 404 on bad ID.
+- [ ] T318 Manual smoke: walk through `/claude/workspaces/default` (URL sentinel for NULL workspace_id), a real workspace ID, and a non-existent ID.
+
+## Cross-cutting checklist (each commit)
+
+- [ ] Cache tag `"anthropic-workspace-costs"` on every new server action so the existing hourly sync `revalidateTag` calls invalidate them.
+- [ ] All new types exported from `src/types/index.ts`.
+- [ ] `pnpm lint && pnpm typecheck` clean.
+- [ ] Lighthouse mobile + desktop pass on `/claude` (Phase 1 + 2 only).
+- [ ] Update `docs/admin-guide.md` (or equivalent) with screenshots after Phase 1.

--- a/specs/026-claude-page-redesign/tasks.md
+++ b/specs/026-claude-page-redesign/tasks.md
@@ -11,89 +11,114 @@ Run `pnpm lint && pnpm typecheck && pnpm test` between each commit, not just at 
 ## Phase 1 — Visual reset + KPI strip (Commit 1)
 
 ### Data layer
-- [ ] T101 Extend `getGlobalCostDashboard` return type with `kpis: DashboardKpis` and `dailyStacked: DailyStackedRow[]` in `src/types/index.ts`.
-- [ ] T102 Implement `getDashboardKpis(month?)` server action in `src/actions/anthropic-global.ts`. Cache tag `"anthropic-workspace-costs"`. Includes MoM math (return `null` when prior month < $1) and `projectMonthEnd()`.
-- [ ] T103 Implement `getDailyTotalsByWorkspace(month?)`. Reshape existing `workspaceBreakdown` into per-day stacked rows: top 8 workspaces + `Other`. **Top-8 rule (decided in spec review)**: rank by `SUM(cost_cents)` for the selected period — re-computed per render based on the month being viewed; ties broken by workspace name ASC. Same cache tag.
-- [ ] T104 Implement `getSyncStatus()` reading the `userId = 0` sentinel row from `anthropicSyncStatus` (per `LOCK_USER_ID` in `src/lib/anthropic-sync.ts:23`). Returns `{ lastSyncedAt, ageMinutes, isStale }` with `isStale` = age > 70 minutes.
-- [ ] T105 Add shared util `projectMonthEnd(mtdCents, daysElapsed, daysInMonth)` in `src/lib/utils.ts` + unit tests.
-- [ ] T106 Unit tests: `tests/unit/anthropic-global-kpis.test.ts` — MoM math, projection math, over-80% counting, staleness boundary.
+- [x] T101 Extend `getGlobalCostDashboard` return type with `kpis: DashboardKpis` and `dailyStacked: DailyStackedRow[]` in `src/types/index.ts`.
+- [x] T102 Implement `getDashboardKpis(month?)` server action in `src/actions/anthropic-global.ts`. Cache tag `"anthropic-workspace-costs"`. Includes MoM math (return `null` when prior month < $1) and `projectMonthEnd()`.
+- [x] T103 Implement `getDailyTotalsByWorkspace(month?)`. Reshape existing `workspaceBreakdown` into per-day stacked rows: top 8 workspaces + `Other`. **Top-8 rule (decided in spec review)**: rank by `SUM(cost_cents)` for the selected period — re-computed per render based on the month being viewed; ties broken by workspace name ASC. Same cache tag.
+- [x] T104 Implement `getSyncStatus()` reading the `userId = 0` sentinel row from `anthropicSyncStatus` (per `LOCK_USER_ID` in `src/lib/anthropic-sync.ts:23`). Returns `{ lastSyncedAt, ageMinutes, isStale }` with `isStale` = age > 70 minutes.
+- [x] T105 Add shared util `projectMonthEnd(mtdCents, daysElapsed, daysInMonth)` in `src/lib/utils.ts` + unit tests.
+- [x] T106 Unit tests: `tests/unit/anthropic-global-kpis.test.ts` — MoM math, projection math, over-80% counting, staleness boundary.
 - [ ] T107 Integration test: seed two months of workspace costs, verify `getDashboardKpis` shape.
 
 ### UI layer
-- [ ] T108 Rename header in `src/app/claude/page.tsx` (line 21 metadata, line 55 h1) → "Claude API Spending"; update sidebar nav label in `src/components/app-sidebar.tsx`.
-- [ ] T109 New `SyncStatusPill` component in `src/components/claude/sync-status-pill.tsx`. Green / amber / grey states per `isStale` flag. Anchored to `/settings/sync`.
-- [ ] T110 New `KpiStrip` component (`src/components/claude/kpi-strip.tsx`) — 4 tiles in `md:grid-cols-2 lg:grid-cols-4`. Tile 3 gets red ring + warning icon if `projectedMonthEndCents > orgBudget`. Tile 4 shows over-80% count out of `workspacesWithLimitCount`.
-- [ ] T111 Update `GlobalMetricsClient` to render `KpiStrip` above the chart. Pass through new props.
-- [ ] T112 Convert the daily chart in `global-metrics-client.tsx` from single-series to stacked Bar (`stackId="costs"`, one `<Bar>` per top-8 workspace + `Other`). Legend on top. Tooltip shows per-workspace breakdown.
-- [ ] T113 Refactor `OrgCreditsPanel` → `OrgBillingBudgetCard`: drop the dead Credit Balance card; full-width; add a Projected month-end column. Move credits stub to a footnote link.
-- [ ] T114 Update `WorkspaceBudgetList` sort consumer + add "Hide $0 + no limit" toggle (default on, persisted to `localStorage` key `claude-hide-zero-workspaces`).
-- [ ] T115 Update SQL in `_getWorkspaceList` to sort: over-limit first, over-80% next, with-limit by utilization DESC, no-limit by spend DESC, $0+no-limit last.
-- [ ] T116 Visual restructure of `WorkspaceBudgetRow`: spend big on left, limit small on right; drill-through icon button on hover (no-op until Phase 3 ships).
+- [x] T108 Rename header in `src/app/claude/page.tsx` (line 21 metadata, line 55 h1) → "Claude API Spending"; update sidebar nav label in `src/components/app-sidebar.tsx`. **Sidebar label was later renamed to "Claude Console"** in commit `331da58`.
+- [x] T109 New `SyncStatusPill` component in `src/components/claude/sync-status-pill.tsx`. Green / amber / grey states per `isStale` flag. Anchored to `/settings/sync`. Later enhanced (commit `d0a5540`) to surface the hourly cron cadence ("Synced 3m ago · next in 57m").
+- [x] T110 New `KpiStrip` component (`src/components/claude/kpi-strip.tsx`) — 4 tiles in `md:grid-cols-2 lg:grid-cols-4`. Tile 3 gets red ring + warning icon if `projectedMonthEndCents > orgBudget`. Tile 4 shows over-80% count out of `workspacesWithLimitCount`.
+- [x] T111 Update `GlobalMetricsClient` to render `KpiStrip` above the chart. Pass through new props.
+- [x] T112 Convert the daily chart in `global-metrics-client.tsx` from single-series to stacked Bar (`stackId="costs"`, one `<Bar>` per top-8 workspace + `Other`). Legend on top. Tooltip shows per-workspace breakdown. **Post-impl additions**: rank-indexed spectral palette (commit `c33d8f6`) and a "Use workspace colors" toggle persisted to `localStorage` key `claude-dashboard:useDbColors` (commit `a229d04`).
+- [x] T113 Refactor `OrgCreditsPanel` → `OrgBillingBudgetCard`: drop the dead Credit Balance card; full-width; add a Projected month-end column. Move credits stub to a footnote link.
+- [x] T114 Update `WorkspaceBudgetList` sort consumer + add "Hide $0 + no limit" toggle (default on, persisted to `localStorage` key `claude-hide-zero-workspaces`).
+- [x] T115 Update SQL in `_getWorkspaceList` to sort: over-limit first, over-80% next, with-limit by utilization DESC, no-limit by spend DESC, $0+no-limit last.
+- [x] T116 Visual restructure of `WorkspaceBudgetRow`: spend big on left, limit small on right; drill-through icon button on hover (no-op until Phase 3 ships). Drill-icon was later promoted to an always-visible `<Link>` in commit `d0a5540`, and the workspace name itself became a link in commit `e076228` — both affordances coexist.
 
 ### Verification
 - [ ] T117 E2E: `tests/e2e/claude-page-phase1.spec.ts` — admin lands on `/claude`, sees new title, 4 KPI tiles, sync pill, stacked chart legend, toggle persists across reload, non-admin gets redirected.
-- [ ] T118 Manual: with the dev DB, confirm "Automations" appears at row 1 (over budget), KPI tile 4 is in warning color, projected tile shows the red ring.
+- [x] T118 Manual: with the dev DB, confirm "Automations" appears at row 1 (over budget), KPI tile 4 is in warning color, projected tile shows the red ring.
 
 ## Phase 2 — Historical trend + sparklines (Commit 2)
 
 ### Data layer
-- [ ] T201 New action `getTwelveMonthTotals()` in `anthropic-global.ts`. SQL: `GROUP BY date_trunc('month', date)` for last 12 months. Returns budget cap alongside each row (uses current `anthropic_org_config` value — no history is retained, consistent with spec 018).
-- [ ] T202 New action `getCumulativePacing()` — window function over 4 months: `SUM(cost_cents) OVER (PARTITION BY date_trunc('month', date) ORDER BY date)`. Pivot per `dayOfMonth`. Pad missing days with `null` so Recharts skips them cleanly.
-- [ ] T203 New action `getTopMovers()` — top 3 by **positive** % delta only (newest 3-month vs oldest 3-month windows), with `>= $5` floor on the prior period to filter noise. **Decline / drops are filtered out** (decided in spec review — user-facing label is "Fastest growing"). Internal function/type names may stay as `getTopMovers` / `TopMover` for git history continuity.
-- [ ] T204 New action `getWorkspaceSparklines()` — single query: 6 months of monthly totals grouped by `(workspace_id, month)`, pivoted server-side into `Record<workspaceId, {month, totalCents}[]>`.
-- [ ] T205 New types in `src/types/index.ts`: `TwelveMonthRow`, `PacingRow`, `TopMover`, `WorkspaceSparkline`.
-- [ ] T206 Unit tests: cumulative pacing math, top-movers ranking + floor, 12-month bucketing across year boundaries.
+- [x] T201 New action `getTwelveMonthTotals()` in `anthropic-global.ts`. SQL: `GROUP BY date_trunc('month', date)` for last 12 months. Returns budget cap alongside each row (uses current `anthropic_org_config` value — no history is retained, consistent with spec 018).
+- [x] T202 New action `getCumulativePacing()` — window function over 4 months: `SUM(cost_cents) OVER (PARTITION BY date_trunc('month', date) ORDER BY date)`. Pivot per `dayOfMonth`. Pad missing days with `null` so Recharts skips them cleanly.
+- [x] T203 New action `getTopMovers()` — top 3 by **positive** % delta only (newest 3-month vs oldest 3-month windows), with `>= $5` floor on the prior period to filter noise. **Decline / drops are filtered out** (decided in spec review — user-facing label is "Fastest growing"). Internal function/type names may stay as `getTopMovers` / `TopMover` for git history continuity.
+- [x] T204 New action `getWorkspaceSparklines()` — single query: 6 months of monthly totals grouped by `(workspace_id, month)`, pivoted server-side into `Record<workspaceId, {month, totalCents}[]>`.
+- [x] T205 New types in `src/types/index.ts`: `TwelveMonthRow`, `PacingRow`, `TopMover`, `WorkspaceSparkline`.
+- [x] T206 Unit tests: cumulative pacing math, top-movers ranking + floor, 12-month bucketing across year boundaries.
 - [ ] T207 Integration test: seed 6 months across multiple workspaces; verify sparkline shape and top movers ranking.
 
 ### UI layer
-- [ ] T208 New `HistoricalTrendCard` container in `src/components/claude/historical-trend-card.tsx` with a 3-way segmented control (Monthly totals / Pacing / **Fastest growing**).
-- [ ] T209 New `TwelveMonthBarChart` (`twelve-month-bar-chart.tsx`) — Recharts BarChart + horizontal dashed budget-cap line; bars exceeding cap get a red top stroke.
-- [ ] T210 New `CumulativePacingChart` (`cumulative-pacing-chart.tsx`) — Recharts LineChart with 4 series. Current month bold; prior 3 in cool greys. Synchronized tooltip across all series.
-- [ ] T211 New `TopMoversChips` (`top-movers-chips.tsx`) — 3 chips with name + ▲ arrow + delta %. Section title is **"Fastest growing (6mo)"** (user-facing label decided in spec review). All chips render with ▲ since the action filters to positive deltas only. Until Phase 3 ships, chips are non-interactive static badges.
-- [ ] T212 New `Sparkline` primitive in `src/components/ui/sparkline.tsx`. Hand-rolled inline SVG `<polyline>` — not Recharts — to avoid 13× instance overhead. Props: `data`, `color?`, `height?`, `width?`. Renders `—` when `data.length < 2`.
-- [ ] T213 Add `<Sparkline>` column to `WorkspaceBudgetRow` (between spend and progress bar). Reuse `displayColor` from `anthropic_workspaces`.
-- [ ] T214 Wire all 4 new actions into `page.tsx` Promise.all and pass into the chart card + workspace list.
+- [x] T208 New `HistoricalTrendCard` container in `src/components/claude/historical-trend-card.tsx` with a 3-way segmented control (Monthly totals / Pacing / **Fastest growing**). **Decision (post-impl)**: kept the tabbed segmented control rather than the side-by-side three-pane layout the mockup explored — segments read cleanly at desktop widths, avoid a tablet-width regression, and the three views are rarely compared simultaneously.
+- [x] T209 New `TwelveMonthBarChart` (`twelve-month-bar-chart.tsx`) — Recharts BarChart + horizontal dashed budget-cap line; bars exceeding cap get a red top stroke. Polished in commit `a1138da` (greyscale ramp by month age, projected-month-end stub) and `331da58` (use `var(--destructive)` directly so the cap line actually paints on this theme).
+- [x] T210 New `CumulativePacingChart` (`cumulative-pacing-chart.tsx`) — Recharts LineChart with 4 series. Current month bold; prior 3 in cool greys. Synchronized tooltip across all series. Polished in commit `a1138da` (dashed projection from latest anchor day, today marker, "tracking" footer).
+- [x] T211 New `TopMoversChips` (`top-movers-chips.tsx`) — 3 chips with name + ▲ arrow + delta %. Section title is **"Fastest growing (6mo)"** (user-facing label decided in spec review). All chips render with ▲ since the action filters to positive deltas only. Phase 3 made chips navigable; commit `d0a5540` added inline `$prev → $next` transitions.
+- [x] T212 New `Sparkline` primitive in `src/components/ui/sparkline.tsx`. Hand-rolled inline SVG `<polyline>` — not Recharts — to avoid 13× instance overhead. Props: `data`, `color?`, `height?`, `width?`. Renders `—` when `data.length < 2`.
+- [x] T213 Add `<Sparkline>` column to `WorkspaceBudgetRow` (between spend and progress bar). Reuse `displayColor` from `anthropic_workspaces`. **Post-impl**: delta label below the sparkline is now `{N}mo` where N is the calendar-month distance between the first and last data points (commit `e076228`) — not a fixed "6mo". Movers >= +100% are highlighted.
+- [x] T214 Wire all 4 new actions into `page.tsx` Promise.all and pass into the chart card + workspace list.
 
 ### Verification
 - [ ] T215 E2E: navigate to `/claude`, confirm Historical Trend card renders, tabs switch views, sparkline column populated.
-- [ ] T216 Manual: with dev DB confirm Automations sparkline ramps up; Top Movers shows Automations + boost-starter-5 + boost-starter-3.
+- [x] T216 Manual: with dev DB confirm Automations sparkline ramps up; Top Movers shows Automations + boost-starter-5 + boost-starter-3.
 
 ## Phase 3 — Drill-through (Commit 3)
 
 ### Schema migration (small, deterministic — no spike)
 
-- [ ] T301 Add Zod field: extend `orgApiKeySchema` in `src/lib/anthropic-keys.ts` (lines 5-11) to capture `workspace_id: z.string().nullable()`. Anthropic's `/v1/organizations/api_keys` already returns it — codebase currently discards it.
-- [ ] T302 Drizzle migration `drizzle/NNNN_anthropic_sync_workspace_id.sql`: `ALTER TABLE anthropic_sync_status ADD COLUMN resolved_workspace_id varchar(100);`. Generate via `pnpm db:generate` after updating the schema in `src/lib/db/schema.ts`.
-- [ ] T303 Update `src/lib/db/schema.ts`: add `resolvedWorkspaceId: varchar("resolved_workspace_id", { length: 100 })` to the `anthropicSyncStatus` table definition.
-- [ ] T304 Update `resolveAllMappings()` in `src/lib/anthropic-sync.ts` (lines 143-221): when persisting `resolvedApiKeyId`, also persist the corresponding `workspace_id` from the `orgKeys` array into `resolved_workspace_id`. Backfill happens automatically on the next hourly sync — no manual backfill required.
-- [ ] T305 Verify in dev DB: after one sync run, every active user's `anthropic_sync_status` row should have a non-null `resolved_workspace_id` (NULL only for the org's default workspace).
+- [x] T301 Add Zod field: extend `orgApiKeySchema` in `src/lib/anthropic-keys.ts` (lines 5-11) to capture `workspace_id: z.string().nullable()`. Anthropic's `/v1/organizations/api_keys` already returns it — codebase currently discards it.
+- [x] T302 Drizzle migration `src/lib/db/migrations/0018_messy_sleepwalker.sql`: `ALTER TABLE anthropic_sync_status ADD COLUMN resolved_workspace_id varchar(100);`. Generated via `pnpm db:generate` after updating the schema.
+- [x] T303 Update `src/lib/db/schema.ts`: add `resolvedWorkspaceId: varchar("resolved_workspace_id", { length: 100 })` to the `anthropicSyncStatus` table definition.
+- [x] T304 Update `resolveAllMappings()` in `src/lib/anthropic-sync.ts` (lines 143-221): when persisting `resolvedApiKeyId`, also persist the corresponding `workspace_id` from the `orgKeys` array into `resolved_workspace_id`. **Correction**: this only auto-populates for users whose mapping is *missing or changed*. Users whose `resolved_api_key_id` was already set before the column existed kept `resolved_workspace_id = NULL` indefinitely — fixed by the new `scripts/backfill-anthropic-workspace-mapping.ts` one-off (commit `67dc7d2`).
+- [x] T305 Verify in dev DB: after one sync run + the backfill script, every active user's `anthropic_sync_status` row has a non-null `resolved_workspace_id` (NULL only for the org's default workspace). Verified locally: 41/41 rows updated.
 
 ### Data layer
 
-- [ ] T306 New action `getWorkspaceDetail(workspaceId | "default", month?)` in `anthropic-global.ts` returning `{ workspace, currentMonthCents, limitCents, utilizationPct, dailyTotals, topUsers, modelBreakdown }`. Cache tag `"anthropic-workspace-costs"`. Top users query joins `anthropic_usage_metrics` → `anthropic_sync_status.user_id` → `resolved_workspace_id`. Model breakdown aggregates `anthropic_usage_metrics.model` filtered by the same join.
-- [ ] T307 New action `getWorkspaceMonths(workspaceId | "default")` for the per-workspace month picker.
-- [ ] T308 Type additions in `src/types/index.ts`: `WorkspaceDetail`, `WorkspaceUser`, `ModelBreakdownRow`.
-- [ ] T309 Unit + integration tests for `getWorkspaceDetail`, including the `"default"` URL sentinel → null SQL value round-trip.
+- [x] T306 New action `getWorkspaceDetail(workspaceId | "default", month?)` in `anthropic-global.ts` returning `{ workspace, currentMonthCents, limitCents, utilizationPct, dailyTotals, topUsers, modelBreakdown }`. Cache tag `"anthropic-workspace-costs"`. Top users query joins `anthropic_usage_metrics` → `anthropic_sync_status.user_id` → `resolved_workspace_id`. Model breakdown aggregates `anthropic_usage_metrics.model` filtered by the same join.
+- [x] T307 New action `getWorkspaceMonths(workspaceId | "default")` for the per-workspace month picker.
+- [x] T308 Type additions in `src/types/index.ts`: `WorkspaceDetail`, `WorkspaceUser`, `ModelBreakdownRow`.
+- [x] T309 Unit tests for `getWorkspaceDetail` (the `"default"` URL sentinel parser, model % math, tie-stable top-user ordering). Integration test deferred.
 
 ### UI layer
 
-- [ ] T310 New route `src/app/claude/workspaces/[workspaceId]/page.tsx` (Server Component, admin gate, parses `"default"` sentinel → `null`).
-- [ ] T311 New `WorkspaceDetailClient` (client wrapper) — month picker + KPI strip scoped to this workspace. **Reuses Phase 1 `KpiStrip`** with these 4 tiles (decided in spec review): (1) Total MTD · (2) MoM delta · (3) Projected month-end · (4) **Utilization %** (replaces the org-level "Over 80% count" tile). When `limitCents IS NULL`, tile 4 shows "No limit set" with an inline action calling `setWorkspaceLimit`.
-- [ ] T312 New `WorkspaceDailyChart` — single-series Recharts BarChart.
-- [ ] T313 New `WorkspaceTopUsers` — table with `User | Requests | Cost`; row click opens the user's existing profile cost page in a new tab. Show a footnote that the per-user sum does not reconcile with the workspace total (different Anthropic endpoints).
-- [ ] T314 New `WorkspaceModelBreakdown` — horizontal stacked bar + legend table (model, tokens in/out, cost, % of workspace).
-- [ ] T315 Make `WorkspaceBudgetRow` a `<Link>` to the detail page. Reuse the drill icon added in Phase 1.
-- [ ] T316 Make `TopMoversChips` navigable. Update breadcrumb on detail page to support back-navigation with `?workspace=` query param preserved on `/claude`.
+- [x] T310 New route `src/app/claude/workspaces/[workspaceId]/page.tsx` (Server Component, admin gate, parses `"default"` sentinel → `null`).
+- [x] T311 New `WorkspaceDetailClient` (client wrapper) — month picker + KPI strip scoped to this workspace. **Reuses Phase 1 `KpiStrip`** with these 4 tiles (decided in spec review): (1) Total MTD · (2) MoM delta · (3) Projected month-end · (4) **Utilization %** (replaces the org-level "Over 80% count" tile). When `limitCents IS NULL`, tile 4 shows "No limit set" with an inline action calling `setWorkspaceLimit`. Post-impl polish (commit `743c612`): removed the duplicate "Over budget" badge under the month picker; the default-workspace limit editor shows a muted hint explaining the limit applies to all API usage not assigned to a named workspace.
+- [x] T312 New `WorkspaceDailyChart` — single-series Recharts BarChart. Polished in commit `743c612`: `maxBarSize=56` to avoid chart-wide blobs on single-data-point workspaces, sub-dollar Y-axis formatter when daily max < $5, and a red dashed per-day budget cap `ReferenceLine` at `limit / daysInMonth`.
+- [x] T313 New `WorkspaceTopUsers` — table with `User | Requests | Cost`; row click opens the user's existing profile cost page in a new tab. Footnote explains the per-user sum does not reconcile with the workspace total (different Anthropic endpoints).
+- [x] T314 New `WorkspaceModelBreakdown` — horizontal stacked bar + legend table (model, tokens in/out, cost, % of workspace). Reconciliation footnote added in commit `743c612` mirroring the top-users one.
+- [x] T315 Make `WorkspaceBudgetRow` a `<Link>` to the detail page. Reuse the drill icon added in Phase 1. **Implementation note**: both the chevron drill icon (commit `d0a5540` promoted it from hover-only to always-visible) *and* the workspace name itself (commit `e076228`) are now navigable.
+- [x] T316 Make `TopMoversChips` navigable. Breadcrumb back uses `?workspace=` to restore the parent filter (commit `d0a5540`).
 
 ### Verification
 
 - [ ] T317 E2E: `tests/e2e/claude-workspace-detail.spec.ts` — list → row click → detail page renders → breadcrumb back restores filter. Non-admin direct-nav redirects. 404 on bad ID.
-- [ ] T318 Manual smoke: walk through `/claude/workspaces/default` (URL sentinel for NULL workspace_id), a real workspace ID, and a non-existent ID.
+- [x] T318 Manual smoke: walk through `/claude/workspaces/default` (URL sentinel for NULL workspace_id), a real workspace ID, and a non-existent ID.
+
+## Phase 4 — Post-implementation refinements (out-of-band)
+
+These tasks were not in the original T101–T318 plan but landed in this PR after reviewing the live page against the mockup. Listed here for traceability.
+
+- [x] T401 Spec/mockup gap closures (commit `d0a5540`) — workspace filter round-trip via `?workspace=`, per-row on-pace projection, sparkline delta labels, Top Movers chip `$prev → $next`, always-visible drill chevron, sync pill cron cadence.
+- [x] T402 Historical-trend chart polish (commit `a1138da`) — greyscale bar ramp + projected-month-end stub on the 12-month chart; dashed projection / today marker / "tracking" footer on the cumulative pacing chart.
+- [x] T403 Spectral color order on daily chart (commit `c33d8f6`) — paint workspaces in palette order by rank instead of hash-shuffled.
+- [x] T404 Daily-chart "Use workspace colors" toggle (commit `a229d04`) — switch between the curated theme palette (default) and each workspace's `display_color` from the DB. Persisted to `localStorage` key `claude-dashboard:useDbColors`.
+- [x] T405 Visible budget cap + sidebar rename (commit `331da58`) — replace `hsl(var(--destructive))` with `var(--destructive)` directly so the cap line paints on this theme's oklch tokens. Sidebar entry renamed "Claude API Spending" → **"Claude Console"**.
+- [x] T406 Dynamic sparkline window + linkable workspace name (commit `e076228`) — `{N}mo` label tracks actual data range; workspace name is now a `<Link>` (chevron stays).
+- [x] T407 Drill-down view polish (commit `743c612`) — per-day budget cap reference line, model-breakdown reconciliation footnote, default-workspace limit-editor hint, removed duplicate "Over budget" badge, bar-width cap, sub-dollar Y-axis formatter.
+- [x] T408 Per-day cost storage bug fix (commit `e1428aa`) — request `bucket_width=1d` from `/v1/organizations/cost_report`, extract `aggregateDailyCosts(buckets)` helper, key by `(workspace_id, YYYY-MM-DD)` from `bucket.starting_at`. Adds `scripts/backfill-anthropic-workspace-costs.ts`.
+- [x] T409 Backfill resolved_workspace_id for pre-migration rows (commit `67dc7d2`) — `scripts/backfill-anthropic-workspace-mapping.ts`; idempotent.
+- [x] T410 Simplify pass (commit `616c88c`) — batch per-day cost upserts (one statement per partial-index bucket), promote stringly-typed sentinels to module constants, flatten pacing-chart ternary.
 
 ## Cross-cutting checklist (each commit)
 
-- [ ] Cache tag `"anthropic-workspace-costs"` on every new server action so the existing hourly sync `revalidateTag` calls invalidate them.
-- [ ] All new types exported from `src/types/index.ts`.
-- [ ] `pnpm lint && pnpm typecheck` clean.
+- [x] Cache tag `"anthropic-workspace-costs"` on every new server action so the existing hourly sync `revalidateTag` calls invalidate them.
+- [x] All new types exported from `src/types/index.ts`.
+- [x] `pnpm lint && pnpm typecheck` clean.
 - [ ] Lighthouse mobile + desktop pass on `/claude` (Phase 1 + 2 only).
 - [ ] Update `docs/admin-guide.md` (or equivalent) with screenshots after Phase 1.
+
+## Deployment notes
+
+When deploying this PR to production:
+
+1. Run the standard migration: `pnpm db:migrate` (applies `0018_messy_sleepwalker.sql`).
+2. After deployment, run **both** one-off backfill scripts (idempotent, safe to re-run):
+   - `pnpm tsx --env-file=.env.local scripts/backfill-anthropic-workspace-costs.ts` — TRUNCATEs `anthropic_workspace_costs` and re-fetches every month with `bucket_width=1d`. Required because pre-fix rows are month-rolled to `YYYY-MM-01`.
+   - `pnpm tsx --env-file=.env.local scripts/backfill-anthropic-workspace-mapping.ts` — retro-populates `resolved_workspace_id` for users whose `anthropic_sync_status` row predates migration 0018.
+3. Verify in the dashboard: the per-day stacked daily chart renders distinct daily bars (not a single block on day 1), and named-workspace drill-downs surface top users / model breakdowns instead of empty tables.

--- a/src/actions/anthropic-global.ts
+++ b/src/actions/anthropic-global.ts
@@ -33,6 +33,9 @@ import type {
   PacingRow,
   TopMover,
   WorkspaceSparkline,
+  WorkspaceDetail,
+  WorkspaceUser,
+  ModelBreakdownRow,
 } from "@/types";
 import { projectMonthEnd } from "@/lib/utils";
 import { run as runAnthropicSync } from "@/lib/sync/sources/anthropic-workspace";
@@ -852,6 +855,223 @@ export async function getWorkspaceSparklines(): Promise<
   return unstable_cache(
     _getWorkspaceSparklines,
     ["anthropic-workspace-sparklines", String(SPARKLINE_MONTHS)],
+    { tags: ["anthropic-workspace-costs"] }
+  )();
+}
+
+// ---------------------------------------------------------------------------
+// Spec 026 — Phase 3 additions (workspace drill-through)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WORKSPACE_SENTINEL = "default";
+
+/**
+ * Translate the URL-level `"default"` sentinel to a SQL NULL workspace_id.
+ */
+function parseWorkspaceParam(workspaceId: string): string | null {
+  if (workspaceId === DEFAULT_WORKSPACE_SENTINEL) return null;
+  return workspaceId;
+}
+
+async function _getWorkspaceMonths(
+  workspaceId: string | null
+): Promise<string[]> {
+  const rows = await db.execute(sql`
+    SELECT DISTINCT to_char(date_trunc('month', date::date), 'YYYY-MM') AS month
+    FROM anthropic_workspace_costs
+    WHERE workspace_id IS NOT DISTINCT FROM ${workspaceId}
+    ORDER BY 1 DESC
+  `);
+  return rows.rows.map((r) => r.month as string);
+}
+
+export async function getWorkspaceMonths(
+  workspaceIdParam: string
+): Promise<string[]> {
+  const admin = await requireAdmin();
+  if (!admin) return [];
+  const workspaceId = parseWorkspaceParam(workspaceIdParam);
+  return unstable_cache(
+    () => _getWorkspaceMonths(workspaceId),
+    ["anthropic-workspace-months", workspaceIdParam],
+    { tags: ["anthropic-workspace-costs"] }
+  )();
+}
+
+async function _getWorkspaceDetail(
+  workspaceId: string | null,
+  month: string
+): Promise<WorkspaceDetail | null> {
+  const monthStart = `${month}-01`;
+  const monthEnd = format(endOfMonth(parseISO(monthStart)), "yyyy-MM-dd");
+  const priorMonthDate = subMonths(parseISO(monthStart), 1);
+  const priorStart = format(startOfMonth(priorMonthDate), "yyyy-MM-dd");
+  const priorEnd = format(endOfMonth(priorMonthDate), "yyyy-MM-dd");
+
+  // Workspace meta
+  const wsResult = await db.execute(sql`
+    SELECT workspace_id, name, is_default, display_color
+    FROM anthropic_workspaces
+    WHERE workspace_id IS NOT DISTINCT FROM ${workspaceId}
+    LIMIT 1
+  `);
+  const wsRow = wsResult.rows[0];
+  if (!wsRow) return null;
+
+  // Daily totals for the selected month
+  const dailyResult = await db.execute(sql`
+    SELECT date::text AS date, COALESCE(SUM(cost_cents), 0)::bigint AS cents
+    FROM anthropic_workspace_costs
+    WHERE workspace_id IS NOT DISTINCT FROM ${workspaceId}
+      AND date >= ${monthStart}::date
+      AND date <= ${monthEnd}::date
+    GROUP BY date
+    ORDER BY date
+  `);
+  const dailyTotals = dailyResult.rows.map((r) => ({
+    date: r.date as string,
+    costCents: Number(r.cents ?? 0),
+  }));
+  const currentMonthCents = dailyTotals.reduce((s, d) => s + d.costCents, 0);
+
+  // Prior month total (for MoM)
+  const priorResult = await db.execute(sql`
+    SELECT COALESCE(SUM(cost_cents), 0)::bigint AS cents
+    FROM anthropic_workspace_costs
+    WHERE workspace_id IS NOT DISTINCT FROM ${workspaceId}
+      AND date >= ${priorStart}::date
+      AND date <= ${priorEnd}::date
+  `);
+  const priorMonthCents = Number(priorResult.rows[0]?.cents ?? 0);
+  const momDeltaCents = currentMonthCents - priorMonthCents;
+  const momDeltaPct =
+    priorMonthCents < 100
+      ? null
+      : Math.round((momDeltaCents / priorMonthCents) * 100);
+
+  // Limit + utilization
+  const limitResult = await db.execute(sql`
+    SELECT limit_cents
+    FROM anthropic_workspace_limits
+    WHERE workspace_id IS NOT DISTINCT FROM ${workspaceId}
+    LIMIT 1
+  `);
+  const limitCents = limitResult.rows[0]?.limit_cents != null
+    ? Number(limitResult.rows[0].limit_cents)
+    : null;
+  const utilizationPct =
+    limitCents != null && limitCents > 0
+      ? Math.round((currentMonthCents / limitCents) * 100)
+      : null;
+
+  // Projected month-end
+  const nowMonth = format(new Date(), "yyyy-MM");
+  const daysInMonth = getDaysInMonth(parseISO(monthStart));
+  const daysElapsed =
+    month === nowMonth ? Math.max(1, getDate(new Date())) : daysInMonth;
+  const projectedMonthEndCents = projectMonthEnd(
+    currentMonthCents,
+    daysElapsed,
+    daysInMonth
+  );
+
+  // Top users — joined via anthropic_sync_status.resolved_workspace_id.
+  // Returns up to 10 users by total cost; IS NOT DISTINCT FROM handles the NULL sentinel cleanly.
+  const usersResult = await db.execute(sql`
+    SELECT
+      u.id AS user_id,
+      u.email,
+      u.name,
+      COALESCE(SUM(m.computed_cost_cents), 0)::bigint AS cents,
+      COALESCE(SUM(m.uncached_input_tokens + m.cache_read_input_tokens + m.cache_creation_input_tokens + m.output_tokens), 0)::bigint AS request_count
+    FROM anthropic_usage_metrics m
+    JOIN anthropic_sync_status s ON s.user_id = m.user_id
+    JOIN users u ON u.id = m.user_id
+    WHERE s.resolved_workspace_id IS NOT DISTINCT FROM ${workspaceId}
+      AND m.date >= ${monthStart}::date
+      AND m.date <= ${monthEnd}::date
+    GROUP BY u.id, u.email, u.name
+    ORDER BY cents DESC
+    LIMIT 10
+  `);
+  const topUsers: WorkspaceUser[] = usersResult.rows.map((r) => ({
+    userId: Number(r.user_id),
+    email: r.email as string,
+    name: (r.name as string) ?? "",
+    costCents: Number(r.cents ?? 0),
+    requestCount: Number(r.request_count ?? 0),
+  }));
+
+  // Model breakdown
+  const modelResult = await db.execute(sql`
+    SELECT
+      m.model AS model_name,
+      COALESCE(SUM(m.uncached_input_tokens + m.cache_read_input_tokens + m.cache_creation_input_tokens), 0)::bigint AS tokens_in,
+      COALESCE(SUM(m.output_tokens), 0)::bigint AS tokens_out,
+      COALESCE(SUM(m.computed_cost_cents), 0)::bigint AS cents
+    FROM anthropic_usage_metrics m
+    JOIN anthropic_sync_status s ON s.user_id = m.user_id
+    WHERE s.resolved_workspace_id IS NOT DISTINCT FROM ${workspaceId}
+      AND m.date >= ${monthStart}::date
+      AND m.date <= ${monthEnd}::date
+    GROUP BY m.model
+    ORDER BY cents DESC
+  `);
+  const userVisibleTotal = modelResult.rows.reduce(
+    (s, r) => s + Number(r.cents ?? 0),
+    0
+  );
+  const modelBreakdown: ModelBreakdownRow[] = modelResult.rows.map((r) => {
+    const cents = Number(r.cents ?? 0);
+    return {
+      modelName: r.model_name as string,
+      tokensIn: Number(r.tokens_in ?? 0),
+      tokensOut: Number(r.tokens_out ?? 0),
+      costCents: cents,
+      pctOfWorkspace:
+        userVisibleTotal === 0 ? 0 : Math.round((cents / userVisibleTotal) * 100),
+    };
+  });
+
+  // Months for the picker
+  const months = await _getWorkspaceMonths(workspaceId);
+
+  return {
+    workspace: {
+      id: (wsRow.workspace_id as string | null) ?? null,
+      name: wsRow.name as string,
+      isDefault: wsRow.is_default as boolean,
+      displayColor: (wsRow.display_color as string | null) ?? null,
+    },
+    month,
+    currentMonthCents,
+    priorMonthCents,
+    limitCents,
+    utilizationPct,
+    projectedMonthEndCents,
+    momDeltaCents,
+    momDeltaPct,
+    dailyTotals,
+    topUsers,
+    modelBreakdown,
+    availableMonths: months,
+  };
+}
+
+export async function getWorkspaceDetail(
+  workspaceIdParam: string,
+  month?: string
+): Promise<WorkspaceDetail | null> {
+  const admin = await requireAdmin();
+  if (!admin) return null;
+  const workspaceId = parseWorkspaceParam(workspaceIdParam);
+  const targetMonth =
+    month && monthSchema.safeParse(month).success
+      ? month
+      : format(new Date(), "yyyy-MM");
+  return unstable_cache(
+    () => _getWorkspaceDetail(workspaceId, targetMonth),
+    ["anthropic-workspace-detail", workspaceIdParam, targetMonth],
     { tags: ["anthropic-workspace-costs"] }
   )();
 }

--- a/src/actions/anthropic-global.ts
+++ b/src/actions/anthropic-global.ts
@@ -29,6 +29,10 @@ import type {
   DashboardKpis,
   DailyStackedRow,
   SyncStatus,
+  TwelveMonthRow,
+  PacingRow,
+  TopMover,
+  WorkspaceSparkline,
 } from "@/types";
 import { projectMonthEnd } from "@/lib/utils";
 import { run as runAnthropicSync } from "@/lib/sync/sources/anthropic-workspace";
@@ -637,4 +641,217 @@ export async function getSyncStatus(): Promise<SyncStatus> {
     ageMinutes,
     isStale: ageMinutes > STALE_MINUTES,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Spec 026 — Phase 2 additions (historical trend + sparklines)
+// ---------------------------------------------------------------------------
+
+const TOP_MOVERS_FLOOR_CENTS = 500;
+const SPARKLINE_MONTHS = 6;
+
+async function _getTwelveMonthTotals(): Promise<TwelveMonthRow[]> {
+  const rows = await db.execute(sql`
+    SELECT
+      to_char(date_trunc('month', date), 'YYYY-MM') AS month,
+      COALESCE(SUM(cost_cents), 0)::bigint AS total_cents
+    FROM anthropic_workspace_costs
+    WHERE date >= (date_trunc('month', current_date) - interval '11 months')::date
+    GROUP BY 1
+    ORDER BY 1
+  `);
+
+  const cfg = await db.query.anthropicOrgConfig.findFirst({
+    where: eq(anthropicOrgConfig.id, 1),
+  });
+  const cap = cfg?.billingBudgetLimitCents ?? null;
+
+  return rows.rows.map((r) => ({
+    month: r.month as string,
+    totalCents: Number(r.total_cents ?? 0),
+    budgetLimitCents: cap,
+  }));
+}
+
+export async function getTwelveMonthTotals(): Promise<TwelveMonthRow[]> {
+  const admin = await requireAdmin();
+  if (!admin) return [];
+  return unstable_cache(
+    _getTwelveMonthTotals,
+    ["anthropic-twelve-month"],
+    { tags: ["anthropic-workspace-costs"] }
+  )();
+}
+
+async function _getCumulativePacing(): Promise<PacingRow[]> {
+  // Window function: cumulative SUM by day-of-month for the last 4 months.
+  const rows = await db.execute(sql`
+    SELECT
+      to_char(date_trunc('month', date), 'YYYY-MM') AS month,
+      EXTRACT(DAY FROM date)::int AS day_of_month,
+      SUM(cost_cents) OVER (
+        PARTITION BY date_trunc('month', date)
+        ORDER BY date
+      )::bigint AS cumulative_cents
+    FROM (
+      SELECT date, SUM(cost_cents)::bigint AS cost_cents
+      FROM anthropic_workspace_costs
+      WHERE date >= (date_trunc('month', current_date) - interval '3 months')::date
+      GROUP BY date
+    ) daily
+    ORDER BY month, day_of_month
+  `);
+
+  // Pivot per (dayOfMonth, monthOffset 0=current, 1=prev, 2=2-back, 3=3-back).
+  const months = new Set<string>();
+  for (const r of rows.rows) months.add(r.month as string);
+  const sortedMonths = Array.from(months).sort().reverse(); // newest first
+
+  const dayMap = new Map<number, PacingRow>();
+  for (const r of rows.rows) {
+    const dom = r.day_of_month as number;
+    const month = r.month as string;
+    const cents = Number(r.cumulative_cents ?? 0);
+    const offset = sortedMonths.indexOf(month);
+    let row = dayMap.get(dom);
+    if (!row) {
+      row = { dayOfMonth: dom, current: null, m1: null, m2: null, m3: null };
+      dayMap.set(dom, row);
+    }
+    if (offset === 0) row.current = cents;
+    else if (offset === 1) row.m1 = cents;
+    else if (offset === 2) row.m2 = cents;
+    else if (offset === 3) row.m3 = cents;
+  }
+
+  // Pad missing days 1..maxDayOfMonth
+  const maxDay = Math.max(31, ...Array.from(dayMap.keys()));
+  for (let d = 1; d <= maxDay; d++) {
+    if (!dayMap.has(d)) {
+      dayMap.set(d, { dayOfMonth: d, current: null, m1: null, m2: null, m3: null });
+    }
+  }
+  return Array.from(dayMap.values()).sort((a, b) => a.dayOfMonth - b.dayOfMonth);
+}
+
+export async function getCumulativePacing(): Promise<PacingRow[]> {
+  const admin = await requireAdmin();
+  if (!admin) return [];
+  return unstable_cache(
+    _getCumulativePacing,
+    ["anthropic-cumulative-pacing"],
+    { tags: ["anthropic-workspace-costs"] }
+  )();
+}
+
+async function _getTopMovers(): Promise<TopMover[]> {
+  // Compare newest 3 months vs the oldest 3 months of the last 6.
+  // Floor on prior_cents >= 500 cents ($5) to suppress noise.
+  const rows = await db.execute(sql`
+    WITH window6 AS (
+      SELECT
+        c.workspace_id,
+        date_trunc('month', c.date) AS month,
+        SUM(c.cost_cents)::bigint AS cents
+      FROM anthropic_workspace_costs c
+      WHERE c.date >= (date_trunc('month', current_date) - interval '5 months')::date
+      GROUP BY c.workspace_id, date_trunc('month', c.date)
+    ),
+    bounds AS (
+      SELECT
+        date_trunc('month', current_date) AS curr_month,
+        date_trunc('month', current_date) - interval '5 months' AS oldest_month
+    ),
+    classified AS (
+      SELECT
+        w6.workspace_id,
+        CASE
+          WHEN w6.month >= (SELECT curr_month FROM bounds) - interval '2 months' THEN 'new'
+          ELSE 'old'
+        END AS bucket,
+        w6.cents
+      FROM window6 w6
+    )
+    SELECT
+      workspace_id,
+      COALESCE(SUM(CASE WHEN bucket = 'new' THEN cents ELSE 0 END), 0)::bigint AS new_cents,
+      COALESCE(SUM(CASE WHEN bucket = 'old' THEN cents ELSE 0 END), 0)::bigint AS old_cents
+    FROM classified
+    GROUP BY workspace_id
+  `);
+
+  const wsMeta = await db.execute(sql`
+    SELECT workspace_id, name FROM anthropic_workspaces WHERE is_archived = false
+  `);
+  const nameMap = new Map<string | null, string>();
+  for (const r of wsMeta.rows) {
+    nameMap.set(r.workspace_id as string | null, r.name as string);
+  }
+
+  const movers: TopMover[] = [];
+  for (const r of rows.rows) {
+    const newCents = Number(r.new_cents ?? 0);
+    const oldCents = Number(r.old_cents ?? 0);
+    if (oldCents < TOP_MOVERS_FLOOR_CENTS) continue;
+    const delta = newCents - oldCents;
+    if (delta <= 0) continue;
+    const pct = Math.round((delta / oldCents) * 100);
+    const wsId = (r.workspace_id as string | null) ?? null;
+    movers.push({
+      workspaceId: wsId,
+      name: nameMap.get(wsId) ?? (wsId === null ? "Default Workspace" : (wsId as string)),
+      priorCents: oldCents,
+      currentCents: newCents,
+      deltaCents: delta,
+      deltaPct: pct,
+      direction: "up",
+    });
+  }
+  return movers.sort((a, b) => b.deltaPct - a.deltaPct).slice(0, 3);
+}
+
+export async function getTopMovers(): Promise<TopMover[]> {
+  const admin = await requireAdmin();
+  if (!admin) return [];
+  return unstable_cache(
+    _getTopMovers,
+    ["anthropic-top-movers"],
+    { tags: ["anthropic-workspace-costs"] }
+  )();
+}
+
+async function _getWorkspaceSparklines(): Promise<Record<string, WorkspaceSparkline>> {
+  const rows = await db.execute(sql`
+    SELECT
+      COALESCE(workspace_id, '__default__') AS key,
+      to_char(date_trunc('month', date), 'YYYY-MM') AS month,
+      COALESCE(SUM(cost_cents), 0)::bigint AS cents
+    FROM anthropic_workspace_costs
+    WHERE date >= (date_trunc('month', current_date) - interval '5 months')::date
+    GROUP BY 1, 2
+    ORDER BY 1, 2
+  `);
+
+  const out: Record<string, WorkspaceSparkline> = {};
+  for (const r of rows.rows) {
+    const key = r.key as string;
+    if (!out[key]) out[key] = { workspaceKey: key, months: [] };
+    out[key].months.push({
+      month: r.month as string,
+      totalCents: Number(r.cents ?? 0),
+    });
+  }
+  return out;
+}
+
+export async function getWorkspaceSparklines(): Promise<
+  Record<string, WorkspaceSparkline>
+> {
+  const admin = await requireAdmin();
+  if (!admin) return {};
+  return unstable_cache(
+    _getWorkspaceSparklines,
+    ["anthropic-workspace-sparklines", String(SPARKLINE_MONTHS)],
+    { tags: ["anthropic-workspace-costs"] }
+  )();
 }

--- a/src/actions/anthropic-global.ts
+++ b/src/actions/anthropic-global.ts
@@ -13,12 +13,24 @@ import {
 import { unstable_cache, revalidateTag, revalidatePath } from "next/cache";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
-import { format, endOfMonth, parseISO } from "date-fns";
+import {
+  format,
+  endOfMonth,
+  parseISO,
+  subMonths,
+  startOfMonth,
+  getDate,
+  getDaysInMonth,
+} from "date-fns";
 import type {
   GlobalCostDashboardData,
   WorkspaceListItem,
   OrgCreditsStatus,
+  DashboardKpis,
+  DailyStackedRow,
+  SyncStatus,
 } from "@/types";
+import { projectMonthEnd } from "@/lib/utils";
 import { run as runAnthropicSync } from "@/lib/sync/sources/anthropic-workspace";
 
 // ---------------------------------------------------------------------------
@@ -146,12 +158,19 @@ async function _getWorkspaceList(): Promise<WorkspaceListItem[]> {
   const startDate = `${currentMonth}-01`;
   const endDate = format(endOfMonth(parseISO(`${currentMonth}-01`)), "yyyy-MM-dd");
 
+  // Sort order (spec 026 T115):
+  //   1. over 100% (utilization >= 100, limited)
+  //   2. over 80% (80 <= utilization < 100, limited)
+  //   3. with-limit by utilization DESC
+  //   4. no-limit by spend DESC
+  //   5. $0 + no-limit last
   const rows = await db.execute(sql`
     SELECT
       w.workspace_id,
       w.name,
       w.is_default,
       w.is_archived,
+      w.display_color,
       COALESCE(c.total_cents, 0) as current_month_cents,
       l.limit_cents
     FROM anthropic_workspaces w
@@ -164,7 +183,23 @@ async function _getWorkspaceList(): Promise<WorkspaceListItem[]> {
     LEFT JOIN anthropic_workspace_limits l
       ON l.workspace_id IS NOT DISTINCT FROM w.workspace_id
     WHERE w.is_archived = false
-    ORDER BY w.is_default DESC, w.name
+    ORDER BY
+      CASE
+        WHEN l.limit_cents IS NOT NULL AND l.limit_cents > 0
+             AND COALESCE(c.total_cents, 0) >= l.limit_cents THEN 1
+        WHEN l.limit_cents IS NOT NULL AND l.limit_cents > 0
+             AND COALESCE(c.total_cents, 0) >= 0.8 * l.limit_cents THEN 2
+        WHEN l.limit_cents IS NOT NULL AND l.limit_cents > 0 THEN 3
+        WHEN COALESCE(c.total_cents, 0) > 0 THEN 4
+        ELSE 5
+      END,
+      CASE
+        WHEN l.limit_cents IS NOT NULL AND l.limit_cents > 0
+          THEN (COALESCE(c.total_cents, 0)::float / l.limit_cents)
+        ELSE NULL
+      END DESC NULLS LAST,
+      COALESCE(c.total_cents, 0) DESC,
+      w.name ASC
   `);
 
   return rows.rows.map((r) => {
@@ -182,6 +217,7 @@ async function _getWorkspaceList(): Promise<WorkspaceListItem[]> {
       currentMonthCents,
       limitCents,
       utilizationPct,
+      displayColor: (r.display_color as string | null) ?? null,
     };
   });
 }
@@ -367,4 +403,238 @@ export async function syncWorkspacesManual(): Promise<
     const msg = e instanceof Error ? e.message : "Unknown error";
     return { success: false, error: msg };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Spec 026 — Phase 1 additions
+// ---------------------------------------------------------------------------
+
+async function _getDashboardKpis(month: string): Promise<DashboardKpis> {
+  const monthStart = `${month}-01`;
+  const monthEnd = format(endOfMonth(parseISO(monthStart)), "yyyy-MM-dd");
+  const priorMonthDate = subMonths(parseISO(monthStart), 1);
+  const priorMonthStart = format(startOfMonth(priorMonthDate), "yyyy-MM-dd");
+  const priorMonthEnd = format(endOfMonth(priorMonthDate), "yyyy-MM-dd");
+
+  const totalsResult = await db.execute(sql`
+    SELECT
+      COALESCE(SUM(CASE WHEN date >= ${monthStart}::date AND date <= ${monthEnd}::date THEN cost_cents ELSE 0 END), 0) AS total_cents,
+      COALESCE(SUM(CASE WHEN date >= ${priorMonthStart}::date AND date <= ${priorMonthEnd}::date THEN cost_cents ELSE 0 END), 0) AS prior_cents
+    FROM anthropic_workspace_costs
+  `);
+  const totalsRow = totalsResult.rows[0];
+  const totalCents = Number(totalsRow?.total_cents ?? 0);
+  const priorMonthCents = Number(totalsRow?.prior_cents ?? 0);
+  const momDeltaCents = totalCents - priorMonthCents;
+  const momDeltaPct =
+    priorMonthCents < 100
+      ? null
+      : Math.round((momDeltaCents / priorMonthCents) * 100);
+
+  const nowMonth = format(new Date(), "yyyy-MM");
+  const daysInMonth = getDaysInMonth(parseISO(monthStart));
+  const daysElapsed =
+    month === nowMonth ? Math.max(1, getDate(new Date())) : daysInMonth;
+  const projectedMonthEndCents = projectMonthEnd(totalCents, daysElapsed, daysInMonth);
+
+  const overRows = await db.execute(sql`
+    SELECT
+      w.workspace_id,
+      w.name,
+      COALESCE(c.total_cents, 0) AS current_month_cents,
+      l.limit_cents
+    FROM anthropic_workspaces w
+    LEFT JOIN (
+      SELECT workspace_id, SUM(cost_cents) AS total_cents
+      FROM anthropic_workspace_costs
+      WHERE date >= ${monthStart}::date AND date <= ${monthEnd}::date
+      GROUP BY workspace_id
+    ) c ON c.workspace_id IS NOT DISTINCT FROM w.workspace_id
+    LEFT JOIN anthropic_workspace_limits l
+      ON l.workspace_id IS NOT DISTINCT FROM w.workspace_id
+    WHERE w.is_archived = false
+      AND l.limit_cents IS NOT NULL
+      AND l.limit_cents > 0
+  `);
+
+  let overCount = 0;
+  let workspacesWithLimitCount = 0;
+  let topName: string | null = null;
+  let topPct: number | null = null;
+  for (const r of overRows.rows) {
+    const limit = Number(r.limit_cents);
+    const cents = Number(r.current_month_cents ?? 0);
+    workspacesWithLimitCount += 1;
+    const pct = Math.round((cents / limit) * 100);
+    if (pct >= 80) overCount += 1;
+    if (topPct === null || pct > topPct) {
+      topPct = pct;
+      topName = (r.name as string) ?? null;
+    }
+  }
+
+  return {
+    totalCents,
+    momDeltaCents,
+    momDeltaPct,
+    projectedMonthEndCents,
+    workspacesOverEightyCount: overCount,
+    workspacesWithLimitCount,
+    topOverWorkspaceName: overCount > 0 ? topName : null,
+    topOverWorkspaceUtilizationPct: overCount > 0 ? topPct : null,
+    priorMonthCents,
+  };
+}
+
+export async function getDashboardKpis(month?: string): Promise<DashboardKpis> {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return {
+      totalCents: 0,
+      momDeltaCents: 0,
+      momDeltaPct: null,
+      projectedMonthEndCents: 0,
+      workspacesOverEightyCount: 0,
+      workspacesWithLimitCount: 0,
+      topOverWorkspaceName: null,
+      topOverWorkspaceUtilizationPct: null,
+      priorMonthCents: 0,
+    };
+  }
+  const targetMonth =
+    month && monthSchema.safeParse(month).success
+      ? month
+      : format(new Date(), "yyyy-MM");
+
+  return unstable_cache(
+    () => _getDashboardKpis(targetMonth),
+    ["anthropic-dashboard-kpis", targetMonth],
+    { tags: ["anthropic-workspace-costs"] }
+  )();
+}
+
+const TOP_STACKED_LIMIT = 8;
+const STACKED_OTHER_KEY = "__other__";
+const STACKED_NULL_KEY = "__default__";
+
+async function _getDailyTotalsByWorkspace(month: string): Promise<{
+  rows: DailyStackedRow[];
+  topWorkspaces: { key: string; name: string; displayColor: string | null }[];
+}> {
+  const monthStart = `${month}-01`;
+  const monthEnd = format(endOfMonth(parseISO(monthStart)), "yyyy-MM-dd");
+
+  const costRows = await db.execute(sql`
+    SELECT date::text AS date, workspace_id, cost_cents
+    FROM anthropic_workspace_costs
+    WHERE date >= ${monthStart}::date AND date <= ${monthEnd}::date
+  `);
+
+  const wsMeta = await db.execute(sql`
+    SELECT workspace_id, name, display_color
+    FROM anthropic_workspaces
+  `);
+
+  const nameMap = new Map<string, { name: string; color: string | null }>();
+  for (const r of wsMeta.rows) {
+    const key = (r.workspace_id as string | null) ?? STACKED_NULL_KEY;
+    nameMap.set(key, {
+      name: r.name as string,
+      color: (r.display_color as string | null) ?? null,
+    });
+  }
+
+  const totals = new Map<string, number>();
+  for (const r of costRows.rows) {
+    const key = (r.workspace_id as string | null) ?? STACKED_NULL_KEY;
+    totals.set(key, (totals.get(key) ?? 0) + Number(r.cost_cents ?? 0));
+  }
+  const ranked = Array.from(totals.entries())
+    .sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      const nameA = nameMap.get(a[0])?.name ?? a[0];
+      const nameB = nameMap.get(b[0])?.name ?? b[0];
+      return nameA.localeCompare(nameB);
+    })
+    .map(([key]) => key);
+
+  const topKeys = new Set(ranked.slice(0, TOP_STACKED_LIMIT));
+  const hasOther = ranked.length > TOP_STACKED_LIMIT;
+
+  const dayMap = new Map<string, DailyStackedRow>();
+  for (const r of costRows.rows) {
+    const date = r.date as string;
+    const key = (r.workspace_id as string | null) ?? STACKED_NULL_KEY;
+    const cents = Number(r.cost_cents ?? 0);
+    let row = dayMap.get(date);
+    if (!row) {
+      row = { date, perWorkspace: {}, total: 0 };
+      dayMap.set(date, row);
+    }
+    const bucket = topKeys.has(key) ? key : STACKED_OTHER_KEY;
+    row.perWorkspace[bucket] = (row.perWorkspace[bucket] ?? 0) + cents;
+    row.total += cents;
+  }
+
+  const rows = Array.from(dayMap.values()).sort((a, b) =>
+    a.date.localeCompare(b.date)
+  );
+
+  const topWorkspaces = ranked.slice(0, TOP_STACKED_LIMIT).map((key) => ({
+    key,
+    name:
+      nameMap.get(key)?.name ??
+      (key === STACKED_NULL_KEY ? "Default Workspace" : key),
+    displayColor: nameMap.get(key)?.color ?? null,
+  }));
+  if (hasOther) {
+    topWorkspaces.push({ key: STACKED_OTHER_KEY, name: "Other", displayColor: null });
+  }
+
+  return { rows, topWorkspaces };
+}
+
+export async function getDailyTotalsByWorkspace(month?: string): Promise<{
+  rows: DailyStackedRow[];
+  topWorkspaces: { key: string; name: string; displayColor: string | null }[];
+}> {
+  const admin = await requireAdmin();
+  if (!admin) return { rows: [], topWorkspaces: [] };
+
+  const targetMonth =
+    month && monthSchema.safeParse(month).success
+      ? month
+      : format(new Date(), "yyyy-MM");
+
+  return unstable_cache(
+    () => _getDailyTotalsByWorkspace(targetMonth),
+    ["anthropic-daily-stacked", targetMonth],
+    { tags: ["anthropic-workspace-costs"] }
+  )();
+}
+
+const STALE_MINUTES = 70;
+const SYNC_SENTINEL_USER_ID = 0;
+
+export async function getSyncStatus(): Promise<SyncStatus> {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return { lastSyncedAt: null, ageMinutes: null, isStale: true };
+  }
+
+  const row = await db.query.anthropicSyncStatus.findFirst({
+    where: eq(anthropicSyncStatus.userId, SYNC_SENTINEL_USER_ID),
+  });
+  const lastSyncedAt =
+    row?.workspaceSyncCompletedAt ?? row?.lastSyncCompletedAt ?? null;
+  if (!lastSyncedAt) {
+    return { lastSyncedAt: null, ageMinutes: null, isStale: true };
+  }
+  const ageMs = Date.now() - lastSyncedAt.getTime();
+  const ageMinutes = Math.floor(ageMs / 60_000);
+  return {
+    lastSyncedAt,
+    ageMinutes,
+    isStale: ageMinutes > STALE_MINUTES,
+  };
 }

--- a/src/actions/anthropic-global.ts
+++ b/src/actions/anthropic-global.ts
@@ -682,7 +682,9 @@ export async function getTwelveMonthTotals(): Promise<TwelveMonthRow[]> {
   return unstable_cache(
     _getTwelveMonthTotals,
     ["anthropic-twelve-month"],
-    { tags: ["anthropic-workspace-costs"] }
+    // "alerts" so org-budget edits revalidate the cap line on the 12-month chart;
+    // "anthropic-workspace-costs" so a sync revalidates the totals themselves.
+    { tags: ["anthropic-workspace-costs", "alerts"] }
   )();
 }
 
@@ -705,17 +707,24 @@ async function _getCumulativePacing(): Promise<PacingRow[]> {
     ORDER BY month, day_of_month
   `);
 
-  // Pivot per (dayOfMonth, monthOffset 0=current, 1=prev, 2=2-back, 3=3-back).
-  const months = new Set<string>();
-  for (const r of rows.rows) months.add(r.month as string);
-  const sortedMonths = Array.from(months).sort().reverse(); // newest first
+  // Build expected month keys from current_date (newest → 3-back) so empty
+  // months stay null instead of shifting labels — a current month with no
+  // data must not mislabel the prior month as "current".
+  const now = new Date();
+  const expectedMonths: string[] = [];
+  for (let i = 0; i < 4; i++) {
+    const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1));
+    const key = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+    expectedMonths.push(key);
+  }
 
   const dayMap = new Map<number, PacingRow>();
   for (const r of rows.rows) {
     const dom = r.day_of_month as number;
     const month = r.month as string;
     const cents = Number(r.cumulative_cents ?? 0);
-    const offset = sortedMonths.indexOf(month);
+    const offset = expectedMonths.indexOf(month);
+    if (offset < 0 || offset > 3) continue;
     let row = dayMap.get(dom);
     if (!row) {
       row = { dayOfMonth: dom, current: null, m1: null, m2: null, m3: null };
@@ -991,7 +1000,7 @@ async function _getWorkspaceDetail(
       AND m.date >= ${monthStart}::date
       AND m.date <= ${monthEnd}::date
     GROUP BY u.id, u.email, u.name
-    ORDER BY cents DESC
+    ORDER BY cents DESC, u.email ASC
     LIMIT 10
   `);
   const topUsers: WorkspaceUser[] = usersResult.rows.map((r) => ({

--- a/src/app/claude/page.tsx
+++ b/src/app/claude/page.tsx
@@ -79,6 +79,10 @@ export default async function ClaudePage() {
           initialMonth={currentMonth}
           orgBudgetCents={orgConfig?.billingBudgetLimitCents ?? null}
           syncStatus={syncStatus}
+          workspaceOptions={workspaceList.map((w) => ({
+            key: w.workspaceId ?? "__default__",
+            name: w.name,
+          }))}
         />
       </Suspense>
 

--- a/src/app/claude/page.tsx
+++ b/src/app/claude/page.tsx
@@ -19,7 +19,7 @@ import { WorkspaceBudgetList } from "@/components/claude/workspace-budget-list";
 import { OrgBillingBudgetCard } from "@/components/claude/org-credits-panel";
 import { HistoricalTrendCard } from "@/components/claude/historical-trend-card";
 import { SyncButton } from "@/components/claude/sync-button";
-import { format } from "date-fns";
+import { format, getDate, getDaysInMonth } from "date-fns";
 import { Bot } from "lucide-react";
 
 export const metadata: Metadata = { title: "Claude API Spending" };
@@ -30,7 +30,10 @@ export default async function ClaudePage() {
     redirect("/");
   }
 
-  const currentMonth = format(new Date(), "yyyy-MM");
+  const now = new Date();
+  const currentMonth = format(now, "yyyy-MM");
+  const todayDayOfMonth = getDate(now);
+  const daysInMonth = getDaysInMonth(now);
   const availableMonths = await getAvailableWorkspaceCostMonths();
 
   if (availableMonths.length === 0) {
@@ -90,6 +93,11 @@ export default async function ClaudePage() {
         twelveMonth={twelveMonth}
         pacing={pacing}
         movers={movers}
+        currentMonth={currentMonth}
+        projectedMonthEndCents={kpis.projectedMonthEndCents}
+        budgetLimitCents={orgConfig?.billingBudgetLimitCents ?? null}
+        todayDayOfMonth={todayDayOfMonth}
+        daysInMonth={daysInMonth}
       />
 
       <section aria-label="Organization billing">

--- a/src/app/claude/page.tsx
+++ b/src/app/claude/page.tsx
@@ -9,10 +9,15 @@ import {
   getDashboardKpis,
   getDailyTotalsByWorkspace,
   getSyncStatus,
+  getTwelveMonthTotals,
+  getCumulativePacing,
+  getTopMovers,
+  getWorkspaceSparklines,
 } from "@/actions/anthropic-global";
 import { GlobalMetricsClient } from "@/components/claude/global-metrics-client";
 import { WorkspaceBudgetList } from "@/components/claude/workspace-budget-list";
 import { OrgBillingBudgetCard } from "@/components/claude/org-credits-panel";
+import { HistoricalTrendCard } from "@/components/claude/historical-trend-card";
 import { SyncButton } from "@/components/claude/sync-button";
 import { format } from "date-fns";
 import { Bot } from "lucide-react";
@@ -32,12 +37,26 @@ export default async function ClaudePage() {
     return <EmptyState />;
   }
 
-  const [kpis, daily, workspaceList, orgConfig, syncStatus] = await Promise.all([
+  const [
+    kpis,
+    daily,
+    workspaceList,
+    orgConfig,
+    syncStatus,
+    twelveMonth,
+    pacing,
+    movers,
+    sparklines,
+  ] = await Promise.all([
     getDashboardKpis(currentMonth),
     getDailyTotalsByWorkspace(currentMonth),
     getWorkspaceList(),
     getOrgConfig(),
     getSyncStatus(),
+    getTwelveMonthTotals(),
+    getCumulativePacing(),
+    getTopMovers(),
+    getWorkspaceSparklines(),
   ]);
 
   return (
@@ -63,6 +82,12 @@ export default async function ClaudePage() {
         />
       </Suspense>
 
+      <HistoricalTrendCard
+        twelveMonth={twelveMonth}
+        pacing={pacing}
+        movers={movers}
+      />
+
       <section aria-label="Organization billing">
         <h2 className="mb-4 text-lg font-semibold">Organization Billing</h2>
         <OrgBillingBudgetCard
@@ -74,7 +99,10 @@ export default async function ClaudePage() {
 
       <section aria-label="Workspace budgets">
         <h2 className="mb-4 text-lg font-semibold">Workspace Budgets</h2>
-        <WorkspaceBudgetList workspaces={workspaceList} />
+        <WorkspaceBudgetList
+          workspaces={workspaceList}
+          sparklines={sparklines}
+        />
       </section>
     </div>
   );

--- a/src/app/claude/page.tsx
+++ b/src/app/claude/page.tsx
@@ -3,22 +3,21 @@ import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import {
-  getGlobalCostDashboard,
   getAvailableWorkspaceCostMonths,
   getWorkspaceList,
   getOrgConfig,
+  getDashboardKpis,
+  getDailyTotalsByWorkspace,
+  getSyncStatus,
 } from "@/actions/anthropic-global";
 import { GlobalMetricsClient } from "@/components/claude/global-metrics-client";
 import { WorkspaceBudgetList } from "@/components/claude/workspace-budget-list";
-import { OrgCreditsPanel } from "@/components/claude/org-credits-panel";
+import { OrgBillingBudgetCard } from "@/components/claude/org-credits-panel";
 import { SyncButton } from "@/components/claude/sync-button";
-import { db } from "@/lib/db";
-import { syncEvents } from "@/lib/db/schema";
-import { eq, desc } from "drizzle-orm";
 import { format } from "date-fns";
 import { Bot } from "lucide-react";
 
-export const metadata: Metadata = { title: "Claude Console" };
+export const metadata: Metadata = { title: "Claude API Spending" };
 
 export default async function ClaudePage() {
   const session = await auth();
@@ -29,50 +28,47 @@ export default async function ClaudePage() {
   const currentMonth = format(new Date(), "yyyy-MM");
   const availableMonths = await getAvailableWorkspaceCostMonths();
 
-  // Check for last sync time
-  const lastEvent = await db.query.syncEvents.findFirst({
-    where: eq(syncEvents.sourceType, "anthropic_api_costs"),
-    orderBy: desc(syncEvents.startedAt),
-  });
-  const lastSyncedAt = lastEvent?.completedAt ?? lastEvent?.startedAt ?? null;
-
-  // Empty state if no data yet
   if (availableMonths.length === 0) {
     return <EmptyState />;
   }
 
-  const creditsStatus = { available: false as const, reason: "not_exposed_by_api" as const };
-  const [dashboardData, workspaceList, orgConfig] = await Promise.all([
-    getGlobalCostDashboard(currentMonth),
+  const [kpis, daily, workspaceList, orgConfig, syncStatus] = await Promise.all([
+    getDashboardKpis(currentMonth),
+    getDailyTotalsByWorkspace(currentMonth),
     getWorkspaceList(),
     getOrgConfig(),
+    getSyncStatus(),
   ]);
 
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Claude Console</h1>
-          <p className="text-muted-foreground">Org-wide Claude API usage and spending</p>
+          <h1 className="text-2xl font-bold tracking-tight">Claude API Spending</h1>
+          <p className="text-muted-foreground">
+            Org-wide usage, budgets, and Anthropic sync status.
+          </p>
         </div>
         <SyncButton />
       </div>
 
       <Suspense fallback={<div className="h-96 animate-pulse rounded-lg bg-muted" />}>
         <GlobalMetricsClient
-          initialData={dashboardData}
+          initialKpis={kpis}
+          initialDaily={daily}
           availableMonths={availableMonths}
           initialMonth={currentMonth}
-          lastSyncedAt={lastSyncedAt}
+          orgBudgetCents={orgConfig?.billingBudgetLimitCents ?? null}
+          syncStatus={syncStatus}
         />
       </Suspense>
 
       <section aria-label="Organization billing">
         <h2 className="mb-4 text-lg font-semibold">Organization Billing</h2>
-        <OrgCreditsPanel
+        <OrgBillingBudgetCard
           orgConfig={orgConfig}
-          currentMonthTotalCents={dashboardData.grandTotalCents}
-          creditsStatus={creditsStatus}
+          currentMonthTotalCents={kpis.totalCents}
+          projectedMonthEndCents={kpis.projectedMonthEndCents}
         />
       </section>
 

--- a/src/app/claude/workspaces/[workspaceId]/page.tsx
+++ b/src/app/claude/workspaces/[workspaceId]/page.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { format } from "date-fns";
+import { ChevronLeft } from "lucide-react";
+import { auth } from "@/lib/auth";
+import { getWorkspaceDetail } from "@/actions/anthropic-global";
+import { Badge } from "@/components/ui/badge";
+import { WorkspaceDetailClient } from "./workspace-detail-client";
+
+type PageProps = {
+  params: Promise<{ workspaceId: string }>;
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { workspaceId } = await params;
+  return {
+    title: `${workspaceId === "default" ? "Default workspace" : workspaceId} · Claude API Spending`,
+  };
+}
+
+export default async function WorkspaceDetailPage({ params }: PageProps) {
+  const session = await auth();
+  if (!session?.user || session.user.role !== "admin") {
+    redirect("/");
+  }
+
+  const { workspaceId } = await params;
+  const currentMonth = format(new Date(), "yyyy-MM");
+  const detail = await getWorkspaceDetail(workspaceId, currentMonth);
+  if (!detail) {
+    notFound();
+  }
+
+  const isOverBudget =
+    detail.utilizationPct != null && detail.utilizationPct >= 100;
+
+  return (
+    <div className="space-y-6">
+      <nav className="text-sm text-muted-foreground">
+        <Link
+          href={`/claude?workspace=${workspaceId}`}
+          className="inline-flex items-center gap-1 hover:underline"
+        >
+          <ChevronLeft className="size-3" /> Claude API Spending
+        </Link>
+      </nav>
+
+      <div className="flex items-center gap-3">
+        <span
+          className="size-3 rounded-full"
+          style={{
+            backgroundColor: detail.workspace.displayColor ?? "#a1a1aa",
+          }}
+          aria-hidden
+        />
+        <h1 className="text-2xl font-bold tracking-tight">{detail.workspace.name}</h1>
+        {detail.workspace.isDefault && (
+          <Badge variant="secondary">Default</Badge>
+        )}
+        {isOverBudget && <Badge variant="destructive">Over budget</Badge>}
+      </div>
+
+      <WorkspaceDetailClient
+        workspaceIdParam={workspaceId}
+        initial={detail}
+      />
+    </div>
+  );
+}

--- a/src/app/claude/workspaces/[workspaceId]/workspace-detail-client.tsx
+++ b/src/app/claude/workspaces/[workspaceId]/workspace-detail-client.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState, useTransition } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
 import { MonthPicker } from "@/components/profile/month-picker";
 import { KpiStrip, type KpiTile } from "@/components/claude/kpi-strip";
 import { WorkspaceDailyChart } from "@/components/claude/workspace-daily-chart";
@@ -18,6 +17,7 @@ import { toast } from "sonner";
 import type { WorkspaceDetail } from "@/types";
 import { AlertTriangle, TrendingDown, TrendingUp } from "lucide-react";
 import { formatCurrency } from "@/lib/utils";
+import { getDaysInMonth, parseISO } from "date-fns";
 
 type Props = {
   workspaceIdParam: string;
@@ -172,23 +172,30 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
           )}
         </div>
         {editing ? (
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">$</span>
-            <Input
-              type="number"
-              min="0"
-              step="0.01"
-              className="w-28"
-              value={limitInput}
-              onChange={(e) => setLimitInput(e.target.value)}
-              autoFocus
-            />
-            <Button size="sm" onClick={handleSaveLimit} disabled={savingLimit}>
-              {savingLimit ? "Saving…" : "Save"}
-            </Button>
-            <Button size="sm" variant="ghost" onClick={() => setEditing(false)} disabled={savingLimit}>
-              Cancel
-            </Button>
+          <div className="flex flex-col items-end gap-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">$</span>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                className="w-28"
+                value={limitInput}
+                onChange={(e) => setLimitInput(e.target.value)}
+                autoFocus
+              />
+              <Button size="sm" onClick={handleSaveLimit} disabled={savingLimit}>
+                {savingLimit ? "Saving…" : "Save"}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setEditing(false)} disabled={savingLimit}>
+                Cancel
+              </Button>
+            </div>
+            {detail.workspace.isDefault && (
+              <p className="text-xs text-muted-foreground">
+                Applies to all API usage not assigned to a named workspace.
+              </p>
+            )}
           </div>
         ) : (
           <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
@@ -196,10 +203,6 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
           </Button>
         )}
       </div>
-
-      {detail.utilizationPct != null && detail.utilizationPct >= 100 && (
-        <Badge variant="destructive">Over budget</Badge>
-      )}
 
       <KpiStrip tiles={tiles} />
 
@@ -211,6 +214,8 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
           <WorkspaceDailyChart
             dailyTotals={detail.dailyTotals}
             color={detail.workspace.displayColor}
+            limitCents={detail.limitCents}
+            daysInMonth={getDaysInMonth(parseISO(`${month}-01`))}
           />
         </CardContent>
       </Card>

--- a/src/app/claude/workspaces/[workspaceId]/workspace-detail-client.tsx
+++ b/src/app/claude/workspaces/[workspaceId]/workspace-detail-client.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { MonthPicker } from "@/components/profile/month-picker";
+import { KpiStrip, type KpiTile } from "@/components/claude/kpi-strip";
+import { WorkspaceDailyChart } from "@/components/claude/workspace-daily-chart";
+import { WorkspaceTopUsers } from "@/components/claude/workspace-top-users";
+import { WorkspaceModelBreakdown } from "@/components/claude/workspace-model-breakdown";
+import {
+  getWorkspaceDetail,
+  setWorkspaceLimit,
+} from "@/actions/anthropic-global";
+import { toast } from "sonner";
+import type { WorkspaceDetail } from "@/types";
+import { AlertTriangle, TrendingDown, TrendingUp } from "lucide-react";
+import { formatCurrency } from "@/lib/utils";
+
+type Props = {
+  workspaceIdParam: string;
+  initial: WorkspaceDetail;
+};
+
+export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
+  const [detail, setDetail] = useState<WorkspaceDetail>(initial);
+  const [month, setMonth] = useState(initial.month);
+  const [isPending, startTransition] = useTransition();
+  const [editing, setEditing] = useState(false);
+  const [limitInput, setLimitInput] = useState(
+    detail.limitCents != null ? String(detail.limitCents / 100) : ""
+  );
+  const [savingLimit, savingTransition] = useTransition();
+
+  function handleMonthChange(next: string) {
+    setMonth(next);
+    startTransition(async () => {
+      const d = await getWorkspaceDetail(workspaceIdParam, next);
+      if (d) setDetail(d);
+    });
+  }
+
+  function handleSaveLimit() {
+    savingTransition(async () => {
+      const dollars = parseFloat(limitInput);
+      const cents =
+        isNaN(dollars) || limitInput.trim() === ""
+          ? null
+          : Math.round(dollars * 100);
+      const r = await setWorkspaceLimit(detail.workspace.id, cents);
+      if (r.success) {
+        toast.success("Limit updated.");
+        setEditing(false);
+        const refreshed = await getWorkspaceDetail(workspaceIdParam, month);
+        if (refreshed) setDetail(refreshed);
+      } else {
+        toast.error(`Failed: ${r.error}`);
+      }
+    });
+  }
+
+  const tiles = useMemo<KpiTile[]>(() => {
+    const monthLabel = (() => {
+      const [y, m] = month.split("-");
+      return new Date(Number(y), Number(m) - 1, 1).toLocaleString("en-US", {
+        month: "short",
+        year: "numeric",
+      });
+    })();
+
+    const momCaption =
+      detail.momDeltaPct === null ? (
+        <span className="text-muted-foreground">— no spend last month</span>
+      ) : detail.momDeltaPct >= 0 ? (
+        <span className="inline-flex items-center gap-1 text-emerald-500">
+          <TrendingUp className="size-3" /> +{detail.momDeltaPct}% vs prior month
+        </span>
+      ) : (
+        <span className="inline-flex items-center gap-1 text-destructive">
+          <TrendingDown className="size-3" /> {detail.momDeltaPct}% vs prior month
+        </span>
+      );
+
+    const isOver =
+      detail.limitCents != null && detail.projectedMonthEndCents > detail.limitCents;
+    const projectedPct =
+      detail.limitCents != null && detail.limitCents > 0
+        ? Math.round((detail.projectedMonthEndCents / detail.limitCents) * 100)
+        : null;
+
+    const utilizationTile: KpiTile =
+      detail.limitCents == null
+        ? {
+            label: "Utilization",
+            value: <span className="text-base text-muted-foreground">No limit set</span>,
+            caption: (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 px-2 text-xs"
+                onClick={() => setEditing(true)}
+              >
+                Set limit
+              </Button>
+            ),
+          }
+        : {
+            label: "Utilization",
+            value: `${detail.utilizationPct ?? 0}%`,
+            caption: `of ${formatCurrency(detail.limitCents)} monthly limit`,
+            tone:
+              (detail.utilizationPct ?? 0) >= 100
+                ? "danger"
+                : (detail.utilizationPct ?? 0) >= 80
+                ? "warn"
+                : "default",
+          };
+
+    return [
+      {
+        label: `Total · ${monthLabel}`,
+        value: formatCurrency(detail.currentMonthCents),
+        caption:
+          detail.priorMonthCents > 0
+            ? `Prior month ${formatCurrency(detail.priorMonthCents)}`
+            : "First month with data",
+      },
+      {
+        label: "MoM Delta",
+        value:
+          detail.momDeltaCents >= 0
+            ? `+${formatCurrency(detail.momDeltaCents)}`
+            : `-${formatCurrency(Math.abs(detail.momDeltaCents))}`,
+        caption: momCaption,
+        tone:
+          detail.momDeltaPct === null
+            ? "default"
+            : detail.momDeltaPct >= 0
+            ? "success"
+            : "danger",
+      },
+      {
+        label: "Projected Month-End",
+        value: formatCurrency(detail.projectedMonthEndCents),
+        caption:
+          detail.limitCents == null
+            ? "No limit set"
+            : `${projectedPct ?? 0}% of ${formatCurrency(detail.limitCents)} limit`,
+        tone: isOver ? "danger" : projectedPct != null && projectedPct >= 80 ? "warn" : "default",
+        ring: isOver,
+        icon: isOver ? <AlertTriangle className="size-3 text-destructive" /> : undefined,
+      },
+      utilizationTile,
+    ];
+  }, [detail, month]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <MonthPicker
+            value={month}
+            onChange={handleMonthChange}
+            months={detail.availableMonths.length > 0 ? detail.availableMonths : [month]}
+          />
+          {isPending && (
+            <span className="text-sm text-muted-foreground animate-pulse">
+              Loading…
+            </span>
+          )}
+        </div>
+        {editing ? (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">$</span>
+            <Input
+              type="number"
+              min="0"
+              step="0.01"
+              className="w-28"
+              value={limitInput}
+              onChange={(e) => setLimitInput(e.target.value)}
+              autoFocus
+            />
+            <Button size="sm" onClick={handleSaveLimit} disabled={savingLimit}>
+              {savingLimit ? "Saving…" : "Save"}
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => setEditing(false)} disabled={savingLimit}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
+            {detail.limitCents != null ? "Edit limit" : "Set limit"}
+          </Button>
+        )}
+      </div>
+
+      {detail.utilizationPct != null && detail.utilizationPct >= 100 && (
+        <Badge variant="destructive">Over budget</Badge>
+      )}
+
+      <KpiStrip tiles={tiles} />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Daily spend</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <WorkspaceDailyChart
+            dailyTotals={detail.dailyTotals}
+            color={detail.workspace.displayColor}
+          />
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Top users this month</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <WorkspaceTopUsers users={detail.topUsers} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Model breakdown</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <WorkspaceModelBreakdown rows={detail.modelBreakdown} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -55,7 +55,7 @@ const navItems: NavItem[] = [
   { title: "Budget", href: "/budget", icon: DollarSign, roles: ["admin"] },
   { title: "Reports", href: "/reports", icon: BarChart3, roles: ["admin"] },
   { title: "Copilot", href: "/copilot", icon: Bot, roles: ["admin"] },
-  { title: "Claude API Spending", href: "/claude", icon: Bot, roles: ["admin"] },
+  { title: "Claude Console", href: "/claude", icon: Bot, roles: ["admin"] },
   { title: "Invoices", href: "/invoices", icon: FileText, roles: ["admin"] },
   { title: "Settings", href: "/settings/appearance", icon: Settings, roles: ["admin", "viewer"] },
 ];

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -55,7 +55,7 @@ const navItems: NavItem[] = [
   { title: "Budget", href: "/budget", icon: DollarSign, roles: ["admin"] },
   { title: "Reports", href: "/reports", icon: BarChart3, roles: ["admin"] },
   { title: "Copilot", href: "/copilot", icon: Bot, roles: ["admin"] },
-  { title: "Claude", href: "/claude", icon: Bot, roles: ["admin"] },
+  { title: "Claude API Spending", href: "/claude", icon: Bot, roles: ["admin"] },
   { title: "Invoices", href: "/invoices", icon: FileText, roles: ["admin"] },
   { title: "Settings", href: "/settings/appearance", icon: Settings, roles: ["admin", "viewer"] },
 ];

--- a/src/components/claude/cumulative-pacing-chart.tsx
+++ b/src/components/claude/cumulative-pacing-chart.tsx
@@ -160,24 +160,24 @@ export function CumulativePacingChart({
           {budgetLimitCents != null && (
             <ReferenceLine
               y={budgetLimitCents / 100}
-              stroke="hsl(var(--destructive))"
+              stroke="var(--destructive)"
               strokeDasharray="3 3"
               label={{
                 value: `Budget ${formatCurrency(budgetLimitCents)}`,
                 position: "insideTopRight",
-                fill: "hsl(var(--destructive))",
+                fill: "var(--destructive)",
                 fontSize: 10,
               }}
             />
           )}
           <ReferenceLine
             x={todayDayOfMonth}
-            stroke="hsl(var(--muted-foreground))"
+            stroke="var(--muted-foreground)"
             strokeDasharray="2 4"
             label={{
               value: "today",
               position: "insideTopLeft",
-              fill: "hsl(var(--muted-foreground))",
+              fill: "var(--muted-foreground)",
               fontSize: 10,
             }}
           />

--- a/src/components/claude/cumulative-pacing-chart.tsx
+++ b/src/components/claude/cumulative-pacing-chart.tsx
@@ -55,20 +55,22 @@ export function CumulativePacingChart({
   const anchorDay = anchorRow?.dayOfMonth ?? null;
   const anchorCents = anchorRow?.current ?? null;
 
+  // Projection anchors at (anchorDay, anchorCents) and terminates at
+  // (daysInMonth, projectedEom). Only the two endpoints carry values; Recharts
+  // draws a straight line between them.
+  function projectionAt(dayOfMonth: number): number | null {
+    if (anchorDay == null || anchorCents == null) return null;
+    if (dayOfMonth === anchorDay) return anchorCents / 100;
+    if (dayOfMonth === daysInMonth) return projectedEomCents / 100;
+    return null;
+  }
+
   const data = rows.map((r) => {
     const isPastAnchor = anchorDay != null && r.dayOfMonth > anchorDay;
     return {
       day: r.dayOfMonth,
       current: !isPastAnchor && r.current != null ? r.current / 100 : null,
-      // Projection: anchor at (anchorDay, anchorCents); terminate at (daysInMonth, projectedEom).
-      currentProjected:
-        anchorDay != null && anchorCents != null
-          ? r.dayOfMonth === anchorDay
-            ? anchorCents / 100
-            : r.dayOfMonth === daysInMonth
-              ? projectedEomCents / 100
-              : null
-          : null,
+      currentProjected: projectionAt(r.dayOfMonth),
       m1: r.m1 != null ? r.m1 / 100 : null,
       m2: r.m2 != null ? r.m2 / 100 : null,
       m3: r.m3 != null ? r.m3 / 100 : null,

--- a/src/components/claude/cumulative-pacing-chart.tsx
+++ b/src/components/claude/cumulative-pacing-chart.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
+import type { PacingRow } from "@/types";
+
+const config: ChartConfig = {
+  current: { label: "Current month", color: "var(--chart-1)" },
+  m1: { label: "1 month ago", color: "#a1a1aa" },
+  m2: { label: "2 months ago", color: "#71717a" },
+  m3: { label: "3 months ago", color: "#52525b" },
+};
+
+export function CumulativePacingChart({ rows }: { rows: PacingRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-muted-foreground">
+        Not enough historical data to chart cumulative pacing.
+      </p>
+    );
+  }
+  const data = rows.map((r) => ({
+    day: r.dayOfMonth,
+    current: r.current != null ? r.current / 100 : null,
+    m1: r.m1 != null ? r.m1 / 100 : null,
+    m2: r.m2 != null ? r.m2 / 100 : null,
+    m3: r.m3 != null ? r.m3 / 100 : null,
+  }));
+
+  return (
+    <ChartContainer config={config} className="h-[220px] w-full">
+      <LineChart data={data} accessibilityLayer margin={{ top: 12, right: 8, bottom: 0, left: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="day"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          tickFormatter={(v: number) => `${v}`}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          tickFormatter={(v: number) => `$${v.toFixed(0)}`}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              formatter={(value, name) => [
+                value == null ? "—" : `$${Number(value).toFixed(2)}`,
+                config[name as string]?.label ?? name,
+              ]}
+            />
+          }
+        />
+        <Line
+          dataKey="m3"
+          type="monotone"
+          stroke="#52525b"
+          strokeWidth={1.5}
+          dot={false}
+          connectNulls
+        />
+        <Line
+          dataKey="m2"
+          type="monotone"
+          stroke="#71717a"
+          strokeWidth={1.5}
+          dot={false}
+          connectNulls
+        />
+        <Line
+          dataKey="m1"
+          type="monotone"
+          stroke="#a1a1aa"
+          strokeWidth={1.5}
+          dot={false}
+          connectNulls
+        />
+        <Line
+          dataKey="current"
+          type="monotone"
+          stroke="var(--chart-1)"
+          strokeWidth={2.5}
+          dot={false}
+          connectNulls={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  );
+}

--- a/src/components/claude/cumulative-pacing-chart.tsx
+++ b/src/components/claude/cumulative-pacing-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
+import { CartesianGrid, Line, LineChart, ReferenceLine, XAxis, YAxis } from "recharts";
 import {
   ChartContainer,
   ChartTooltip,
@@ -8,15 +8,35 @@ import {
 } from "@/components/ui/chart";
 import type { ChartConfig } from "@/components/ui/chart";
 import type { PacingRow } from "@/types";
+import { cn, formatCurrency } from "@/lib/utils";
 
 const config: ChartConfig = {
   current: { label: "Current month", color: "var(--chart-1)" },
+  currentProjected: { label: "Projected", color: "var(--chart-1)" },
   m1: { label: "1 month ago", color: "#a1a1aa" },
   m2: { label: "2 months ago", color: "#71717a" },
   m3: { label: "3 months ago", color: "#52525b" },
 };
 
-export function CumulativePacingChart({ rows }: { rows: PacingRow[] }) {
+function monthLabelOffset(offset: number): string {
+  const now = new Date();
+  const d = new Date(now.getFullYear(), now.getMonth() - offset, 1);
+  return d.toLocaleString("en-US", { month: "short" });
+}
+
+export function CumulativePacingChart({
+  rows,
+  budgetLimitCents,
+  projectedEomCents,
+  todayDayOfMonth,
+  daysInMonth,
+}: {
+  rows: PacingRow[];
+  budgetLimitCents: number | null;
+  projectedEomCents: number;
+  todayDayOfMonth: number;
+  daysInMonth: number;
+}) {
   if (rows.length === 0) {
     return (
       <p className="py-10 text-center text-sm text-muted-foreground">
@@ -24,74 +44,238 @@ export function CumulativePacingChart({ rows }: { rows: PacingRow[] }) {
       </p>
     );
   }
-  const data = rows.map((r) => ({
-    day: r.dayOfMonth,
-    current: r.current != null ? r.current / 100 : null,
-    m1: r.m1 != null ? r.m1 / 100 : null,
-    m2: r.m2 != null ? r.m2 / 100 : null,
-    m3: r.m3 != null ? r.m3 / 100 : null,
-  }));
+
+  // Anchor the projection at the latest known cumulative ≤ today.
+  // Data freshness may lag — yesterday's row is a fine anchor when today's
+  // sync hasn't landed yet.
+  const sortedDays = [...rows].sort((a, b) => a.dayOfMonth - b.dayOfMonth);
+  const anchorRow = [...sortedDays]
+    .reverse()
+    .find((r) => r.dayOfMonth <= todayDayOfMonth && r.current != null);
+  const anchorDay = anchorRow?.dayOfMonth ?? null;
+  const anchorCents = anchorRow?.current ?? null;
+
+  const data = rows.map((r) => {
+    const isPastAnchor = anchorDay != null && r.dayOfMonth > anchorDay;
+    return {
+      day: r.dayOfMonth,
+      current: !isPastAnchor && r.current != null ? r.current / 100 : null,
+      // Projection: anchor at (anchorDay, anchorCents); terminate at (daysInMonth, projectedEom).
+      currentProjected:
+        anchorDay != null && anchorCents != null
+          ? r.dayOfMonth === anchorDay
+            ? anchorCents / 100
+            : r.dayOfMonth === daysInMonth
+              ? projectedEomCents / 100
+              : null
+          : null,
+      m1: r.m1 != null ? r.m1 / 100 : null,
+      m2: r.m2 != null ? r.m2 / 100 : null,
+      m3: r.m3 != null ? r.m3 / 100 : null,
+    };
+  });
+
+  // Ensure the projection has its end anchor even if the rows array doesn't
+  // include `daysInMonth` (cumulative pacing only emits days that have data).
+  if (
+    anchorCents != null &&
+    anchorDay != null &&
+    anchorDay < daysInMonth &&
+    !data.some((d) => d.day === daysInMonth)
+  ) {
+    data.push({
+      day: daysInMonth,
+      current: null,
+      currentProjected: projectedEomCents / 100,
+      m1: null,
+      m2: null,
+      m3: null,
+    });
+  }
+
+  // Y-axis upper bound: include the budget cap and the projected end-of-month
+  // so both reference lines are visible above the highest data point.
+  const maxObservedDollars = data.reduce((acc, d) => {
+    const candidates = [d.current, d.currentProjected, d.m1, d.m2, d.m3];
+    for (const v of candidates) if (v != null) acc = Math.max(acc, v);
+    return acc;
+  }, 0);
+  const yMax =
+    Math.max(
+      maxObservedDollars,
+      budgetLimitCents != null ? budgetLimitCents / 100 : 0,
+      projectedEomCents / 100
+    ) * 1.1;
+
+  // Tracking comparison: compare current's anchor day to the most recent prior
+  // month with a value at the same day. Use the anchor row (latest non-null
+  // current ≤ today), not strictly today, so the label stays meaningful when
+  // today's data hasn't synced yet.
+  let trackingLabel = "—";
+  let trackingTone: "warn" | "muted" = "muted";
+  if (anchorRow && anchorCents != null) {
+    const candidates: { offset: number; cents: number }[] = [];
+    if (anchorRow.m1 != null) candidates.push({ offset: 1, cents: anchorRow.m1 });
+    if (anchorRow.m2 != null) candidates.push({ offset: 2, cents: anchorRow.m2 });
+    if (anchorRow.m3 != null) candidates.push({ offset: 3, cents: anchorRow.m3 });
+    const cmp = candidates[0];
+    if (cmp && cmp.cents > 0) {
+      const pct = Math.round(((anchorCents - cmp.cents) / cmp.cents) * 100);
+      const sign = pct > 0 ? "+" : "";
+      trackingLabel = `Day ${anchorRow.dayOfMonth}: tracking ${sign}${pct}% vs ${monthLabelOffset(cmp.offset)} at same day`;
+      trackingTone = pct > 0 ? "warn" : "muted";
+    }
+  }
 
   return (
-    <ChartContainer config={config} className="h-[220px] w-full">
-      <LineChart data={data} accessibilityLayer margin={{ top: 12, right: 8, bottom: 0, left: 8 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis
-          dataKey="day"
-          tickLine={false}
-          axisLine={false}
-          tickMargin={6}
-          tickFormatter={(v: number) => `${v}`}
-        />
-        <YAxis
-          tickLine={false}
-          axisLine={false}
-          tickMargin={6}
-          tickFormatter={(v: number) => `$${v.toFixed(0)}`}
-        />
-        <ChartTooltip
-          content={
-            <ChartTooltipContent
-              formatter={(value, name) => [
-                value == null ? "—" : `$${Number(value).toFixed(2)}`,
-                config[name as string]?.label ?? name,
-              ]}
+    <div className="space-y-3">
+      <div className="flex items-baseline justify-between text-xs">
+        <span className="font-semibold uppercase tracking-wider text-muted-foreground">
+          Cumulative pacing
+        </span>
+        <span className="text-muted-foreground">
+          By day-of-month · this month vs. prior 3
+        </span>
+      </div>
+      <ChartContainer config={config} className="h-[220px] w-full">
+        <LineChart data={data} accessibilityLayer margin={{ top: 12, right: 8, bottom: 0, left: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="day"
+            type="number"
+            domain={[1, daysInMonth]}
+            ticks={[1, 5, 10, 15, 20, 25, daysInMonth]}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={6}
+            tickFormatter={(v: number) => `${v}`}
+          />
+          <YAxis
+            domain={[0, yMax]}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={6}
+            tickFormatter={(v: number) => `$${v.toFixed(0)}`}
+          />
+          {budgetLimitCents != null && (
+            <ReferenceLine
+              y={budgetLimitCents / 100}
+              stroke="hsl(var(--destructive))"
+              strokeDasharray="3 3"
+              label={{
+                value: `Budget ${formatCurrency(budgetLimitCents)}`,
+                position: "insideTopRight",
+                fill: "hsl(var(--destructive))",
+                fontSize: 10,
+              }}
             />
-          }
-        />
-        <Line
-          dataKey="m3"
-          type="monotone"
-          stroke="#52525b"
-          strokeWidth={1.5}
-          dot={false}
-          connectNulls
-        />
-        <Line
-          dataKey="m2"
-          type="monotone"
-          stroke="#71717a"
-          strokeWidth={1.5}
-          dot={false}
-          connectNulls
-        />
-        <Line
-          dataKey="m1"
-          type="monotone"
-          stroke="#a1a1aa"
-          strokeWidth={1.5}
-          dot={false}
-          connectNulls
-        />
-        <Line
-          dataKey="current"
-          type="monotone"
-          stroke="var(--chart-1)"
-          strokeWidth={2.5}
-          dot={false}
-          connectNulls={false}
-        />
-      </LineChart>
-    </ChartContainer>
+          )}
+          <ReferenceLine
+            x={todayDayOfMonth}
+            stroke="hsl(var(--muted-foreground))"
+            strokeDasharray="2 4"
+            label={{
+              value: "today",
+              position: "insideTopLeft",
+              fill: "hsl(var(--muted-foreground))",
+              fontSize: 10,
+            }}
+          />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                formatter={(value, name) => [
+                  value == null ? "—" : `$${Number(value).toFixed(2)}`,
+                  config[name as string]?.label ?? name,
+                ]}
+              />
+            }
+          />
+          <Line
+            dataKey="m3"
+            type="monotone"
+            stroke="#52525b"
+            strokeWidth={1.5}
+            dot={false}
+            connectNulls
+          />
+          <Line
+            dataKey="m2"
+            type="monotone"
+            stroke="#71717a"
+            strokeWidth={1.5}
+            dot={false}
+            connectNulls
+          />
+          <Line
+            dataKey="m1"
+            type="monotone"
+            stroke="#a1a1aa"
+            strokeWidth={1.5}
+            dot={false}
+            connectNulls
+          />
+          <Line
+            dataKey="current"
+            type="monotone"
+            stroke="var(--chart-1)"
+            strokeWidth={2.5}
+            dot={false}
+            connectNulls={false}
+          />
+          <Line
+            dataKey="currentProjected"
+            type="linear"
+            stroke="var(--chart-1)"
+            strokeOpacity={0.85}
+            strokeWidth={2}
+            strokeDasharray="4 3"
+            dot={false}
+            connectNulls
+          />
+        </LineChart>
+      </ChartContainer>
+      <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+        <ul className="flex flex-wrap items-center gap-3">
+          <LineSwatch color="var(--chart-1)" label="this month" />
+          <LineSwatch color="var(--chart-1)" label="projection" dashed />
+          <LineSwatch color="#a1a1aa" label={`${monthLabelOffset(1)} (prior)`} />
+          <LineSwatch color="#71717a" label={monthLabelOffset(2)} />
+          <LineSwatch color="#52525b" label={monthLabelOffset(3)} />
+        </ul>
+        <span
+          className={cn(
+            "font-medium",
+            trackingTone === "warn" ? "text-amber-400" : "text-muted-foreground"
+          )}
+        >
+          {trackingLabel}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function LineSwatch({
+  color,
+  label,
+  dashed = false,
+}: {
+  color: string;
+  label: string;
+  dashed?: boolean;
+}) {
+  return (
+    <li className="flex items-center gap-1.5">
+      <span
+        aria-hidden
+        className="inline-block h-0.5 w-3"
+        style={{
+          backgroundColor: dashed ? "transparent" : color,
+          borderTop: dashed ? `2px dashed ${color}` : undefined,
+        }}
+      />
+      {label}
+    </li>
   );
 }

--- a/src/components/claude/global-metrics-client.tsx
+++ b/src/components/claude/global-metrics-client.tsx
@@ -45,14 +45,6 @@ const FALLBACK_PALETTE = [
   "#fdba74",
 ];
 
-function hashKey(key: string): number {
-  let h = 0;
-  for (let i = 0; i < key.length; i++) {
-    h = (h * 31 + key.charCodeAt(i)) | 0;
-  }
-  return Math.abs(h);
-}
-
 function resolveSeriesColor(
   key: string,
   displayColor: string | null,
@@ -61,7 +53,10 @@ function resolveSeriesColor(
 ): string {
   if (key === "__other__") return "#71717a";
   if (useDbColors && displayColor && displayColor.trim()) return displayColor;
-  return FALLBACK_PALETTE[(hashKey(key) + idx) % FALLBACK_PALETTE.length];
+  // Spectral assignment by rank: top-spend workspace gets palette[0], next
+  // gets palette[1], etc. Trade-off: a workspace's color follows its rank,
+  // so it can shift when spend ordering changes. Worth it for the visual.
+  return FALLBACK_PALETTE[idx % FALLBACK_PALETTE.length];
 }
 
 type StackedSeries = {

--- a/src/components/claude/global-metrics-client.tsx
+++ b/src/components/claude/global-metrics-client.tsx
@@ -1,137 +1,175 @@
 "use client";
 
 import { useState, useTransition, useMemo } from "react";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Legend } from "recharts";
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartConfig } from "@/components/ui/chart";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MonthPicker } from "@/components/profile/month-picker";
-import { getGlobalCostDashboard } from "@/actions/anthropic-global";
-import { formatDistanceToNow } from "date-fns";
-import type { GlobalCostDashboardData } from "@/types";
+import {
+  getDailyTotalsByWorkspace,
+  getDashboardKpis,
+} from "@/actions/anthropic-global";
+import type {
+  DailyStackedRow,
+  DashboardKpis,
+  SyncStatus,
+} from "@/types";
 import { formatCurrency } from "@/lib/utils";
+import { KpiStrip, buildOrgKpiTiles } from "@/components/claude/kpi-strip";
+import { SyncStatusPill } from "@/components/claude/sync-status-pill";
 
-type GlobalMetricsClientProps = {
-  initialData: GlobalCostDashboardData;
-  availableMonths: string[];
-  initialMonth: string;
-  lastSyncedAt: Date | null;
+// Deterministic palette fallback when workspace.displayColor is null.
+const FALLBACK_PALETTE = [
+  "#d4f057",
+  "#86efac",
+  "#67e8f9",
+  "#93c5fd",
+  "#c4b5fd",
+  "#f9a8d4",
+  "#fcd34d",
+  "#fdba74",
+];
+
+function hashKey(key: string): number {
+  let h = 0;
+  for (let i = 0; i < key.length; i++) {
+    h = (h * 31 + key.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+function resolveSeriesColor(
+  key: string,
+  displayColor: string | null,
+  idx: number
+): string {
+  if (displayColor && displayColor.trim()) return displayColor;
+  if (key === "__other__") return "#71717a";
+  return FALLBACK_PALETTE[(hashKey(key) + idx) % FALLBACK_PALETTE.length];
+}
+
+type StackedSeries = {
+  key: string;
+  name: string;
+  displayColor: string | null;
 };
 
-const ALL_WORKSPACES = "__all__";
-
-const chartConfig = {
-  cost: { label: "Cost (USD)", color: "var(--chart-1)" },
-} satisfies ChartConfig;
+type GlobalMetricsClientProps = {
+  initialKpis: DashboardKpis;
+  initialDaily: { rows: DailyStackedRow[]; topWorkspaces: StackedSeries[] };
+  availableMonths: string[];
+  initialMonth: string;
+  orgBudgetCents: number | null;
+  syncStatus: SyncStatus;
+};
 
 export function GlobalMetricsClient({
-  initialData,
+  initialKpis,
+  initialDaily,
   availableMonths,
   initialMonth,
-  lastSyncedAt,
+  orgBudgetCents,
+  syncStatus,
 }: GlobalMetricsClientProps) {
-  const [dashboardData, setDashboardData] = useState<GlobalCostDashboardData>(initialData);
+  const [kpis, setKpis] = useState<DashboardKpis>(initialKpis);
+  const [daily, setDaily] = useState(initialDaily);
   const [selectedMonth, setSelectedMonth] = useState<string>(initialMonth);
-  const [selectedWorkspace, setSelectedWorkspace] = useState<string>(ALL_WORKSPACES);
   const [isPending, startTransition] = useTransition();
 
   function handleMonthChange(newMonth: string) {
     setSelectedMonth(newMonth);
-    setSelectedWorkspace(ALL_WORKSPACES);
     startTransition(async () => {
-      const data = await getGlobalCostDashboard(newMonth);
-      setDashboardData(data);
+      const [k, d] = await Promise.all([
+        getDashboardKpis(newMonth),
+        getDailyTotalsByWorkspace(newMonth),
+      ]);
+      setKpis(k);
+      setDaily(d);
     });
   }
 
-  const { displayDailyTotals, displayTotal } = useMemo(() => {
-    if (selectedWorkspace === ALL_WORKSPACES) {
-      return {
-        displayDailyTotals: dashboardData.dailyTotals,
-        displayTotal: dashboardData.grandTotalCents,
-      };
+  const tiles = useMemo(
+    () =>
+      buildOrgKpiTiles({
+        month: selectedMonth,
+        totalCents: kpis.totalCents,
+        momDeltaCents: kpis.momDeltaCents,
+        momDeltaPct: kpis.momDeltaPct,
+        priorMonthCents: kpis.priorMonthCents,
+        projectedMonthEndCents: kpis.projectedMonthEndCents,
+        orgBudgetCents,
+        workspacesOverEightyCount: kpis.workspacesOverEightyCount,
+        workspacesWithLimitCount: kpis.workspacesWithLimitCount,
+        topOverWorkspaceName: kpis.topOverWorkspaceName,
+        topOverWorkspaceUtilizationPct: kpis.topOverWorkspaceUtilizationPct,
+      }),
+    [kpis, orgBudgetCents, selectedMonth]
+  );
+
+  const seriesWithColors = useMemo(
+    () =>
+      daily.topWorkspaces.map((s, idx) => ({
+        ...s,
+        color: resolveSeriesColor(s.key, s.displayColor, idx),
+      })),
+    [daily.topWorkspaces]
+  );
+
+  const chartConfig = useMemo<ChartConfig>(() => {
+    const out: ChartConfig = {};
+    for (const s of seriesWithColors) {
+      out[s.key] = { label: s.name, color: s.color };
     }
-    const ws = dashboardData.workspaceBreakdown.find(
-      (w) => (w.workspaceId ?? "__null__") === selectedWorkspace
-    );
-    return {
-      displayDailyTotals: ws?.dailyTotals ?? [],
-      displayTotal: ws?.totalCents ?? 0,
-    };
-  }, [dashboardData, selectedWorkspace]);
+    return out;
+  }, [seriesWithColors]);
 
   const chartData = useMemo(
     () =>
-      displayDailyTotals.map((d) => ({
-        date: d.date,
-        cost: d.costCents / 100,
-      })),
-    [displayDailyTotals]
+      daily.rows.map((d) => {
+        const row: Record<string, number | string> = { date: d.date };
+        for (const s of seriesWithColors) {
+          row[s.key] = (d.perWorkspace[s.key] ?? 0) / 100;
+        }
+        return row;
+      }),
+    [daily.rows, seriesWithColors]
   );
 
   return (
     <div className="space-y-4">
-      {/* Controls row */}
-      <div className="flex flex-wrap items-center gap-3">
-        <MonthPicker
-          value={selectedMonth}
-          onChange={handleMonthChange}
-          months={availableMonths}
-        />
-        <Select value={selectedWorkspace} onValueChange={setSelectedWorkspace}>
-          <SelectTrigger className="w-[220px]">
-            <SelectValue placeholder="All workspaces" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL_WORKSPACES}>All workspaces</SelectItem>
-            {dashboardData.workspaceBreakdown.map((ws) => (
-              <SelectItem
-                key={ws.workspaceId ?? "__null__"}
-                value={ws.workspaceId ?? "__null__"}
-              >
-                {ws.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {lastSyncedAt && (
-          <p className="text-sm text-muted-foreground">
-            Last synced {formatDistanceToNow(lastSyncedAt, { addSuffix: true })}
-          </p>
-        )}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <MonthPicker
+            value={selectedMonth}
+            onChange={handleMonthChange}
+            months={availableMonths}
+          />
+          {isPending && (
+            <span className="text-sm text-muted-foreground animate-pulse">
+              Loading…
+            </span>
+          )}
+        </div>
+        <SyncStatusPill status={syncStatus} />
       </div>
 
-      {/* Summary card */}
+      <KpiStrip tiles={tiles} />
+
       <Card>
         <CardHeader className="pb-2">
-          <CardDescription>
-            {selectedWorkspace === ALL_WORKSPACES ? "Total org spend" : "Workspace spend"} —{" "}
-            {selectedMonth}
-          </CardDescription>
-          <CardTitle className="text-3xl tabular-nums">
-            {isPending ? (
-              <span className="animate-pulse text-muted-foreground">Loading…</span>
-            ) : (
-              formatCurrency(displayTotal)
-            )}
-          </CardTitle>
+          <CardTitle className="text-base">Daily spend by workspace</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Stacked · top {seriesWithColors.filter((s) => s.key !== "__other__").length}{" "}
+            workspaces
+            {seriesWithColors.some((s) => s.key === "__other__") && " + Other"} ·{" "}
+            <span className="tabular-nums">{formatCurrency(kpis.totalCents)}</span>{" "}
+            this period
+          </p>
         </CardHeader>
         <CardContent>
           {chartData.length === 0 ? (
@@ -139,7 +177,7 @@ export function GlobalMetricsClient({
               No data for this period.
             </p>
           ) : (
-            <ChartContainer config={chartConfig} className="min-h-[300px] w-full">
+            <ChartContainer config={chartConfig} className="min-h-[320px] w-full">
               <BarChart data={chartData} accessibilityLayer>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis
@@ -164,15 +202,28 @@ export function GlobalMetricsClient({
                 <ChartTooltip
                   content={
                     <ChartTooltipContent
-                      formatter={(value) => `$${Number(value).toFixed(2)}`}
+                      formatter={(value, name) => [
+                        `$${Number(value).toFixed(2)}`,
+                        chartConfig[name as string]?.label ?? name,
+                      ]}
                     />
                   }
                 />
-                <Bar
-                  dataKey="cost"
-                  fill="var(--chart-1)"
-                  radius={[4, 4, 0, 0]}
-                />
+                <Legend wrapperStyle={{ paddingTop: 8 }} />
+                {seriesWithColors.map((s) => (
+                  <Bar
+                    key={s.key}
+                    dataKey={s.key}
+                    stackId="costs"
+                    fill={s.color}
+                    name={s.name}
+                    radius={
+                      s.key === seriesWithColors[seriesWithColors.length - 1].key
+                        ? [4, 4, 0, 0]
+                        : [0, 0, 0, 0]
+                    }
+                  />
+                ))}
               </BarChart>
             </ChartContainer>
           )}

--- a/src/components/claude/global-metrics-client.tsx
+++ b/src/components/claude/global-metrics-client.tsx
@@ -168,6 +168,30 @@ export function GlobalMetricsClient({
     return out;
   }, [seriesWithColors]);
 
+  // The daily chart's series come from `topWorkspaces` (top 8 + "Other"), so
+  // restrict the dropdown to keys that actually have a series — otherwise
+  // selecting a non-top workspace renders an empty chart. Workspaces outside
+  // the top 8 still show up in the workspace budget list and sparklines below.
+  const seriesKeys = useMemo(
+    () => new Set(seriesWithColors.map((s) => s.key)),
+    [seriesWithColors]
+  );
+  const filterableOptions = useMemo(
+    () => workspaceOptions.filter((w) => seriesKeys.has(w.key)),
+    [workspaceOptions, seriesKeys]
+  );
+
+  // Fall back to "All workspaces" if a previously-selected workspace dropped
+  // out of the top 8 between renders (e.g., a month switch reshuffles ranks).
+  useEffect(() => {
+    if (
+      selectedWorkspace !== ALL_WORKSPACES &&
+      !seriesKeys.has(selectedWorkspace)
+    ) {
+      setSelectedWorkspace(ALL_WORKSPACES);
+    }
+  }, [selectedWorkspace, seriesKeys]);
+
   const visibleSeries = useMemo(
     () =>
       selectedWorkspace === ALL_WORKSPACES
@@ -206,7 +230,7 @@ export function GlobalMetricsClient({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={ALL_WORKSPACES}>All workspaces</SelectItem>
-              {workspaceOptions.map((w) => (
+              {filterableOptions.map((w) => (
                 <SelectItem key={w.key} value={w.key}>
                   {w.name}
                 </SelectItem>

--- a/src/components/claude/global-metrics-client.tsx
+++ b/src/components/claude/global-metrics-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useTransition, useMemo } from "react";
+import { useState, useTransition, useMemo, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Legend } from "recharts";
 import {
   ChartContainer,
@@ -9,6 +10,13 @@ import {
 } from "@/components/ui/chart";
 import type { ChartConfig } from "@/components/ui/chart";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { MonthPicker } from "@/components/profile/month-picker";
 import {
   getDailyTotalsByWorkspace,
@@ -59,6 +67,8 @@ type StackedSeries = {
   displayColor: string | null;
 };
 
+const ALL_WORKSPACES = "__all__";
+
 type GlobalMetricsClientProps = {
   initialKpis: DashboardKpis;
   initialDaily: { rows: DailyStackedRow[]; topWorkspaces: StackedSeries[] };
@@ -66,6 +76,7 @@ type GlobalMetricsClientProps = {
   initialMonth: string;
   orgBudgetCents: number | null;
   syncStatus: SyncStatus;
+  workspaceOptions: { key: string; name: string }[];
 };
 
 export function GlobalMetricsClient({
@@ -75,11 +86,25 @@ export function GlobalMetricsClient({
   initialMonth,
   orgBudgetCents,
   syncStatus,
+  workspaceOptions,
 }: GlobalMetricsClientProps) {
   const [kpis, setKpis] = useState<DashboardKpis>(initialKpis);
   const [daily, setDaily] = useState(initialDaily);
   const [selectedMonth, setSelectedMonth] = useState<string>(initialMonth);
+  const [selectedWorkspace, setSelectedWorkspace] = useState<string>(ALL_WORKSPACES);
   const [isPending, startTransition] = useTransition();
+
+  // Honor the ?workspace=<id> query param when returning from the
+  // workspace detail page breadcrumb. "default" → the NULL workspace.
+  const searchParams = useSearchParams();
+  useEffect(() => {
+    const ws = searchParams.get("workspace");
+    if (!ws) return;
+    const key = ws === "default" ? "__default__" : ws;
+    if (workspaceOptions.some((w) => w.key === key)) {
+      setSelectedWorkspace(key);
+    }
+  }, [searchParams, workspaceOptions]);
 
   function handleMonthChange(newMonth: string) {
     setSelectedMonth(newMonth);
@@ -128,16 +153,24 @@ export function GlobalMetricsClient({
     return out;
   }, [seriesWithColors]);
 
+  const visibleSeries = useMemo(
+    () =>
+      selectedWorkspace === ALL_WORKSPACES
+        ? seriesWithColors
+        : seriesWithColors.filter((s) => s.key === selectedWorkspace),
+    [seriesWithColors, selectedWorkspace]
+  );
+
   const chartData = useMemo(
     () =>
       daily.rows.map((d) => {
         const row: Record<string, number | string> = { date: d.date };
-        for (const s of seriesWithColors) {
+        for (const s of visibleSeries) {
           row[s.key] = (d.perWorkspace[s.key] ?? 0) / 100;
         }
         return row;
       }),
-    [daily.rows, seriesWithColors]
+    [daily.rows, visibleSeries]
   );
 
   return (
@@ -149,6 +182,22 @@ export function GlobalMetricsClient({
             onChange={handleMonthChange}
             months={availableMonths}
           />
+          <Select
+            value={selectedWorkspace}
+            onValueChange={setSelectedWorkspace}
+          >
+            <SelectTrigger className="w-[220px]">
+              <SelectValue placeholder="All workspaces" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_WORKSPACES}>All workspaces</SelectItem>
+              {workspaceOptions.map((w) => (
+                <SelectItem key={w.key} value={w.key}>
+                  {w.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           {isPending && (
             <span className="text-sm text-muted-foreground animate-pulse">
               Loading…
@@ -162,11 +211,16 @@ export function GlobalMetricsClient({
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">Daily spend by workspace</CardTitle>
+          <CardTitle className="text-base">
+            {selectedWorkspace === ALL_WORKSPACES
+              ? "Daily spend by workspace"
+              : `Daily spend · ${visibleSeries[0]?.name ?? "Workspace"}`}
+          </CardTitle>
           <p className="text-sm text-muted-foreground">
-            Stacked · top {seriesWithColors.filter((s) => s.key !== "__other__").length}{" "}
-            workspaces
-            {seriesWithColors.some((s) => s.key === "__other__") && " + Other"} ·{" "}
+            {selectedWorkspace === ALL_WORKSPACES
+              ? `Stacked · top ${seriesWithColors.filter((s) => s.key !== "__other__").length} workspaces${seriesWithColors.some((s) => s.key === "__other__") ? " + Other" : ""}`
+              : "Single workspace · filtered view"}
+            {" · "}
             <span className="tabular-nums">{formatCurrency(kpis.totalCents)}</span>{" "}
             this period
           </p>
@@ -210,7 +264,7 @@ export function GlobalMetricsClient({
                   }
                 />
                 <Legend wrapperStyle={{ paddingTop: 8 }} />
-                {seriesWithColors.map((s) => (
+                {visibleSeries.map((s) => (
                   <Bar
                     key={s.key}
                     dataKey={s.key}
@@ -218,7 +272,7 @@ export function GlobalMetricsClient({
                     fill={s.color}
                     name={s.name}
                     radius={
-                      s.key === seriesWithColors[seriesWithColors.length - 1].key
+                      s.key === visibleSeries[visibleSeries.length - 1]?.key
                         ? [4, 4, 0, 0]
                         : [0, 0, 0, 0]
                     }

--- a/src/components/claude/global-metrics-client.tsx
+++ b/src/components/claude/global-metrics-client.tsx
@@ -17,6 +17,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import { MonthPicker } from "@/components/profile/month-picker";
 import {
   getDailyTotalsByWorkspace,
@@ -54,10 +56,11 @@ function hashKey(key: string): number {
 function resolveSeriesColor(
   key: string,
   displayColor: string | null,
-  idx: number
+  idx: number,
+  useDbColors: boolean
 ): string {
-  if (displayColor && displayColor.trim()) return displayColor;
   if (key === "__other__") return "#71717a";
+  if (useDbColors && displayColor && displayColor.trim()) return displayColor;
   return FALLBACK_PALETTE[(hashKey(key) + idx) % FALLBACK_PALETTE.length];
 }
 
@@ -92,7 +95,22 @@ export function GlobalMetricsClient({
   const [daily, setDaily] = useState(initialDaily);
   const [selectedMonth, setSelectedMonth] = useState<string>(initialMonth);
   const [selectedWorkspace, setSelectedWorkspace] = useState<string>(ALL_WORKSPACES);
+  const [useDbColors, setUseDbColors] = useState<boolean>(false);
   const [isPending, startTransition] = useTransition();
+
+  // Persist the color-source preference across reloads (localStorage). The
+  // default is the theme palette — distinct hues out of the box; the DB's
+  // display_color values from the Anthropic Admin API often collide.
+  useEffect(() => {
+    const saved = localStorage.getItem("claude-dashboard:useDbColors");
+    if (saved === "true") setUseDbColors(true);
+  }, []);
+  useEffect(() => {
+    localStorage.setItem(
+      "claude-dashboard:useDbColors",
+      String(useDbColors)
+    );
+  }, [useDbColors]);
 
   // Honor the ?workspace=<id> query param when returning from the
   // workspace detail page breadcrumb. "default" → the NULL workspace.
@@ -140,9 +158,9 @@ export function GlobalMetricsClient({
     () =>
       daily.topWorkspaces.map((s, idx) => ({
         ...s,
-        color: resolveSeriesColor(s.key, s.displayColor, idx),
+        color: resolveSeriesColor(s.key, s.displayColor, idx, useDbColors),
       })),
-    [daily.topWorkspaces]
+    [daily.topWorkspaces, useDbColors]
   );
 
   const chartConfig = useMemo<ChartConfig>(() => {
@@ -211,19 +229,36 @@ export function GlobalMetricsClient({
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">
-            {selectedWorkspace === ALL_WORKSPACES
-              ? "Daily spend by workspace"
-              : `Daily spend · ${visibleSeries[0]?.name ?? "Workspace"}`}
-          </CardTitle>
-          <p className="text-sm text-muted-foreground">
-            {selectedWorkspace === ALL_WORKSPACES
-              ? `Stacked · top ${seriesWithColors.filter((s) => s.key !== "__other__").length} workspaces${seriesWithColors.some((s) => s.key === "__other__") ? " + Other" : ""}`
-              : "Single workspace · filtered view"}
-            {" · "}
-            <span className="tabular-nums">{formatCurrency(kpis.totalCents)}</span>{" "}
-            this period
-          </p>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <CardTitle className="text-base">
+                {selectedWorkspace === ALL_WORKSPACES
+                  ? "Daily spend by workspace"
+                  : `Daily spend · ${visibleSeries[0]?.name ?? "Workspace"}`}
+              </CardTitle>
+              <p className="text-sm text-muted-foreground">
+                {selectedWorkspace === ALL_WORKSPACES
+                  ? `Stacked · top ${seriesWithColors.filter((s) => s.key !== "__other__").length} workspaces${seriesWithColors.some((s) => s.key === "__other__") ? " + Other" : ""}`
+                  : "Single workspace · filtered view"}
+                {" · "}
+                <span className="tabular-nums">{formatCurrency(kpis.totalCents)}</span>{" "}
+                this period
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch
+                id="use-db-colors"
+                checked={useDbColors}
+                onCheckedChange={setUseDbColors}
+              />
+              <Label
+                htmlFor="use-db-colors"
+                className="cursor-pointer text-xs text-muted-foreground"
+              >
+                Use workspace colors
+              </Label>
+            </div>
+          </div>
         </CardHeader>
         <CardContent>
           {chartData.length === 0 ? (

--- a/src/components/claude/global-metrics-client.tsx
+++ b/src/components/claude/global-metrics-client.tsx
@@ -51,7 +51,7 @@ function resolveSeriesColor(
   idx: number,
   useDbColors: boolean
 ): string {
-  if (key === "__other__") return "#71717a";
+  if (key === OTHER_KEY) return "#71717a";
   if (useDbColors && displayColor && displayColor.trim()) return displayColor;
   // Spectral assignment by rank: top-spend workspace gets palette[0], next
   // gets palette[1], etc. Trade-off: a workspace's color follows its rank,
@@ -66,6 +66,8 @@ type StackedSeries = {
 };
 
 const ALL_WORKSPACES = "__all__";
+const OTHER_KEY = "__other__";
+const DEFAULT_KEY = "__default__";
 
 type GlobalMetricsClientProps = {
   initialKpis: DashboardKpis;
@@ -113,7 +115,7 @@ export function GlobalMetricsClient({
   useEffect(() => {
     const ws = searchParams.get("workspace");
     if (!ws) return;
-    const key = ws === "default" ? "__default__" : ws;
+    const key = ws === "default" ? DEFAULT_KEY : ws;
     if (workspaceOptions.some((w) => w.key === key)) {
       setSelectedWorkspace(key);
     }
@@ -233,7 +235,7 @@ export function GlobalMetricsClient({
               </CardTitle>
               <p className="text-sm text-muted-foreground">
                 {selectedWorkspace === ALL_WORKSPACES
-                  ? `Stacked · top ${seriesWithColors.filter((s) => s.key !== "__other__").length} workspaces${seriesWithColors.some((s) => s.key === "__other__") ? " + Other" : ""}`
+                  ? `Stacked · top ${seriesWithColors.filter((s) => s.key !== OTHER_KEY).length} workspaces${seriesWithColors.some((s) => s.key === OTHER_KEY) ? " + Other" : ""}`
                   : "Single workspace · filtered view"}
                 {" · "}
                 <span className="tabular-nums">{formatCurrency(kpis.totalCents)}</span>{" "}

--- a/src/components/claude/historical-trend-card.tsx
+++ b/src/components/claude/historical-trend-card.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { TwelveMonthBarChart } from "@/components/claude/twelve-month-bar-chart";
+import { CumulativePacingChart } from "@/components/claude/cumulative-pacing-chart";
+import { TopMoversChips } from "@/components/claude/top-movers-chips";
+import { cn } from "@/lib/utils";
+import type { PacingRow, TopMover, TwelveMonthRow } from "@/types";
+
+type View = "monthly" | "pacing" | "growing";
+
+type HistoricalTrendCardProps = {
+  twelveMonth: TwelveMonthRow[];
+  pacing: PacingRow[];
+  movers: TopMover[];
+};
+
+export function HistoricalTrendCard({
+  twelveMonth,
+  pacing,
+  movers,
+}: HistoricalTrendCardProps) {
+  const [view, setView] = useState<View>("monthly");
+
+  return (
+    <Card>
+      <CardHeader className="space-y-3 pb-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-base">Historical trend</CardTitle>
+            <CardDescription>
+              Last 12 months · monthly totals, pacing vs prior months, and the
+              fastest-growing workspaces.
+            </CardDescription>
+          </div>
+          <div className="inline-flex rounded-md border bg-muted p-0.5 text-xs">
+            <SegBtn active={view === "monthly"} onClick={() => setView("monthly")}>
+              Monthly totals
+            </SegBtn>
+            <SegBtn active={view === "pacing"} onClick={() => setView("pacing")}>
+              Pacing
+            </SegBtn>
+            <SegBtn active={view === "growing"} onClick={() => setView("growing")}>
+              Fastest growing
+            </SegBtn>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="text-muted-foreground">Fastest growing (6mo):</span>
+          <TopMoversChips movers={movers} />
+        </div>
+      </CardHeader>
+      <CardContent>
+        {view === "monthly" && <TwelveMonthBarChart rows={twelveMonth} />}
+        {view === "pacing" && <CumulativePacingChart rows={pacing} />}
+        {view === "growing" && (
+          <div className="py-2">
+            <p className="text-sm text-muted-foreground">
+              {movers.length === 0
+                ? "No workspaces have meaningful positive growth over the last 6 months."
+                : `${movers.length} workspace${movers.length === 1 ? "" : "s"} have grown over the last 6 months (positive deltas only, ≥$5 prior period):`}
+            </p>
+            <ul className="mt-3 space-y-2 text-sm">
+              {movers.map((m) => (
+                <li
+                  key={m.workspaceId ?? "__default__"}
+                  className="flex items-center justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2"
+                >
+                  <span className="font-medium">{m.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    ${(m.priorCents / 100).toFixed(0)} → ${(m.currentCents / 100).toFixed(0)}
+                  </span>
+                  <span className="font-mono text-xs text-destructive">▲ +{m.deltaPct}%</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SegBtn({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      className={cn(
+        "h-7 rounded-sm px-3 text-xs",
+        active && "bg-background shadow-sm"
+      )}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/claude/historical-trend-card.tsx
+++ b/src/components/claude/historical-trend-card.tsx
@@ -21,12 +21,22 @@ type HistoricalTrendCardProps = {
   twelveMonth: TwelveMonthRow[];
   pacing: PacingRow[];
   movers: TopMover[];
+  currentMonth: string;
+  projectedMonthEndCents: number;
+  budgetLimitCents: number | null;
+  todayDayOfMonth: number;
+  daysInMonth: number;
 };
 
 export function HistoricalTrendCard({
   twelveMonth,
   pacing,
   movers,
+  currentMonth,
+  projectedMonthEndCents,
+  budgetLimitCents,
+  todayDayOfMonth,
+  daysInMonth,
 }: HistoricalTrendCardProps) {
   const [view, setView] = useState<View>("monthly");
 
@@ -59,8 +69,22 @@ export function HistoricalTrendCard({
         </div>
       </CardHeader>
       <CardContent>
-        {view === "monthly" && <TwelveMonthBarChart rows={twelveMonth} />}
-        {view === "pacing" && <CumulativePacingChart rows={pacing} />}
+        {view === "monthly" && (
+          <TwelveMonthBarChart
+            rows={twelveMonth}
+            currentMonth={currentMonth}
+            projectedMonthEndCents={projectedMonthEndCents}
+          />
+        )}
+        {view === "pacing" && (
+          <CumulativePacingChart
+            rows={pacing}
+            budgetLimitCents={budgetLimitCents}
+            projectedEomCents={projectedMonthEndCents}
+            todayDayOfMonth={todayDayOfMonth}
+            daysInMonth={daysInMonth}
+          />
+        )}
         {view === "growing" && (
           <div className="py-2">
             <p className="text-sm text-muted-foreground">

--- a/src/components/claude/kpi-strip.tsx
+++ b/src/components/claude/kpi-strip.tsx
@@ -1,0 +1,181 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { cn, formatCurrency } from "@/lib/utils";
+import { AlertTriangle, TrendingDown, TrendingUp } from "lucide-react";
+import type { ReactNode } from "react";
+
+export type KpiTile = {
+  label: string;
+  value: ReactNode;
+  caption?: ReactNode;
+  tone?: "default" | "warn" | "danger" | "success";
+  ring?: boolean;
+  icon?: ReactNode;
+};
+
+type KpiStripProps = {
+  tiles: KpiTile[];
+};
+
+export function KpiStrip({ tiles }: KpiStripProps) {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {tiles.map((tile, idx) => (
+        <KpiTileCard key={idx} tile={tile} />
+      ))}
+    </div>
+  );
+}
+
+function KpiTileCard({ tile }: { tile: KpiTile }) {
+  const captionId = `kpi-caption-${tile.label.replace(/\s+/g, "-").toLowerCase()}`;
+  return (
+    <Card
+      className={cn(
+        "relative overflow-hidden",
+        tile.ring && tile.tone === "danger" && "ring-2 ring-destructive/60"
+      )}
+    >
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            {tile.label}
+          </p>
+          {tile.icon}
+        </div>
+        <p
+          className="mt-2 text-2xl font-bold tabular-nums tracking-tight"
+          aria-describedby={captionId}
+        >
+          {tile.value}
+        </p>
+        {tile.caption !== undefined && (
+          <p
+            id={captionId}
+            className={cn(
+              "mt-1 text-xs",
+              tile.tone === "danger"
+                ? "text-destructive"
+                : tile.tone === "warn"
+                ? "text-amber-500"
+                : tile.tone === "success"
+                ? "text-emerald-500"
+                : "text-muted-foreground"
+            )}
+          >
+            {tile.caption}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Helper builder for the org-level KPI strip on `/claude`.
+ */
+export function buildOrgKpiTiles(args: {
+  month: string;
+  totalCents: number;
+  momDeltaCents: number;
+  momDeltaPct: number | null;
+  priorMonthCents: number;
+  projectedMonthEndCents: number;
+  orgBudgetCents: number | null;
+  workspacesOverEightyCount: number;
+  workspacesWithLimitCount: number;
+  topOverWorkspaceName: string | null;
+  topOverWorkspaceUtilizationPct: number | null;
+}): KpiTile[] {
+  const {
+    month,
+    totalCents,
+    momDeltaCents,
+    momDeltaPct,
+    priorMonthCents,
+    projectedMonthEndCents,
+    orgBudgetCents,
+    workspacesOverEightyCount,
+    workspacesWithLimitCount,
+    topOverWorkspaceName,
+    topOverWorkspaceUtilizationPct,
+  } = args;
+
+  const [year, monthNum] = month.split("-");
+  const monthLabel = new Date(Number(year), Number(monthNum) - 1, 1).toLocaleString(
+    "en-US",
+    { month: "short", year: "numeric" }
+  );
+
+  const momCaption =
+    momDeltaPct === null ? (
+      <span className="text-muted-foreground">— no spend last month</span>
+    ) : momDeltaPct >= 0 ? (
+      <span className="inline-flex items-center gap-1 text-emerald-500">
+        <TrendingUp className="size-3" /> +{momDeltaPct}% vs prior month
+      </span>
+    ) : (
+      <span className="inline-flex items-center gap-1 text-destructive">
+        <TrendingDown className="size-3" /> {momDeltaPct}% vs prior month
+      </span>
+    );
+
+  const isOverBudget =
+    orgBudgetCents != null && projectedMonthEndCents > orgBudgetCents;
+  const projectedPct =
+    orgBudgetCents != null && orgBudgetCents > 0
+      ? Math.round((projectedMonthEndCents / orgBudgetCents) * 100)
+      : null;
+
+  const tiles: KpiTile[] = [
+    {
+      label: `Total · ${monthLabel}`,
+      value: formatCurrency(totalCents),
+      caption:
+        priorMonthCents > 0
+          ? `Prior month ${formatCurrency(priorMonthCents)}`
+          : "First month with data",
+    },
+    {
+      label: "MoM Delta",
+      value:
+        momDeltaCents >= 0
+          ? `+${formatCurrency(momDeltaCents)}`
+          : `-${formatCurrency(Math.abs(momDeltaCents))}`,
+      caption: momCaption,
+      tone: momDeltaPct === null ? "default" : momDeltaPct >= 0 ? "success" : "danger",
+    },
+    {
+      label: "Projected Month-End",
+      value: formatCurrency(projectedMonthEndCents),
+      caption:
+        orgBudgetCents == null
+          ? "No org budget set"
+          : isOverBudget
+          ? `${projectedPct}% of ${formatCurrency(orgBudgetCents)} budget`
+          : `${projectedPct ?? 0}% of ${formatCurrency(orgBudgetCents)} budget`,
+      tone: isOverBudget ? "danger" : projectedPct != null && projectedPct >= 80 ? "warn" : "default",
+      ring: isOverBudget,
+      icon: isOverBudget ? <AlertTriangle className="size-3 text-destructive" /> : undefined,
+    },
+    {
+      label: "Workspaces Over 80%",
+      value: (
+        <span>
+          {workspacesOverEightyCount}
+          <span className="text-base font-medium text-muted-foreground">
+            {" "}
+            / {workspacesWithLimitCount}
+          </span>
+        </span>
+      ),
+      caption:
+        workspacesOverEightyCount === 0
+          ? "All within limits"
+          : topOverWorkspaceName && topOverWorkspaceUtilizationPct != null
+          ? `${topOverWorkspaceName} · ${topOverWorkspaceUtilizationPct}%`
+          : null,
+      tone: workspacesOverEightyCount > 0 ? "warn" : "default",
+    },
+  ];
+  return tiles;
+}

--- a/src/components/claude/org-credits-panel.tsx
+++ b/src/components/claude/org-credits-panel.tsx
@@ -12,22 +12,19 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { setOrgBillingBudget } from "@/actions/anthropic-global";
 import { toast } from "sonner";
-import type { OrgCreditsStatus } from "@/types";
 import { formatCurrency } from "@/lib/utils";
-import { Info } from "lucide-react";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 
-type OrgCreditsPanelProps = {
+type OrgBillingBudgetCardProps = {
   orgConfig: { billingBudgetLimitCents: number | null } | null;
   currentMonthTotalCents: number;
-  creditsStatus: OrgCreditsStatus;
+  projectedMonthEndCents: number;
 };
 
-export function OrgCreditsPanel({
+export function OrgBillingBudgetCard({
   orgConfig,
   currentMonthTotalCents,
-  creditsStatus,
-}: OrgCreditsPanelProps) {
+  projectedMonthEndCents,
+}: OrgBillingBudgetCardProps) {
   const [editing, setEditing] = useState(false);
   const [inputValue, setInputValue] = useState(
     orgConfig?.billingBudgetLimitCents != null
@@ -58,61 +55,92 @@ export function OrgCreditsPanel({
     limitCents != null && limitCents > 0
       ? Math.round((currentMonthTotalCents / limitCents) * 100)
       : null;
+  const projectedPct =
+    limitCents != null && limitCents > 0
+      ? Math.round((projectedMonthEndCents / limitCents) * 100)
+      : null;
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Monthly Billing Budget</CardTitle>
-          <CardDescription>
-            Org-wide monthly spend limit for Claude API usage.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <p className="text-sm text-muted-foreground">Current month spend</p>
-              <p className="text-xl font-semibold tabular-nums">
-                {formatCurrency(currentMonthTotalCents)}
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Monthly Billing Budget</CardTitle>
+        <CardDescription>
+          Org-wide monthly spend limit for Claude API usage.{" "}
+          <a
+            href="https://console.anthropic.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-4"
+          >
+            Credit balance is not exposed by the Anthropic API — view in console.
+          </a>
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-6 md:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">
+              Current spend
+            </p>
+            <p className="mt-1 text-xl font-semibold tabular-nums">
+              {formatCurrency(currentMonthTotalCents)}
+            </p>
+            {limitCents != null && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {utilizationPct ?? 0}% of {formatCurrency(limitCents)} budget
               </p>
-              {limitCents != null && (
-                <div className="mt-1 space-y-1">
-                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-                    <div
-                      className={`h-full rounded-full transition-all ${
-                        (utilizationPct ?? 0) >= 100
-                          ? "bg-destructive"
-                          : (utilizationPct ?? 0) >= 80
-                          ? "bg-yellow-500"
-                          : "bg-primary"
-                      }`}
-                      style={{ width: `${Math.min(utilizationPct ?? 0, 100)}%` }}
-                    />
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {utilizationPct ?? 0}% of {formatCurrency(limitCents)} budget
-                  </p>
-                </div>
-              )}
-            </div>
+            )}
+          </div>
 
-            <div className="flex shrink-0 items-center gap-2">
-              {editing ? (
-                <>
-                  <div className="flex items-center gap-1">
-                    <span className="text-sm text-muted-foreground">$</span>
-                    <Input
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      value={inputValue}
-                      onChange={(e) => setInputValue(e.target.value)}
-                      className="w-32"
-                      placeholder="No limit"
-                      aria-label="Monthly billing budget limit in dollars"
-                      autoFocus
-                    />
-                  </div>
+          <div>
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">
+              Projected month-end
+            </p>
+            <p
+              className={`mt-1 text-xl font-semibold tabular-nums ${
+                projectedPct != null && projectedPct >= 100
+                  ? "text-destructive"
+                  : projectedPct != null && projectedPct >= 80
+                  ? "text-amber-500"
+                  : ""
+              }`}
+            >
+              {formatCurrency(projectedMonthEndCents)}
+            </p>
+            {limitCents != null && (
+              <p
+                className={`mt-1 text-xs ${
+                  projectedPct != null && projectedPct >= 100
+                    ? "text-destructive"
+                    : "text-muted-foreground"
+                }`}
+              >
+                {projectedPct ?? 0}% of {formatCurrency(limitCents)} budget
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col items-start justify-start gap-2">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">
+              Budget
+            </p>
+            {editing ? (
+              <>
+                <div className="flex w-full items-center gap-1">
+                  <span className="text-sm text-muted-foreground">$</span>
+                  <Input
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                    className="w-32"
+                    placeholder="No limit"
+                    aria-label="Monthly billing budget limit in dollars"
+                    autoFocus
+                  />
+                </div>
+                <div className="flex gap-2">
                   <Button size="sm" onClick={handleSave} disabled={isPending}>
                     {isPending ? "Saving…" : "Save"}
                   </Button>
@@ -124,44 +152,38 @@ export function OrgCreditsPanel({
                   >
                     Cancel
                   </Button>
-                </>
-              ) : (
-                <>
-                  <span className="text-sm text-muted-foreground">
-                    {limitCents != null ? formatCurrency(limitCents) : "No budget set"}
-                  </span>
-                  <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
-                    {limitCents != null ? "Edit budget" : "Set budget"}
-                  </Button>
-                </>
-              )}
+                </div>
+              </>
+            ) : (
+              <div className="flex w-full items-center justify-between gap-2">
+                <p className="text-xl font-semibold tabular-nums">
+                  {limitCents != null ? formatCurrency(limitCents) : "—"}
+                </p>
+                <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
+                  {limitCents != null ? "Edit" : "Set"}
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {limitCents != null && (
+          <div className="mt-4 space-y-1">
+            <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className={`h-full rounded-full transition-all ${
+                  (utilizationPct ?? 0) >= 100
+                    ? "bg-destructive"
+                    : (utilizationPct ?? 0) >= 80
+                    ? "bg-amber-500"
+                    : "bg-primary"
+                }`}
+                style={{ width: `${Math.min(utilizationPct ?? 0, 100)}%` }}
+              />
             </div>
           </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Credit Balance</CardTitle>
-          <CardDescription>Remaining Anthropic credits for this org.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Alert>
-            <Info className="size-4" />
-            <AlertDescription>
-              Credit balance is not available via the Anthropic API.{" "}
-              <a
-                href="https://console.anthropic.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline underline-offset-4"
-              >
-                View in Anthropic Console
-              </a>
-            </AlertDescription>
-          </Alert>
-        </CardContent>
-      </Card>
-    </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/claude/sync-status-pill.tsx
+++ b/src/components/claude/sync-status-pill.tsx
@@ -22,7 +22,10 @@ export function SyncStatusPill({ status, className }: SyncStatusPillProps) {
     label = `Stale · ${formatDistanceToNow(lastSyncedAt, { addSuffix: true })}`;
   } else {
     tone = "green";
-    label = `Synced ${formatDistanceToNow(lastSyncedAt, { addSuffix: true })}`;
+    // Hourly cron — surface "next in Xm" for predictability.
+    const ageMin = status.ageMinutes ?? 0;
+    const nextIn = Math.max(0, 60 - ageMin);
+    label = `Synced ${formatDistanceToNow(lastSyncedAt, { addSuffix: true })} · next in ${nextIn}m`;
   }
 
   const toneClass =

--- a/src/components/claude/sync-status-pill.tsx
+++ b/src/components/claude/sync-status-pill.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { cn } from "@/lib/utils";
+import type { SyncStatus } from "@/types";
+
+type SyncStatusPillProps = {
+  status: SyncStatus;
+  className?: string;
+};
+
+export function SyncStatusPill({ status, className }: SyncStatusPillProps) {
+  const { lastSyncedAt, isStale } = status;
+
+  let tone: "green" | "amber" | "grey";
+  let label: string;
+
+  if (!lastSyncedAt) {
+    tone = "grey";
+    label = "Never synced";
+  } else if (isStale) {
+    tone = "amber";
+    label = `Stale · ${formatDistanceToNow(lastSyncedAt, { addSuffix: true })}`;
+  } else {
+    tone = "green";
+    label = `Synced ${formatDistanceToNow(lastSyncedAt, { addSuffix: true })}`;
+  }
+
+  const toneClass =
+    tone === "green"
+      ? "bg-emerald-950/40 text-emerald-400 border-emerald-800"
+      : tone === "amber"
+      ? "bg-amber-950/40 text-amber-400 border-amber-800"
+      : "bg-muted text-muted-foreground border-muted-foreground/20";
+
+  const dotClass =
+    tone === "green"
+      ? "bg-emerald-500"
+      : tone === "amber"
+      ? "bg-amber-500"
+      : "bg-muted-foreground";
+
+  return (
+    <Link
+      href="/settings/sync"
+      aria-live="polite"
+      aria-label={`Anthropic sync status: ${label}`}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors hover:opacity-90",
+        toneClass,
+        className
+      )}
+    >
+      <span className={cn("size-1.5 rounded-full", dotClass)} aria-hidden />
+      <span>{label}</span>
+    </Link>
+  );
+}

--- a/src/components/claude/top-movers-chips.tsx
+++ b/src/components/claude/top-movers-chips.tsx
@@ -1,0 +1,31 @@
+import { TrendingUp } from "lucide-react";
+import type { TopMover } from "@/types";
+
+type TopMoversChipsProps = {
+  movers: TopMover[];
+};
+
+export function TopMoversChips({ movers }: TopMoversChipsProps) {
+  if (movers.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No growing workspaces (none have grown 6mo at &gt; $5 prior).
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {movers.map((m) => (
+        <span
+          key={m.workspaceId ?? "__default__"}
+          className="inline-flex items-center gap-1 rounded-md border border-destructive/40 bg-destructive/5 px-2 py-1 text-xs text-destructive"
+          title={`${m.name}: $${(m.priorCents / 100).toFixed(0)} → $${(m.currentCents / 100).toFixed(0)} over 6 months`}
+        >
+          <TrendingUp className="size-3" />
+          <span className="font-medium">{m.name}</span>
+          <span>+{m.deltaPct}%</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/claude/top-movers-chips.tsx
+++ b/src/components/claude/top-movers-chips.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { TrendingUp } from "lucide-react";
 import type { TopMover } from "@/types";
 
@@ -16,15 +17,16 @@ export function TopMoversChips({ movers }: TopMoversChipsProps) {
   return (
     <div className="flex flex-wrap items-center gap-2">
       {movers.map((m) => (
-        <span
+        <Link
           key={m.workspaceId ?? "__default__"}
-          className="inline-flex items-center gap-1 rounded-md border border-destructive/40 bg-destructive/5 px-2 py-1 text-xs text-destructive"
+          href={`/claude/workspaces/${m.workspaceId ?? "default"}`}
+          className="inline-flex items-center gap-1 rounded-md border border-destructive/40 bg-destructive/5 px-2 py-1 text-xs text-destructive transition-colors hover:bg-destructive/10"
           title={`${m.name}: $${(m.priorCents / 100).toFixed(0)} → $${(m.currentCents / 100).toFixed(0)} over 6 months`}
         >
           <TrendingUp className="size-3" />
           <span className="font-medium">{m.name}</span>
           <span>+{m.deltaPct}%</span>
-        </span>
+        </Link>
       ))}
     </div>
   );

--- a/src/components/claude/top-movers-chips.tsx
+++ b/src/components/claude/top-movers-chips.tsx
@@ -20,11 +20,14 @@ export function TopMoversChips({ movers }: TopMoversChipsProps) {
         <Link
           key={m.workspaceId ?? "__default__"}
           href={`/claude/workspaces/${m.workspaceId ?? "default"}`}
-          className="inline-flex items-center gap-1 rounded-md border border-destructive/40 bg-destructive/5 px-2 py-1 text-xs text-destructive transition-colors hover:bg-destructive/10"
+          className="inline-flex items-center gap-1.5 rounded-md border border-destructive/40 bg-destructive/5 px-2 py-1 text-xs text-destructive transition-colors hover:bg-destructive/10"
           title={`${m.name}: $${(m.priorCents / 100).toFixed(0)} → $${(m.currentCents / 100).toFixed(0)} over 6 months`}
         >
           <TrendingUp className="size-3" />
           <span className="font-medium">{m.name}</span>
+          <span className="text-muted-foreground">
+            ${(m.priorCents / 100).toFixed(0)} → ${(m.currentCents / 100).toFixed(0)}
+          </span>
           <span>+{m.deltaPct}%</span>
         </Link>
       ))}

--- a/src/components/claude/twelve-month-bar-chart.tsx
+++ b/src/components/claude/twelve-month-bar-chart.tsx
@@ -19,7 +19,7 @@ const config: ChartConfig = {
 const GREY_RAMP = ["#a1a1aa", "#71717a", "#52525b", "#3f3f46"] as const;
 
 function fillForAge(monthsBack: number, overCap: boolean): string {
-  if (overCap) return "hsl(var(--destructive))";
+  if (overCap) return "var(--destructive)";
   if (monthsBack === 0) return "var(--chart-1)";
   if (monthsBack <= 2) return GREY_RAMP[0];
   if (monthsBack <= 5) return GREY_RAMP[1];
@@ -116,9 +116,9 @@ export function TwelveMonthBarChart({
           {cap != null && (
             <ReferenceLine
               y={cap / 100}
-              stroke="hsl(var(--destructive))"
+              stroke="var(--destructive)"
               strokeDasharray="3 3"
-              label={{ value: `Budget ${formatCurrency(cap)}`, position: "insideTopRight", fill: "hsl(var(--destructive))", fontSize: 10 }}
+              label={{ value: `Budget ${formatCurrency(cap)}`, position: "insideTopRight", fill: "var(--destructive)", fontSize: 10 }}
             />
           )}
           <ChartTooltip

--- a/src/components/claude/twelve-month-bar-chart.tsx
+++ b/src/components/claude/twelve-month-bar-chart.tsx
@@ -12,9 +12,38 @@ import { formatCurrency } from "@/lib/utils";
 
 const config: ChartConfig = {
   total: { label: "Spend", color: "var(--chart-1)" },
+  projected: { label: "Projected", color: "var(--chart-1)" },
 };
 
-export function TwelveMonthBarChart({ rows }: { rows: TwelveMonthRow[] }) {
+// Greyscale ramp by month age, matching mockup.html:392-404.
+const GREY_RAMP = ["#a1a1aa", "#71717a", "#52525b", "#3f3f46"] as const;
+
+function fillForAge(monthsBack: number, overCap: boolean): string {
+  if (overCap) return "hsl(var(--destructive))";
+  if (monthsBack === 0) return "var(--chart-1)";
+  if (monthsBack <= 2) return GREY_RAMP[0];
+  if (monthsBack <= 5) return GREY_RAMP[1];
+  if (monthsBack <= 7) return GREY_RAMP[2];
+  return GREY_RAMP[3];
+}
+
+function monthLabel(month: string): string {
+  const [y, m] = month.split("-");
+  return new Date(Number(y), Number(m) - 1, 1).toLocaleString("en-US", {
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export function TwelveMonthBarChart({
+  rows,
+  currentMonth,
+  projectedMonthEndCents,
+}: {
+  rows: TwelveMonthRow[];
+  currentMonth: string;
+  projectedMonthEndCents: number;
+}) {
   if (rows.length === 0) {
     return (
       <p className="py-10 text-center text-sm text-muted-foreground">
@@ -23,57 +52,141 @@ export function TwelveMonthBarChart({ rows }: { rows: TwelveMonthRow[] }) {
     );
   }
   const cap = rows[0]?.budgetLimitCents ?? null;
+  const lastIdx = rows.length - 1;
 
-  const data = rows.map((r) => ({
-    month: r.month,
-    total: r.totalCents / 100,
-    overCap: cap != null && r.totalCents > cap,
-  }));
+  const data = rows.map((r, i) => {
+    const monthsBack = lastIdx - i;
+    const isCurrent = r.month === currentMonth;
+    const overCap = cap != null && r.totalCents > cap;
+    const total = r.totalCents / 100;
+    const projectedStub =
+      isCurrent && projectedMonthEndCents > r.totalCents
+        ? (projectedMonthEndCents - r.totalCents) / 100
+        : null;
+    return {
+      month: r.month,
+      total,
+      projected: projectedStub,
+      fill: fillForAge(monthsBack, overCap),
+    };
+  });
+
+  const firstLabel = monthLabel(rows[0].month);
+  const lastLabel = monthLabel(rows[lastIdx].month);
+
+  const maxStackedValue = data.reduce(
+    (acc, d) => Math.max(acc, d.total + (d.projected ?? 0)),
+    0
+  );
+  const yMax =
+    (cap != null
+      ? Math.max(maxStackedValue, cap / 100)
+      : maxStackedValue) * 1.1;
 
   return (
-    <ChartContainer config={config} className="h-[220px] w-full">
-      <BarChart data={data} accessibilityLayer margin={{ top: 12, right: 8, bottom: 0, left: 8 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis
-          dataKey="month"
-          tickLine={false}
-          axisLine={false}
-          tickMargin={6}
-          tickFormatter={(value: string) => {
-            const [, m] = value.split("-");
-            return new Date(2000, Number(m) - 1, 1).toLocaleString("en-US", { month: "short" });
-          }}
-        />
-        <YAxis
-          tickLine={false}
-          axisLine={false}
-          tickMargin={6}
-          tickFormatter={(value: number) => `$${value.toFixed(0)}`}
-        />
-        {cap != null && (
-          <ReferenceLine
-            y={cap / 100}
-            stroke="hsl(var(--destructive))"
-            strokeDasharray="3 3"
-            label={{ value: `Budget ${formatCurrency(cap)}`, position: "insideTopRight", fill: "hsl(var(--destructive))", fontSize: 10 }}
+    <div className="space-y-3">
+      <div className="flex items-baseline justify-between text-xs">
+        <span className="font-semibold uppercase tracking-wider text-muted-foreground">
+          Monthly totals
+        </span>
+        <span className="text-muted-foreground">
+          {firstLabel} → {lastLabel} (projected)
+        </span>
+      </div>
+      <ChartContainer config={config} className="h-[220px] w-full">
+        <BarChart data={data} accessibilityLayer margin={{ top: 12, right: 8, bottom: 0, left: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="month"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={6}
+            tickFormatter={(value: string) => {
+              const [, m] = value.split("-");
+              return new Date(2000, Number(m) - 1, 1).toLocaleString("en-US", { month: "short" });
+            }}
           />
-        )}
-        <ChartTooltip
-          content={
-            <ChartTooltipContent
-              formatter={(value) => `$${Number(value).toFixed(2)}`}
+          <YAxis
+            domain={[0, yMax]}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={6}
+            tickFormatter={(value: number) => `$${value.toFixed(0)}`}
+          />
+          {cap != null && (
+            <ReferenceLine
+              y={cap / 100}
+              stroke="hsl(var(--destructive))"
+              strokeDasharray="3 3"
+              label={{ value: `Budget ${formatCurrency(cap)}`, position: "insideTopRight", fill: "hsl(var(--destructive))", fontSize: 10 }}
             />
-          }
+          )}
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                formatter={(value) =>
+                  value == null ? "—" : `$${Number(value).toFixed(2)}`
+                }
+              />
+            }
+          />
+          <Bar dataKey="total" stackId="month" radius={[0, 0, 0, 0]}>
+            {data.map((d, i) => (
+              <Cell key={`actual-${i}`} fill={d.fill} />
+            ))}
+          </Bar>
+          <Bar dataKey="projected" stackId="month" radius={[4, 4, 0, 0]}>
+            {data.map((d, i) => (
+              <Cell
+                key={`proj-${i}`}
+                fill="var(--chart-1)"
+                fillOpacity={0.28}
+                stroke="var(--chart-1)"
+                strokeOpacity={0.6}
+                strokeDasharray="3 3"
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ChartContainer>
+      <ul className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+        <LegendSwatch color="var(--chart-1)" label="this month" />
+        <LegendSwatch
+          color="var(--chart-1)"
+          label="projected"
+          opacity={0.28}
+          dashed
         />
-        <Bar dataKey="total" radius={[4, 4, 0, 0]}>
-          {data.map((d, i) => (
-            <Cell
-              key={i}
-              fill={d.overCap ? "hsl(var(--destructive))" : "var(--chart-1)"}
-            />
-          ))}
-        </Bar>
-      </BarChart>
-    </ChartContainer>
+        <LegendSwatch color={GREY_RAMP[0]} label="prior month" />
+        <LegendSwatch color={GREY_RAMP[3]} label="older" />
+      </ul>
+    </div>
+  );
+}
+
+function LegendSwatch({
+  color,
+  label,
+  opacity = 1,
+  dashed = false,
+}: {
+  color: string;
+  label: string;
+  opacity?: number;
+  dashed?: boolean;
+}) {
+  return (
+    <li className="flex items-center gap-1.5">
+      <span
+        aria-hidden
+        className="inline-block h-2.5 w-3 rounded-sm"
+        style={{
+          backgroundColor: color,
+          opacity,
+          border: dashed ? `1px dashed ${color}` : undefined,
+        }}
+      />
+      {label}
+    </li>
   );
 }

--- a/src/components/claude/twelve-month-bar-chart.tsx
+++ b/src/components/claude/twelve-month-bar-chart.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, ReferenceLine, XAxis, YAxis, Cell } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
+import type { TwelveMonthRow } from "@/types";
+import { formatCurrency } from "@/lib/utils";
+
+const config: ChartConfig = {
+  total: { label: "Spend", color: "var(--chart-1)" },
+};
+
+export function TwelveMonthBarChart({ rows }: { rows: TwelveMonthRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-muted-foreground">
+        No historical data yet.
+      </p>
+    );
+  }
+  const cap = rows[0]?.budgetLimitCents ?? null;
+
+  const data = rows.map((r) => ({
+    month: r.month,
+    total: r.totalCents / 100,
+    overCap: cap != null && r.totalCents > cap,
+  }));
+
+  return (
+    <ChartContainer config={config} className="h-[220px] w-full">
+      <BarChart data={data} accessibilityLayer margin={{ top: 12, right: 8, bottom: 0, left: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          tickFormatter={(value: string) => {
+            const [, m] = value.split("-");
+            return new Date(2000, Number(m) - 1, 1).toLocaleString("en-US", { month: "short" });
+          }}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          tickFormatter={(value: number) => `$${value.toFixed(0)}`}
+        />
+        {cap != null && (
+          <ReferenceLine
+            y={cap / 100}
+            stroke="hsl(var(--destructive))"
+            strokeDasharray="3 3"
+            label={{ value: `Budget ${formatCurrency(cap)}`, position: "insideTopRight", fill: "hsl(var(--destructive))", fontSize: 10 }}
+          />
+        )}
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              formatter={(value) => `$${Number(value).toFixed(2)}`}
+            />
+          }
+        />
+        <Bar dataKey="total" radius={[4, 4, 0, 0]}>
+          {data.map((d, i) => (
+            <Cell
+              key={i}
+              fill={d.overCap ? "hsl(var(--destructive))" : "var(--chart-1)"}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/src/components/claude/workspace-budget-list.tsx
+++ b/src/components/claude/workspace-budget-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import {
   Card,
   CardContent,
@@ -10,10 +10,14 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { ChevronRight } from "lucide-react";
 import { setWorkspaceLimit } from "@/actions/anthropic-global";
 import { toast } from "sonner";
 import type { WorkspaceListItem } from "@/types";
-import { formatCurrency } from "@/lib/utils";
+import { cn, formatCurrency } from "@/lib/utils";
+
+const HIDE_ZERO_STORAGE_KEY = "claude-hide-zero-workspaces";
 
 type WorkspaceBudgetRowProps = {
   workspace: WorkspaceListItem;
@@ -29,7 +33,10 @@ function WorkspaceBudgetRow({ workspace }: WorkspaceBudgetRowProps) {
   function handleSave() {
     startTransition(async () => {
       const dollars = parseFloat(inputValue);
-      const limitCents = isNaN(dollars) || inputValue.trim() === "" ? null : Math.round(dollars * 100);
+      const limitCents =
+        isNaN(dollars) || inputValue.trim() === ""
+          ? null
+          : Math.round(dollars * 100);
       try {
         const result = await setWorkspaceLimit(workspace.workspaceId, limitCents);
         if (result.success) {
@@ -44,40 +51,72 @@ function WorkspaceBudgetRow({ workspace }: WorkspaceBudgetRowProps) {
     });
   }
 
-  const utilizationColor =
-    workspace.utilizationPct == null
-      ? ""
-      : workspace.utilizationPct >= 100
-      ? "bg-destructive"
-      : workspace.utilizationPct >= 80
-      ? "bg-yellow-500"
-      : "";
+  const pct = workspace.utilizationPct;
+  const isOver = pct != null && pct >= 100;
+  const isWarn = pct != null && pct >= 80 && pct < 100;
+  const barClass = isOver
+    ? "bg-destructive"
+    : isWarn
+    ? "bg-amber-500"
+    : "bg-primary";
 
   return (
-    <div className="flex items-center justify-between gap-4 py-3">
+    <div className="group flex items-center justify-between gap-4 py-3">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
+          <span
+            className="size-2 shrink-0 rounded-full"
+            style={{ backgroundColor: workspace.displayColor ?? "#a1a1aa" }}
+            aria-hidden
+          />
           <span className="truncate font-medium">{workspace.name}</span>
           {workspace.isDefault && (
             <Badge variant="secondary" className="shrink-0 text-xs">
               Default
             </Badge>
           )}
+          {isOver && (
+            <Badge variant="destructive" className="shrink-0 text-xs">
+              Over budget
+            </Badge>
+          )}
+          {isWarn && (
+            <Badge
+              variant="outline"
+              className="shrink-0 border-amber-500 text-amber-500 text-xs"
+            >
+              {pct}%
+            </Badge>
+          )}
+          <button
+            type="button"
+            className="ml-auto opacity-0 transition-opacity group-hover:opacity-60 hover:!opacity-100"
+            title="Drill into workspace (Phase 3)"
+            aria-label={`Drill into ${workspace.name}`}
+            disabled
+          >
+            <ChevronRight className="size-4" />
+          </button>
         </div>
-        <p className="text-sm text-muted-foreground">
-          {formatCurrency(workspace.currentMonthCents)} this month
-        </p>
+        <div className="mt-1 flex items-baseline gap-3">
+          <span className="text-xl font-semibold tabular-nums">
+            {formatCurrency(workspace.currentMonthCents)}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            of{" "}
+            {workspace.limitCents != null
+              ? formatCurrency(workspace.limitCents)
+              : "no limit"}
+          </span>
+        </div>
         {workspace.limitCents != null && (
-          <div className="mt-1 space-y-1">
+          <div className="mt-1.5 space-y-1">
             <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
               <div
-                className={`h-full rounded-full transition-all ${utilizationColor || "bg-primary"}`}
+                className={cn("h-full rounded-full transition-all", barClass)}
                 style={{ width: `${Math.min(workspace.utilizationPct ?? 0, 100)}%` }}
               />
             </div>
-            <p className="text-xs text-muted-foreground">
-              {workspace.utilizationPct ?? 0}% of {formatCurrency(workspace.limitCents)} limit
-            </p>
           </div>
         )}
       </div>
@@ -112,18 +151,9 @@ function WorkspaceBudgetRow({ workspace }: WorkspaceBudgetRowProps) {
             </Button>
           </>
         ) : (
-          <>
-            <span className="text-sm text-muted-foreground">
-              {workspace.limitCents != null ? formatCurrency(workspace.limitCents) : "No limit"}
-            </span>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setEditing(true)}
-            >
-              Set limit
-            </Button>
-          </>
+          <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
+            {workspace.limitCents != null ? "Edit limit" : "Set limit"}
+          </Button>
         )}
       </div>
     </div>
@@ -135,6 +165,40 @@ type WorkspaceBudgetListProps = {
 };
 
 export function WorkspaceBudgetList({ workspaces }: WorkspaceBudgetListProps) {
+  const [hideZero, setHideZero] = useState(true);
+  const [hydrated, setHydrated] = useState(false);
+  const [showHidden, setShowHidden] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(HIDE_ZERO_STORAGE_KEY);
+      if (stored != null) setHideZero(stored === "true");
+    } catch {
+      // ignore
+    }
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(HIDE_ZERO_STORAGE_KEY, String(hideZero));
+    } catch {
+      // ignore
+    }
+  }, [hideZero, hydrated]);
+
+  const { visible, hidden } = useMemo(() => {
+    if (!hideZero) return { visible: workspaces, hidden: [] as WorkspaceListItem[] };
+    const v: WorkspaceListItem[] = [];
+    const h: WorkspaceListItem[] = [];
+    for (const w of workspaces) {
+      if (w.currentMonthCents === 0 && w.limitCents == null) h.push(w);
+      else v.push(w);
+    }
+    return { visible: v, hidden: h };
+  }, [hideZero, workspaces]);
+
   if (workspaces.length === 0) {
     return (
       <Card>
@@ -147,18 +211,49 @@ export function WorkspaceBudgetList({ workspaces }: WorkspaceBudgetListProps) {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Workspace Monthly Limits</CardTitle>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+        <CardTitle className="text-base">Workspace Budgets</CardTitle>
+        <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+          <span>Hide $0 + no limit</span>
+          <Switch
+            checked={hideZero}
+            onCheckedChange={setHideZero}
+            aria-label="Hide workspaces with $0 spend and no limit"
+          />
+        </label>
       </CardHeader>
       <CardContent>
         <div className="divide-y">
-          {workspaces.map((ws) => (
+          {visible.map((ws) => (
             <WorkspaceBudgetRow
               key={ws.workspaceId ?? "__default__"}
               workspace={ws}
             />
           ))}
         </div>
+        {hidden.length > 0 && (
+          <div className="pt-3">
+            <button
+              type="button"
+              className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+              onClick={() => setShowHidden((s) => !s)}
+            >
+              {showHidden
+                ? `Hide ${hidden.length} workspace${hidden.length === 1 ? "" : "s"} with no spend`
+                : `Show ${hidden.length} hidden workspace${hidden.length === 1 ? "" : "s"}`}
+            </button>
+            {showHidden && (
+              <div className="mt-2 divide-y">
+                {hidden.map((ws) => (
+                  <WorkspaceBudgetRow
+                    key={ws.workspaceId ?? "__default__"}
+                    workspace={ws}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/claude/workspace-budget-list.tsx
+++ b/src/components/claude/workspace-budget-list.tsx
@@ -44,16 +44,34 @@ function PaceLabel({ workspace }: { workspace: WorkspaceListItem }) {
   );
 }
 
+/**
+ * Inclusive calendar-month distance between two "YYYY-MM" strings.
+ * `"2026-03"` → `"2026-05"` returns 3 (Mar, Apr, May).
+ */
+function calendarMonthsCovered(firstMonth: string, lastMonth: string): number {
+  const [fy, fm] = firstMonth.split("-").map(Number);
+  const [ly, lm] = lastMonth.split("-").map(Number);
+  return (ly - fy) * 12 + (lm - fm) + 1;
+}
+
 function SparklineDeltaLabel({
   months,
 }: {
   months: { month: string; totalCents: number }[];
 }) {
   if (months.length < 2) {
-    return <span className="text-[10px] text-muted-foreground">—</span>;
+    return <span className="text-[10px] text-muted-foreground">new</span>;
   }
+  // The window number reflects the *calendar distance* between the two data
+  // points being compared (first ↔ last), not the count of entries — that
+  // keeps the label in lockstep with the percentage. E.g., a workspace with
+  // data only in Jan + May renders "Nmo" where N is 5 calendar months apart.
   const first = months[0].totalCents;
   const last = months[months.length - 1].totalCents;
+  const windowMonths = calendarMonthsCovered(
+    months[0].month,
+    months[months.length - 1].month
+  );
   if (first === 0 && last === 0) {
     return <span className="text-[10px] text-muted-foreground">flat</span>;
   }
@@ -71,7 +89,7 @@ function SparklineDeltaLabel({
     >
       {big ? "▲ " : ""}
       {pct >= 0 ? "+" : ""}
-      {pct}% 6mo
+      {pct}% {windowMonths}mo
     </span>
   );
 }
@@ -127,7 +145,12 @@ function WorkspaceBudgetRow({ workspace, sparkline }: WorkspaceBudgetRowProps) {
             style={{ backgroundColor: workspace.displayColor ?? "#a1a1aa" }}
             aria-hidden
           />
-          <span className="truncate font-medium">{workspace.name}</span>
+          <Link
+            href={`/claude/workspaces/${workspace.workspaceId ?? "default"}`}
+            className="truncate font-medium underline-offset-4 transition-colors hover:text-primary hover:underline"
+          >
+            {workspace.name}
+          </Link>
           {workspace.isDefault && (
             <Badge variant="secondary" className="shrink-0 text-xs">
               Default

--- a/src/components/claude/workspace-budget-list.tsx
+++ b/src/components/claude/workspace-budget-list.tsx
@@ -17,9 +17,64 @@ import { setWorkspaceLimit } from "@/actions/anthropic-global";
 import { Sparkline } from "@/components/ui/sparkline";
 import { toast } from "sonner";
 import type { WorkspaceListItem, WorkspaceSparkline } from "@/types";
-import { cn, formatCurrency } from "@/lib/utils";
+import { cn, formatCurrency, projectMonthEnd } from "@/lib/utils";
+import { getDaysInMonth, getDate } from "date-fns";
 
 const HIDE_ZERO_STORAGE_KEY = "claude-hide-zero-workspaces";
+
+function PaceLabel({ workspace }: { workspace: WorkspaceListItem }) {
+  if (workspace.limitCents == null || workspace.limitCents <= 0) return null;
+  const now = new Date();
+  const daysInMonth = getDaysInMonth(now);
+  const daysElapsed = Math.max(1, getDate(now));
+  const projected = projectMonthEnd(
+    workspace.currentMonthCents,
+    daysElapsed,
+    daysInMonth
+  );
+  const pacePct = Math.round((projected / workspace.limitCents) * 100);
+  const overPace = pacePct >= 100;
+  return (
+    <p className="text-xs text-muted-foreground">
+      {workspace.utilizationPct ?? 0}% ·{" "}
+      <span className={overPace ? "text-destructive" : ""}>
+        on pace {formatCurrency(projected)} ({pacePct}%)
+      </span>
+    </p>
+  );
+}
+
+function SparklineDeltaLabel({
+  months,
+}: {
+  months: { month: string; totalCents: number }[];
+}) {
+  if (months.length < 2) {
+    return <span className="text-[10px] text-muted-foreground">—</span>;
+  }
+  const first = months[0].totalCents;
+  const last = months[months.length - 1].totalCents;
+  if (first === 0 && last === 0) {
+    return <span className="text-[10px] text-muted-foreground">flat</span>;
+  }
+  if (first < 500) {
+    return <span className="text-[10px] text-muted-foreground">new</span>;
+  }
+  const pct = Math.round(((last - first) / first) * 100);
+  const big = pct >= 100;
+  return (
+    <span
+      className={cn(
+        "text-[10px]",
+        big ? "text-amber-500 font-medium" : "text-muted-foreground"
+      )}
+    >
+      {big ? "▲ " : ""}
+      {pct >= 0 ? "+" : ""}
+      {pct}% 6mo
+    </span>
+  );
+}
 
 type WorkspaceBudgetRowProps = {
   workspace: WorkspaceListItem;
@@ -93,7 +148,7 @@ function WorkspaceBudgetRow({ workspace, sparkline }: WorkspaceBudgetRowProps) {
           )}
           <Link
             href={`/claude/workspaces/${workspace.workspaceId ?? "default"}`}
-            className="ml-auto opacity-0 transition-opacity group-hover:opacity-60 hover:!opacity-100"
+            className="ml-auto text-muted-foreground transition-colors hover:text-foreground"
             title="Drill into workspace"
             aria-label={`Drill into ${workspace.name}`}
           >
@@ -119,17 +174,19 @@ function WorkspaceBudgetRow({ workspace, sparkline }: WorkspaceBudgetRowProps) {
                 style={{ width: `${Math.min(workspace.utilizationPct ?? 0, 100)}%` }}
               />
             </div>
+            <PaceLabel workspace={workspace} />
           </div>
         )}
       </div>
 
-      <div className="hidden shrink-0 items-center gap-3 md:flex">
+      <div className="hidden shrink-0 flex-col items-center gap-1 md:flex">
         <Sparkline
           data={(sparkline?.months ?? []).map((m) => m.totalCents / 100)}
           color={workspace.displayColor ?? "currentColor"}
           ariaLabel={`6-month trend for ${workspace.name}`}
           className="text-muted-foreground"
         />
+        <SparklineDeltaLabel months={sparkline?.months ?? []} />
       </div>
 
       <div className="flex shrink-0 items-center gap-2">

--- a/src/components/claude/workspace-budget-list.tsx
+++ b/src/components/claude/workspace-budget-list.tsx
@@ -13,17 +13,19 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { ChevronRight } from "lucide-react";
 import { setWorkspaceLimit } from "@/actions/anthropic-global";
+import { Sparkline } from "@/components/ui/sparkline";
 import { toast } from "sonner";
-import type { WorkspaceListItem } from "@/types";
+import type { WorkspaceListItem, WorkspaceSparkline } from "@/types";
 import { cn, formatCurrency } from "@/lib/utils";
 
 const HIDE_ZERO_STORAGE_KEY = "claude-hide-zero-workspaces";
 
 type WorkspaceBudgetRowProps = {
   workspace: WorkspaceListItem;
+  sparkline?: WorkspaceSparkline;
 };
 
-function WorkspaceBudgetRow({ workspace }: WorkspaceBudgetRowProps) {
+function WorkspaceBudgetRow({ workspace, sparkline }: WorkspaceBudgetRowProps) {
   const [editing, setEditing] = useState(false);
   const [inputValue, setInputValue] = useState(
     workspace.limitCents != null ? String(workspace.limitCents / 100) : ""
@@ -121,6 +123,15 @@ function WorkspaceBudgetRow({ workspace }: WorkspaceBudgetRowProps) {
         )}
       </div>
 
+      <div className="hidden shrink-0 items-center gap-3 md:flex">
+        <Sparkline
+          data={(sparkline?.months ?? []).map((m) => m.totalCents / 100)}
+          color={workspace.displayColor ?? "currentColor"}
+          ariaLabel={`6-month trend for ${workspace.name}`}
+          className="text-muted-foreground"
+        />
+      </div>
+
       <div className="flex shrink-0 items-center gap-2">
         {editing ? (
           <>
@@ -162,9 +173,13 @@ function WorkspaceBudgetRow({ workspace }: WorkspaceBudgetRowProps) {
 
 type WorkspaceBudgetListProps = {
   workspaces: WorkspaceListItem[];
+  sparklines?: Record<string, WorkspaceSparkline>;
 };
 
-export function WorkspaceBudgetList({ workspaces }: WorkspaceBudgetListProps) {
+export function WorkspaceBudgetList({
+  workspaces,
+  sparklines,
+}: WorkspaceBudgetListProps) {
   const [hideZero, setHideZero] = useState(true);
   const [hydrated, setHydrated] = useState(false);
   const [showHidden, setShowHidden] = useState(false);
@@ -228,6 +243,7 @@ export function WorkspaceBudgetList({ workspaces }: WorkspaceBudgetListProps) {
             <WorkspaceBudgetRow
               key={ws.workspaceId ?? "__default__"}
               workspace={ws}
+              sparkline={sparklines?.[ws.workspaceId ?? "__default__"]}
             />
           ))}
         </div>

--- a/src/components/claude/workspace-budget-list.tsx
+++ b/src/components/claude/workspace-budget-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, useTransition } from "react";
+import Link from "next/link";
 import {
   Card,
   CardContent,
@@ -90,15 +91,14 @@ function WorkspaceBudgetRow({ workspace, sparkline }: WorkspaceBudgetRowProps) {
               {pct}%
             </Badge>
           )}
-          <button
-            type="button"
+          <Link
+            href={`/claude/workspaces/${workspace.workspaceId ?? "default"}`}
             className="ml-auto opacity-0 transition-opacity group-hover:opacity-60 hover:!opacity-100"
-            title="Drill into workspace (Phase 3)"
+            title="Drill into workspace"
             aria-label={`Drill into ${workspace.name}`}
-            disabled
           >
             <ChevronRight className="size-4" />
-          </button>
+          </Link>
         </div>
         <div className="mt-1 flex items-baseline gap-3">
           <span className="text-xl font-semibold tabular-nums">

--- a/src/components/claude/workspace-daily-chart.tsx
+++ b/src/components/claude/workspace-daily-chart.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, ReferenceLine, XAxis, YAxis } from "recharts";
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartConfig } from "@/components/ui/chart";
+import { formatCurrency } from "@/lib/utils";
 
 const config: ChartConfig = {
   cost: { label: "Daily spend", color: "var(--chart-1)" },
@@ -15,9 +16,15 @@ const config: ChartConfig = {
 export function WorkspaceDailyChart({
   dailyTotals,
   color,
+  limitCents,
+  daysInMonth,
 }: {
   dailyTotals: { date: string; costCents: number }[];
   color?: string | null;
+  /** Monthly limit in cents — drives the per-day prorated cap reference line. */
+  limitCents?: number | null;
+  /** Days in the selected month, used to prorate the monthly limit. */
+  daysInMonth?: number;
 }) {
   if (dailyTotals.length === 0) {
     return (
@@ -30,6 +37,23 @@ export function WorkspaceDailyChart({
     date: d.date,
     cost: d.costCents / 100,
   }));
+
+  const dailyCapDollars =
+    limitCents != null && daysInMonth && daysInMonth > 0
+      ? limitCents / 100 / daysInMonth
+      : null;
+
+  // Sub-dollar values lose precision under `toFixed(0)` — when the chart's
+  // max is below ~$5, switch to 2 decimals so ticks read e.g. "$0.50" not
+  // four duplicate "$1" labels.
+  const maxValue = data.reduce(
+    (acc, d) => Math.max(acc, d.cost),
+    dailyCapDollars ?? 0
+  );
+  const useFineTicks = maxValue < 5;
+  const fmtAxis = (v: number) =>
+    useFineTicks ? `$${v.toFixed(2)}` : `$${v.toFixed(0)}`;
+
   return (
     <ChartContainer config={config} className="h-[260px] w-full">
       <BarChart data={data} accessibilityLayer>
@@ -51,8 +75,21 @@ export function WorkspaceDailyChart({
           tickLine={false}
           axisLine={false}
           tickMargin={6}
-          tickFormatter={(v: number) => `$${v.toFixed(0)}`}
+          tickFormatter={fmtAxis}
         />
+        {dailyCapDollars != null && (
+          <ReferenceLine
+            y={dailyCapDollars}
+            stroke="var(--destructive)"
+            strokeDasharray="3 3"
+            label={{
+              value: `Daily cap ${formatCurrency(Math.round(dailyCapDollars * 100))}`,
+              position: "insideTopRight",
+              fill: "var(--destructive)",
+              fontSize: 10,
+            }}
+          />
+        )}
         <ChartTooltip
           content={
             <ChartTooltipContent
@@ -60,7 +97,12 @@ export function WorkspaceDailyChart({
             />
           }
         />
-        <Bar dataKey="cost" fill={color ?? "var(--chart-1)"} radius={[4, 4, 0, 0]} />
+        <Bar
+          dataKey="cost"
+          fill={color ?? "var(--chart-1)"}
+          radius={[4, 4, 0, 0]}
+          maxBarSize={56}
+        />
       </BarChart>
     </ChartContainer>
   );

--- a/src/components/claude/workspace-daily-chart.tsx
+++ b/src/components/claude/workspace-daily-chart.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
+
+const config: ChartConfig = {
+  cost: { label: "Daily spend", color: "var(--chart-1)" },
+};
+
+export function WorkspaceDailyChart({
+  dailyTotals,
+  color,
+}: {
+  dailyTotals: { date: string; costCents: number }[];
+  color?: string | null;
+}) {
+  if (dailyTotals.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-muted-foreground">
+        No daily data for this period.
+      </p>
+    );
+  }
+  const data = dailyTotals.map((d) => ({
+    date: d.date,
+    cost: d.costCents / 100,
+  }));
+  return (
+    <ChartContainer config={config} className="h-[260px] w-full">
+      <BarChart data={data} accessibilityLayer>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          tickFormatter={(value: string) => {
+            const d = new Date(value + "T00:00:00");
+            return d.toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+            });
+          }}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          tickFormatter={(v: number) => `$${v.toFixed(0)}`}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              formatter={(value) => `$${Number(value).toFixed(2)}`}
+            />
+          }
+        />
+        <Bar dataKey="cost" fill={color ?? "var(--chart-1)"} radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/src/components/claude/workspace-model-breakdown.tsx
+++ b/src/components/claude/workspace-model-breakdown.tsx
@@ -88,6 +88,11 @@ export function WorkspaceModelBreakdown({
           ))}
         </TableBody>
       </Table>
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        Model-level totals come from Anthropic&apos;s usage endpoint and may not
+        exactly match the workspace headline cost (different rounding and
+        aggregation windows).
+      </p>
     </div>
   );
 }

--- a/src/components/claude/workspace-model-breakdown.tsx
+++ b/src/components/claude/workspace-model-breakdown.tsx
@@ -1,0 +1,93 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { ModelBreakdownRow } from "@/types";
+import { formatCurrency } from "@/lib/utils";
+
+const PALETTE = [
+  "#c084fc",
+  "#67e8f9",
+  "#86efac",
+  "#fcd34d",
+  "#f9a8d4",
+  "#93c5fd",
+];
+
+export function WorkspaceModelBreakdown({
+  rows,
+}: {
+  rows: ModelBreakdownRow[];
+}) {
+  if (rows.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        No model-level data for this workspace.
+      </p>
+    );
+  }
+
+  const total = rows.reduce((s, r) => s + r.costCents, 0);
+
+  return (
+    <div className="space-y-3">
+      <div
+        className="flex h-3 w-full overflow-hidden rounded-full bg-muted"
+        role="img"
+        aria-label="Stacked bar showing model cost distribution"
+      >
+        {rows.map((r, i) => {
+          const widthPct = total === 0 ? 0 : (r.costCents / total) * 100;
+          return (
+            <div
+              key={r.modelName}
+              style={{
+                width: `${widthPct}%`,
+                backgroundColor: PALETTE[i % PALETTE.length],
+              }}
+              title={`${r.modelName} · ${formatCurrency(r.costCents)} · ${r.pctOfWorkspace}%`}
+            />
+          );
+        })}
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Model</TableHead>
+            <TableHead className="text-right">Tokens In</TableHead>
+            <TableHead className="text-right">Tokens Out</TableHead>
+            <TableHead className="text-right">Cost</TableHead>
+            <TableHead className="text-right">% Workspace</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((r, i) => (
+            <TableRow key={r.modelName}>
+              <TableCell className="font-medium">
+                <span className="mr-2 inline-block size-2 rounded-sm align-middle" style={{ backgroundColor: PALETTE[i % PALETTE.length] }} />
+                {r.modelName}
+              </TableCell>
+              <TableCell className="text-right tabular-nums text-muted-foreground">
+                {r.tokensIn.toLocaleString()}
+              </TableCell>
+              <TableCell className="text-right tabular-nums text-muted-foreground">
+                {r.tokensOut.toLocaleString()}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatCurrency(r.costCents)}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {r.pctOfWorkspace}%
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/claude/workspace-top-users.tsx
+++ b/src/components/claude/workspace-top-users.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { WorkspaceUser } from "@/types";
+import { formatCurrency } from "@/lib/utils";
+
+export function WorkspaceTopUsers({ users }: { users: WorkspaceUser[] }) {
+  if (users.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        No per-user data yet for this workspace.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>User</TableHead>
+            <TableHead className="text-right">Tokens</TableHead>
+            <TableHead className="text-right">Cost</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {users.map((u) => (
+            <TableRow key={u.userId}>
+              <TableCell className="font-medium">
+                <Link
+                  href={`/profile?userId=${u.userId}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="hover:underline"
+                >
+                  {u.name || u.email}
+                </Link>
+                <p className="text-xs text-muted-foreground">{u.email}</p>
+              </TableCell>
+              <TableCell className="text-right tabular-nums text-muted-foreground">
+                {u.requestCount.toLocaleString()}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {formatCurrency(u.costCents)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <p className="px-1 text-[11px] text-muted-foreground">
+        Per-user totals come from Anthropic&apos;s usage endpoint and will not
+        exactly match the workspace headline cost (different rounding and
+        aggregation windows). Mid-month workspace moves attribute historical
+        usage to the user&apos;s current workspace.
+      </p>
+    </div>
+  );
+}

--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@/lib/utils";
+
+type SparklineProps = {
+  data: number[];
+  color?: string;
+  height?: number;
+  width?: number;
+  ariaLabel?: string;
+  className?: string;
+};
+
+/**
+ * Hand-rolled inline-SVG sparkline. Avoids Recharts' instance overhead
+ * when rendering many sparklines (e.g. per-workspace row).
+ *
+ * Renders an em-dash when fewer than 2 data points are available.
+ */
+export function Sparkline({
+  data,
+  color = "currentColor",
+  height = 28,
+  width = 96,
+  ariaLabel,
+  className,
+}: SparklineProps) {
+  if (data.length < 2) {
+    return (
+      <span
+        role="img"
+        aria-label={ariaLabel ?? "Insufficient data for sparkline"}
+        className={cn("inline-block text-muted-foreground", className)}
+        style={{ width, height }}
+      >
+        —
+      </span>
+    );
+  }
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const stepX = data.length === 1 ? width : width / (data.length - 1);
+  const points = data
+    .map((v, i) => {
+      const x = i * stepX;
+      const y = height - ((v - min) / range) * height;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg
+      role="img"
+      aria-label={
+        ariaLabel ??
+        `Sparkline showing trend across ${data.length} data points`
+      }
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={cn("overflow-visible", className)}
+      style={{ color }}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx={(data.length - 1) * stepX}
+        cy={height - ((data[data.length - 1] - min) / range) * height}
+        r="1.5"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/src/lib/anthropic-keys.ts
+++ b/src/lib/anthropic-keys.ts
@@ -8,6 +8,9 @@ export const orgApiKeySchema = z.object({
   partial_key_hint: z.string(),
   status: z.string(),
   type: z.string(),
+  // Anthropic returns null for keys in the org's default workspace; that
+  // null is meaningful and must be preserved as null (not coerced to a string).
+  workspace_id: z.string().nullable().optional().default(null),
 });
 
 export const orgApiKeysResponseSchema = z.object({

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -202,13 +202,21 @@ export async function resolveAllMappings(): Promise<Map<string, number>> {
         const apiKeyId = resolveApiKeyId(decrypted, orgKeys);
         if (apiKeyId) {
           mapping.set(apiKeyId, u.userId);
-          // Upsert sync status with resolved ID
+          // Look up the workspace_id of the matched org key. Anthropic returns
+          // null for keys in the default workspace — preserve that as SQL NULL.
+          const orgKey = orgKeys.find((k) => k.id === apiKeyId);
+          const workspaceId = orgKey?.workspace_id ?? null;
+          // Upsert sync status with resolved ID + workspace_id
           await db
             .insert(anthropicSyncStatus)
-            .values({ userId: u.userId, resolvedApiKeyId: apiKeyId })
+            .values({
+              userId: u.userId,
+              resolvedApiKeyId: apiKeyId,
+              resolvedWorkspaceId: workspaceId,
+            })
             .onConflictDoUpdate({
               target: [anthropicSyncStatus.userId],
-              set: { resolvedApiKeyId: apiKeyId },
+              set: { resolvedApiKeyId: apiKeyId, resolvedWorkspaceId: workspaceId },
             });
         }
       } catch (err) {

--- a/src/lib/db/migrations/0018_messy_sleepwalker.sql
+++ b/src/lib/db/migrations/0018_messy_sleepwalker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "anthropic_sync_status" ADD COLUMN "resolved_workspace_id" varchar(100);

--- a/src/lib/db/migrations/meta/0018_snapshot.json
+++ b/src/lib/db/migrations/meta/0018_snapshot.json
@@ -1,0 +1,3594 @@
+{
+  "id": "f0ad84b9-a6bf-4b2b-8958-3cc146f276bc",
+  "prevId": "13abc984-57a7-4d76-80fc-2a2d4a74cc94",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_tiers": {
+      "name": "access_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_cost_cents": {
+          "name": "monthly_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_tiers_tool_id_idx": {
+          "name": "access_tiers_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_tiers_tool_name_idx": {
+          "name": "access_tiers_tool_name_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_tiers_tool_id_ai_tools_id_fk": {
+          "name": "access_tiers_tool_id_ai_tools_id_fk",
+          "tableFrom": "access_tiers",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tools": {
+      "name": "ai_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_licenses": {
+          "name": "max_licenses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tool_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_tools_name_idx": {
+          "name": "ai_tools_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_vendor_idx": {
+          "name": "ai_tools_vendor_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.annual_budgets": {
+      "name": "annual_budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fiscal_year": {
+          "name": "fiscal_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_cents": {
+          "name": "total_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "budget_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annual_budgets_fiscal_year_idx": {
+          "name": "annual_budgets_fiscal_year_idx",
+          "columns": [
+            {
+              "expression": "fiscal_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annual_budgets_status_idx": {
+          "name": "annual_budgets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_org_config": {
+      "name": "anthropic_org_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "billing_budget_limit_cents": {
+          "name": "billing_budget_limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anthropic_org_config_updated_by_users_id_fk": {
+          "name": "anthropic_org_config_updated_by_users_id_fk",
+          "tableFrom": "anthropic_org_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_org_config_id_check": {
+          "name": "anthropic_org_config_id_check",
+          "value": "\"anthropic_org_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_sync_status": {
+      "name": "anthropic_sync_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_days": {
+          "name": "synced_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_api_key_id": {
+          "name": "resolved_api_key_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_workspace_id": {
+          "name": "resolved_workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sync_completed_at": {
+          "name": "workspace_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "anthropic_sync_status_user_id_idx": {
+          "name": "anthropic_sync_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_usage_metrics": {
+      "name": "anthropic_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncached_input_tokens": {
+          "name": "uncached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_cost_cents": {
+          "name": "computed_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pricing_resolved": {
+          "name": "pricing_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_usage_metrics_user_date_model_idx": {
+          "name": "anthropic_usage_metrics_user_date_model_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_user_date_idx": {
+          "name": "anthropic_usage_metrics_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_date_idx": {
+          "name": "anthropic_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_pricing_resolved_idx": {
+          "name": "anthropic_usage_metrics_pricing_resolved_idx",
+          "columns": [
+            {
+              "expression": "pricing_resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anthropic_usage_metrics_user_id_users_id_fk": {
+          "name": "anthropic_usage_metrics_user_id_users_id_fk",
+          "tableFrom": "anthropic_usage_metrics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_costs": {
+      "name": "anthropic_workspace_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_costs_workspace_date_idx": {
+          "name": "anthropic_workspace_costs_workspace_date_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_default_date_idx": {
+          "name": "anthropic_workspace_costs_default_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_date_idx": {
+          "name": "anthropic_workspace_costs_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_workspace_id_idx": {
+          "name": "anthropic_workspace_costs_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_workspace_costs_cost_cents_check": {
+          "name": "anthropic_workspace_costs_cost_cents_check",
+          "value": "\"anthropic_workspace_costs\".\"cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_limits": {
+      "name": "anthropic_workspace_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_cents": {
+          "name": "limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_limits_workspace_id_idx": {
+          "name": "anthropic_workspace_limits_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_limits_default_idx": {
+          "name": "anthropic_workspace_limits_default_idx",
+          "columns": [
+            {
+              "expression": "(1)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspaces": {
+      "name": "anthropic_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_color": {
+          "name": "display_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_created_at": {
+          "name": "anthropic_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspaces_workspace_id_idx": {
+          "name": "anthropic_workspaces_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspaces\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspaces_is_default_idx": {
+          "name": "anthropic_workspaces_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspaces\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspaces_archived_idx": {
+          "name": "anthropic_workspaces_archived_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assignment_comments": {
+      "name": "assignment_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assignment_comments_assignment_id_idx": {
+          "name": "assignment_comments_assignment_id_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_comments_author_id_idx": {
+          "name": "assignment_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_comments_created_at_idx": {
+          "name": "assignment_comments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assignment_comments_assignment_id_license_assignments_id_fk": {
+          "name": "assignment_comments_assignment_id_license_assignments_id_fk",
+          "tableFrom": "assignment_comments",
+          "tableTo": "license_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_comments_author_id_users_id_fk": {
+          "name": "assignment_comments_author_id_users_id_fk",
+          "tableFrom": "assignment_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billed_costs": {
+      "name": "billed_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor_reference": {
+          "name": "vendor_reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billed_costs_period_id_idx": {
+          "name": "billed_costs_period_id_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billed_costs_invoice_date_idx": {
+          "name": "billed_costs_invoice_date_idx",
+          "columns": [
+            {
+              "expression": "invoice_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billed_costs_period_id_budget_periods_id_fk": {
+          "name": "billed_costs_period_id_budget_periods_id_fk",
+          "tableFrom": "billed_costs",
+          "tableTo": "budget_periods",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_periods": {
+      "name": "budget_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_amount_cents": {
+          "name": "planned_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_periods_budget_id_idx": {
+          "name": "budget_periods_budget_id_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_periods_budget_period_idx": {
+          "name": "budget_periods_budget_period_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_periods_budget_id_annual_budgets_id_fk": {
+          "name": "budget_periods_budget_id_annual_budgets_id_fk",
+          "tableFrom": "budget_periods",
+          "tableTo": "annual_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_history": {
+      "name": "change_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "change_history_entity_idx": {
+          "name": "change_history_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_history_changed_by_idx": {
+          "name": "change_history_changed_by_idx",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_history_created_at_idx": {
+          "name": "change_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_history_changed_by_users_id_fk": {
+          "name": "change_history_changed_by_users_id_fk",
+          "tableFrom": "change_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_billing_snapshots": {
+      "name": "copilot_billing_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_month": {
+          "name": "billing_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seats": {
+          "name": "total_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_seats": {
+          "name": "active_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_cost_cents": {
+          "name": "seat_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost_cents": {
+          "name": "total_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_billing_snapshots_connection_month_idx": {
+          "name": "copilot_billing_snapshots_connection_month_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_billing_snapshots_connection_id_github_connections_id_fk": {
+          "name": "copilot_billing_snapshots_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_billing_snapshots",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_usage_metrics": {
+      "name": "copilot_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_engaged_users": {
+          "name": "total_engaged_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_suggestions": {
+          "name": "total_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_acceptances": {
+          "name": "total_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_suggested": {
+          "name": "total_lines_suggested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_accepted": {
+          "name": "total_lines_accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_chat_turns": {
+          "name": "total_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_chat_acceptances": {
+          "name": "total_chat_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_dotcom_chat_turns": {
+          "name": "total_dotcom_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pr_summaries": {
+          "name": "total_pr_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_breakdown": {
+          "name": "language_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_breakdown": {
+          "name": "editor_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_usage_metrics_connection_date_idx": {
+          "name": "copilot_usage_metrics_connection_date_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_usage_metrics_date_idx": {
+          "name": "copilot_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_usage_metrics_connection_id_github_connections_id_fk": {
+          "name": "copilot_usage_metrics_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_usage_metrics",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_login": {
+          "name": "org_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_avatar_url": {
+          "name": "org_avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_scopes_csv": {
+          "name": "token_scopes_csv",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_sync_enabled": {
+          "name": "copilot_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "copilot_sync_schedule": {
+          "name": "copilot_sync_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        }
+      },
+      "indexes": {
+        "github_connections_status_idx": {
+          "name": "github_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_connections_connected_by_users_id_fk": {
+          "name": "github_connections_connected_by_users_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_profiles": {
+      "name": "github_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_profiles_user_id_idx": {
+          "name": "github_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_profiles_github_id_idx": {
+          "name": "github_profiles_github_id_idx",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_profiles_github_login_idx": {
+          "name": "github_profiles_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_profiles_user_id_users_id_fk": {
+          "name": "github_profiles_user_id_users_id_fk",
+          "tableFrom": "github_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sync_events": {
+      "name": "github_sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_members": {
+          "name": "total_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manually_matched_count": {
+          "name": "manually_matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "copilot_sync_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "seats_processed": {
+          "name": "seats_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_processed": {
+          "name": "metrics_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_processed": {
+          "name": "billing_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_linked": {
+          "name": "billing_linked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_skipped": {
+          "name": "billing_skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_sync_events_connection_id_idx": {
+          "name": "github_sync_events_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_sync_events_triggered_by_idx": {
+          "name": "github_sync_events_triggered_by_idx",
+          "columns": [
+            {
+              "expression": "triggered_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sync_events_connection_id_github_connections_id_fk": {
+          "name": "github_sync_events_connection_id_github_connections_id_fk",
+          "tableFrom": "github_sync_events",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_sync_events_triggered_by_users_id_fk": {
+          "name": "github_sync_events_triggered_by_users_id_fk",
+          "tableFrom": "github_sync_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_filters": {
+      "name": "ingestion_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "filter_field",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "filter_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_filters_enabled_idx": {
+          "name": "ingestion_filters_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_filters_created_by_users_id_fk": {
+          "name": "ingestion_filters_created_by_users_id_fk",
+          "tableFrom": "ingestion_filters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_log": {
+      "name": "ingestion_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "ingestion_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "ingestion_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_invoice_id": {
+          "name": "linked_invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_log_outcome_idx": {
+          "name": "ingestion_log_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_log_created_at_idx": {
+          "name": "ingestion_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_log_vendor_idx": {
+          "name": "ingestion_log_vendor_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_log_channel_idx": {
+          "name": "ingestion_log_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_log_linked_invoice_id_invoices_id_fk": {
+          "name": "ingestion_log_linked_invoice_id_invoices_id_fk",
+          "tableFrom": "ingestion_log",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "linked_invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ingestion_log_uploaded_by_users_id_fk": {
+          "name": "ingestion_log_uploaded_by_users_id_fk",
+          "tableFrom": "ingestion_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_tokens": {
+      "name": "invite_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_token_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_tokens_token_hash_idx": {
+          "name": "invite_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_tokens_user_id_idx": {
+          "name": "invite_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_tokens_active_user_idx": {
+          "name": "invite_tokens_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_tokens\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_tokens_user_id_users_id_fk": {
+          "name": "invite_tokens_user_id_users_id_fk",
+          "tableFrom": "invite_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_billed_cost_id": {
+          "name": "linked_billed_cost_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filtered_out": {
+          "name": "filtered_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_created_at_idx": {
+          "name": "invoices_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_linked_billed_cost_id_idx": {
+          "name": "invoices_linked_billed_cost_id_idx",
+          "columns": [
+            {
+              "expression": "linked_billed_cost_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_billed_cost_id_billed_costs_id_fk": {
+          "name": "invoices_linked_billed_cost_id_billed_costs_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "billed_costs",
+          "columnsFrom": [
+            "linked_billed_cost_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invoices_uploaded_by_users_id_fk": {
+          "name": "invoices_uploaded_by_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_assignments": {
+      "name": "license_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_at_assignment_cents": {
+          "name": "cost_at_assignment_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace": {
+          "name": "workspace",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "license_assignments_user_id_idx": {
+          "name": "license_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_tool_id_idx": {
+          "name": "license_assignments_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_tier_id_idx": {
+          "name": "license_assignments_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_status_idx": {
+          "name": "license_assignments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_active_lookup_idx": {
+          "name": "license_assignments_active_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_assignments_user_id_users_id_fk": {
+          "name": "license_assignments_user_id_users_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_assignments_tool_id_ai_tools_id_fk": {
+          "name": "license_assignments_tool_id_ai_tools_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_assignments_tier_id_access_tiers_id_fk": {
+          "name": "license_assignments_tier_id_access_tiers_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "access_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_events": {
+      "name": "sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "sync_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "backfill_start_date": {
+          "name": "backfill_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sync_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_events_source_type_idx": {
+          "name": "sync_events_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_outcome_idx": {
+          "name": "sync_events_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_started_at_idx": {
+          "name": "sync_events_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_source_started_idx": {
+          "name": "sync_events_source_started_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_events_triggered_by_users_id_fk": {
+          "name": "sync_events_triggered_by_users_id_fk",
+          "tableFrom": "sync_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_sources": {
+      "name": "sync_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cron_schedule": {
+          "name": "cron_schedule",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_sources_source_type_idx": {
+          "name": "sync_sources_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circle": {
+          "name": "circle",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"theme\":\"system\"}'::jsonb"
+        },
+        "profile": {
+          "name": "profile",
+          "type": "user_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_agent": {
+          "name": "is_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_circle_idx": {
+          "name": "users_circle_idx",
+          "columns": [
+            {
+              "expression": "circle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_status_idx": {
+          "name": "users_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.budget_status": {
+      "name": "budget_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.change_type": {
+      "name": "change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "deleted",
+        "status_change"
+      ]
+    },
+    "public.copilot_sync_type": {
+      "name": "copilot_sync_type",
+      "schema": "public",
+      "values": [
+        "members",
+        "copilot"
+      ]
+    },
+    "public.filter_field": {
+      "name": "filter_field",
+      "schema": "public",
+      "values": [
+        "vendor",
+        "invoice_number"
+      ]
+    },
+    "public.filter_mode": {
+      "name": "filter_mode",
+      "schema": "public",
+      "values": [
+        "whitelist",
+        "blacklist"
+      ]
+    },
+    "public.github_connection_status": {
+      "name": "github_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disconnected"
+      ]
+    },
+    "public.github_sync_status": {
+      "name": "github_sync_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.ingestion_channel": {
+      "name": "ingestion_channel",
+      "schema": "public",
+      "values": [
+        "manual",
+        "api",
+        "bulk"
+      ]
+    },
+    "public.ingestion_outcome": {
+      "name": "ingestion_outcome",
+      "schema": "public",
+      "values": [
+        "success",
+        "failed",
+        "filtered"
+      ]
+    },
+    "public.invite_token_status": {
+      "name": "invite_token_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "consumed",
+        "invalidated"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "quarterly"
+      ]
+    },
+    "public.sync_operation_type": {
+      "name": "sync_operation_type",
+      "schema": "public",
+      "values": [
+        "regular",
+        "backfill"
+      ]
+    },
+    "public.sync_outcome": {
+      "name": "sync_outcome",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "success",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.sync_source_type": {
+      "name": "sync_source_type",
+      "schema": "public",
+      "values": [
+        "github_copilot_billing",
+        "anthropic_api_usage",
+        "anthropic_team_invoices",
+        "github_members",
+        "invoice_period_matching",
+        "anthropic_api_costs"
+      ]
+    },
+    "public.tool_status": {
+      "name": "tool_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "public",
+      "values": [
+        "boost",
+        "maxed",
+        "indie"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "viewer"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -1,132 +1,139 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1772536082534,
-			"tag": "0000_yielding_phil_sheldon",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1772556093144,
-			"tag": "0001_white_skin",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1772723265843,
-			"tag": "0002_outstanding_kronos",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1772723109634,
-			"tag": "0003_peaceful_unus",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1772734135272,
-			"tag": "0004_powerful_virginia_dare",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1772935200000,
-			"tag": "0005_fix_preferences_default",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1772935200001,
-			"tag": "0006_shallow_ronan",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1773064780340,
-			"tag": "0007_cold_marrow",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1773153607432,
-			"tag": "0008_bright_captain_marvel",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1773135718632,
-			"tag": "0009_quick_namor",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1774024602162,
-			"tag": "0010_naive_joshua_kane",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1774483200000,
-			"tag": "0011_fix_period_end_dates",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1774362118117,
-			"tag": "0012_flashy_metal_master",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1774617761000,
-			"tag": "0013_add_anthropic_workspace_columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1774523819181,
-			"tag": "0014_giant_santa_claus",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1774699200000,
-			"tag": "0015_add_ingestion_log",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1777555673717,
-			"tag": "0016_thick_titania",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1777555881406,
-			"tag": "0017_add_is_agent_to_users",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1772536082534,
+      "tag": "0000_yielding_phil_sheldon",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1772556093144,
+      "tag": "0001_white_skin",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772723265843,
+      "tag": "0002_outstanding_kronos",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772723109634,
+      "tag": "0003_peaceful_unus",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1772734135272,
+      "tag": "0004_powerful_virginia_dare",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772935200000,
+      "tag": "0005_fix_preferences_default",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1772935200001,
+      "tag": "0006_shallow_ronan",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1773064780340,
+      "tag": "0007_cold_marrow",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1773153607432,
+      "tag": "0008_bright_captain_marvel",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1773135718632,
+      "tag": "0009_quick_namor",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1774024602162,
+      "tag": "0010_naive_joshua_kane",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1774483200000,
+      "tag": "0011_fix_period_end_dates",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1774362118117,
+      "tag": "0012_flashy_metal_master",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1774617761000,
+      "tag": "0013_add_anthropic_workspace_columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1774523819181,
+      "tag": "0014_giant_santa_claus",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1774699200000,
+      "tag": "0015_add_ingestion_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1777555673717,
+      "tag": "0016_thick_titania",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1777555881406,
+      "tag": "0017_add_is_agent_to_users",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1778854766149,
+      "tag": "0018_messy_sleepwalker",
+      "breakpoints": true
+    }
+  ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -575,6 +575,7 @@ export const anthropicSyncStatus = pgTable(
     lastSyncError: varchar("last_sync_error", { length: 500 }),
     syncedDays: integer("synced_days").notNull().default(0),
     resolvedApiKeyId: varchar("resolved_api_key_id", { length: 100 }),
+    resolvedWorkspaceId: varchar("resolved_workspace_id", { length: 100 }),
     workspaceSyncCompletedAt: timestamp("workspace_sync_completed_at"),
   },
   (table) => [uniqueIndex("anthropic_sync_status_user_id_idx").on(table.userId)]

--- a/src/lib/sync/sources/anthropic-workspace.ts
+++ b/src/lib/sync/sources/anthropic-workspace.ts
@@ -209,28 +209,42 @@ async function fetchAndUpsertWorkspaceCosts(month: string): Promise<number> {
 
   const dailyRows = aggregateDailyCosts(buckets);
 
-  let upserted = 0;
-  for (const { workspaceId, date, costCents } of dailyRows) {
-    if (workspaceId) {
-      await db.execute(sql`
-        INSERT INTO anthropic_workspace_costs (workspace_id, date, cost_cents)
-        VALUES (${workspaceId}, ${date}, ${costCents})
-        ON CONFLICT (workspace_id, date) WHERE workspace_id IS NOT NULL
-        DO UPDATE SET cost_cents = ${costCents}, updated_at = now()
-      `);
-    } else {
-      // Default workspace (null workspace_id)
-      await db.execute(sql`
-        INSERT INTO anthropic_workspace_costs (workspace_id, date, cost_cents)
-        VALUES (NULL, ${date}, ${costCents})
-        ON CONFLICT (date) WHERE workspace_id IS NULL
-        DO UPDATE SET cost_cents = ${costCents}, updated_at = now()
-      `);
-    }
-    upserted++;
+  // Batch upserts to one statement per partial-index bucket — without batching
+  // this loop would issue ~1800 round-trips on a 6-month backfill (rows × days).
+  // The two partial unique indexes (workspace_id IS NOT NULL / IS NULL) require
+  // two separate ON CONFLICT clauses, hence two batches.
+  const namedRows = dailyRows.filter((r) => r.workspaceId !== null);
+  const defaultRows = dailyRows.filter((r) => r.workspaceId === null);
+
+  if (namedRows.length > 0) {
+    const valuesSql = sql.join(
+      namedRows.map(
+        (r) => sql`(${r.workspaceId}, ${r.date}, ${r.costCents})`
+      ),
+      sql`, `
+    );
+    await db.execute(sql`
+      INSERT INTO anthropic_workspace_costs (workspace_id, date, cost_cents)
+      VALUES ${valuesSql}
+      ON CONFLICT (workspace_id, date) WHERE workspace_id IS NOT NULL
+      DO UPDATE SET cost_cents = EXCLUDED.cost_cents, updated_at = now()
+    `);
   }
 
-  return upserted;
+  if (defaultRows.length > 0) {
+    const valuesSql = sql.join(
+      defaultRows.map((r) => sql`(NULL, ${r.date}, ${r.costCents})`),
+      sql`, `
+    );
+    await db.execute(sql`
+      INSERT INTO anthropic_workspace_costs (workspace_id, date, cost_cents)
+      VALUES ${valuesSql}
+      ON CONFLICT (date) WHERE workspace_id IS NULL
+      DO UPDATE SET cost_cents = EXCLUDED.cost_cents, updated_at = now()
+    `);
+  }
+
+  return namedRows.length + defaultRows.length;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/sync/sources/anthropic-workspace.ts
+++ b/src/lib/sync/sources/anthropic-workspace.ts
@@ -91,6 +91,7 @@ async function fetchCostReport(
     const query = [
       `starting_at=${encodeURIComponent(startingAt)}`,
       `ending_at=${encodeURIComponent(endingAt)}`,
+      "bucket_width=1d",
       "group_by[]=workspace_id",
       ...(page ? [`page=${encodeURIComponent(page)}`] : []),
     ].join("&");
@@ -147,6 +148,41 @@ async function fetchAndUpsertWorkspaces(): Promise<number> {
   return response.data.length;
 }
 
+/**
+ * Aggregate a cost_report response into one entry per (workspace_id, day).
+ *
+ * Anthropic returns daily buckets (with `bucket_width=1d`) where each bucket's
+ * `results[]` is grouped by `workspace_id`. A single workspace may appear in
+ * multiple result rows of the same bucket (e.g., split by `cost_type`), which
+ * must be summed into a single per-day cost.
+ */
+export function aggregateDailyCosts(
+  buckets: z.infer<typeof costReportBucketSchema>[]
+): { workspaceId: string | null; date: string; costCents: number }[] {
+  // key: `${workspaceId ?? "__default__"}|${YYYY-MM-DD}`
+  const byKey = new Map<
+    string,
+    { workspaceId: string | null; date: string; costCents: number }
+  >();
+
+  for (const bucket of buckets) {
+    const date = bucket.starting_at.slice(0, 10); // "YYYY-MM-DDTHH:..." → "YYYY-MM-DD"
+    for (const r of bucket.results) {
+      const wsId = r.workspace_id ?? null;
+      const key = `${wsId ?? "__default__"}|${date}`;
+      const cents = Math.round(parseFloat(r.amount));
+      const existing = byKey.get(key);
+      if (existing) {
+        existing.costCents += cents;
+      } else {
+        byKey.set(key, { workspaceId: wsId, date, costCents: cents });
+      }
+    }
+  }
+
+  return Array.from(byKey.values());
+}
+
 async function fetchAndUpsertWorkspaceCosts(month: string): Promise<number> {
   // month format: YYYY-MM
   const startDate = `${month}-01T00:00:00Z`;
@@ -171,23 +207,14 @@ async function fetchAndUpsertWorkspaceCosts(month: string): Promise<number> {
     fetchCostReport(startDate, endDate)
   );
 
-  // Flatten all results across time buckets and aggregate per workspace
-  const allResults = buckets.flatMap(bucket => bucket.results);
-  const costByWorkspace = new Map<string | null, number>();
-  for (const r of allResults) {
-    const wsId = r.workspace_id ?? null;
-    const amountCents = Math.round(parseFloat(r.amount));
-    costByWorkspace.set(wsId, (costByWorkspace.get(wsId) ?? 0) + amountCents);
-  }
+  const dailyRows = aggregateDailyCosts(buckets);
 
   let upserted = 0;
-  const dateStr = `${month}-01`;
-
-  for (const [wsId, costCents] of costByWorkspace) {
-    if (wsId) {
+  for (const { workspaceId, date, costCents } of dailyRows) {
+    if (workspaceId) {
       await db.execute(sql`
         INSERT INTO anthropic_workspace_costs (workspace_id, date, cost_cents)
-        VALUES (${wsId}, ${dateStr}, ${costCents})
+        VALUES (${workspaceId}, ${date}, ${costCents})
         ON CONFLICT (workspace_id, date) WHERE workspace_id IS NOT NULL
         DO UPDATE SET cost_cents = ${costCents}, updated_at = now()
       `);
@@ -195,7 +222,7 @@ async function fetchAndUpsertWorkspaceCosts(month: string): Promise<number> {
       // Default workspace (null workspace_id)
       await db.execute(sql`
         INSERT INTO anthropic_workspace_costs (workspace_id, date, cost_cents)
-        VALUES (NULL, ${dateStr}, ${costCents})
+        VALUES (NULL, ${date}, ${costCents})
         ON CONFLICT (date) WHERE workspace_id IS NULL
         DO UPDATE SET cost_cents = ${costCents}, updated_at = now()
       `);

--- a/src/lib/sync/sources/anthropic-workspace.ts
+++ b/src/lib/sync/sources/anthropic-workspace.ts
@@ -1,6 +1,6 @@
 import { withSyncLock, retryWithBackoff, type SyncCounts } from "@/lib/sync/framework";
 import { db } from "@/lib/db";
-import { anthropicWorkspaceCosts } from "@/lib/db/schema";
+import { anthropicWorkspaceCosts, anthropicSyncStatus } from "@/lib/db/schema";
 import { sql } from "drizzle-orm";
 import { z } from "zod";
 import { ANTHROPIC_API_VERSION } from "@/lib/anthropic-constants";
@@ -319,6 +319,19 @@ export async function run(
         } catch (err) {
           appendError(counts, `Cost sync failed: ${err instanceof Error ? err.message : String(err)}`);
         }
+      }
+
+      // Stamp the sentinel row so getSyncStatus() (the dashboard's sync pill)
+      // reflects this workspace-cost sync. The user-keyed `lastSyncCompletedAt`
+      // is owned by the per-user usage sync; this column tracks the cost path.
+      if (counts.errorCount === 0) {
+        await db
+          .insert(anthropicSyncStatus)
+          .values({ userId: 0, workspaceSyncCompletedAt: new Date() })
+          .onConflictDoUpdate({
+            target: [anthropicSyncStatus.userId],
+            set: { workspaceSyncCompletedAt: new Date() },
+          });
       }
 
       return counts;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -50,6 +50,19 @@ export function getCurrentMonth(): string {
   return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
+/**
+ * Linear extrapolation of month-to-date spending to a projected month-end total.
+ * Returns 0 when daysElapsed is 0 to avoid divide-by-zero.
+ */
+export function projectMonthEnd(
+  mtdCents: number,
+  daysElapsed: number,
+  daysInMonth: number
+): number {
+  if (daysElapsed === 0) return 0;
+  return Math.round((mtdCents / daysElapsed) * daysInMonth);
+}
+
 export function formatDate(date: Date | string | null): string {
   if (!date) return "—";
   const d = typeof date === "string" ? new Date(date) : date;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -481,6 +481,39 @@ export interface GlobalCostDashboardData {
   }[];
 }
 
+// Spec 026 — Claude page redesign
+
+export interface DashboardKpis {
+  totalCents: number;
+  momDeltaCents: number;
+  momDeltaPct: number | null;
+  projectedMonthEndCents: number;
+  workspacesOverEightyCount: number;
+  workspacesWithLimitCount: number;
+  topOverWorkspaceName: string | null;
+  topOverWorkspaceUtilizationPct: number | null;
+  priorMonthCents: number;
+}
+
+export interface DailyStackedRow {
+  date: string;
+  perWorkspace: Record<string, number>;
+  total: number;
+}
+
+export interface StackedSeries {
+  key: string;
+  name: string;
+  color: string;
+  isOther: boolean;
+}
+
+export interface SyncStatus {
+  lastSyncedAt: Date | null;
+  ageMinutes: number | null;
+  isStale: boolean;
+}
+
 export interface WorkspaceListItem {
   workspaceId: string | null;
   name: string;
@@ -489,6 +522,7 @@ export interface WorkspaceListItem {
   currentMonthCents: number;
   limitCents: number | null;
   utilizationPct: number | null;
+  displayColor: string | null;
 }
 
 export interface WorkspaceAlert {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -543,6 +543,45 @@ export interface WorkspaceSparkline {
   months: { month: string; totalCents: number }[];
 }
 
+// Spec 026 — Phase 3 (workspace drill-through)
+
+export interface WorkspaceUser {
+  userId: number;
+  email: string;
+  name: string;
+  costCents: number;
+  requestCount: number;
+}
+
+export interface ModelBreakdownRow {
+  modelName: string;
+  tokensIn: number;
+  tokensOut: number;
+  costCents: number;
+  pctOfWorkspace: number;
+}
+
+export interface WorkspaceDetail {
+  workspace: {
+    id: string | null;
+    name: string;
+    isDefault: boolean;
+    displayColor: string | null;
+  };
+  month: string;
+  currentMonthCents: number;
+  priorMonthCents: number;
+  limitCents: number | null;
+  utilizationPct: number | null;
+  projectedMonthEndCents: number;
+  momDeltaCents: number;
+  momDeltaPct: number | null;
+  dailyTotals: { date: string; costCents: number }[];
+  topUsers: WorkspaceUser[];
+  modelBreakdown: ModelBreakdownRow[];
+  availableMonths: string[];
+}
+
 export interface WorkspaceListItem {
   workspaceId: string | null;
   name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -514,6 +514,35 @@ export interface SyncStatus {
   isStale: boolean;
 }
 
+export interface TwelveMonthRow {
+  month: string;
+  totalCents: number;
+  budgetLimitCents: number | null;
+}
+
+export interface PacingRow {
+  dayOfMonth: number;
+  current: number | null;
+  m1: number | null;
+  m2: number | null;
+  m3: number | null;
+}
+
+export interface TopMover {
+  workspaceId: string | null;
+  name: string;
+  priorCents: number;
+  currentCents: number;
+  deltaCents: number;
+  deltaPct: number;
+  direction: "up";
+}
+
+export interface WorkspaceSparkline {
+  workspaceKey: string;
+  months: { month: string; totalCents: number }[];
+}
+
 export interface WorkspaceListItem {
   workspaceId: string | null;
   name: string;

--- a/tests/integration/sync/workspace-costs.test.ts
+++ b/tests/integration/sync/workspace-costs.test.ts
@@ -6,6 +6,8 @@ describe("Workspace cost sync idempotency", () => {
   const testWorkspaceId = "test-ws-idempotent-" + Date.now();
   const testDate = "2020-01-01"; // Far past to avoid conflicts
   const testDateNull = "2020-01-02"; // Separate date for null workspace tests
+  const perDayWorkspaceId = "test-ws-per-day-" + Date.now();
+  const perDayDates = ["2020-02-01", "2020-02-02", "2020-02-03"];
 
   afterAll(async () => {
     // Cleanup test data
@@ -14,6 +16,9 @@ describe("Workspace cost sync idempotency", () => {
     );
     await db.execute(
       sql`DELETE FROM anthropic_workspace_costs WHERE workspace_id IS NULL AND date = ${testDateNull}`
+    );
+    await db.execute(
+      sql`DELETE FROM anthropic_workspace_costs WHERE workspace_id = ${perDayWorkspaceId}`
     );
   });
 
@@ -65,6 +70,47 @@ describe("Workspace cost sync idempotency", () => {
     );
     expect(rows.rows).toHaveLength(1);
     expect(rows.rows[0].cost_cents).toBe(500); // Last write wins
+  });
+
+  it("stores one row per (workspace_id, date) for a multi-day sync", async () => {
+    // Simulate the fixed sync writing per-day rows for the same workspace
+    // across three consecutive days.
+    for (const [i, date] of perDayDates.entries()) {
+      const cents = (i + 1) * 100; // 100, 200, 300
+      await db.execute(sql`
+        INSERT INTO anthropic_workspace_costs (workspace_id, date, cost_cents)
+        VALUES (${perDayWorkspaceId}, ${date}, ${cents})
+        ON CONFLICT (workspace_id, date) WHERE workspace_id IS NOT NULL
+        DO UPDATE SET cost_cents = ${cents}, updated_at = now()
+      `);
+    }
+
+    const rows = await db.execute(
+      sql`SELECT date::text AS date, cost_cents FROM anthropic_workspace_costs
+          WHERE workspace_id = ${perDayWorkspaceId}
+          ORDER BY date ASC`
+    );
+
+    expect(rows.rows).toHaveLength(3);
+    expect(rows.rows.map((r) => r.date)).toEqual(perDayDates);
+    expect(rows.rows.map((r) => Number(r.cost_cents))).toEqual([100, 200, 300]);
+
+    // Re-running the same upserts must not produce duplicates or change values.
+    for (const [i, date] of perDayDates.entries()) {
+      const cents = (i + 1) * 100;
+      await db.execute(sql`
+        INSERT INTO anthropic_workspace_costs (workspace_id, date, cost_cents)
+        VALUES (${perDayWorkspaceId}, ${date}, ${cents})
+        ON CONFLICT (workspace_id, date) WHERE workspace_id IS NOT NULL
+        DO UPDATE SET cost_cents = ${cents}, updated_at = now()
+      `);
+    }
+
+    const rerunRows = await db.execute(
+      sql`SELECT COUNT(*)::int AS count FROM anthropic_workspace_costs
+          WHERE workspace_id = ${perDayWorkspaceId}`
+    );
+    expect(Number(rerunRows.rows[0].count)).toBe(3);
   });
 
   it("handles default workspace (null workspace_id) upsert correctly", async () => {

--- a/tests/unit/anthropic-global-kpis.test.ts
+++ b/tests/unit/anthropic-global-kpis.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { projectMonthEnd } from "@/lib/utils";
+
+describe("projectMonthEnd", () => {
+  it("returns 0 when no days have elapsed", () => {
+    expect(projectMonthEnd(50_000, 0, 31)).toBe(0);
+  });
+
+  it("linearly extrapolates mid-month spending to full month", () => {
+    expect(projectMonthEnd(15_000, 15, 30)).toBe(30_000);
+  });
+
+  it("equals total when days elapsed equals days in month", () => {
+    expect(projectMonthEnd(42_000, 30, 30)).toBe(42_000);
+  });
+
+  it("rounds to the nearest cent", () => {
+    expect(projectMonthEnd(10_000, 3, 31)).toBe(103_333);
+  });
+
+  it("handles a 28-day February", () => {
+    expect(projectMonthEnd(7_000, 7, 28)).toBe(28_000);
+  });
+});
+
+describe("MoM math (mirrors getDashboardKpis)", () => {
+  function mom(curr: number, prior: number) {
+    const delta = curr - prior;
+    const pct = prior < 100 ? null : Math.round((delta / prior) * 100);
+    return { delta, pct };
+  }
+
+  it("returns null pct when prior month is below $1 floor", () => {
+    expect(mom(50_000, 99).pct).toBeNull();
+    expect(mom(50_000, 0).pct).toBeNull();
+  });
+
+  it("computes positive percent delta correctly", () => {
+    expect(mom(120_000, 100_000)).toEqual({ delta: 20_000, pct: 20 });
+  });
+
+  it("computes negative percent delta correctly", () => {
+    expect(mom(80_000, 100_000)).toEqual({ delta: -20_000, pct: -20 });
+  });
+});
+
+describe("Over-80% counting (mirrors getDashboardKpis loop)", () => {
+  type Row = { limitCents: number; currentCents: number };
+  function over80({ limitCents, currentCents }: Row): boolean {
+    if (limitCents <= 0) return false;
+    return Math.round((currentCents / limitCents) * 100) >= 80;
+  }
+
+  it("counts at exactly 80%", () => {
+    expect(over80({ limitCents: 10_000, currentCents: 8_000 })).toBe(true);
+  });
+
+  it("does not count at 79%", () => {
+    expect(over80({ limitCents: 10_000, currentCents: 7_900 })).toBe(false);
+  });
+
+  it("counts at 100%+", () => {
+    expect(over80({ limitCents: 10_000, currentCents: 12_500 })).toBe(true);
+  });
+});
+
+describe("Sync staleness boundary (mirrors getSyncStatus)", () => {
+  const STALE_MINUTES = 70;
+  function isStale(ageMinutes: number): boolean {
+    return ageMinutes > STALE_MINUTES;
+  }
+  it("70 minutes is still fresh", () => {
+    expect(isStale(70)).toBe(false);
+  });
+  it("71 minutes is stale", () => {
+    expect(isStale(71)).toBe(true);
+  });
+});

--- a/tests/unit/anthropic-phase2.test.ts
+++ b/tests/unit/anthropic-phase2.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+
+// These tests mirror the pure-math portions of Phase 2 server actions so they
+// can run without a live database. The SQL itself is covered in the e2e tests.
+
+describe("Top Movers ranking + $5 floor", () => {
+  type Bucket = { workspaceId: string; old: number; new: number };
+  function rank(rows: Bucket[]): { workspaceId: string; deltaPct: number }[] {
+    const out: { workspaceId: string; deltaPct: number }[] = [];
+    for (const r of rows) {
+      if (r.old < 500) continue;
+      const delta = r.new - r.old;
+      if (delta <= 0) continue;
+      out.push({ workspaceId: r.workspaceId, deltaPct: Math.round((delta / r.old) * 100) });
+    }
+    return out.sort((a, b) => b.deltaPct - a.deltaPct).slice(0, 3);
+  }
+
+  it("excludes workspaces whose prior period is below $5", () => {
+    const ranked = rank([
+      { workspaceId: "a", old: 100, new: 999 }, // <$5 prior → skipped
+      { workspaceId: "b", old: 600, new: 1_200 },
+    ]);
+    expect(ranked.map((r) => r.workspaceId)).toEqual(["b"]);
+  });
+
+  it("excludes workspaces whose delta is negative or zero", () => {
+    const ranked = rank([
+      { workspaceId: "down", old: 1_000, new: 800 },
+      { workspaceId: "flat", old: 1_000, new: 1_000 },
+      { workspaceId: "up", old: 1_000, new: 1_500 },
+    ]);
+    expect(ranked.map((r) => r.workspaceId)).toEqual(["up"]);
+  });
+
+  it("returns at most 3 workspaces sorted by deltaPct DESC", () => {
+    const ranked = rank([
+      { workspaceId: "a", old: 1_000, new: 2_000 },     // +100%
+      { workspaceId: "b", old: 1_000, new: 1_500 },     // +50%
+      { workspaceId: "c", old: 1_000, new: 5_000 },     // +400%
+      { workspaceId: "d", old: 1_000, new: 3_000 },     // +200%
+      { workspaceId: "e", old: 1_000, new: 1_100 },     // +10%
+    ]);
+    expect(ranked.map((r) => r.workspaceId)).toEqual(["c", "d", "a"]);
+  });
+});
+
+describe("Cumulative pacing math", () => {
+  function cumulate(daily: number[]): number[] {
+    const out: number[] = [];
+    let acc = 0;
+    for (const v of daily) {
+      acc += v;
+      out.push(acc);
+    }
+    return out;
+  }
+
+  it("monotonically increases (or stays flat)", () => {
+    const c = cumulate([100, 200, 0, 50]);
+    expect(c).toEqual([100, 300, 300, 350]);
+  });
+
+  it("final value equals the sum of the inputs", () => {
+    const inputs = [10, 20, 30, 40];
+    const c = cumulate(inputs);
+    expect(c[c.length - 1]).toBe(inputs.reduce((a, b) => a + b, 0));
+  });
+});
+
+describe("12-month bucketing", () => {
+  function bucketByMonth(rows: { date: string; cents: number }[]) {
+    const out = new Map<string, number>();
+    for (const r of rows) {
+      const month = r.date.slice(0, 7);
+      out.set(month, (out.get(month) ?? 0) + r.cents);
+    }
+    return Array.from(out.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([month, cents]) => ({ month, totalCents: cents }));
+  }
+
+  it("groups daily rows into per-month totals across a year boundary", () => {
+    const rows = [
+      { date: "2025-12-31", cents: 100 },
+      { date: "2026-01-01", cents: 200 },
+      { date: "2026-01-15", cents: 50 },
+      { date: "2026-02-01", cents: 75 },
+    ];
+    expect(bucketByMonth(rows)).toEqual([
+      { month: "2025-12", totalCents: 100 },
+      { month: "2026-01", totalCents: 250 },
+      { month: "2026-02", totalCents: 75 },
+    ]);
+  });
+});

--- a/tests/unit/anthropic-phase3.test.ts
+++ b/tests/unit/anthropic-phase3.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+
+// Mirrors the URL "default" sentinel parser inside getWorkspaceDetail.
+function parseWorkspaceParam(workspaceId: string): string | null {
+  if (workspaceId === "default") return null;
+  return workspaceId;
+}
+
+describe("workspace param parser", () => {
+  it("translates 'default' URL sentinel to SQL NULL", () => {
+    expect(parseWorkspaceParam("default")).toBeNull();
+  });
+  it("passes through real workspace ids unchanged", () => {
+    expect(parseWorkspaceParam("wrkspc_01ABC")).toBe("wrkspc_01ABC");
+  });
+});
+
+describe("Model breakdown percent math", () => {
+  type Row = { modelName: string; costCents: number };
+  function withPct(rows: Row[]) {
+    const total = rows.reduce((s, r) => s + r.costCents, 0);
+    return rows.map((r) => ({
+      ...r,
+      pctOfWorkspace: total === 0 ? 0 : Math.round((r.costCents / total) * 100),
+    }));
+  }
+  it("sums to approximately 100 (rounding-tolerant)", () => {
+    const rows = withPct([
+      { modelName: "opus", costCents: 3020 },
+      { modelName: "sonnet", costCents: 1642 },
+      { modelName: "haiku", costCents: 587 },
+    ]);
+    const total = rows.reduce((s, r) => s + r.pctOfWorkspace, 0);
+    expect(total).toBeGreaterThanOrEqual(99);
+    expect(total).toBeLessThanOrEqual(101);
+  });
+  it("emits zero across the board when total cost is zero", () => {
+    const rows = withPct([
+      { modelName: "opus", costCents: 0 },
+      { modelName: "sonnet", costCents: 0 },
+    ]);
+    expect(rows.every((r) => r.pctOfWorkspace === 0)).toBe(true);
+  });
+});
+
+describe("Top-user tie ordering (mirrors ORDER BY cents DESC, secondary stable)", () => {
+  type User = { userId: number; email: string; costCents: number };
+  function rank(users: User[]) {
+    return [...users].sort((a, b) => {
+      if (b.costCents !== a.costCents) return b.costCents - a.costCents;
+      return a.email.localeCompare(b.email);
+    });
+  }
+  it("breaks ties deterministically (e.g. by email)", () => {
+    const ranked = rank([
+      { userId: 1, email: "bob@unic.com", costCents: 1_000 },
+      { userId: 2, email: "alice@unic.com", costCents: 1_000 },
+      { userId: 3, email: "carol@unic.com", costCents: 500 },
+    ]);
+    expect(ranked.map((r) => r.email)).toEqual([
+      "alice@unic.com",
+      "bob@unic.com",
+      "carol@unic.com",
+    ]);
+  });
+});

--- a/tests/unit/sync/anthropic-workspace-backfill.test.ts
+++ b/tests/unit/sync/anthropic-workspace-backfill.test.ts
@@ -7,16 +7,23 @@ vi.mock("@/lib/sync/framework", () => ({
   retryWithBackoff: (fn: () => Promise<unknown>) => fn(),
 }));
 
-// Mock database
+// Mock database — also stub the drizzle insert chain used to stamp the sync
+// sentinel row at the end of a successful run.
 vi.mock("@/lib/db", () => ({
   db: {
     execute: vi.fn().mockResolvedValue(undefined),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+      })),
+    })),
   },
 }));
 
 // Mock schema (imported but only used for type reference in raw SQL)
 vi.mock("@/lib/db/schema", () => ({
   anthropicWorkspaceCosts: {},
+  anthropicSyncStatus: { userId: {} },
 }));
 
 // Mock constants

--- a/tests/unit/sync/anthropic-workspace-daily-buckets.test.ts
+++ b/tests/unit/sync/anthropic-workspace-daily-buckets.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+
+// The aggregator is a pure function — no DB / network mocks needed.
+import { aggregateDailyCosts } from "@/lib/sync/sources/anthropic-workspace";
+
+type Bucket = Parameters<typeof aggregateDailyCosts>[0][number];
+
+function bucket(
+  startingAt: string,
+  results: Array<{ workspace_id: string | null; amount: string }>
+): Bucket {
+  return {
+    starting_at: startingAt,
+    ending_at: startingAt, // Not used by aggregator
+    results: results.map((r) => ({
+      workspace_id: r.workspace_id,
+      amount: r.amount,
+    })),
+  };
+}
+
+describe("aggregateDailyCosts", () => {
+  it("returns one row per (workspace, day) for multi-day buckets", () => {
+    const buckets: Bucket[] = [
+      bucket("2026-05-01T00:00:00Z", [
+        { workspace_id: "ws1", amount: "100.00" },
+        { workspace_id: "ws2", amount: "50.00" },
+      ]),
+      bucket("2026-05-02T00:00:00Z", [
+        { workspace_id: "ws1", amount: "200.00" },
+        { workspace_id: "ws2", amount: "75.00" },
+      ]),
+      bucket("2026-05-03T00:00:00Z", [
+        { workspace_id: "ws1", amount: "300.00" },
+      ]),
+    ];
+
+    const rows = aggregateDailyCosts(buckets);
+
+    expect(rows).toHaveLength(5);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        { workspaceId: "ws1", date: "2026-05-01", costCents: 100 },
+        { workspaceId: "ws2", date: "2026-05-01", costCents: 50 },
+        { workspaceId: "ws1", date: "2026-05-02", costCents: 200 },
+        { workspaceId: "ws2", date: "2026-05-02", costCents: 75 },
+        { workspaceId: "ws1", date: "2026-05-03", costCents: 300 },
+      ])
+    );
+  });
+
+  it("sums multiple result rows for the same workspace within a single bucket", () => {
+    // Anthropic may split a workspace's cost across multiple result rows
+    // (e.g., by cost_type) inside the same daily bucket.
+    const buckets: Bucket[] = [
+      bucket("2026-05-01T00:00:00Z", [
+        { workspace_id: "ws1", amount: "10.50" },
+        { workspace_id: "ws1", amount: "20.25" },
+        { workspace_id: "ws1", amount: "5.00" },
+      ]),
+    ];
+
+    const rows = aggregateDailyCosts(buckets);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      workspaceId: "ws1",
+      date: "2026-05-01",
+      // 10.50 + 20.25 + 5.00 = 35.75 → 36 after rounding each separately:
+      // Math.round(10.50)=11, Math.round(20.25)=20, Math.round(5.00)=5 → 36
+      costCents: 36,
+    });
+  });
+
+  it("routes null workspace_id to the default-workspace bucket", () => {
+    const buckets: Bucket[] = [
+      bucket("2026-05-01T00:00:00Z", [
+        { workspace_id: null, amount: "42.00" },
+        { workspace_id: "ws1", amount: "100.00" },
+      ]),
+      bucket("2026-05-02T00:00:00Z", [
+        { workspace_id: null, amount: "8.00" },
+      ]),
+    ];
+
+    const rows = aggregateDailyCosts(buckets);
+
+    expect(rows).toHaveLength(3);
+    const defaults = rows.filter((r) => r.workspaceId === null);
+    expect(defaults).toHaveLength(2);
+    expect(defaults).toEqual(
+      expect.arrayContaining([
+        { workspaceId: null, date: "2026-05-01", costCents: 42 },
+        { workspaceId: null, date: "2026-05-02", costCents: 8 },
+      ])
+    );
+  });
+
+  it("keeps null-workspace and named-workspace entries separate on the same day", () => {
+    const buckets: Bucket[] = [
+      bucket("2026-05-01T00:00:00Z", [
+        { workspace_id: null, amount: "10.00" },
+        { workspace_id: "ws1", amount: "20.00" },
+      ]),
+    ];
+
+    const rows = aggregateDailyCosts(buckets);
+
+    expect(rows).toHaveLength(2);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        { workspaceId: null, date: "2026-05-01", costCents: 10 },
+        { workspaceId: "ws1", date: "2026-05-01", costCents: 20 },
+      ])
+    );
+  });
+
+  it("returns an empty array when no buckets are provided", () => {
+    expect(aggregateDailyCosts([])).toEqual([]);
+  });
+
+  it("returns an empty array when buckets have no results", () => {
+    const buckets: Bucket[] = [
+      bucket("2026-05-01T00:00:00Z", []),
+      bucket("2026-05-02T00:00:00Z", []),
+    ];
+    expect(aggregateDailyCosts(buckets)).toEqual([]);
+  });
+
+  it("derives date as the UTC calendar date from starting_at", () => {
+    // starting_at is RFC3339 UTC; we take the first 10 chars (YYYY-MM-DD).
+    // Aliasing here protects against accidental local-TZ conversions.
+    const buckets: Bucket[] = [
+      bucket("2026-05-15T23:59:59Z", [
+        { workspace_id: "ws1", amount: "1.00" },
+      ]),
+    ];
+
+    const rows = aggregateDailyCosts(buckets);
+    expect(rows[0].date).toBe("2026-05-15");
+  });
+});


### PR DESCRIPTION
## Summary

Implements feature 026 — the redesigned `/claude` page (now sidebar-labeled **Claude Console**) — across three phases plus a polish round.

- **Phase 1**: KPI strip, sync-status pill, stacked per-day spend chart, workspace budget list with smart sort
- **Phase 2**: 12-month bar chart, cumulative pacing chart, fastest-growing chips, 6-month sparklines on workspace rows
- **Phase 3**: per-workspace drill-through at `/claude/workspaces/[id]` with top-users + model breakdown, `resolved_workspace_id` linkage from `anthropic_sync_status`
- **Polish round** (this session): per-day cost storage bug fix, chart visual fidelity to mockup (greyscale ramp, projection stubs, today marker, budget cap reference lines), dynamic sparkline window, color-source toggle for the daily chart, linkable workspace names, drill-down polish, sidebar rename

The Anthropic Admin API cost report was being stored as monthly aggregate rows (`YYYY-MM-01`) instead of per-day — fixed by passing `bucket_width=1d` and writing one row per `(workspace_id, day)`. Per-day upserts are now batched into two statements per sync (one per partial-index bucket).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (0 warnings)
- [x] `pnpm test` — 222/222 unit tests pass, including 7 new tests for the cost-bucket aggregator and 1 new integration test asserting per-day row idempotency
- [x] Live verified on the worktree DB branch — `/claude` renders with spectral-rainbow daily chart, 12-month bars with budget cap line, pacing chart with today marker + projection, workspace list with linkable names and dynamic sparkline labels
- [x] Drill-down verified for named workspace (boost-starter-5) and default workspace — top users and model breakdown populate; daily chart shows per-day budget cap reference line
- [ ] Re-verify after running the production backfill (see rollout below)

## Production rollout

Run in this exact order after merge:

**1. Deploy the code** via your usual path.

**2. Run pending migration `0018`** in prod if not already applied (adds `resolved_workspace_id` to `anthropic_sync_status`):
\`\`\`bash
pnpm db:migrate
\`\`\`

**3. Backfill workspace costs** — wipe the table and refetch with the fixed per-day path. The fix is order-sensitive: run this **after** code deploy, otherwise the buggy upsert path would re-write monthly-aggregate rows.
\`\`\`bash
psql \"\$DATABASE_URL\" -c \"TRUNCATE TABLE anthropic_workspace_costs RESTART IDENTITY;\"
pnpm tsx --env-file=.env.local scripts/backfill-anthropic-workspace-costs.ts 2025-11-01
\`\`\`
Default fetches the last 6 months; pass a different `YYYY-MM-DD` to extend (max 24 months per spec).

**4. Backfill workspace mapping** — populates `resolved_workspace_id` for users that were resolved before migration 0018 existed. Without this, the per-workspace top-users and model-breakdown cards on the drill-down stay empty.
\`\`\`bash
pnpm tsx --env-file=.env.local scripts/backfill-anthropic-workspace-mapping.ts
\`\`\`

**5. Trigger a fresh sync** to refresh the \`last_synced_at\` timestamp — either click the dashboard's **Trigger Sync** button or POST to \`/api/anthropic/sync\` with the cron secret.

Both backfill scripts are **idempotent** — safe to re-run.

## Verification queries

After step 4, the named-workspace drill-downs should populate. Spot check:
\`\`\`sql
SELECT COALESCE(w.name, '(default)') AS workspace, COUNT(*) AS users
FROM anthropic_sync_status s
LEFT JOIN anthropic_workspaces w
  ON w.workspace_id IS NOT DISTINCT FROM s.resolved_workspace_id
GROUP BY 1 ORDER BY users DESC;

SELECT COUNT(*) AS rows, COUNT(DISTINCT date) AS days
FROM anthropic_workspace_costs;
\`\`\`
Expect: \`days\` ≈ elapsed days since the backfill start date × (months synced), \`users\` distributed across multiple named workspaces (not concentrated in default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)