### PR TITLE
fix(copilot): treat metrics 404 as no-data, not a sync failure

### DIFF
--- a/src/lib/copilot-api.ts
+++ b/src/lib/copilot-api.ts
@@ -199,6 +199,7 @@ export async function fetchCopilotSeats(
   let page = 1;
   let rateLimitRemaining = 5000;
   let rateLimitReset = 0;
+  let lastStatus = 200;
 
   while (true) {
     const result = await githubFetch<CopilotSeatsPage>(
@@ -209,6 +210,7 @@ export async function fetchCopilotSeats(
 
     rateLimitRemaining = result.rateLimitRemaining;
     rateLimitReset = result.rateLimitReset;
+    lastStatus = result.status;
 
     if (result.error) {
       return {
@@ -240,7 +242,7 @@ export async function fetchCopilotSeats(
   return {
     data: allSeats,
     error: null,
-    status: 200,
+    status: lastStatus,
     rateLimitRemaining,
     rateLimitReset,
   };

--- a/src/lib/copilot-api.ts
+++ b/src/lib/copilot-api.ts
@@ -161,6 +161,7 @@ function stripScopes<T>(result: GitHubApiResponse<T>): CopilotApiResponse<T> {
   return {
     data: result.data,
     error: result.error,
+    status: result.status,
     rateLimitRemaining: result.rateLimitRemaining,
     rateLimitReset: result.rateLimitReset,
   };
@@ -176,13 +177,13 @@ function stripScopes<T>(result: GitHubApiResponse<T>): CopilotApiResponse<T> {
  */
 export async function fetchCopilotBilling(
   token: string,
-  org: string
+  org: string,
 ): Promise<CopilotApiResponse<CopilotBillingData>> {
   return stripScopes(
     await githubFetch<CopilotBillingData>(
       `/orgs/${encodeURIComponent(org)}/copilot/billing`,
-      token
-    )
+      token,
+    ),
   );
 }
 
@@ -192,7 +193,7 @@ export async function fetchCopilotBilling(
  */
 export async function fetchCopilotSeats(
   token: string,
-  org: string
+  org: string,
 ): Promise<CopilotApiResponse<CopilotSeat[]>> {
   const allSeats: CopilotSeat[] = [];
   let page = 1;
@@ -203,14 +204,20 @@ export async function fetchCopilotSeats(
     const result = await githubFetch<CopilotSeatsPage>(
       `/orgs/${encodeURIComponent(org)}/copilot/billing/seats`,
       token,
-      { per_page: "100", page: String(page) }
+      { per_page: "100", page: String(page) },
     );
 
     rateLimitRemaining = result.rateLimitRemaining;
     rateLimitReset = result.rateLimitReset;
 
     if (result.error) {
-      return { data: null, error: result.error, rateLimitRemaining, rateLimitReset };
+      return {
+        data: null,
+        error: result.error,
+        status: result.status,
+        rateLimitRemaining,
+        rateLimitReset,
+      };
     }
 
     const seats = result.data?.seats || [];
@@ -223,13 +230,20 @@ export async function fetchCopilotSeats(
       return {
         data: null,
         error: `Rate limit approaching (${rateLimitRemaining} remaining). Reset at ${new Date(rateLimitReset * 1000).toISOString()}`,
+        status: result.status,
         rateLimitRemaining,
         rateLimitReset,
       };
     }
   }
 
-  return { data: allSeats, error: null, rateLimitRemaining, rateLimitReset };
+  return {
+    data: allSeats,
+    error: null,
+    status: 200,
+    rateLimitRemaining,
+    rateLimitReset,
+  };
 }
 
 /**
@@ -240,7 +254,7 @@ export async function fetchCopilotMetrics(
   token: string,
   org: string,
   since?: string,
-  until?: string
+  until?: string,
 ): Promise<CopilotApiResponse<CopilotDailyMetrics[]>> {
   const params: Record<string, string> = {};
   if (since) params.since = since;
@@ -250,8 +264,8 @@ export async function fetchCopilotMetrics(
     await githubFetch<CopilotDailyMetrics[]>(
       `/orgs/${encodeURIComponent(org)}/copilot/metrics`,
       token,
-      Object.keys(params).length > 0 ? params : undefined
-    )
+      Object.keys(params).length > 0 ? params : undefined,
+    ),
   );
 }
 
@@ -260,21 +274,20 @@ export async function fetchCopilotMetrics(
  * by making a lightweight request and inspecting the `x-oauth-scopes` header.
  */
 export async function validateCopilotScopes(
-  token: string
+  token: string,
 ): Promise<CopilotApiResponse<{ valid: boolean; scopes: string[] }>> {
   const result = await githubFetch<unknown>("/user", token);
 
   const scopes = result.scopes;
   const hasScope = scopes.some(
-    (s) =>
-      s === "manage_billing:copilot" ||
-      s === "admin:org"
+    (s) => s === "manage_billing:copilot" || s === "admin:org",
   );
 
   if (result.error) {
     return {
       data: null,
       error: result.error,
+      status: result.status,
       rateLimitRemaining: result.rateLimitRemaining,
       rateLimitReset: result.rateLimitReset,
     };
@@ -284,6 +297,7 @@ export async function validateCopilotScopes(
     return {
       data: { valid: false, scopes },
       error: `Token missing required scope: manage_billing:copilot. Current scopes: ${scopes.join(", ")}`,
+      status: result.status,
       rateLimitRemaining: result.rateLimitRemaining,
       rateLimitReset: result.rateLimitReset,
     };
@@ -292,6 +306,7 @@ export async function validateCopilotScopes(
   return {
     data: { valid: true, scopes },
     error: null,
+    status: result.status,
     rateLimitRemaining: result.rateLimitRemaining,
     rateLimitReset: result.rateLimitReset,
   };

--- a/src/lib/copilot-sync.ts
+++ b/src/lib/copilot-sync.ts
@@ -45,16 +45,13 @@ interface MetricsSyncResult {
 
 export async function syncBillingData(
   connection: SyncConnection,
-  token: string
+  token: string,
 ): Promise<BillingSyncResult> {
-  const billingResponse = await fetchCopilotBilling(
-    token,
-    connection.orgLogin
-  );
+  const billingResponse = await fetchCopilotBilling(token, connection.orgLogin);
 
   if (billingResponse.error || !billingResponse.data) {
     throw new Error(
-      billingResponse.error ?? "Failed to fetch Copilot billing data"
+      billingResponse.error ?? "Failed to fetch Copilot billing data",
     );
   }
 
@@ -93,7 +90,7 @@ export async function syncBillingData(
     const tier = await db.query.accessTiers.findFirst({
       where: and(
         eq(accessTiers.toolId, tool.id),
-        eq(accessTiers.name, tierName)
+        eq(accessTiers.name, tierName),
       ),
     });
 
@@ -155,13 +152,13 @@ export async function syncBillingData(
 
 export async function syncSeatAssignments(
   connection: SyncConnection,
-  token: string
+  token: string,
 ): Promise<SeatSyncResult> {
   const seatsResponse = await fetchCopilotSeats(token, connection.orgLogin);
 
   if (seatsResponse.error || !seatsResponse.data) {
     throw new Error(
-      seatsResponse.error ?? "Failed to fetch Copilot seat assignments"
+      seatsResponse.error ?? "Failed to fetch Copilot seat assignments",
     );
   }
 
@@ -174,7 +171,7 @@ export async function syncSeatAssignments(
 
   if (!tool) {
     throw new Error(
-      "GitHub Copilot tool not found. Run syncBillingData first."
+      "GitHub Copilot tool not found. Run syncBillingData first.",
     );
   }
 
@@ -189,7 +186,7 @@ export async function syncSeatAssignments(
   const tiers = await db.query.accessTiers.findMany({
     where: eq(accessTiers.toolId, tool.id),
   });
-  const tierByName = new Map<string, typeof tiers[number]>();
+  const tierByName = new Map<string, (typeof tiers)[number]>();
   for (const tier of tiers) {
     tierByName.set(tier.name, tier);
   }
@@ -198,11 +195,17 @@ export async function syncSeatAssignments(
   const allToolAssignments = await db.query.licenseAssignments.findMany({
     where: eq(licenseAssignments.toolId, tool.id),
   });
-  const assignmentByUserId = new Map<number, typeof allToolAssignments[number]>();
+  const assignmentByUserId = new Map<
+    number,
+    (typeof allToolAssignments)[number]
+  >();
   for (const a of allToolAssignments) {
     // Prefer copilot-sync over manual if both somehow exist
     const existing = assignmentByUserId.get(a.userId);
-    if (!existing || (existing.source === "manual" && a.source === "copilot-sync")) {
+    if (
+      !existing ||
+      (existing.source === "manual" && a.source === "copilot-sync")
+    ) {
       assignmentByUserId.set(a.userId, a);
     }
   }
@@ -289,7 +292,7 @@ export async function syncSeatAssignments(
 
 export async function syncUsageMetrics(
   connection: SyncConnection,
-  token: string
+  token: string,
 ): Promise<MetricsSyncResult> {
   // Find latest metric date for this connection
   const latestRow = await db.query.copilotUsageMetrics.findFirst({
@@ -308,12 +311,22 @@ export async function syncUsageMetrics(
   const metricsResponse = await fetchCopilotMetrics(
     token,
     connection.orgLogin,
-    since
+    since,
   );
 
   if (metricsResponse.error || !metricsResponse.data) {
+    // GitHub returns 404 when the org has the Copilot Metrics API policy
+    // disabled, or when fewer than 5 members have generated telemetry in the
+    // window. The admin has to flip that on GitHub's side — there's nothing
+    // we can do from here, so don't fail the whole sync over it.
+    if (metricsResponse.status === 404) {
+      console.warn(
+        `[copilot-sync] Copilot metrics not available for org "${connection.orgLogin}" (404). The "Copilot Metrics API access" policy may be disabled, or the org has fewer than 5 users emitting telemetry. See https://docs.github.com/en/copilot/managing-copilot/managing-policies-and-features-for-copilot-in-your-organization`,
+      );
+      return { metricsProcessed: 0 };
+    }
     throw new Error(
-      metricsResponse.error ?? "Failed to fetch Copilot usage metrics"
+      metricsResponse.error ?? "Failed to fetch Copilot usage metrics",
     );
   }
 
@@ -326,7 +339,12 @@ export async function syncUsageMetrics(
     // (the top-level languages[] only has name + engaged_users, no counts)
     const langTotals = new Map<
       string,
-      { suggestions: number; acceptances: number; linesSuggested: number; linesAccepted: number }
+      {
+        suggestions: number;
+        acceptances: number;
+        linesSuggested: number;
+        linesAccepted: number;
+      }
     >();
 
     let totalSuggestions = 0;
@@ -364,7 +382,7 @@ export async function syncUsageMetrics(
       ([language, totals]) => ({
         language,
         ...totals,
-      })
+      }),
     );
 
     // Build editor breakdown by summing across models[].languages[]
@@ -435,10 +453,7 @@ export async function syncUsageMetrics(
         editorBreakdown,
       })
       .onConflictDoUpdate({
-        target: [
-          copilotUsageMetrics.connectionId,
-          copilotUsageMetrics.date,
-        ],
+        target: [copilotUsageMetrics.connectionId, copilotUsageMetrics.date],
         set: {
           totalActiveUsers: day.total_active_users,
           totalEngagedUsers: day.total_engaged_users,
@@ -465,7 +480,7 @@ export async function syncUsageMetrics(
 
 export async function runCopilotSync(
   connectionId: number,
-  syncEventId: number
+  syncEventId: number,
 ): Promise<void> {
   // Get the triggering admin from the sync event for audit attribution
   const syncEvent = await db.query.githubSyncEvents.findFirst({
@@ -520,7 +535,7 @@ export async function runCopilotSync(
     billingResult = await syncBillingData(syncConnection, token);
   } catch (err) {
     errors.push(
-      `Billing sync failed: ${err instanceof Error ? err.message : String(err)}`
+      `Billing sync failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
@@ -529,7 +544,7 @@ export async function runCopilotSync(
     seatResult = await syncSeatAssignments(syncConnection, token);
   } catch (err) {
     errors.push(
-      `Seat sync failed: ${err instanceof Error ? err.message : String(err)}`
+      `Seat sync failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
@@ -538,13 +553,13 @@ export async function runCopilotSync(
     metricsResult = await syncUsageMetrics(syncConnection, token);
   } catch (err) {
     errors.push(
-      `Metrics sync failed: ${err instanceof Error ? err.message : String(err)}`
+      `Metrics sync failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
   // Determine final status
   const successCount = [billingResult, seatResult, metricsResult].filter(
-    (r) => r !== null
+    (r) => r !== null,
   ).length;
 
   let finalStatus: "completed" | "partial" | "failed";

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -10,6 +10,7 @@ const GITHUB_API_BASE = "https://api.github.com";
 export interface GitHubApiResponse<T> {
   data: T | null;
   error: string | null;
+  status: number;
   scopes: string[];
   rateLimitRemaining: number;
   rateLimitReset: number;
@@ -22,19 +23,16 @@ function parseHeaders(headers: Headers) {
     .filter(Boolean);
   const rateLimitRemaining = parseInt(
     headers.get("x-ratelimit-remaining") || "0",
-    10
+    10,
   );
-  const rateLimitReset = parseInt(
-    headers.get("x-ratelimit-reset") || "0",
-    10
-  );
+  const rateLimitReset = parseInt(headers.get("x-ratelimit-reset") || "0", 10);
   return { scopes, rateLimitRemaining, rateLimitReset };
 }
 
 export async function githubFetch<T>(
   path: string,
   token: string,
-  params?: Record<string, string>
+  params?: Record<string, string>,
 ): Promise<GitHubApiResponse<T>> {
   const url = new URL(`${GITHUB_API_BASE}${path}`);
   if (params) {
@@ -53,7 +51,7 @@ export async function githubFetch<T>(
   });
 
   const { scopes, rateLimitRemaining, rateLimitReset } = parseHeaders(
-    response.headers
+    response.headers,
   );
 
   if (!response.ok) {
@@ -64,6 +62,7 @@ export async function githubFetch<T>(
     return {
       data: null,
       error: message,
+      status: response.status,
       scopes,
       rateLimitRemaining,
       rateLimitReset,
@@ -71,7 +70,14 @@ export async function githubFetch<T>(
   }
 
   const data = (await response.json()) as T;
-  return { data, error: null, scopes, rateLimitRemaining, rateLimitReset };
+  return {
+    data,
+    error: null,
+    status: response.status,
+    scopes,
+    rateLimitRemaining,
+    rateLimitReset,
+  };
 }
 
 // Types for GitHub API responses
@@ -109,7 +115,7 @@ export async function validateTokenAndListOrgs(token: string) {
   // Check required scopes
   const requiredScopes = ["read:org", "read:user"];
   const missingScopes = requiredScopes.filter(
-    (s) => !result.scopes.includes(s)
+    (s) => !result.scopes.includes(s),
   );
 
   if (missingScopes.length > 0) {
@@ -133,7 +139,7 @@ export async function validateTokenAndListOrgs(token: string) {
 export async function fetchOrgMembers(
   token: string,
   orgLogin: string,
-  onProgress?: (fetched: number) => void
+  onProgress?: (fetched: number) => void,
 ) {
   const allMembers: GitHubOrgMember[] = [];
   let page = 1;
@@ -144,7 +150,7 @@ export async function fetchOrgMembers(
     const result = await githubFetch<GitHubOrgMember[]>(
       `/orgs/${encodeURIComponent(orgLogin)}/members`,
       token,
-      { per_page: "100", page: String(page) }
+      { per_page: "100", page: String(page) },
     );
 
     rateLimitRemaining = result.rateLimitRemaining;
@@ -187,7 +193,7 @@ export async function fetchOrgMembers(
 export async function fetchUserProfile(token: string, username: string) {
   const result = await githubFetch<GitHubUserProfile>(
     `/users/${encodeURIComponent(username)}`,
-    token
+    token,
   );
 
   if (result.error || !result.data) {
@@ -242,7 +248,7 @@ export function matchMembersToUsers(
     email: string;
     githubUsername: string | null;
     status: "active" | "inactive";
-  }>
+  }>,
 ): {
   matched: SyncMatchedMember[];
   unmatched: SyncUnmatchedMember[];
@@ -280,7 +286,7 @@ export function matchMembersToUsers(
   // Emit conflicts for duplicate githubUsername values
   for (const dupKey of duplicateUsernames) {
     const dupes = systemUsers.filter(
-      (u) => u.githubUsername?.toLowerCase() === dupKey
+      (u) => u.githubUsername?.toLowerCase() === dupKey,
     );
     usernameMap.delete(dupKey);
     conflicts.push({


### PR DESCRIPTION
## Summary

- The daily Copilot sync was failing with `Metrics sync failed: Not Found` because GitHub's `/orgs/{org}/copilot/metrics` returns 404 when the org's *Copilot Metrics API access* policy is off (or fewer than 5 members have telemetry in the 28-day window). That's a GitHub-side configuration the admin has to flip — the client can't fix it.
- Detect 404 in `syncUsageMetrics` and treat it as "no metrics this run" instead of throwing. Billing + seat sync now complete with a clean `success` outcome, and a warning is logged pointing to the GitHub policy docs.
- To make the 404 check robust, plumb the HTTP status code through `GitHubApiResponse` / `CopilotApiResponse` and key off `status === 404` instead of the fragile `error === "Not Found"` string match.

## Test plan

- [x] Reproduced the 404 against the live `unic` org on a `wt/copilot-metrics-fix` Neon branch — sync event previously had `outcome: "partial"`, `errorMessage: "Metrics sync failed: Not Found"`.
- [x] After the fix: sync event has `outcome: "success"`, `errorCount: 0`, `errorMessage: null`. Billing snapshot upserted (`createdCount: 1`), 77 seats processed (`updatedCount: 77`), metrics skipped with warning logged.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean for changed files (pre-existing unrelated errors in another worktree's `.next/` artifacts).
- [ ] Confirm the next scheduled cron run on production shows `outcome: "success"` instead of `"partial"`/`"failed"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)