### PR TITLE
fix(anthropic): repair cost sync and console dropdowns on the 1st of month

### DIFF
--- a/src/actions/anthropic-global.ts
+++ b/src/actions/anthropic-global.ts
@@ -37,7 +37,7 @@ import type {
   WorkspaceUser,
   ModelBreakdownRow,
 } from "@/types";
-import { projectMonthEnd } from "@/lib/utils";
+import { getCurrentMonth, projectMonthEnd } from "@/lib/utils";
 import { run as runAnthropicSync } from "@/lib/sync/sources/anthropic-workspace";
 import {
   loadDashboardKpis,
@@ -152,11 +152,18 @@ async function _getAvailableWorkspaceCostMonths(): Promise<string[]> {
 export async function getAvailableWorkspaceCostMonths(): Promise<string[]> {
   const admin = await requireAdmin();
   if (!admin) return [];
-  return unstable_cache(
+  const months = await unstable_cache(
     _getAvailableWorkspaceCostMonths,
     ["anthropic-available-months"],
     { tags: ["anthropic-workspace-costs"] }
   )();
+  // Ensure the current month is always offered, even before its first sync (e.g.
+  // on the 1st). Computed outside the cache so it stays correct across rollover.
+  const currentMonth = getCurrentMonth();
+  if (!months.includes(currentMonth)) {
+    return [currentMonth, ...months];
+  }
+  return months;
 }
 
 export const getAvailableMonths = getAvailableWorkspaceCostMonths;

--- a/src/actions/anthropic-users.ts
+++ b/src/actions/anthropic-users.ts
@@ -28,7 +28,7 @@ import {
   COST_DISTRIBUTION_BUCKETS,
   bucketCents,
 } from "@/lib/claude-users-buckets";
-import { projectMonthEnd } from "@/lib/utils";
+import { getCurrentMonth, projectMonthEnd } from "@/lib/utils";
 import type {
   UserListRow,
   UsersDashboardKpis,
@@ -311,11 +311,18 @@ async function _getAvailableUserMonths(): Promise<string[]> {
 export async function getAvailableUserMonths(): Promise<string[]> {
   const admin = await requireAdmin();
   if (!admin) return [];
-  return unstable_cache(
+  const months = await unstable_cache(
     _getAvailableUserMonths,
     ["anthropic-available-user-months"],
     { tags: ["anthropic-workspace-costs"] }
   )();
+  // Ensure the current month is always offered, even before its first sync (e.g.
+  // on the 1st). Computed outside the cache so it stays correct across rollover.
+  const currentMonth = getCurrentMonth();
+  if (!months.includes(currentMonth)) {
+    return [currentMonth, ...months];
+  }
+  return months;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/profile/month-picker.tsx
+++ b/src/components/profile/month-picker.tsx
@@ -20,12 +20,20 @@ function formatMonthLabel(month: string): string {
   return date.toLocaleDateString("en-US", { year: "numeric", month: "long" });
 }
 
+/**
+ * Build the selectable month options, guaranteeing the selected `value` is
+ * always present so the trigger never renders blank. On the 1st of a month the
+ * data source may not yet contain the current month (no synced rows for day 0),
+ * and a URL-supplied `?month=` can reference an arbitrary month. We dedupe and
+ * re-sort newest-first ("YYYY-MM" sorts chronologically as a string) so an
+ * injected value lands in its correct chronological position, not at the head.
+ */
+export function buildMonthOptions(value: string, months: string[]): string[] {
+  return [...new Set([value, ...months])].sort().reverse();
+}
+
 export function MonthPicker({ value, onChange, months }: MonthPickerProps) {
-  // Always make the selected value selectable. On the 1st of a month the data
-  // source may not yet contain the current month (no synced rows for day 0),
-  // which would otherwise leave `value` with no matching SelectItem and render
-  // a blank trigger. Prepend it when missing (newest-first ordering).
-  const options = months.includes(value) ? months : [value, ...months];
+  const options = buildMonthOptions(value, months);
 
   return (
     <Select value={value} onValueChange={onChange}>

--- a/src/components/profile/month-picker.tsx
+++ b/src/components/profile/month-picker.tsx
@@ -21,8 +21,11 @@ function formatMonthLabel(month: string): string {
 }
 
 export function MonthPicker({ value, onChange, months }: MonthPickerProps) {
-  // If no months available, generate current month
-  const options = months.length > 0 ? months : [value];
+  // Always make the selected value selectable. On the 1st of a month the data
+  // source may not yet contain the current month (no synced rows for day 0),
+  // which would otherwise leave `value` with no matching SelectItem and render
+  // a blank trigger. Prepend it when missing (newest-first ordering).
+  const options = months.includes(value) ? months : [value, ...months];
 
   return (
     <Select value={value} onValueChange={onChange}>

--- a/src/lib/sync/sources/anthropic-workspace.ts
+++ b/src/lib/sync/sources/anthropic-workspace.ts
@@ -193,13 +193,24 @@ async function fetchAndUpsertWorkspaceCosts(month: string): Promise<number> {
   const nextYear = endMonth === 12 ? endYear + 1 : endYear;
   const monthEndDate = `${nextYear}-${String(nextMonth).padStart(2, "0")}-01T00:00:00Z`;
 
-  // Cap endDate to now — Anthropic rejects requests where ending_at is in the future.
+  // Cap endDate to the start of *tomorrow* (next UTC midnight), not `now`.
+  // With bucket_width=1d the API snaps both endpoints to day boundaries and
+  // requires ending_at to be strictly after starting_at. Capping at `now`
+  // breaks on the 1st of the month: starting_at (month-start midnight) and
+  // ending_at (a few minutes into the same day) land in the same daily bucket,
+  // so the API returns 400 "ending date must be after starting date". Rounding
+  // up to the next midnight guarantees at least one full daily bucket and
+  // matches the documented "current date + 1 day" pattern.
   const now = new Date();
   const startDateObj = new Date(startDate);
   const monthEndDateObj = new Date(monthEndDate);
-  const effectiveEnd = monthEndDateObj > now ? now : monthEndDateObj;
+  const startOfTomorrow = new Date(now);
+  startOfTomorrow.setUTCHours(0, 0, 0, 0);
+  startOfTomorrow.setUTCDate(startOfTomorrow.getUTCDate() + 1);
+  const effectiveEnd =
+    monthEndDateObj < startOfTomorrow ? monthEndDateObj : startOfTomorrow;
   if (effectiveEnd.getTime() <= startDateObj.getTime()) {
-    // Month hasn't started yet or no time has elapsed — nothing to sync.
+    // Month hasn't started yet — nothing to sync.
     return 0;
   }
   const endDate = effectiveEnd.toISOString();

--- a/tests/unit/components/month-picker.test.ts
+++ b/tests/unit/components/month-picker.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { buildMonthOptions } from "@/components/profile/month-picker";
+
+describe("buildMonthOptions", () => {
+  it("returns the months unchanged when the value is already present", () => {
+    const months = ["2026-06", "2026-05", "2026-04"];
+    expect(buildMonthOptions("2026-05", months)).toEqual([
+      "2026-06",
+      "2026-05",
+      "2026-04",
+    ]);
+  });
+
+  it("injects the current month at the head when it is the newest (1st-of-month case)", () => {
+    // No rows for the current month yet — the value must still be selectable.
+    const months = ["2026-05", "2026-04"];
+    expect(buildMonthOptions("2026-06", months)).toEqual([
+      "2026-06",
+      "2026-05",
+      "2026-04",
+    ]);
+  });
+
+  it("falls back to a single option when no months are available", () => {
+    expect(buildMonthOptions("2026-06", [])).toEqual(["2026-06"]);
+  });
+
+  it("inserts a past value in chronological position, not at the head", () => {
+    const months = ["2026-06", "2026-05"];
+    expect(buildMonthOptions("2026-01", months)).toEqual([
+      "2026-06",
+      "2026-05",
+      "2026-01",
+    ]);
+  });
+
+  it("inserts a future value at the head while preserving newest-first order", () => {
+    const months = ["2026-06", "2026-05"];
+    expect(buildMonthOptions("2099-01", months)).toEqual([
+      "2099-01",
+      "2026-06",
+      "2026-05",
+    ]);
+  });
+
+  it("does not duplicate a value already present but out of order", () => {
+    const months = ["2026-04", "2026-06", "2026-05"];
+    const result = buildMonthOptions("2026-06", months);
+    expect(result).toEqual(["2026-06", "2026-05", "2026-04"]);
+    expect(result.filter((m) => m === "2026-06")).toHaveLength(1);
+  });
+});

--- a/tests/unit/sync/anthropic-workspace-backfill.test.ts
+++ b/tests/unit/sync/anthropic-workspace-backfill.test.ts
@@ -98,22 +98,29 @@ describe("anthropic-workspace date-range capping", () => {
     vi.useRealTimers();
   });
 
-  it("skips cost fetch when now equals startDate (month just began)", async () => {
+  it("fetches a one-day window when cron fires at the exact month start", async () => {
     vi.useFakeTimers();
-    // Cron fires at the exact start of May 2026 — the scenario from issue #72
+    // Cron fires at the exact start of May 2026 — the scenario from issue #72.
+    // ending_at must round up to the next UTC midnight (May 2) so the 1d-bucket
+    // range is valid, instead of collapsing to a zero-width same-day range that
+    // the API rejects with "ending date must be after starting date".
     vi.setSystemTime(new Date(Date.UTC(2026, 4, 1, 0, 0, 0))); // 2026-05-01T00:00:00Z
 
-    // Workspace call succeeds
     mockFetch.mockResolvedValueOnce(workspacesResponse([]));
-    // No cost report call should be made — month just started, ending_at would equal starting_at
+    mockFetch.mockResolvedValueOnce(
+      costReportResponse([{ workspace_id: "ws1", amount: "0.00" }])
+    );
 
     const result = await run(1, { month: "2026-05" });
     expect(result).toHaveProperty("eventId");
-    // Only the workspace fetch should have been called (1 call), not the cost report
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // Workspace fetch + a valid one-day cost report fetch (May 1 -> May 2).
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const calledUrl: string = mockFetch.mock.calls[1][0] as string;
+    expect(calledUrl).toContain("2026-05-01");
+    expect(calledUrl).toContain("2026-05-02");
   });
 
-  it("caps endDate to now when month end is in the future", async () => {
+  it("caps endDate to the next UTC midnight when month end is in the future", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(Date.UTC(2026, 4, 15, 12, 0, 0))); // 2026-05-15T12:00:00Z
 
@@ -126,12 +133,14 @@ describe("anthropic-workspace date-range capping", () => {
 
     // The cost report fetch should have been called
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    // Verify ending_at in the URL is not June 1 (which would be in the future)
     const costReportCall = mockFetch.mock.calls[1];
     const calledUrl: string = costReportCall[0] as string;
+    // Not capped to the future month end (June 1)...
     expect(calledUrl).not.toContain("2026-06-01");
-    // ending_at should encode the current time (2026-05-15T12:00:00.000Z)
-    expect(calledUrl).toContain("2026-05-15");
+    // ...and rounded up to the next UTC midnight (May 16), not the partial
+    // current time, so every requested bucket is a complete day.
+    expect(calledUrl).toContain("2026-05-16");
+    expect(calledUrl).not.toContain("2026-05-15T12");
   });
 
   it("uses full month range for past months without capping", async () => {
@@ -151,25 +160,30 @@ describe("anthropic-workspace date-range capping", () => {
     expect(calledUrl).toContain("2026-05-01");
   });
 
-  it("skips current-month iteration in backfill when cron fires at exact month start", async () => {
+  it("fetches a one-day current-month window during backfill at exact month start", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(Date.UTC(2026, 4, 1, 0, 0, 0))); // 2026-05-01T00:00:00Z
 
     // Workspaces succeeds
     mockFetch.mockResolvedValueOnce(workspacesResponse([]));
-    // April cost report succeeds
+    // April cost report (full past month) succeeds
     mockFetch.mockResolvedValueOnce(
       costReportResponse([{ workspace_id: "ws1", amount: "300.00" }])
     );
-    // May cost report must NOT be called (effectiveEnd <= startDate)
+    // May cost report (one-day window May 1 -> May 2) succeeds — no longer skipped
+    mockFetch.mockResolvedValueOnce(
+      costReportResponse([{ workspace_id: "ws1", amount: "0.00" }])
+    );
 
     const result = await run(1, {
       backfillStartDate: new Date(Date.UTC(2026, 3, 1)), // Apr 2026
     });
 
     expect(result).toHaveProperty("eventId");
-    // 1 workspace + 1 April cost report = 2 calls; May should be skipped
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // 1 workspace + April + May = 3 calls; May is fetched with a valid one-day range
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    const mayUrl: string = mockFetch.mock.calls[2][0] as string;
+    expect(mayUrl).toContain("2026-05-02");
   });
 });
 


### PR DESCRIPTION
## Problem

On the **first day of a new month** the Anthropic cost sync fails:

> Cost sync failed: Anthropic cost_report API error 400: `{"type":"invalid_request_error","message":"Invalid date range: ending date must be after starting date"}`

and the **Claude cloud console** subpages (`/claude`, `/claude/users`) render blank month dropdowns showing no data.

## Root cause

Two distinct first-of-month bugs, both from date math collapsing to a zero-width / invalid range on day 1.

### 1. Sync 400 — `fetchAndUpsertWorkspaceCosts`

The cost report is requested with `bucket_width=1d`, but `ending_at` was capped at **`now`**. On the 1st, a cron firing at `…-01T00:05Z` produces `starting_at = …-01T00:00Z` and `ending_at = …-01T00:05Z` — the **same calendar day**. With daily bucketing the API snaps both endpoints to the same midnight boundary, so `ending_at` is no longer strictly after `starting_at` → **400**. The old `effectiveEnd <= startDate` guard only caught literal equality, not the sub-day-bucket case, so the sync was broken for the entire first calendar day every month.

**Fix:** round `ending_at` **up to the next UTC midnight** (start of tomorrow), guaranteeing at least one complete daily bucket. Matches Anthropic's documented `ending_at = current date + 1 day` (`specs/016-claude-api-costs/contracts/anthropic-usage-api.md`). Past-month backfills and future-month skipping unchanged.

### 2. Blank console dropdowns

`/claude` and `/claude/users` select the **current month** but build dropdown options only from months that already have synced rows. On the 1st there are no rows for the current month yet, so the selected value has no matching `SelectItem` → blank trigger + empty data. The profile page was already immune because it injects the current month.

**Fix (defence in depth):**
- `MonthPicker` always includes the selected `value` in its options (single chokepoint).
- `getAvailableWorkspaceCostMonths` / `getAvailableUserMonths` prepend the current month when absent — computed **outside** `unstable_cache` so it survives month rollover. Mirrors the safe profile path in `anthropic-usage.ts`.

## Changes

| File | Change |
|---|---|
| `src/lib/sync/sources/anthropic-workspace.ts` | Cap `ending_at` to next UTC midnight, not `now` |
| `src/components/profile/month-picker.tsx` | Always make the selected value selectable |
| `src/actions/anthropic-global.ts` | Inject current month into available-months list |
| `src/actions/anthropic-users.ts` | Same injection |
| `tests/unit/sync/anthropic-workspace-backfill.test.ts` | Updated 3 tests that asserted the old `now`-capping behaviour |

## Validation

- `pnpm typecheck` ✅
- `pnpm lint` (zero warnings) ✅
- `pnpm test tests/unit/sync/anthropic-workspace-*` → 16/16 ✅

## Notes

- A latent version of the same daily-bucket hazard exists in `src/lib/anthropic-sync.ts` `computeSyncWindow` (per-user usage sync), but it's shielded because "today" is fetched separately via `todaySyncWindow()`. Left untouched to keep this fix focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
