### PR TITLE
fix(anthropic): guard usage sync window against zero-width daily range

### DIFF
--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -254,10 +254,12 @@ export function computeSyncWindow(latestDateStr: string | null): { startingAt: s
   // Guard against a zero-width or inverted range. With bucket_width=1d the
   // usage_report API rejects ending_at <= starting_at with a 400 ("ending date
   // must be after starting date"), the same failure that hit the cost path on
-  // the 1st (#103). latestDateStr should always be < today, but a same-day or
-  // future-dated row (bad backfill, clock skew, timezone edge) could otherwise
-  // push startDate to/after endDate. Clamp so the historical window always
-  // spans at least one complete day ending at start-of-today.
+  // the 1st (#103). latestDateStr should always be < today, and even a same-day
+  // row is safe because we subtract a day (latest == today still yields a valid
+  // [yesterday, today) window). Only a future-dated row (bad backfill, clock
+  // skew, timezone edge) could push startDate to/after endDate. Clamp so the
+  // historical window always spans at least one complete day ending at
+  // start-of-today.
   const maxStart = new Date(endDate);
   maxStart.setUTCDate(maxStart.getUTCDate() - 1);
   if (startDate.getTime() > maxStart.getTime()) {

--- a/src/lib/anthropic-sync.ts
+++ b/src/lib/anthropic-sync.ts
@@ -236,7 +236,7 @@ function formatAnthropicTimestamp(date: Date): string {
   return date.toISOString().replace(/\.\d+Z$/, "Z");
 }
 
-function computeSyncWindow(latestDateStr: string | null): { startingAt: string; endingAt: string } {
+export function computeSyncWindow(latestDateStr: string | null): { startingAt: string; endingAt: string } {
   const now = new Date();
   now.setUTCHours(0, 0, 0, 0);
   let startDate: Date;
@@ -250,6 +250,19 @@ function computeSyncWindow(latestDateStr: string | null): { startingAt: string; 
   }
   // End at start-of-today; today is covered separately with hourly buckets
   const endDate = new Date(now);
+
+  // Guard against a zero-width or inverted range. With bucket_width=1d the
+  // usage_report API rejects ending_at <= starting_at with a 400 ("ending date
+  // must be after starting date"), the same failure that hit the cost path on
+  // the 1st (#103). latestDateStr should always be < today, but a same-day or
+  // future-dated row (bad backfill, clock skew, timezone edge) could otherwise
+  // push startDate to/after endDate. Clamp so the historical window always
+  // spans at least one complete day ending at start-of-today.
+  const maxStart = new Date(endDate);
+  maxStart.setUTCDate(maxStart.getUTCDate() - 1);
+  if (startDate.getTime() > maxStart.getTime()) {
+    startDate = maxStart;
+  }
 
   return {
     startingAt: formatAnthropicTimestamp(startDate),

--- a/tests/unit/sync/anthropic-sync-window.test.ts
+++ b/tests/unit/sync/anthropic-sync-window.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+// computeSyncWindow is a pure helper, but importing its module pulls in the DB
+// pool, env validation, and a top-level `sql` template over the schema. Stub
+// those import-time dependencies so the unit under test loads in isolation.
+vi.mock("@/lib/env", () => ({ env: { ANTHROPIC_ADMIN_API_KEY: undefined } }));
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("@/lib/db/schema", () => ({
+  anthropicUsageMetrics: {},
+  anthropicSyncStatus: {},
+  licenseAssignments: {},
+  aiTools: { vendor: {}, name: {}, id: {} },
+}));
+vi.mock("@/lib/crypto", () => ({ decryptApiKey: vi.fn() }));
+vi.mock("@/lib/anthropic-keys", () => ({
+  fetchOrgApiKeys: vi.fn(),
+  resolveApiKeyId: vi.fn(),
+}));
+vi.mock("@/lib/anthropic-pricing", () => ({
+  resolveModelPricing: vi.fn(),
+  computeCostCents: vi.fn(),
+}));
+
+import { computeSyncWindow } from "@/lib/anthropic-sync";
+
+// computeSyncWindow returns the historical (daily-bucket) window. Today is
+// fetched separately with hourly buckets, so endingAt is always start-of-today
+// UTC. These tests pin "now" and assert the window is always valid for a
+// bucket_width=1d request (startingAt strictly before endingAt).
+
+describe("computeSyncWindow", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ends at start-of-today UTC", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 5, 15, 9, 30, 0))); // 2026-06-15T09:30Z
+    const { endingAt } = computeSyncWindow("2026-06-14");
+    expect(endingAt).toBe("2026-06-15T00:00:00Z");
+  });
+
+  it("starts one day before the latest stored date (re-sync the boundary day)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 5, 15, 9, 30, 0)));
+    const { startingAt, endingAt } = computeSyncWindow("2026-06-14");
+    // latest - 1 day = 2026-06-13
+    expect(startingAt).toBe("2026-06-13T00:00:00Z");
+    expect(endingAt).toBe("2026-06-15T00:00:00Z");
+  });
+
+  it("backfills DEFAULT_BACKFILL_DAYS (31) when there is no stored date", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 5, 15, 9, 30, 0)));
+    const { startingAt, endingAt } = computeSyncWindow(null);
+    expect(startingAt).toBe("2026-05-15T00:00:00Z"); // 31 days before Jun 15
+    expect(endingAt).toBe("2026-06-15T00:00:00Z");
+  });
+
+  it("yields a valid one-day window when the latest date is yesterday's-edge (latest = today)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 5, 15, 9, 30, 0)));
+    // latest == today: startDate = today-1 = yesterday, endDate = today
+    const { startingAt, endingAt } = computeSyncWindow("2026-06-15");
+    expect(startingAt).toBe("2026-06-14T00:00:00Z");
+    expect(endingAt).toBe("2026-06-15T00:00:00Z");
+    expect(new Date(startingAt).getTime()).toBeLessThan(
+      new Date(endingAt).getTime()
+    );
+  });
+
+  it("clamps a future-dated latest so the range is never zero-width or inverted", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 5, 15, 9, 30, 0)));
+    // Pathological: a stored date in the future (bad backfill / clock skew).
+    // Without the guard, startDate (latest-1 = Jun 17) would exceed endDate
+    // (Jun 15) and the API would 400. The clamp pins startDate to yesterday.
+    const { startingAt, endingAt } = computeSyncWindow("2026-06-18");
+    expect(startingAt).toBe("2026-06-14T00:00:00Z");
+    expect(endingAt).toBe("2026-06-15T00:00:00Z");
+    expect(new Date(startingAt).getTime()).toBeLessThan(
+      new Date(endingAt).getTime()
+    );
+  });
+
+  it("always produces startingAt strictly before endingAt across a month boundary", () => {
+    vi.useFakeTimers();
+    // First of the month — the scenario class that broke the cost path.
+    vi.setSystemTime(new Date(Date.UTC(2026, 6, 1, 0, 5, 0))); // 2026-07-01T00:05Z
+    const { startingAt, endingAt } = computeSyncWindow("2026-06-30");
+    expect(endingAt).toBe("2026-07-01T00:00:00Z");
+    expect(startingAt).toBe("2026-06-29T00:00:00Z");
+    expect(new Date(startingAt).getTime()).toBeLessThan(
+      new Date(endingAt).getTime()
+    );
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to #103, which fixed a first-of-month 400 in the **workspace cost** sync. During that PR's review I flagged a latent variant of the same daily-bucket hazard in the **per-user usage** sync (`src/lib/anthropic-sync.ts`). This PR hardens it.

## Problem

`computeSyncWindow` builds the historical sync window passed to the `usage_report` API with `bucket_width=1d`. `ending_at` is fixed at **start-of-today UTC** (today is fetched separately with hourly buckets), and `starting_at` is derived from the latest stored date minus one day.

The latest stored date should always be `< today`, so the window is normally valid. But a **same-day or future-dated row** — from a bad backfill, clock skew, or a timezone edge — would push `startDate` to or past `endDate`, producing a zero-width / inverted range. With `bucket_width=1d` the API rejects that with the exact same **400 "ending date must be after starting date"** that broke the cost path in #103.

It hadn't fired in production (today is shielded by the separate `todaySyncWindow()` hourly path), so this is defense-in-depth rather than an active outage — but the function should never be able to emit an invalid range regardless of what's in the table.

## Fix

Clamp `startDate` to at most `endDate − 1 day`, so the historical window always spans **at least one complete daily bucket** ending at start-of-today. The clamp is a no-op in all normal cases (including `latest == today`, which already yields a valid `[yesterday, today)` window); it only engages for the pathological future-dated case.

## Changes

| File | Change |
|---|---|
| `src/lib/anthropic-sync.ts` | Clamp `computeSyncWindow` start to `endDate − 1 day`; export the helper |
| `tests/unit/sync/anthropic-sync-window.test.ts` | New unit tests: normal, no-data (31-day backfill), `latest == today`, future-dated clamp, month-boundary |

## Validation

- `pnpm typecheck` ✅
- `pnpm lint` (zero warnings) ✅
- `pnpm test tests/unit/sync/ tests/unit/actions/running-costs.test.ts` → 51/51 ✅ (6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
