### PR TITLE
fix(anthropic): skip current-month cost sync on the 1st (real fix for #103)

### DIFF
--- a/src/lib/sync/sources/anthropic-workspace.ts
+++ b/src/lib/sync/sources/anthropic-workspace.ts
@@ -193,24 +193,24 @@ async function fetchAndUpsertWorkspaceCosts(month: string): Promise<number> {
   const nextYear = endMonth === 12 ? endYear + 1 : endYear;
   const monthEndDate = `${nextYear}-${String(nextMonth).padStart(2, "0")}-01T00:00:00Z`;
 
-  // Cap endDate to the start of *tomorrow* (next UTC midnight), not `now`.
-  // With bucket_width=1d the API snaps both endpoints to day boundaries and
-  // requires ending_at to be strictly after starting_at. Capping at `now`
-  // breaks on the 1st of the month: starting_at (month-start midnight) and
-  // ending_at (a few minutes into the same day) land in the same daily bucket,
-  // so the API returns 400 "ending date must be after starting date". Rounding
-  // up to the next midnight guarantees at least one full daily bucket and
-  // matches the documented "current date + 1 day" pattern.
+  // The cost_report API (bucket_width=1d) only returns COMPLETE UTC days. The
+  // newest boundary it will honour is the start of today — a `now` or future
+  // `ending_at` is silently floored back to start-of-today (verified against
+  // the live API). So cap the window there. When there is no complete day in
+  // the range yet — i.e. on the 1st of the month, where the month-start equals
+  // today — bail out: any request would have ending_at collapse onto
+  // starting_at and the API rejects it with 400 "ending date must be after
+  // starting date". (#103 capped at the *next* midnight, a future instant the
+  // API floors right back to start-of-today, so it still 400'd on the 1st.)
   const now = new Date();
   const startDateObj = new Date(startDate);
   const monthEndDateObj = new Date(monthEndDate);
-  const startOfTomorrow = new Date(now);
-  startOfTomorrow.setUTCHours(0, 0, 0, 0);
-  startOfTomorrow.setUTCDate(startOfTomorrow.getUTCDate() + 1);
+  const startOfToday = new Date(now);
+  startOfToday.setUTCHours(0, 0, 0, 0);
   const effectiveEnd =
-    monthEndDateObj < startOfTomorrow ? monthEndDateObj : startOfTomorrow;
+    monthEndDateObj < startOfToday ? monthEndDateObj : startOfToday;
   if (effectiveEnd.getTime() <= startDateObj.getTime()) {
-    // Month hasn't started yet — nothing to sync.
+    // No complete day to report yet (1st of the month, or a future month).
     return 0;
   }
   const endDate = effectiveEnd.toISOString();

--- a/tests/unit/sync/anthropic-workspace-backfill.test.ts
+++ b/tests/unit/sync/anthropic-workspace-backfill.test.ts
@@ -98,29 +98,24 @@ describe("anthropic-workspace date-range capping", () => {
     vi.useRealTimers();
   });
 
-  it("fetches a one-day window when cron fires at the exact month start", async () => {
+  it("skips cost fetch when cron fires on the 1st (no complete day yet)", async () => {
     vi.useFakeTimers();
-    // Cron fires at the exact start of May 2026 — the scenario from issue #72.
-    // ending_at must round up to the next UTC midnight (May 2) so the 1d-bucket
-    // range is valid, instead of collapsing to a zero-width same-day range that
-    // the API rejects with "ending date must be after starting date".
+    // Cron fires at the exact start of May 2026. cost_report only returns
+    // COMPLETE UTC days; on the 1st the month-start equals start-of-today, so
+    // there is no complete day to report. Any request would have ending_at
+    // collapse onto starting_at, which the live API rejects with 400 "ending
+    // date must be after starting date". The sync must skip, not call the API.
     vi.setSystemTime(new Date(Date.UTC(2026, 4, 1, 0, 0, 0))); // 2026-05-01T00:00:00Z
 
     mockFetch.mockResolvedValueOnce(workspacesResponse([]));
-    mockFetch.mockResolvedValueOnce(
-      costReportResponse([{ workspace_id: "ws1", amount: "0.00" }])
-    );
 
     const result = await run(1, { month: "2026-05" });
     expect(result).toHaveProperty("eventId");
-    // Workspace fetch + a valid one-day cost report fetch (May 1 -> May 2).
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    const calledUrl: string = mockFetch.mock.calls[1][0] as string;
-    expect(calledUrl).toContain("2026-05-01");
-    expect(calledUrl).toContain("2026-05-02");
+    // Only the workspace fetch — no cost report call.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("caps endDate to the next UTC midnight when month end is in the future", async () => {
+  it("caps endDate to start-of-today (not now, not the future month end)", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(Date.UTC(2026, 4, 15, 12, 0, 0))); // 2026-05-15T12:00:00Z
 
@@ -135,11 +130,11 @@ describe("anthropic-workspace date-range capping", () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
     const costReportCall = mockFetch.mock.calls[1];
     const calledUrl: string = costReportCall[0] as string;
-    // Not capped to the future month end (June 1)...
+    // ending_at is start-of-today (May 15 00:00) — the newest complete-day
+    // boundary the API honours. Not the future month end (June 1), and not the
+    // partial current time (which the API would floor back to start-of-today).
     expect(calledUrl).not.toContain("2026-06-01");
-    // ...and rounded up to the next UTC midnight (May 16), not the partial
-    // current time, so every requested bucket is a complete day.
-    expect(calledUrl).toContain("2026-05-16");
+    expect(calledUrl).toContain("2026-05-15T00");
     expect(calledUrl).not.toContain("2026-05-15T12");
   });
 
@@ -160,30 +155,28 @@ describe("anthropic-workspace date-range capping", () => {
     expect(calledUrl).toContain("2026-05-01");
   });
 
-  it("fetches a one-day current-month window during backfill at exact month start", async () => {
+  it("skips the current-month iteration in backfill when cron fires on the 1st", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(Date.UTC(2026, 4, 1, 0, 0, 0))); // 2026-05-01T00:00:00Z
 
     // Workspaces succeeds
     mockFetch.mockResolvedValueOnce(workspacesResponse([]));
-    // April cost report (full past month) succeeds
+    // April cost report (full past month, Apr 1 -> May 1) succeeds
     mockFetch.mockResolvedValueOnce(
       costReportResponse([{ workspace_id: "ws1", amount: "300.00" }])
     );
-    // May cost report (one-day window May 1 -> May 2) succeeds — no longer skipped
-    mockFetch.mockResolvedValueOnce(
-      costReportResponse([{ workspace_id: "ws1", amount: "0.00" }])
-    );
+    // May has no complete day yet on May 1 — it must be skipped (no API call).
 
     const result = await run(1, {
       backfillStartDate: new Date(Date.UTC(2026, 3, 1)), // Apr 2026
     });
 
     expect(result).toHaveProperty("eventId");
-    // 1 workspace + April + May = 3 calls; May is fetched with a valid one-day range
-    expect(mockFetch).toHaveBeenCalledTimes(3);
-    const mayUrl: string = mockFetch.mock.calls[2][0] as string;
-    expect(mayUrl).toContain("2026-05-02");
+    // 1 workspace + 1 April cost report = 2 calls; May is skipped.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const aprUrl: string = mockFetch.mock.calls[1][0] as string;
+    expect(aprUrl).toContain("2026-04-01");
+    expect(aprUrl).toContain("2026-05-01");
   });
 });
 


### PR DESCRIPTION
## Problem

The Anthropic **cost sync still fails on the 1st of the month**, despite #103:

> Cost sync failed: Anthropic cost_report API error 400: `{"type":"invalid_request_error","message":"Invalid date range: ending date must be after starting date"}`

#103 fixed the dropdown half of the original report but **misdiagnosed the sync half** — its "round `ending_at` up to the next UTC midnight" change does not fix the 400 (and is what's running in production now).

## Root cause (verified against the live API)

I probed the real `cost_report` endpoint with the admin key. The API behaves as follows with `bucket_width=1d`:

| `starting_at` | `ending_at` | Result |
|---|---|---|
| `2026-06-01T00:00` | `2026-06-02T00:00` (next midnight — **#103's output**) | **400** |
| `2026-06-01T00:00` | `2026-06-01T09:34` (now) | **400** |
| `2026-05-01T00:00` | `2026-06-01T00:00` (full last month) | 200 |
| `2026-05-01T00:00` | `2026-06-02T00:00` (future end) | 200 |

So:
- `cost_report` only returns **complete UTC days**. The effective `ending_at` is **floored to start-of-today** — a `now` or future end is silently clamped back.
- The 400 fires whenever the range contains **no complete day** — i.e. when `starting_at` is today's start.
- On the **1st**, the current month's start (`June 1 00:00`) **equals** start-of-today, so there is never a complete day yet → every `ending_at` collapses onto `starting_at` → 400.

#103 capped at the *next* midnight (a future instant) — but the API floors that right back to start-of-today, so it still 400'd on the 1st.

## Fix

Cap the window at **start-of-today** (the newest complete-day boundary the API honours) and **bail when no complete day exists yet** — which is exactly the 1st of the month (and future months). Days 2..31 and past-month backfills are unchanged.

```ts
const startOfToday = new Date(now);
startOfToday.setUTCHours(0, 0, 0, 0);
const effectiveEnd = monthEndDateObj < startOfToday ? monthEndDateObj : startOfToday;
if (effectiveEnd.getTime() <= startDateObj.getTime()) {
  return 0; // no complete day to report yet (1st of month, or future month)
}
```

## Verification on the running application

Created a Neon branch (`wt/fix-sync-first-of-month`) from production data (527 cost rows, Jan 30 → May 29, 0 June rows) and ran the **actual cron route** + backfill against it via `pnpm dev`:

| `sync_event` | Code | Outcome | Notes |
|---|---|---|---|
| 3363 | **old #103** | `partial`, error_count 1 | Reproduced the **exact prod 400** message |
| 3362 / 3364 | **fixed**, regular | `success`, 0 errors | June correctly skipped |
| 3366 | **fixed**, backfill | `success`, 0 errors | **upserted 527 past-month rows**, June skipped |

## Changes

| File | Change |
|---|---|
| `src/lib/sync/sources/anthropic-workspace.ts` | Cap `ending_at` at start-of-today; skip when no complete day exists |
| `tests/unit/sync/anthropic-workspace-backfill.test.ts` | Updated the 3 cases #103 changed to assert skip-on-the-1st + start-of-today capping |

## Validation
- `pnpm typecheck` ✅ · `pnpm lint` (0 warnings) ✅ · `pnpm test tests/unit/sync/` → 41/41 ✅

## Notes
- Supersedes the cost-sync portion of #103 (the dropdown fix from #103 stays). The separate usage-sync guard in #104 is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
