### PR TITLE
feat(anthropic): add Opus 4.8 to model pricing table

### DIFF
--- a/src/lib/anthropic-pricing.ts
+++ b/src/lib/anthropic-pricing.ts
@@ -29,7 +29,7 @@ export const MODEL_PRICING: ModelPricing[] = [
     cacheReadPerMToken: 1.5,
     cacheWritePerMToken: 18.75,
   },
-  // Opus 4.5 / 4.6 / 4.7 — $5/$25
+  // Opus 4.5 / 4.6 / 4.7 / 4.8 — $5/$25
   {
     prefix: "claude-opus-4-5",
     inputPerMToken: 5,
@@ -46,6 +46,13 @@ export const MODEL_PRICING: ModelPricing[] = [
   },
   {
     prefix: "claude-opus-4-7",
+    inputPerMToken: 5,
+    outputPerMToken: 25,
+    cacheReadPerMToken: 0.5,
+    cacheWritePerMToken: 6.25,
+  },
+  {
+    prefix: "claude-opus-4-8",
     inputPerMToken: 5,
     outputPerMToken: 25,
     cacheReadPerMToken: 0.5,

--- a/tests/unit/anthropic-pricing.test.ts
+++ b/tests/unit/anthropic-pricing.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveModelPricing,
+  computeCostCents,
+} from "@/lib/anthropic-pricing";
+
+describe("resolveModelPricing", () => {
+  it("resolves Opus 4.8 to the $5/$25 tier", () => {
+    const { pricing, resolved } = resolveModelPricing(
+      "claude-opus-4-8-20260101",
+    );
+
+    expect(resolved).toBe(true);
+    expect(pricing.prefix).toBe("claude-opus-4-8");
+    expect(pricing.inputPerMToken).toBe(5);
+    expect(pricing.outputPerMToken).toBe(25);
+    expect(pricing.cacheReadPerMToken).toBe(0.5);
+    expect(pricing.cacheWritePerMToken).toBe(6.25);
+  });
+
+  it("keeps Opus 4.5/4.6/4.7 on the $5/$25 tier", () => {
+    for (const model of [
+      "claude-opus-4-5-20251101",
+      "claude-opus-4-6-20251201",
+      "claude-opus-4-7-20260101",
+    ]) {
+      const { pricing, resolved } = resolveModelPricing(model);
+      expect(resolved).toBe(true);
+      expect(pricing.inputPerMToken).toBe(5);
+      expect(pricing.outputPerMToken).toBe(25);
+    }
+  });
+
+  it("resolves Opus 4.0/4.1 to the $15/$75 tier", () => {
+    const { pricing, resolved } = resolveModelPricing(
+      "claude-opus-4-1-20250805",
+    );
+    expect(resolved).toBe(true);
+    expect(pricing.inputPerMToken).toBe(15);
+    expect(pricing.outputPerMToken).toBe(75);
+  });
+
+  it("falls back to the highest (Opus 4.0/4.1) tier for unknown models", () => {
+    const { pricing, resolved } = resolveModelPricing("gpt-5.5-turbo");
+    expect(resolved).toBe(false);
+    expect(pricing.inputPerMToken).toBe(15);
+    expect(pricing.outputPerMToken).toBe(75);
+  });
+});
+
+describe("computeCostCents", () => {
+  it("computes cost in cents from token counts and Opus 4.8 pricing", () => {
+    const { pricing } = resolveModelPricing("claude-opus-4-8-20260101");
+
+    // 1M uncached input ($5) + 1M output ($25) = $30.00 = 3000 cents
+    const cents = computeCostCents(
+      {
+        uncachedInputTokens: 1_000_000,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+        outputTokens: 1_000_000,
+      },
+      pricing,
+    );
+
+    expect(cents).toBe(3000);
+  });
+});


### PR DESCRIPTION
## Summary

Opus 4.8 was missing from the Anthropic pricing table (`src/lib/anthropic-pricing.ts`), so its cost calculations fell back to the Opus 4.0/4.1 rate ($15/$75) instead of the correct rate.

Web research confirmed Opus 4.8 standard API pricing matches the existing Opus 4.5/4.6/4.7 tier:
- **$5** / M input tokens
- **$25** / M output tokens
- **$0.50** / M cache read (90% discount)
- **$6.25** / M cache write (1.25×)

This PR adds an explicit `claude-opus-4-8` entry so `resolveModelPricing` matches it directly.

## Notes
- No change needed in `cost-chart.tsx` — `formatModelName` derives the display name ("Opus 4.8") from the model string via regex.
- The running-costs unit test mocks the pricing module, so no fixtures were affected.
- Pricing nuances intentionally not encoded (table tracks standard pricing only, consistent with existing rows): Fast mode is 2× ($10/$50), US-only inference is 1.1×.

## Sources
- https://www.anthropic.com/claude/opus
- https://platform.claude.com/docs/en/about-claude/pricing
- https://openrouter.ai/anthropic/claude-opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)