### PR TITLE
feat(anthropic): current-day cost estimate (spec 033)

### DIFF
--- a/specs/033-current-day-cost-estimate/implementation-notes.html
+++ b/specs/033-current-day-cost-estimate/implementation-notes.html
@@ -266,6 +266,22 @@
           the estimate rides the <em>usage</em> sync (30 min), per D2.</li>
         </ul>
       </div>
+      <div class="entry">
+        <h4>Review feedback (PR #107, Copilot) — UTC consistency <span class="chip done">done</span></h4>
+        <p class="muted">All three review comments were the same class of issue: <strong>local-vs-UTC date drift</strong>.
+        The spend data and <code>daysElapsed</code> are UTC-keyed, but a few day/month calculations still used local-time
+        helpers — harmless in production (Vercel runs UTC) but off-by-one at a UTC boundary in non-UTC runtimes. Fixed:</p>
+        <ul class="muted">
+          <li>Added <code>getUtcDaysInMonth</code> to <span class="file-path">utils.ts</span>; used it in
+          <span class="file-path">page.tsx</span> and <span class="file-path">workspace-budget-list.tsx</span> in place of
+          <code>getDaysInMonth(now)</code> (which read the <em>local</em> month).</li>
+          <li>Refactored <span class="file-path">forecast-workspace.ts</span> to do <strong>all</strong> date math in UTC
+          (dense-series day keys, <code>daysElapsed</code>, MTD window, <code>crossesCapOn</code>) via
+          <code>formatUtcDateOnly</code> + <code>Date.UTC</code>, dropping the local-time date-fns calls. Behaviour is
+          unchanged for in-UTC runtimes; only the boundary off-by-one is removed.</li>
+          <li>Added a regression test pinning UTC "today" at a month boundary (23:30Z on May 31 stays in May).</li>
+        </ul>
+      </div>
     </div>
 
     <script>

--- a/specs/033-current-day-cost-estimate/implementation-notes.html
+++ b/specs/033-current-day-cost-estimate/implementation-notes.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Spec 033 — Implementation notes</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0a0a0a; --panel: #121212; --panel-2: #181818; --border: #262626; --border-2: #2e2e2e;
+        --text: #fafafa; --muted: #a1a1aa; --muted-2: #71717a;
+        --primary: #d4f057; --info: #67e8f9; --warn: #facc15; --danger: #f87171; --success: #4ade80;
+      }
+      html, body { background: var(--bg); color: var(--text); }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.55; }
+      code, pre, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .container { max-width: 1000px; margin: 0 auto; padding: 32px 24px; }
+      .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 16px 18px; }
+      h1, h2, h3 { letter-spacing: -0.01em; }
+      h2 { margin-top: 2rem; font-size: 1.4rem; font-weight: 700; }
+      h3 { margin-top: 1.25rem; font-size: 1.05rem; font-weight: 600; color: var(--info); }
+      .chip { display: inline-flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 6px; font-size: 11px; background: #181818; border: 1px solid var(--border-2); color: var(--muted); }
+      .chip.decision { color: #d4f057; border-color: #3f5d10; background: #161c07; }
+      .chip.deviation { color: #fca5a5; border-color: #7f1d1d; background: #2a0a0a; }
+      .chip.tradeoff { color: #67e8f9; border-color: #155e75; background: #082f3a; }
+      .chip.open { color: #facc15; border-color: #5a4607; background: #1c1407; }
+      .chip.done { color: #86efac; border-color: #14532d; background: #0a1c10; }
+      .file-path { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px; color: #67e8f9; }
+      .entry { border-left: 3px solid var(--border-2); padding: 4px 0 4px 14px; margin: 14px 0; }
+      .entry.decision { border-color: var(--primary); }
+      .entry.deviation { border-color: var(--danger); }
+      .entry.tradeoff { border-color: var(--info); }
+      .entry.open { border-color: var(--warn); }
+      .entry h4 { font-size: 0.98rem; font-weight: 600; margin-bottom: 4px; }
+      .muted { color: var(--muted); }
+      pre.code { background: #060606; border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; overflow-x: auto; font-size: 12px; line-height: 1.5; color: #e4e4e7; }
+      ul { padding-left: 20px; } li { margin: 4px 0; }
+      a { color: #d4f057; text-underline-offset: 3px; }
+      table { width: 100%; border-collapse: collapse; font-size: 13px; margin-top: 8px; }
+      th, td { padding: 6px 10px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+      th { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header style="border-bottom:1px solid var(--border); padding-bottom:16px; margin-bottom:8px;">
+        <div class="flex flex-wrap gap-2 mb-3" style="display:flex;gap:8px;flex-wrap:wrap;">
+          <span class="chip">Spec 033</span>
+          <span class="chip done">Implementation notes</span>
+          <span class="chip">Branch · 033-current-day-cost-estimate</span>
+        </div>
+        <h1 style="font-size:1.8rem;font-weight:800;">Current-day cost estimate — implementation notes</h1>
+        <p class="muted" style="margin-top:8px;max-width:60rem;">
+          A running log of where the implementation interprets, diverges from, or trades off against
+          <a href="plan.html">plan.html</a> / <a href="mockup.html">mockup.html</a>. Legend:
+          <span class="chip decision">decision</span> ambiguity resolved ·
+          <span class="chip deviation">deviation</span> intentional departure ·
+          <span class="chip tradeoff">tradeoff</span> alternative considered ·
+          <span class="chip open">open</span> needs your confirmation.
+        </p>
+      </header>
+
+      <h2>Scope recap</h2>
+      <div class="card">
+        <p>Tier B, one PR, three phases: <strong>data → maths → UI</strong>. A pure, calibrated "estimated today"
+        figure surfaced as a <em>separate</em> DTO field, plus the projection-denominator fix. Alerts and budget
+        running-costs stay actual-only. 0 migrations, 0 packages.</p>
+      </div>
+
+      <h2>Architecture decisions</h2>
+      <div id="decisions"></div>
+
+      <h2>Deviations from the plan</h2>
+      <div id="deviations"></div>
+
+      <h2>Tradeoffs</h2>
+      <div id="tradeoffs"></div>
+
+      <h2>Open questions for review</h2>
+      <div id="open"></div>
+
+      <h2>Phase log</h2>
+      <div id="phases"></div>
+
+      <footer style="border-top:1px solid var(--border);margin-top:32px;padding-top:16px;" class="muted">
+        <p style="font-size:12px;">Living document — updated as implementation proceeds.</p>
+      </footer>
+    </div>
+
+    <!-- ============================= CONTENT ============================= -->
+    <!-- Entries are plain HTML below; kept inline (not JS) so the file renders statically. -->
+    <script>
+      // no-op; content authored directly in the sections below via DOM injection at build-time-by-hand.
+    </script>
+
+    <template id="ignore"></template>
+
+    <!-- DECISIONS -->
+    <div hidden id="src-decisions">
+      <div class="entry decision">
+        <h4>D1 · Estimate computed in <span class="file-path">queries.ts</span> (uncached layer), not the cached actions</h4>
+        <p class="muted">The cron Teams evaluator reads <code>loadDashboardKpis</code> / <code>loadCostHistory</code>
+        directly (uncached, "wants fresh reads"); the dashboard wraps them in <code>unstable_cache</code>. Putting the
+        estimate in the query layer means the evaluator gets a fresh estimate every cron run, and the dashboard inherits
+        the existing refresh cadence (manual sync / tag revalidation) — identical freshness to the actuals beside it.</p>
+      </div>
+      <div class="entry decision">
+        <h4>D2 · <code>asOf</code> = sentinel row <code>last_sync_completed_at</code> (per-user usage sync)</h4>
+        <p class="muted">The estimate is only as fresh as the hourly per-user usage sync. That completion timestamp is
+        written on the <code>user_id = 0</code> sentinel row by <span class="file-path">anthropic-sync.ts</span> (the
+        per-user path), distinct from <code>workspace_sync_completed_at</code> (the cost_report path). The freshness
+        label reads the former.</p>
+      </div>
+      <div class="entry decision">
+        <h4>D3 · <code>null</code> estimate when stale or zero — UI falls back to actual-only</h4>
+        <p class="muted">Per the plan's null rule, the query layer returns <code>null</code> when (a) there is no
+        per-user usage for today (<code>rawUserCents === 0</code>), or (b) the usage sync is stale
+        (<code>asOf</code> older than the existing 70-minute threshold). A stale estimate is worse than none, so we
+        <em>hide</em> rather than dim. See tradeoff T2.</p>
+      </div>
+      <div class="entry decision">
+        <h4>D4 · UTC day boundary for <code>daysElapsed</code></h4>
+        <p class="muted">All four projection callers used <code>getDate()</code> (local) while the cost tables key on
+        UTC calendar dates. Switched to a UTC day count (and <code>getCurrentMonth()</code>, already UTC, for the
+        "is current month" test) so numerator and denominator agree with the data's day boundary.</p>
+      </div>
+      <div class="entry decision">
+        <h4>D5 · App design tokens, not mockup hex</h4>
+        <p class="muted">The mockup uses literal lime <code>#d4f057</code>. The real charts use
+        <code>var(--chart-1)</code> with the existing ghost vocabulary (<code>fillOpacity 0.28</code>,
+        <code>strokeOpacity 0.6</code>, <code>strokeDasharray "3 3"</code> for bars; the pacing projection line keeps
+        its existing <code>"4 3"</code>). Per CLAUDE.md ("design tokens only — no hardcoded color"), the estimate
+        reuses those tokens, so it reads as "ghost/projected" in whatever theme is active rather than a fixed lime.</p>
+      </div>
+      <div class="entry decision">
+        <h4>D6 · KPI headline stays the actual total; estimate is a labeled sub-line</h4>
+        <p class="muted">The mockup merges actual + est into the headline ("$43,960"). The plan §6.1 instead says the
+        tiles get an <em>"incl. est. today" sub-label</em>. Followed the plan: the <code>Total · {month}</code> /
+        <code>Projected</code> headline values are unchanged (actual total; projection already folds in the estimate via
+        the maths layer), and a <span class="chip decision">est.</span>-chipped sub-line ("incl. +$X est. today")
+        surfaces the estimate. This is the more conservative reading and keeps the headline number un-inflated, matching
+        the "never merged into totalCents" guard. The big <em>projected</em> number does reflect the estimate (that's
+        the whole point of the projection fix).</p>
+      </div>
+      <div class="entry decision">
+        <h4>D7 · Stacked "today (est.)" bar via a reserved series key</h4>
+        <p class="muted">The org daily chart is a stacked bar chart. The estimate is a single org total (not a
+        per-workspace breakdown <em>in that chart</em>), so the server appends one trailing row keyed under a reserved
+        <code>__estimated__</code> series (mirroring the existing <code>__other__</code>/<code>__default__</code>
+        keys, which are intentionally duplicated client-side). The client renders it as one dashed ghost bar, and only
+        in the org-wide ("All workspaces") view. The workspace <em>detail</em> daily chart appends a per-workspace ghost
+        bar from that workspace's own estimate.</p>
+      </div>
+      <div class="entry decision">
+        <h4>D8 · <code>/claude</code> page now computes "today"/"current month" in UTC</h4>
+        <p class="muted">The page passed <code>getDate(now)</code> / <code>format(now,"yyyy-MM")</code> (local) into the
+        pacing chart's today line and the KPI loaders. Switched to <code>now.getUTCDate()</code> and
+        <code>getCurrentMonth()</code> so the dashboard's "today" matches the UTC day the cost tables and the estimate
+        gating use (and the already-UTC available-months list).</p>
+      </div>
+    </div>
+
+    <!-- DEVIATIONS -->
+    <div hidden id="src-deviations">
+      <div class="entry deviation">
+        <h4>V1 · User-detail page gets the UTC fix but <em>no</em> estimate field</h4>
+        <p class="muted">The plan lists <span class="file-path">anthropic-users.ts</span> among the four projection
+        callers (Tier A). But the per-user detail page's <code>currentMonthCents</code> comes from
+        <code>anthropic_usage_metrics</code>, which <strong>already includes today</strong> (hourly). It is the source —
+        the scope guard says it needs no calibration. So its numerator already includes today and only the denominator
+        needed the UTC alignment; no <code>todayEstimate</code> is threaded onto <code>UserDetail</code>. This matches
+        the spec's intent, just makes explicit that the "off-by-one" framing doesn't apply there.</p>
+      </div>
+    </div>
+
+    <!-- TRADEOFFS -->
+    <div hidden id="src-tradeoffs">
+      <div class="entry tradeoff">
+        <h4>T1 · Per-workspace calibration vs. a single global ratio</h4>
+        <p class="muted">Each workspace's estimate is calibrated against <em>its own</em> recent per-user-vs-cost_report
+        ratio (clamped 0.5–2.0, falls back to ×1 when thin). Alternative: one global ratio applied to every workspace's
+        raw per-user sum. Per-workspace is more honest where mix differs, and the clamp + confident fallback guards thin
+        data. Global aggregate uses the summed components (one global ratio for the org KPI).</p>
+      </div>
+      <div class="entry tradeoff">
+        <h4>T2 · Hide a stale estimate vs. dim it</h4>
+        <p class="muted">The plan offered "dim it / hide". Chose hide (<code>null</code>) for safety — a dimmed-but-stale
+        number can still be misread as current. The freshness label still shows the sync age while fresh.</p>
+      </div>
+    </div>
+
+    <!-- OPEN -->
+    <div hidden id="src-open">
+      <div class="entry open">
+        <h4>Q1 · Teams cron alerts now include the estimate in the run-rate (confirm)</h4>
+        <p class="muted">Per plan Phase 2 (T2.2) the cron Teams forecast (<span class="file-path">forecast-workspace.ts</span>
+        via <span class="file-path">teams/evaluator.ts</span>) now fills today's missing <code>cost_report</code> slot
+        with the per-workspace estimate. This is a real behavior change: a workspace can tip into <em>at_risk</em> /
+        cross its cap a little earlier (more accurate, no longer diluted by a phantom $0 today). The 80/100/120 utilization
+        thresholds are unchanged (they read actual <code>cost_report</code> only). Flagging because it changes when
+        production alerts fire. The plan calls this an intended "benefit"; confirm you're happy with it.</p>
+      </div>
+      <div class="entry open">
+        <h4>Q2 · Dashboard estimate freshness follows the existing cache cadence</h4>
+        <p class="muted">The estimate lives inside the same <code>unstable_cache</code> reads as the actuals, busted by
+        manual sync / <code>revalidateTag</code> (the hourly crons don't revalidate — pre-existing). The cron Teams
+        evaluator reads uncached, so <em>it</em> always sees a fresh estimate. No new cron revalidation was added (would
+        change existing caching behavior). If you want the dashboard estimate to refresh hourly without a manual sync,
+        that's a small follow-up (have the usage cron <code>revalidateTag("anthropic-workspace-costs")</code>).</p>
+      </div>
+    </div>
+
+    <!-- PHASES -->
+    <div hidden id="src-phases">
+      <div class="entry">
+        <h4>Phase 1 — estimation backend <span class="chip done">done</span></h4>
+        <p class="muted"><span class="file-path">estimate-today.ts</span> (pure helper + constants + <code>TodayEstimate</code>);
+        query helpers <code>loadTodayEstimate</code> / <code>loadTodayEstimatesByWorkspace</code> /
+        <code>loadTodayEstimateInputs</code> in <span class="file-path">queries.ts</span> (3 aggregates + sentinel
+        <code>asOf</code>); <code>todayEstimate</code> threaded onto <code>DashboardKpis</code>,
+        <code>WorkspaceListItem</code>, <code>WorkspaceDetail</code> (separate field, <code>totalCents</code> unchanged).
+        8 unit tests for the helper (clamp band, thin-data fallback, zero, rounding, boundary).</p>
+      </div>
+      <div class="entry">
+        <h4>Phase 2 — projection &amp; run-rate <span class="chip done">done</span></h4>
+        <p class="muted">All four projection callers now use <code>spentSoFar = mtdActual + est.cents</code> with a UTC
+        <code>daysElapsed</code> (queries / workspace-detail / pace label; user-detail gets the UTC fix only — see V1).
+        <span class="file-path">forecast-workspace.ts</span> takes an optional <code>todayEstimateCents</code> (default 0
+        ⇒ unchanged) that fills today's slot + MTD; the evaluator passes per-workspace estimates. Alerts &amp; running
+        costs untouched. Tests: forecast est-fill / no-double-count / default-equivalence; projection 1st-of-month
+        non-zero, mid-month hand-calc, actual-only invariants.</p>
+      </div>
+      <div class="entry">
+        <h4>Phase 3 — UI <span class="chip done">done</span></h4>
+        <p class="muted">Shared <span class="file-path">today-estimate.tsx</span> (est. chip + tooltip + sub-label +
+        <code>totalTileCaption</code>). KPI strip (org + workspace detail) sub-labels; org-credits panel current-spend
+        note; org daily chart trailing ghost bar; workspace-detail daily chart ghost bar; cumulative pacing projection
+        re-anchored at today. Threaded through <span class="file-path">page.tsx</span> /
+        <span class="file-path">historical-trend-card.tsx</span> / clients. Lint + typecheck clean; 382 unit tests green.</p>
+      </div>
+      <div class="entry">
+        <h4>/simplify <span class="chip done">done</span></h4>
+        <p class="muted">Applied: extracted the UTC date helper (3 copies → <code>formatUtcDateOnly</code> in
+        <span class="file-path">utils.ts</span>) and the duplicated "Total tile" caption (→ <code>totalTileCaption</code>).
+        Skipped (noted): clamp extraction (keeps the pure helper dependency-free), inlining <code>buildTodayEstimate</code>
+        (would duplicate the gating), a projection-caption helper (org/workspace wordings legitimately differ). Efficiency
+        &amp; altitude: no actionable findings (separate <code>unstable_cache</code> boundaries; per-site projection is
+        the right depth).</p>
+      </div>
+      <div class="entry">
+        <h4>Browser verification — Neon branch <code>wt/fix-sync-first-of-month</code> (real data) <span class="chip done">done</span></h4>
+        <p class="muted">Forked from <code>main</code>; today is literally the 1st of the month, so this is the headline
+        scenario. Verified end-to-end (DB → query → DTO → SSR + hydrated UI), authenticated as the seeded agent admin:</p>
+        <ul class="muted">
+          <li><strong>Org KPI strip:</strong> Total <code>$0.00</code> + <code>$112.61 est. today</code> with the dashed
+          <span class="chip decision">est.</span> chip; Projected month-end <code>$3,378.30</code> = "97% of $3,500 budget ·
+          incl. est. today". Math checks exactly: 11,261¢ × 30 ÷ 1 = 337,830¢.</li>
+          <li><strong>1st-of-month win:</strong> June <code>cost_report</code> is still empty (MTD actual $0); the estimate
+          turns a would-be $0 / — into a real, calibrated number from hour one.</li>
+          <li><strong>Daily chart:</strong> single dashed ghost "today (est.)" bar (June has no actual bars yet — expected).</li>
+          <li><strong>Per-workspace:</strong> <code>boost-starter-1</code> shows <code>+$45.43 est. today</code> (its own
+          calibration ~0.945, distinct from the global ~1.016) and "95% of $700 limit · incl. est. today". The default
+          workspace has no today usage → estimate null → $0 (correct fallback).</li>
+          <li><strong>Freshness:</strong> the "Stale · 16h" pill (workspace sync) coexists with a live estimate — confirms
+          the estimate rides the <em>usage</em> sync (30 min), per D2.</li>
+        </ul>
+      </div>
+    </div>
+
+    <script>
+      for (const sec of ["decisions","deviations","tradeoffs","open","phases"]) {
+        const src = document.getElementById("src-" + sec);
+        const dst = document.getElementById(sec);
+        if (src && dst) dst.innerHTML = src.innerHTML || '<p class="muted">None yet.</p>';
+      }
+    </script>
+  </body>
+</html>

--- a/specs/033-current-day-cost-estimate/mockup.html
+++ b/specs/033-current-day-cost-estimate/mockup.html
@@ -1,0 +1,273 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Spec 033 — Current-day cost estimate · UI mockup</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0a0a0a; --panel: #121212; --panel-2: #181818; --border: #262626; --border-2: #2e2e2e;
+        --text: #fafafa; --muted: #a1a1aa; --muted-2: #71717a;
+        --primary: #d4f057; --primary-ink: #0a0a0a;
+        --success: #4ade80; --warn: #facc15; --danger: #f87171; --info: #67e8f9;
+        --bar: #67e8f9; --bar-2: #3aa0b3;
+      }
+      html, body { background: var(--bg); color: var(--text); }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.5; }
+      .tabular { font-variant-numeric: tabular-nums; }
+      .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; }
+      .card-2 { background: var(--panel-2); border: 1px solid var(--border); border-radius: 12px; }
+      .container { max-width: 1100px; margin: 0 auto; padding: 32px 24px; }
+      .chip { display: inline-flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 6px; font-size: 11px; background: #181818; border: 1px solid var(--border-2); color: var(--muted); }
+      .chip.est { color: #d4f057; border-color: #3f5d10; background: #161c07; }
+      .chip.info { color: #67e8f9; border-color: #155e75; background: #082f3a; }
+      .chip.warn { color: #facc15; border-color: #5a4607; background: #1c1407; }
+      .kpi-tile { padding: 16px 18px; border-radius: 12px; border: 1px solid var(--border); background: var(--panel); }
+      .kpi-label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+      .kpi-value { font-size: 28px; font-weight: 600; }
+      .kpi-sub { font-size: 12px; color: var(--muted); margin-top: 4px; }
+      .legend-swatch { width: 12px; height: 12px; border-radius: 2px; display: inline-block; vertical-align: middle; margin-right: 6px; }
+      .annot { border-left: 3px solid var(--primary); background: rgba(212, 240, 87, 0.05); padding: 10px 12px; border-radius: 0 8px 8px 0; font-size: 12px; color: var(--muted); }
+      .annot.info { border-color: var(--info); background: rgba(103,232,249,0.05); }
+      a.link { color: #d4f057; text-decoration: underline; text-underline-offset: 4px; }
+      .tooltip-mock { background: #0a0a0a; border: 1px solid var(--border-2); border-radius: 8px; padding: 10px 12px; font-size: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.5); display: inline-block; }
+      .num { font-variant-numeric: tabular-nums; }
+      .label-est { fill: #d4f057; font-size: 9px; }
+      .grid-line { stroke: #1c1c1c; }
+      .axis-label { fill: #71717a; font-size: 9px; }
+    </style>
+  </head>
+  <body>
+    <div class="container space-y-10">
+
+      <header class="pb-5 border-b border-[var(--border)]">
+        <div class="flex flex-wrap items-center gap-2 mb-3 text-xs">
+          <span class="chip">Spec 033</span>
+          <span class="chip est">Tier B mockup</span>
+          <span class="chip">Static — illustrative numbers</span>
+          <a class="chip info" href="plan.html">← back to plan.html</a>
+        </div>
+        <h1 class="text-2xl font-bold tracking-tight">Current-day cost estimate — UI mockup</h1>
+        <p class="text-[var(--muted)] text-sm mt-2 max-w-3xl">
+          How the clearly-labelled <strong>estimated today</strong> figure appears on the Claude dashboard. The estimate is always a
+          <span style="color:#d4f057">dashed / ghosted, "est." chipped</span> treatment — visually distinct from solid actuals — and is never
+          merged into the actual month-to-date total. Three views: the KPI strip, the daily cost chart, and the cumulative pacing chart, plus the
+          1st-of-month before/after that motivates the change.
+        </p>
+      </header>
+
+      <!-- ============ 1. KPI STRIP ============ -->
+      <section class="space-y-3">
+        <h2 class="text-lg font-semibold">1 · KPI strip — Month-to-date &amp; Projected month-end</h2>
+        <p class="text-sm text-[var(--muted)]">Scenario: <span class="chip">12 June, mid-month</span> · org monthly budget $90,000.</p>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <!-- MTD tile -->
+          <div class="kpi-tile">
+            <div class="kpi-label">Month-to-date</div>
+            <div class="kpi-value num">$43,960</div>
+            <div class="kpi-sub flex items-center gap-1.5 flex-wrap">
+              <span>$42,320 actual</span>
+              <span class="text-[var(--muted-2)]">+</span>
+              <span style="color:#d4f057">$1,640 est. today</span>
+              <span class="chip est" title="Estimated from per-user usage, calibrated to recent billed days. Not yet billed.">est.</span>
+            </div>
+          </div>
+          <!-- Projected tile -->
+          <div class="kpi-tile">
+            <div class="kpi-label">Projected month-end</div>
+            <div class="kpi-value num">$109,900 <span class="text-base font-medium" style="color:#facc15">122%</span></div>
+            <div class="kpi-sub">of $90,000 budget · run-rate incl. today</div>
+          </div>
+          <!-- Last-complete-day tile (unchanged actual) -->
+          <div class="kpi-tile">
+            <div class="kpi-label">Yesterday (actual)</div>
+            <div class="kpi-value num">$3,710</div>
+            <div class="kpi-sub">11 June · billed via cost_report</div>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <div class="annot">
+            <strong>What changed:</strong> the MTD tile now shows <code>actual + est. today</code> with the estimate broken out and chipped.
+            The big number stays honest — hover the <span class="chip est">est.</span> chip for the tooltip below. The actual-only value is still one click away.
+          </div>
+          <div class="card-2 p-3">
+            <div class="text-[11px] uppercase tracking-wider text-[var(--muted)] mb-2">Tooltip on the "est." chip</div>
+            <div class="tooltip-mock">
+              <div class="font-medium mb-1">Estimated today · $1,640</div>
+              <div class="text-[var(--muted)] leading-relaxed">
+                Derived from today's per-user usage ($1,380), calibrated ×1.19 to the last 7 billed days.<br/>
+                Updates hourly. Replaced by the billed figure tomorrow.<br/>
+                <span class="text-[var(--muted-2)]">Per-user and billed totals don't reconcile exactly.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ 2. DAILY COST CHART ============ -->
+      <section class="space-y-3">
+        <h2 class="text-lg font-semibold">2 · Daily cost chart — ghost "today (est.)" bar</h2>
+        <div class="card p-5">
+          <div class="flex items-center justify-between mb-4">
+            <div>
+              <div class="text-sm font-semibold">Daily Anthropic cost</div>
+              <div class="text-xs text-[var(--muted)]">June 2026 · USD</div>
+            </div>
+            <div class="flex items-center gap-4 text-xs text-[var(--muted)]">
+              <span><span class="legend-swatch" style="background:#67e8f9"></span>actual (billed)</span>
+              <span><span class="legend-swatch" style="background:transparent;border:1.5px dashed #d4f057"></span>today (est.)</span>
+            </div>
+          </div>
+          <!-- SVG bar chart: 11 solid actual bars + 1 dashed ghost "today" bar -->
+          <svg viewBox="0 0 720 220" width="100%" height="220" role="img" aria-label="Daily cost bar chart with estimated today bar">
+            <!-- gridlines -->
+            <line class="grid-line" x1="40" y1="20"  x2="710" y2="20"/>
+            <line class="grid-line" x1="40" y1="70"  x2="710" y2="70"/>
+            <line class="grid-line" x1="40" y1="120" x2="710" y2="120"/>
+            <line class="grid-line" x1="40" y1="170" x2="710" y2="170"/>
+            <line class="grid-line" x1="40" y1="180" x2="710" y2="180"/>
+            <text class="axis-label" x="34" y="24" text-anchor="end">$5k</text>
+            <text class="axis-label" x="34" y="124" text-anchor="end">$2.5k</text>
+            <text class="axis-label" x="34" y="184" text-anchor="end">$0</text>
+            <!-- actual bars (days 1-11) -->
+            <g fill="#67e8f9">
+              <rect x="52"  y="96"  width="34" height="84"  rx="3"/>
+              <rect x="104" y="60"  width="34" height="120" rx="3"/>
+              <rect x="156" y="110" width="34" height="70"  rx="3"/>
+              <rect x="208" y="78"  width="34" height="102" rx="3"/>
+              <rect x="260" y="48"  width="34" height="132" rx="3"/>
+              <rect x="312" y="70"  width="34" height="110" rx="3"/>
+              <rect x="364" y="120" width="34" height="60"  rx="3"/>
+              <rect x="416" y="92"  width="34" height="88"  rx="3"/>
+              <rect x="468" y="56"  width="34" height="124" rx="3"/>
+              <rect x="520" y="84"  width="34" height="96"  rx="3"/>
+              <rect x="572" y="106" width="34" height="74"  rx="3"/>
+            </g>
+            <!-- today (est.) ghost bar: dashed outline, low-opacity fill -->
+            <rect x="624" y="124" width="34" height="56" rx="3" fill="#d4f057" fill-opacity="0.22" stroke="#d4f057" stroke-width="1.5" stroke-dasharray="4 3"/>
+            <text class="label-est" x="641" y="116" text-anchor="middle">est.</text>
+            <!-- x labels -->
+            <g class="axis-label" text-anchor="middle">
+              <text x="69"  y="196">1</text>
+              <text x="225" y="196">4</text>
+              <text x="381" y="196">7</text>
+              <text x="537" y="196">10</text>
+              <text x="641" y="196">12</text>
+            </g>
+            <text class="label-est" x="641" y="210" text-anchor="middle" style="font-size:9px;fill:#d4f057">today</text>
+          </svg>
+          <div class="annot mt-3">
+            <strong>Pattern reused:</strong> the same ghost/dashed treatment as the existing "projected" bar in
+            <code>twelve-month-bar-chart.tsx</code> (<code>fillOpacity 0.22</code>, <code>strokeDasharray "4 3"</code>). The estimate is a single
+            trailing bar at "today"; every prior bar is a solid billed actual. Tomorrow the dashed bar becomes a solid billed bar automatically.
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ 3. CUMULATIVE PACING ============ -->
+      <section class="space-y-3">
+        <h2 class="text-lg font-semibold">3 · Cumulative pacing — projection anchored at today</h2>
+        <div class="card p-5">
+          <div class="flex items-center justify-between mb-4">
+            <div>
+              <div class="text-sm font-semibold">Cumulative spend vs budget</div>
+              <div class="text-xs text-[var(--muted)]">June 2026 · pacing toward $90,000</div>
+            </div>
+            <div class="flex items-center gap-4 text-xs text-[var(--muted)]">
+              <span><span class="legend-swatch" style="background:#67e8f9"></span>actual</span>
+              <span><span class="legend-swatch" style="background:transparent;border-top:2px dashed #d4f057;height:0;width:14px"></span>projection (incl. est. today)</span>
+            </div>
+          </div>
+          <svg viewBox="0 0 720 240" width="100%" height="240" role="img" aria-label="Cumulative spend line with dashed projection from today">
+            <!-- budget ceiling -->
+            <line x1="40" y1="36" x2="710" y2="36" stroke="#7f1d1d" stroke-width="1" stroke-dasharray="2 4"/>
+            <text class="axis-label" x="710" y="32" text-anchor="end" style="fill:#fca5a5">budget $90k</text>
+            <!-- gridlines -->
+            <line class="grid-line" x1="40" y1="90"  x2="710" y2="90"/>
+            <line class="grid-line" x1="40" y1="150" x2="710" y2="150"/>
+            <line class="grid-line" x1="40" y1="200" x2="710" y2="200"/>
+            <text class="axis-label" x="34" y="204" text-anchor="end">$0</text>
+            <!-- actual cumulative line (days 1..11), solid -->
+            <polyline fill="none" stroke="#67e8f9" stroke-width="2.5"
+              points="52,198 112,184 172,176 232,160 292,140 352,128 412,120 472,104 532,92 560,86 588,82"/>
+            <!-- anchor point at 'today' (= MTD + est today) -->
+            <circle cx="588" cy="82" r="3.5" fill="#67e8f9"/>
+            <circle cx="606" cy="78" r="3.5" fill="#d4f057"/>
+            <text class="label-est" x="606" y="70" text-anchor="middle">+est. today</text>
+            <!-- dashed projection from anchor to month-end (crosses budget) -->
+            <polyline fill="none" stroke="#d4f057" stroke-width="2.5" stroke-dasharray="5 4" stroke-opacity="0.9"
+              points="606,78 710,30"/>
+            <!-- 'today' reference line -->
+            <line x1="606" y1="20" x2="606" y2="210" stroke="#d4f057" stroke-width="1" stroke-dasharray="2 4" stroke-opacity="0.6"/>
+            <text class="label-est" x="606" y="224" text-anchor="middle" style="fill:#d4f057">today (12 Jun)</text>
+            <!-- x labels -->
+            <g class="axis-label" text-anchor="middle">
+              <text x="52" y="224">1</text>
+              <text x="710" y="224">30</text>
+            </g>
+          </svg>
+          <div class="annot info mt-3">
+            <strong>Pattern reused:</strong> <code>cumulative-pacing-chart.tsx</code> already draws a dashed projection line and a "today" reference
+            line. The only change: the projection anchor moves from "last complete day" to <em>today</em>, using <code>MTD + est. today</code> — so the
+            line crosses the budget ceiling at the right date instead of lagging a day behind.
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ 4. BEFORE / AFTER (1st of month) ============ -->
+      <section class="space-y-3">
+        <h2 class="text-lg font-semibold">4 · Why it matters most on the 1st — before / after</h2>
+        <p class="text-sm text-[var(--muted)]">Scenario: <span class="chip warn">1 June, 14:00 UTC</span> — <code>cost_report</code> has no data for the current month yet.</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <!-- BEFORE -->
+          <div class="card p-5">
+            <div class="text-xs uppercase tracking-wider text-[var(--muted)] mb-3">Today (current behaviour)</div>
+            <div class="space-y-3">
+              <div class="kpi-tile">
+                <div class="kpi-label">Month-to-date</div>
+                <div class="kpi-value num text-[var(--muted-2)]">$0</div>
+                <div class="kpi-sub">no billed days yet</div>
+              </div>
+              <div class="kpi-tile">
+                <div class="kpi-label">Projected month-end</div>
+                <div class="kpi-value num text-[var(--muted-2)]">$0 <span class="text-base">—</span></div>
+                <div class="kpi-sub" style="color:#f87171">projects 0 — under-counts all month</div>
+              </div>
+            </div>
+          </div>
+          <!-- AFTER -->
+          <div class="card p-5" style="border-color:#3f5d10">
+            <div class="text-xs uppercase tracking-wider mb-3" style="color:#d4f057">Today (with estimate — Tier B)</div>
+            <div class="space-y-3">
+              <div class="kpi-tile">
+                <div class="kpi-label">Month-to-date</div>
+                <div class="kpi-value num">$1,180 <span class="chip est">est.</span></div>
+                <div class="kpi-sub"><span style="color:#d4f057">$1,180 est. today</span> · $0 billed so far</div>
+              </div>
+              <div class="kpi-tile">
+                <div class="kpi-label">Projected month-end</div>
+                <div class="kpi-value num">$35,400 <span class="text-base font-medium" style="color:#4ade80">39%</span></div>
+                <div class="kpi-sub">run-rate from est. today · of $90,000</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="annot">
+          On the 1st, the current views show <strong>$0 / —</strong> until the 2nd. With the estimate, the dashboard has a real, calibrated number from
+          hour one — the core "as up-to-date as possible near month end" goal. (The projection-denominator fix in <a class="link" href="plan.html">Tier&nbsp;A</a>
+          is what stops the "projects 0" failure independently of the estimate.)
+        </div>
+      </section>
+
+      <footer class="pt-6 border-t border-[var(--border)] text-xs text-[var(--muted)]">
+        Spec 033 · UI mockup (static, illustrative numbers) · companion to <a class="link" href="plan.html">plan.html</a> ·
+        reuses dashed/ghost vocabulary from <code>cumulative-pacing-chart.tsx</code> &amp; <code>twelve-month-bar-chart.tsx</code>.
+      </footer>
+
+    </div>
+  </body>
+</html>

--- a/specs/033-current-day-cost-estimate/plan.html
+++ b/specs/033-current-day-cost-estimate/plan.html
@@ -1,0 +1,507 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Spec 033 — Current-day cost estimate · Proposal</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0a0a0a; --panel: #121212; --panel-2: #181818; --border: #262626; --border-2: #2e2e2e;
+        --text: #fafafa; --muted: #a1a1aa; --muted-2: #71717a;
+        --primary: #d4f057; --primary-ink: #0a0a0a;
+        --success: #4ade80; --warn: #facc15; --danger: #f87171; --info: #67e8f9;
+      }
+      html, body { background: var(--bg); color: var(--text); }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.55; }
+      code, pre, .mono { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; }
+      h1, h2, h3, h4 { letter-spacing: -0.01em; }
+      .container { max-width: 1080px; margin: 0 auto; padding: 32px 24px; }
+      .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; }
+      .card-2 { background: var(--panel-2); border: 1px solid var(--border); border-radius: 12px; }
+      .chip { display: inline-flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 6px; font-size: 11px; background: #181818; border: 1px solid var(--border-2); color: var(--muted); }
+      .chip.warn { color: #facc15; border-color: #5a4607; background: #1c1407; }
+      .chip.danger { color: #fca5a5; border-color: #7f1d1d; background: #2a0a0a; }
+      .chip.info { color: #67e8f9; border-color: #155e75; background: #082f3a; }
+      .chip.success { color: #86efac; border-color: #14532d; background: #0a1c10; }
+      a.link { color: #d4f057; text-decoration: underline; text-underline-offset: 4px; }
+      table.spec-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+      table.spec-table th, table.spec-table td { padding: 8px 10px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+      table.spec-table th { color: var(--muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+      table.spec-table tbody tr:hover { background: rgba(255,255,255,0.02); }
+      .toc a { color: var(--muted); } .toc a:hover { color: var(--text); }
+      .phase-pill { padding: 4px 10px; border-radius: 8px; font-size: 12px; font-weight: 600; }
+      .phase-1 { background: #0a1c10; color: #86efac; border: 1px solid #14532d; }
+      .phase-2 { background: #082f3a; color: #67e8f9; border: 1px solid #155e75; }
+      .phase-3 { background: #2a1607; color: #fcd34d; border: 1px solid #78350f; }
+      .anchor { scroll-margin-top: 24px; }
+      .file-path { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px; color: #67e8f9; }
+      .ac-list { padding-left: 22px; } .ac-list li { margin: 6px 0; } .ac-list li::marker { color: #4ade80; }
+      .risk-list li::marker { color: #f87171; }
+      pre.code { background: #060606; border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; overflow-x: auto; font-size: 12px; line-height: 1.5; color: #e4e4e7; }
+      pre.code .k { color: #c084fc; } pre.code .s { color: #86efac; } pre.code .n { color: #fcd34d; } pre.code .c { color: #71717a; font-style: italic; } pre.code .t { color: #67e8f9; }
+      .callout { border-left: 3px solid var(--primary); background: rgba(212, 240, 87, 0.04); padding: 12px 14px; border-radius: 0 8px 8px 0; }
+      .callout.warn { border-color: #facc15; background: rgba(250, 204, 21, 0.04); }
+      .callout.danger { border-color: #f87171; background: rgba(248, 113, 113, 0.04); }
+      .callout.info { border-color: #67e8f9; background: rgba(103, 232, 249, 0.04); }
+      .badge-add { color: #86efac; background: #0a1c10; border: 1px solid #14532d; padding: 1px 6px; border-radius: 4px; font-size: 11px; }
+      .badge-mod { color: #fcd34d; background: #2a1607; border: 1px solid #78350f; padding: 1px 6px; border-radius: 4px; font-size: 11px; }
+      .opt { border: 1px solid var(--border); border-radius: 12px; padding: 16px; }
+      .opt.rec { border-color: #3f5d10; box-shadow: 0 0 0 1px rgba(212,240,87,0.15) inset; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+
+      <header class="mb-10 pb-6 border-b border-[var(--border)]">
+        <div class="flex flex-wrap items-center gap-3 mb-3 text-xs">
+          <span class="chip">Spec 033</span>
+          <span class="chip success">Status · Approved (Tier B) — ready for implementation</span>
+          <span class="chip">Created 2026-06-01 · finalized 2026-06-01</span>
+          <span class="chip">Owner · tobias.studer@unic.com</span>
+          <span class="chip success">0 migrations · 0 packages · 3 phases · 1 PR</span>
+        </div>
+        <h1 class="text-3xl font-bold tracking-tight">Current-day cost estimate ("predicted today")</h1>
+        <p class="text-[var(--muted)] mt-2 max-w-3xl">
+          Anthropic <code class="mono text-[var(--text)]">cost_report</code> only ever returns <strong>complete UTC days</strong>, so the
+          workspace / global cost views are always missing today — and the whole current month until the 2nd (see spec 033's sibling fix,
+          PR&nbsp;#105). Meanwhile we <em>already</em> have a real, hourly-fresh per-<strong>user</strong> cost for today.
+          This proposal surfaces a clearly-labelled <strong>estimated</strong> current-day figure so month-to-date totals and
+          month-end projections are accurate sooner — especially near month end, where budget decisions are made.
+        </p>
+        <div class="mt-3 flex flex-wrap gap-2 text-xs">
+          <a class="chip info" href="mockup.html">mockup.html — UI mockup ↗</a>
+        </div>
+        <div class="mt-3 callout text-sm max-w-3xl">
+          <strong>Scope locked: Tier B (approved).</strong> This document is now an implementation-ready plan — the projection fix and the
+          calibrated, clearly-labelled "estimated today" surfaced across the Claude dashboard. The budget-layer integration (former Tier&nbsp;C) and
+          any movement of <em>alert</em> thresholds are explicitly <a class="link" href="#scope">out of scope</a>. Build order, tasks, data contracts
+          and acceptance criteria are in <a class="link" href="#plan">§5</a>; the full change surface is in <a class="link" href="#files">§6</a>.
+          See <a class="link" href="mockup.html">mockup.html</a> for the target UI.
+        </div>
+      </header>
+
+      <!-- TOC -->
+      <nav class="card p-5 mb-10 toc">
+        <h2 class="text-sm font-semibold mb-3">Contents</h2>
+        <ol class="text-sm space-y-1 list-decimal list-inside">
+          <li><a href="#problem">The problem &amp; what we already have</a></li>
+          <li><a href="#two-bugs">Two separate issues hide here</a></li>
+          <li><a href="#reconcile">Hard constraint: per-user ≠ workspace totals</a></li>
+          <li><a href="#approach">Estimation approach (the maths)</a></li>
+          <li><a href="#plan">Build plan — phases, tasks &amp; acceptance criteria</a></li>
+          <li><a href="#files">Change surface &amp; complete touch-point map</a></li>
+          <li><a href="#data-flow">Data flow</a></li>
+          <li><a href="#ui">UI: how "estimated" looks distinct</a></li>
+          <li><a href="#tests">Test plan</a></li>
+          <li><a href="#risks">Risks &amp; mitigations</a></li>
+          <li><a href="#impact">Impact summary</a></li>
+          <li><a href="#scope">Explicitly out of scope</a></li>
+        </ol>
+      </nav>
+
+      <!-- 1 -->
+      <section id="problem" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">1 · The problem &amp; what we already have</h2>
+        <p class="text-sm text-[var(--muted)] mb-4 max-w-3xl">There are two Anthropic cost data sources in the app, and they have very different freshness:</p>
+        <table class="spec-table card">
+          <thead><tr><th>Source</th><th>Table</th><th>Grain</th><th>Has "today"?</th><th>Sync</th></tr></thead>
+          <tbody>
+            <tr>
+              <td>Per-<strong>user</strong> usage (<code>usage_report</code>)</td>
+              <td><span class="file-path">anthropic_usage_metrics</span></td>
+              <td>user × model × day, with real <code>computed_cost_cents</code></td>
+              <td><span class="chip success">YES — hourly, incl. today</span></td>
+              <td>hourly (<code>0 * * * *</code>)</td>
+            </tr>
+            <tr>
+              <td><strong>Workspace</strong> / global cost (<code>cost_report</code>)</td>
+              <td><span class="file-path">anthropic_workspace_costs</span></td>
+              <td>workspace × day, <code>cost_cents</code></td>
+              <td><span class="chip danger">NO — complete days only</span></td>
+              <td>hourly, but only writes finished days</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="text-sm text-[var(--muted)] mt-4 max-w-3xl">
+          The dashboards, the workspace budget list, the org-credits panel and the budget pages all read the <em>workspace</em> table — the one
+          that never has today. So every "month-to-date" and "projected month-end" figure is silently running a day behind (and is empty for the
+          whole current month on the 1st). The per-user table already holds a real, ~hourly-fresh cost for today
+          (<span class="file-path">schema.ts:553-591</span>, written by <span class="file-path">anthropic-sync.ts</span>'s
+          <code>todaySyncWindow()</code>/<code>fetchTodayAggregated()</code> hourly path, costed via <span class="file-path">anthropic-pricing.ts</span>).
+          That is the signal we can lean on.
+        </p>
+      </section>
+
+      <!-- 2 -->
+      <section id="two-bugs" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">2 · Two separate issues hide here</h2>
+        <p class="text-sm text-[var(--muted)] mb-4 max-w-3xl">Worth separating, because one is a near-zero-risk fix and the other is the actual feature you asked for.</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div class="card-2 p-4">
+            <div class="flex items-center gap-2 mb-1"><span class="chip danger">Bug</span><span class="text-sm font-semibold">Projection denominator is off by a day</span></div>
+            <p class="text-xs text-[var(--muted)]">
+              <code>projectMonthEnd(mtd, daysElapsed, daysInMonth)</code> (<span class="file-path">utils.ts:86-93</span>) is called with
+              <code>daysElapsed = Math.max(1, getDate(today))</code> (<span class="file-path">queries.ts:84-88</span>,
+              <span class="file-path">anthropic-global.ts:835</span>, <span class="file-path">anthropic-users.ts:812</span>,
+              <span class="file-path">workspace-budget-list.tsx:27</span>) — but <code>mtd</code> comes from the workspace table that
+              <em>excludes today</em>. The numerator skips today; the denominator counts it. Result: it under-projects all month, and projects
+              <strong>0</strong> on the 1st. This alone hurts month-end budget management — and is fixable independently of any prediction.
+            </p>
+          </div>
+          <div class="card-2 p-4">
+            <div class="flex items-center gap-2 mb-1"><span class="chip info">Feature</span><span class="text-sm font-semibold">No current-day figure at all</span></div>
+            <p class="text-xs text-[var(--muted)]">
+              Even with the denominator fixed, today's actual spend is invisible in the workspace/global views until the next day. Near month end
+              that is exactly when you want it. The fix: derive a <strong>calibrated estimate</strong> of today's cost from the per-user data we
+              already have, and surface it as a distinct, clearly-labelled value.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- 3 -->
+      <section id="reconcile" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">3 · Hard constraint — per-user costs do <em>not</em> equal workspace costs</h2>
+        <div class="callout danger text-sm max-w-3xl mb-4">
+          This is the single most important design constraint, and the codebase already documents it:
+          <em>"Per-user totals do not sum to org / workspace totals … Different rounding, different aggregation windows. The two will not reconcile exactly."</em>
+          — <span class="file-path">specs/027-claude-users-subpage/data-model.md:107</span> (also 016/026).
+        </div>
+        <p class="text-sm text-[var(--muted)] mb-3 max-w-3xl">Why they diverge for the <em>same</em> day:</p>
+        <ul class="ac-list text-sm text-[var(--muted)] max-w-3xl">
+          <li><strong>Different endpoints.</strong> Per-user = <code>usage_report</code> tokens × a hardcoded pricing table; workspace = <code>cost_report</code> billed dollars. Spec 016 notes <code>cost_report</code> coverage differs (e.g. Priority Tier).</li>
+          <li><strong>Pricing-table drift.</strong> Unknown/new models fall back to the highest Opus price (<span class="file-path">anthropic-pricing.ts:85-95</span>); rate changes, batch/service-tier discounts aren't modelled.</li>
+          <li><strong>Unmapped spend.</strong> Any API key not registered as a Hub license assignment is dropped (<span class="file-path">anthropic-sync.ts</span> <code>if (!userId) continue;</code>) — present in <code>cost_report</code>, absent from per-user. Pure under-count.</li>
+          <li><strong>Rounding</strong> at different grains.</li>
+        </ul>
+        <div class="callout text-sm max-w-3xl mt-4">
+          <strong>Consequence:</strong> we must <u>not</u> treat "sum of per-user today" as the workspace cost. The honest move is to use it as a signal and
+          <strong>calibrate</strong> it against how the two sources actually relate on recent complete days.
+        </div>
+      </section>
+
+      <!-- 4 -->
+      <section id="approach" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">4 · Estimation approach (the maths)</h2>
+        <p class="text-sm text-[var(--muted)] mb-3 max-w-3xl">One small, pure, well-tested helper. No new tables, no new packages.</p>
+        <pre class="code"><span class="c">// src/lib/anthropic/estimate-today.ts  (NEW, pure + unit-tested)</span>
+<span class="k">export function</span> estimateTodayCostCents(input: {
+  todayUserCostCents: <span class="t">number</span>;        <span class="c">// SUM(usage_metrics.computed_cost_cents) WHERE date = today (real, hourly)</span>
+  recentUserCostCents: <span class="t">number</span>;      <span class="c">// SUM over last N COMPLETE days, per-user source</span>
+  recentWorkspaceCostCents: <span class="t">number</span>; <span class="c">// SUM over the SAME N complete days, workspace source</span>
+}): { estimatedTodayCents: <span class="t">number</span>; calibration: <span class="t">number</span>; confident: <span class="t">boolean</span> } {
+  <span class="c">// Calibration = how much bigger the billed workspace total runs vs our per-user estimate.</span>
+  <span class="k">const</span> raw = input.recentUserCostCents > 0
+    ? input.recentWorkspaceCostCents / input.recentUserCostCents
+    : <span class="n">1</span>;
+  <span class="c">// Clamp to a sane band so a noisy week can't 3× the number; fall back to 1.0 when thin.</span>
+  <span class="k">const</span> calibration = clamp(raw, <span class="n">0.5</span>, <span class="n">2.0</span>);
+  <span class="k">const</span> confident = input.recentUserCostCents > <span class="n">0</span> && input.recentWorkspaceCostCents > <span class="n">0</span>;
+  <span class="k">return</span> {
+    estimatedTodayCents: <span class="t">Math</span>.round(input.todayUserCostCents * (confident ? calibration : <span class="n">1</span>)),
+    calibration, confident,
+  };
+}</pre>
+        <p class="text-sm text-[var(--muted)] mt-4 max-w-3xl">
+          The estimate is <strong>today's spend so far</strong> (cumulative to the current hour), not a full-day extrapolation — it's the most
+          defensible "as up to date as possible" number. For the <em>projection</em>, this estimated-today is added to MTD <em>and</em> the
+          off-by-one denominator is corrected, so month-end pacing stops under-counting. We deliberately do <strong>not</strong> extrapolate the
+          partial day to a full day in the MTD figure (that would overstate actuals); the run-rate already handles the remaining days.
+        </p>
+        <div class="callout info text-sm max-w-3xl mt-3">
+          <strong>Self-correcting.</strong> When tomorrow's real <code>cost_report</code> day lands, the estimate for that date disappears and is replaced by
+          the actual — the estimate only ever occupies the single trailing "today" slot. Calibration is recomputed each load from the latest complete days.
+        </div>
+      </section>
+
+      <!-- 5 -->
+      <section id="plan" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">5 · Build plan — phases, tasks &amp; acceptance criteria</h2>
+        <p class="text-sm text-[var(--muted)] mb-4 max-w-3xl">
+          Scope is <strong>Tier B</strong>, shipped as <strong>one PR</strong> in three ordered phases: <em>data → maths → UI</em>. Each phase is
+          independently reviewable and leaves the app working. The former "Tier A" projection fix is folded into Phase 2; the former "Tier C"
+          budget integration is <a class="link" href="#scope">out of scope</a>.
+        </p>
+
+        <h3 class="text-sm font-semibold text-[var(--muted)] mb-2">5.1 · Data contracts &amp; constants <span class="font-normal">(agree these first)</span></h3>
+        <pre class="code"><span class="c">// src/lib/anthropic/estimate-today.ts</span>
+<span class="k">export const</span> CALIBRATION_LOOKBACK_DAYS = <span class="n">7</span>;   <span class="c">// complete days used to calibrate</span>
+<span class="k">export const</span> CALIBRATION_MIN = <span class="n">0.5</span>;          <span class="c">// clamp band — a noisy week can't 2×/½× the figure</span>
+<span class="k">export const</span> CALIBRATION_MAX = <span class="n">2.0</span>;
+
+<span class="c">// The estimate carried on every DTO that currently exposes month-to-date cost.</span>
+<span class="c">// `null` ⇒ no estimate to show (no per-user data today, or usage sync stale) ⇒ UI falls back to actual-only.</span>
+<span class="k">export type</span> <span class="t">TodayEstimate</span> = {
+  cents: <span class="t">number</span>;          <span class="c">// calibrated estimate of today's spend SO FAR (cumulative to now)</span>
+  rawUserCents: <span class="t">number</span>;   <span class="c">// uncalibrated per-user sum for today</span>
+  calibration: <span class="t">number</span>;    <span class="c">// ratio applied (1.0 when not confident)</span>
+  confident: <span class="t">boolean</span>;     <span class="c">// had ≥1 recent complete day in BOTH sources to calibrate</span>
+  asOfIso: <span class="t">string</span>;        <span class="c">// timestamp of the per-user usage sync → drives the freshness label</span>
+};</pre>
+        <div class="card-2 p-4 text-sm text-[var(--muted)] mt-3 mb-2 max-w-3xl">
+          <div class="text-[11px] uppercase tracking-wider text-[var(--muted)] mb-2">Final projection model (current month)</div>
+          <p class="mb-2">Reuse <code>projectMonthEnd(spentSoFar, daysElapsed, daysInMonth)</code> <span class="file-path">utils.ts:86-93</span> <strong>unchanged</strong>; fix the inputs so numerator and denominator agree (both include today):</p>
+          <pre class="code"><span class="k">const</span> daysElapsed   = getUTCDate(today);                       <span class="c">// includes today</span>
+<span class="k">const</span> spentSoFar    = mtdActualCents + (todayEstimate?.cents ?? <span class="n">0</span>); <span class="c">// complete days + today's est.</span>
+<span class="k">const</span> projected     = projectMonthEnd(spentSoFar, daysElapsed, daysInMonth);</pre>
+          <p class="mt-2">Past months: unchanged (<code>daysElapsed = daysInMonth</code>, no estimate). <code>forecastWorkspaceMonth</code> <span class="file-path">forecast-workspace.ts</span>: set today's dense-series slot to <code>todayEstimate.cents</code> (instead of 0) and add it to <code>mtdCents</code>.</p>
+        </div>
+        <div class="callout text-sm max-w-3xl mb-6">
+          <strong>Scope guard (must hold for every task):</strong> the estimate is a <em>separate</em> field — never merged into <code>totalCents</code>,
+          <code>getRunningCostsForPeriod</code>, or any alert threshold. Per-<em>user</em> detail pages already read today's real per-user cost directly
+          and need <strong>no</strong> calibration (they <em>are</em> the source) — calibration applies only where we compare against the workspace/global <code>cost_report</code> figure.
+        </div>
+
+        <h3 class="text-sm font-semibold text-[var(--muted)] mb-3">5.2 · Phases</h3>
+
+        <div class="space-y-4">
+          <!-- Phase 1 -->
+          <div class="opt">
+            <div class="flex items-center gap-2 mb-2"><span class="phase-pill phase-1">Phase 1</span><span class="text-sm font-semibold">Estimation backend — helper, query &amp; DTO field</span><span class="chip ml-auto">no UI change yet</span></div>
+            <p class="text-xs text-[var(--muted)] mb-2">Produce a calibrated <code>TodayEstimate</code> and thread it (as a separate field) through the read DTOs. Nothing renders it yet.</p>
+            <table class="spec-table">
+              <tbody>
+                <tr><td style="width:64px"><span class="badge-add">T1.1</span></td><td><span class="file-path">estimate-today.ts</span> — pure <code>estimateTodayCostCents()</code> + constants (§5.1). No I/O.</td></tr>
+                <tr><td><span class="badge-mod">T1.2</span></td><td><span class="file-path">queries.ts</span> — query today's per-user <code>SUM(computed_cost_cents) WHERE date = today</code>, and the same-window sums (user &amp; workspace) over the last <code>CALIBRATION_LOOKBACK_DAYS</code> complete days. Per-workspace variant joins <code>anthropic_sync_status.resolved_workspace_id</code>.</td></tr>
+                <tr><td><span class="badge-mod">T1.3</span></td><td>Add <code>todayEstimate: TodayEstimate | null</code> to the dashboard-KPI, workspace-list and workspace-detail DTOs in <span class="file-path">queries.ts</span> / <span class="file-path">anthropic-global.ts</span>. Populate it; do <strong>not</strong> yet change projections.</td></tr>
+              </tbody>
+            </table>
+            <div class="mt-2 text-xs"><span class="chip success">Acceptance</span> <span class="text-[var(--muted)]">Unit tests for the helper (clamp band, thin-data fallback→1.0, zero today→null, rounding). DTOs expose <code>todayEstimate</code>; existing <code>totalCents</code> byte-for-byte unchanged. Verified on the Neon branch: estimate within a sane band of the next-day actual for several days.</span></div>
+          </div>
+
+          <!-- Phase 2 -->
+          <div class="opt">
+            <div class="flex items-center gap-2 mb-2"><span class="phase-pill phase-2">Phase 2</span><span class="text-sm font-semibold">Projection &amp; run-rate consume the estimate</span><span class="chip ml-auto">the month-end-accuracy win</span></div>
+            <p class="text-xs text-[var(--muted)] mb-2">Apply the projection model from §5.1 so MTD pacing includes today and stops under-counting / returning 0 on the 1st.</p>
+            <table class="spec-table">
+              <tbody>
+                <tr><td style="width:64px"><span class="badge-mod">T2.1</span></td><td>Update the 4 <code>projectMonthEnd</code> callers — <span class="file-path">queries.ts:84-88</span>, <span class="file-path">anthropic-global.ts:835</span>, <span class="file-path">anthropic-users.ts:812</span>, <span class="file-path">workspace-budget-list.tsx:27</span> — to pass <code>spentSoFar = mtdActual + todayEstimate.cents</code> with <code>daysElapsed = getUTCDate(today)</code>.</td></tr>
+                <tr><td><span class="badge-mod">T2.2</span></td><td><span class="file-path">forecast-workspace.ts:41-140</span> — fill today's dense-series slot with <code>todayEstimate.cents</code> (not 0) and add to <code>mtdCents</code>. One cron consumer (<span class="file-path">teams/evaluator.ts</span>) benefits automatically; no copy change.</td></tr>
+              </tbody>
+            </table>
+            <div class="mt-2 text-xs"><span class="chip success">Acceptance</span> <span class="text-[var(--muted)]">Unit tests: mid-month projection matches hand-calc; 1st-of-month projects a non-zero, sensible figure; past months unchanged. Alert thresholds (<span class="file-path">alerts.ts</span>) still read actual-only MTD — assert unchanged.</span></div>
+          </div>
+
+          <!-- Phase 3 -->
+          <div class="opt">
+            <div class="flex items-center gap-2 mb-2"><span class="phase-pill phase-3">Phase 3</span><span class="text-sm font-semibold">Surface it — distinctly labelled UI</span><span class="chip ml-auto">see mockup.html</span></div>
+            <p class="text-xs text-[var(--muted)] mb-2">Render the estimate using the existing dashed/ghost vocabulary. Always visually distinct from actuals.</p>
+            <table class="spec-table">
+              <tbody>
+                <tr><td style="width:64px"><span class="badge-mod">T3.1</span></td><td><span class="file-path">kpi-strip.tsx</span> / <span class="file-path">org-credits-panel.tsx</span> — "incl. est. today" sub-label + <code>est.</code> chip &amp; tooltip on MTD / projected tiles (hidden when <code>todayEstimate === null</code>).</td></tr>
+                <tr><td><span class="badge-mod">T3.2</span></td><td><span class="file-path">workspace-daily-chart.tsx</span> + the stacked dashboard chart (<span class="file-path">global-metrics-client.tsx</span>) — append one ghost/dashed "today (est.)" bar (mirror <span class="file-path">twelve-month-bar-chart.tsx:144-155</span>).</td></tr>
+                <tr><td><span class="badge-mod">T3.3</span></td><td><span class="file-path">cumulative-pacing-chart.tsx:177-243</span> — move the dashed projection anchor to today using <code>MTD + est. today</code>.</td></tr>
+                <tr><td><span class="badge-mod">T3.4</span></td><td>Freshness: show the per-user usage sync age (<code>asOfIso</code>) near the estimate; if stale, dim it / hide per T1 null rule.</td></tr>
+              </tbody>
+            </table>
+            <div class="mt-2 text-xs"><span class="chip success">Acceptance</span> <span class="text-[var(--muted)]">Matches <a class="link" href="mockup.html">mockup.html</a>. Estimate is never solid-styled; exactly one trailing est. point per chart; 1st-of-month shows a real figure instead of $0/—. Lint + typecheck clean; verified in-app on the Neon branch.</span></div>
+          </div>
+        </div>
+
+        <div class="callout text-sm max-w-3xl mt-4">
+          <strong>Sequencing:</strong> Phase 1 → 2 → 3, one PR. Phases 1–2 are backend-only and safe to land behind no UI; Phase 3 is purely additive rendering.
+          Each phase ships with its tests green. Verification mirrors PR&nbsp;#105: run against the <code>wt/fix-sync-first-of-month</code> Neon branch
+          (real data) and compare the estimate to the next day's billed actual.
+        </div>
+      </section>
+
+      <!-- 6 -->
+      <section id="files" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">6 · Change surface &amp; complete touch-point map</h2>
+        <h3 class="text-sm font-semibold text-[var(--muted)] mb-2">6.1 · File-by-file change list <span class="font-normal">(approved Tier B scope)</span></h3>
+        <table class="spec-table card">
+          <thead><tr><th>File</th><th></th><th>Change</th></tr></thead>
+          <tbody>
+            <tr><td><span class="file-path">src/lib/anthropic/estimate-today.ts</span></td><td><span class="badge-add">new</span></td><td>Pure <code>estimateTodayCostCents()</code> helper (§4). No I/O.</td></tr>
+            <tr><td><span class="file-path">src/lib/anthropic/queries.ts</span></td><td><span class="badge-mod">mod</span></td><td>Add a query for today's per-user sum + recent-complete-day sums (user &amp; workspace); compute <code>estimatedTodayCents</code>; fix <code>daysElapsed</code> (:84-88). Return it on the KPI DTO.</td></tr>
+            <tr><td><span class="file-path">src/actions/anthropic-global.ts</span></td><td><span class="badge-mod">mod</span></td><td>Thread <code>estimatedTodayCents</code> through <code>getDashboardKpis</code> / <code>getWorkspaceDetail</code>; append a dashed "today (est.)" point to daily totals (:402-496, :789-843). Reuse projection denominator fix.</td></tr>
+            <tr><td><span class="file-path">src/components/claude/kpi-strip.tsx</span></td><td><span class="badge-mod">mod</span></td><td>"Month-to-date" + "Projected month-end" tiles show "incl. est. today" sub-label when an estimate is present.</td></tr>
+            <tr><td><span class="file-path">…/cumulative-pacing-chart.tsx</span></td><td><span class="badge-mod">mod</span></td><td>Anchor the existing dashed projection at today using <code>MTD + estimatedToday</code> (chart already has a dashed line + "today" reference line — :234-243, :177-187).</td></tr>
+            <tr><td><span class="file-path">…/workspace-daily-chart.tsx</span></td><td><span class="badge-mod">mod</span></td><td>Append one ghost/dashed "today (est.)" bar (mirror the ghost-bar pattern from <span class="file-path">twelve-month-bar-chart.tsx:144-155</span>).</td></tr>
+            <tr><td><span class="file-path">tests/unit/anthropic/estimate-today.test.ts</span></td><td><span class="badge-add">new</span></td><td>Calibration band, thin-data fallback, zero cases, self-correction.</td></tr>
+          </tbody>
+        </table>
+        <p class="text-xs text-[var(--muted)] mt-3">Tier A is the subset that touches only <span class="file-path">utils.ts</span> callers / projection denominator. Tier C additionally touches <span class="file-path">budget-utils.ts</span> + budget components.</p>
+
+        <h3 class="text-sm font-semibold text-[var(--muted)] mt-8 mb-2">6.2 · Complete touch-point map — every area the feature reaches</h3>
+        <p class="text-sm text-[var(--muted)] mb-3 max-w-3xl">
+          Every place in the app that this feature reads from, writes to, changes, or merely <em>benefits</em> from — grouped by layer, with the
+          tier that introduces it and the kind of touch. This is the full blast-radius inventory, not just the approved-scope edits above.
+        </p>
+        <div class="flex flex-wrap gap-2 mb-3 text-[11px]">
+          <span class="badge-add">new</span><span class="text-[var(--muted)]">new file</span>
+          <span class="badge-mod">mod</span><span class="text-[var(--muted)]">modified</span>
+          <span class="chip">read</span><span class="text-[var(--muted)]">read-only source</span>
+          <span class="chip warn">decide</span><span class="text-[var(--muted)]">explicit decision point</span>
+          <span class="chip success">benefits</span><span class="text-[var(--muted)]">improves automatically, no edit</span>
+        </div>
+
+        <table class="spec-table card">
+          <thead><tr><th>Area</th><th>Role in the feature</th><th>Tier</th><th>Touch</th></tr></thead>
+          <tbody>
+            <tr><td colspan="4" class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] pt-3">A · Data sources (read)</td></tr>
+            <tr><td><span class="file-path">anthropic_usage_metrics.computed_cost_cents</span> <span class="text-[var(--muted-2)]">(schema.ts:553-591)</span></td><td>The <strong>signal</strong> — today's real per-user cost, hourly-fresh.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="chip">read</span></td></tr>
+            <tr><td><span class="file-path">anthropic_workspace_costs.cost_cents</span> <span class="text-[var(--muted-2)]">(schema.ts:716-737)</span></td><td>Actuals + the calibration denominator (recent complete days).</td><td><span class="phase-pill phase-2">B</span></td><td><span class="chip">read</span></td></tr>
+            <tr><td><span class="file-path">anthropic_sync_status.resolved_workspace_id</span> <span class="text-[var(--muted-2)]">(schema.ts:594-609)</span></td><td>user→workspace mapping for the <em>per-workspace</em> estimate.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="chip">read</span></td></tr>
+
+            <tr><td colspan="4" class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] pt-3">B · Estimation core</td></tr>
+            <tr><td><span class="file-path">src/lib/anthropic/estimate-today.ts</span></td><td>Pure <code>estimateTodayCostCents()</code> (calibration + clamp + fallback).</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-add">new</span></td></tr>
+            <tr><td><span class="file-path">src/lib/anthropic/queries.ts</span> <span class="text-[var(--muted-2)]">(new query helper)</span></td><td>Today per-user sum + recent-day sums (global &amp; per-workspace via the mapping join).</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+
+            <tr><td colspan="4" class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] pt-3">C · Projection &amp; run-rate</td></tr>
+            <tr><td><span class="file-path">src/lib/utils.ts:86-93</span> <code>projectMonthEnd</code></td><td>Pure extrapolator — unchanged signature; callers fix the daysElapsed/MTD mismatch.</td><td><span class="phase-pill phase-1">A</span></td><td><span class="chip success">benefits</span></td></tr>
+            <tr><td><span class="file-path">queries.ts:84-88</span> <code>loadDashboardKpis</code></td><td>Dashboard projection — fix denominator; add est. today to MTD.</td><td><span class="phase-pill phase-1">A</span> <span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">anthropic-global.ts:835-843</span> workspace detail</td><td>Per-workspace projection — same fix.</td><td><span class="phase-pill phase-1">A</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">anthropic-users.ts:812-819</span> user detail</td><td>Per-user projection — same fix.</td><td><span class="phase-pill phase-1">A</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">workspace-budget-list.tsx:27-35</span></td><td>Client-side "on pace $X (Y%)" label — same fix; consumes est. today.</td><td><span class="phase-pill phase-1">A</span> <span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">forecast-workspace.ts:41-140</span> <code>forecastWorkspaceMonth</code></td><td>7-day run-rate (cron alerts). Today's missing slot dilutes run-rate; est. today fills it.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+
+            <tr><td colspan="4" class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] pt-3">D · Dashboard read / aggregation (server actions)</td></tr>
+            <tr><td><span class="file-path">anthropic-global.ts</span> <code>getDashboardKpis</code> / <code>getWorkspaceDetail</code></td><td>Thread <code>estimatedTodayCents</code> through the DTOs (separate field).</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">anthropic-global.ts:402-496</span> <code>getDailyTotalsByWorkspace</code></td><td>Append a dashed "today (est.)" point to the stacked daily series.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">queries.ts</span> <code>loadWorkspaceList</code> (:143-204), <code>loadCostHistory</code> (:211-239)</td><td>Carry per-workspace est. today; loadCostHistory already returns the dense series we calibrate from.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">anthropic-global.ts</span> sparkline / 12-month / pacing queries (:519,:561,:626,:699,:748)</td><td>Read workspace costs; gain the trailing est. point where the current month is shown.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+
+            <tr><td colspan="4" class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] pt-3">E · Claude UI components</td></tr>
+            <tr><td><span class="file-path">kpi-strip.tsx:148-156</span></td><td>"incl. est. today" sub-label + <code>est.</code> chip/tooltip on MTD &amp; projection tiles.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">org-credits-panel.tsx:97-118</span></td><td>"Projected month-end" reflects est.-today-aware projection.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">cumulative-pacing-chart.tsx:177-243</span></td><td>Anchor the existing dashed projection at <em>today</em> using MTD + est. today.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">workspace-daily-chart.tsx:37-115</span></td><td>Ghost/dashed "today (est.)" bar (mirrors twelve-month ghost bar).</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">twelve-month-bar-chart.tsx:144-165</span></td><td>Source of the ghost-bar visual vocabulary; current month may include est. today.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">historical-trend-card.tsx:76,83</span>, <span class="file-path">global-metrics-client.tsx</span></td><td>Pass-through wiring for the new field / stacked-row est. point.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+
+            <tr><td colspan="4" class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] pt-3">F · Pages / routes</td></tr>
+            <tr><td><span class="file-path">src/app/claude/page.tsx</span>, <span class="file-path">.../workspaces/[workspaceId]</span>, <span class="file-path">.../users/[userId]</span></td><td>Render the est.-aware DTOs. Mostly pass-through if the field is threaded server-side.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="badge-mod">mod</span></td></tr>
+
+            <tr><td colspan="4" class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] pt-3">G · Alerts <span class="chip warn">decision</span></td></tr>
+            <tr><td><span class="file-path">src/actions/alerts.ts:14-30</span> <code>getActiveAlerts</code></td><td>Utilization % from MTD (excl. today). <strong>Decision:</strong> keep actual-only (Tier B default) or let est. today move thresholds (firing earlier).</td><td><span class="phase-pill phase-3">C?</span></td><td><span class="chip warn">decide</span></td></tr>
+            <tr><td><span class="file-path">src/lib/teams/evaluator.ts:76,84</span> (cron Teams alerts)</td><td>Consumes <code>forecastWorkspaceMonth</code>; benefits from the run-rate fix automatically. No change unless we want est.-today in the alert copy.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="chip success">benefits</span></td></tr>
+
+            <tr><td colspan="4" class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] pt-3">H · Budget &amp; reports (Tier C only)</td></tr>
+            <tr><td><span class="file-path">budget-utils.ts:83-143</span> <code>getRunningCostsForPeriod</code></td><td>Add a <em>separate</em> <code>estimatedRunningCostCents</code> — never inflate the actual total.</td><td><span class="phase-pill phase-3">C</span></td><td><span class="chip warn">decide</span></td></tr>
+            <tr><td><span class="file-path">budget.ts:612-648</span> <code>fetchActualByPeriod</code> (billed + running)</td><td>Surface the estimated delta alongside actual in the forecast input.</td><td><span class="phase-pill phase-3">C</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">budget/[id]/page.tsx</span>, <span class="file-path">budget/page.tsx</span>, <span class="file-path">budget-health-hero.tsx</span>, <span class="file-path">period-allocations-table.tsx</span>, <span class="file-path">past-month-spotlight.tsx</span></td><td>Render actual + dashed "est. today" delta; needs a new "estimated" affordance (none today).</td><td><span class="phase-pill phase-3">C</span></td><td><span class="badge-mod">mod</span></td></tr>
+            <tr><td><span class="file-path">src/actions/reports.ts</span></td><td>Shares <code>fetchActualByPeriod</code> — inherits the estimate if Tier C ships.</td><td><span class="phase-pill phase-3">C</span></td><td><span class="chip success">benefits</span></td></tr>
+
+            <tr><td colspan="4" class="text-[11px] uppercase tracking-wider text-[var(--muted-2)] pt-3">I · Sync / freshness dependency (no code change)</td></tr>
+            <tr><td><span class="file-path">vercel.json</span> — <code>anthropic-usage</code> cron (hourly)</td><td>The estimate is only as fresh as the per-user usage sync. If that cron is degraded, the estimate goes stale — surface its sync-status pill near the figure.</td><td><span class="phase-pill phase-2">B</span></td><td><span class="chip">read</span></td></tr>
+            <tr><td><span class="file-path">anthropic-sync.ts</span> (today path) &amp; <span class="file-path">anthropic-workspace.ts</span> (PR #105)</td><td>Producers of the two signals. No change — #105's skip-on-the-1st is exactly the gap the estimate fills.</td><td>—</td><td><span class="chip success">benefits</span></td></tr>
+          </tbody>
+        </table>
+
+        <div class="callout warn text-sm max-w-3xl mt-4">
+          <strong>Two decision points (highlighted <span class="chip warn">decide</span> above):</strong>
+          (1) whether the estimate should move <em>alert</em> thresholds, and (2) whether budget actuals should carry an estimated delta (Tier C).
+          Both are resolved <strong>no</strong> in the approved Tier B — alerts and budget actuals stay actual-only — to avoid an estimate ever being
+          mistaken for a billed number.
+        </div>
+      </section>
+
+      <!-- 7 -->
+      <section id="data-flow" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">7 · Data flow</h2>
+        <pre class="code"><span class="c">load dashboard / workspace detail</span>
+   │
+   ├─ existing: SUM(anthropic_workspace_costs.cost_cents)  →  MTD actual (complete days)
+   │
+   ├─ NEW: SUM(anthropic_usage_metrics.computed_cost_cents WHERE date = today)      → todayUserCostCents
+   ├─ NEW: SUM(usage_metrics) & SUM(workspace_costs) over last N complete days      → calibration inputs
+   │            (per-workspace variant joins anthropic_sync_status.resolved_workspace_id)
+   │
+   └─ estimateTodayCostCents(...)  →  { estimatedTodayCents, calibration, confident }
+                │
+                ├─ KPI DTO:   totalCents (actual, unchanged)  +  estimatedTodayCents (separate field)
+                ├─ projection: projectMonthEnd(MTD + estimatedToday, completedDays-correct, daysInMonth)
+                └─ charts:     append dashed "today (est.)" point  (never merged into the actual series)</pre>
+        <div class="callout info text-sm max-w-3xl mt-3">
+          The estimate is computed at the <strong>read/aggregation boundary</strong> and carried as a distinct field — it is never written to
+          <code>anthropic_workspace_costs</code>. That keeps every existing SUM query, <code>getRunningCostsForPeriod</code>, and the alert thresholds
+          reading <em>actuals only</em> unless we explicitly opt them in (Tier C).
+        </div>
+      </section>
+
+      <!-- 8 -->
+      <section id="ui" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">8 · UI — how "estimated" stays visually distinct</h2>
+        <div class="callout info text-sm max-w-3xl mb-4">
+          <strong>See the mockup:</strong> <a class="link" href="mockup.html">mockup.html</a> renders all four views — the KPI strip
+          ("incl. est. today" + <span class="chip est" style="color:#d4f057;border-color:#3f5d10;background:#161c07">est.</span> chip &amp; tooltip),
+          the daily chart with the ghost "today (est.)" bar, the cumulative pacing chart with the projection anchored at today, and the
+          1st-of-month before/after.
+        </div>
+        <p class="text-sm text-[var(--muted)] mb-3 max-w-3xl">We reuse the projection vocabulary the app already ships, so nothing new to design:</p>
+        <ul class="ac-list text-sm text-[var(--muted)] max-w-3xl">
+          <li><strong>Dashed / ghost bar</strong> for "today (est.)" on daily charts — same treatment as the existing projected bar (<code>fillOpacity 0.28</code>, <code>strokeDasharray "3 3"</code>, <span class="file-path">twelve-month-bar-chart.tsx:144-155</span>).</li>
+          <li><strong>Dashed projection line</strong> in the cumulative pacing chart already exists and even has a "today" reference line (<span class="file-path">cumulative-pacing-chart.tsx:177-243</span>) — we just anchor it at <code>MTD + est. today</code>.</li>
+          <li><strong>Sub-labels</strong> on KPI tiles: "Month-to-date · incl. est. today" and a tooltip explaining the estimate is derived from per-user usage and calibrated to recent billed days.</li>
+          <li>A small <span class="chip">est.</span> chip + tooltip noting per-user and workspace figures don't reconcile exactly (consistent with the existing reconciliation footnotes).</li>
+        </ul>
+      </section>
+
+      <!-- 9 -->
+      <section id="tests" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">9 · Test plan</h2>
+        <ul class="ac-list text-sm text-[var(--muted)] max-w-3xl">
+          <li>Unit: <code>estimateTodayCostCents</code> — calibration clamp (0.5–2.0), thin-data fallback to 1.0, zero today, zero recent, rounding.</li>
+          <li>Unit: projection denominator — MTD excl. today ÷ completed days; 1st-of-month no longer yields 0; mid-month matches hand-calc.</li>
+          <li>Unit: per-workspace estimate joins <code>resolved_workspace_id</code> correctly (incl. NULL default workspace).</li>
+          <li>Component/DTO: <code>estimatedTodayCents</code> is a separate field; actual <code>totalCents</code> unchanged; charts append exactly one trailing est. point.</li>
+          <li>Verify on a Neon branch with production data (same method used for PR&nbsp;#105): compare estimated-today vs the actual that lands the next day for a few days to sanity-check calibration.</li>
+        </ul>
+      </section>
+
+      <!-- 10 -->
+      <section id="risks" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">10 · Risks &amp; mitigations</h2>
+        <table class="spec-table card">
+          <thead><tr><th>Risk</th><th>Mitigation</th></tr></thead>
+          <tbody>
+            <tr><td>Estimate diverges from the real cost (pricing drift, unmapped spend, priority tier).</td><td>Calibrate against recent complete days; clamp the ratio; label clearly as "est."; never present as actual. Self-corrects next day.</td></tr>
+            <tr><td>Estimate silently inflates a "hard" number (budget actual, alert threshold).</td><td>Keep it a <em>separate field</em>; Tiers A/B do not touch <code>getRunningCostsForPeriod</code> or <code>getActiveAlerts</code>. Tier C adds a distinct estimated field only.</td></tr>
+            <tr><td>Calibration noisy when org has little recent data.</td><td><code>confident=false</code> → fall back to uncalibrated per-user sum (still better than nothing) or hide the estimate entirely (config-able).</td></tr>
+            <tr><td>Users with no resolved API key contribute nothing.</td><td>Same limitation as today's per-user views; documented in tooltip. Calibration ratio partially compensates at the global level.</td></tr>
+            <tr><td>Scope creep into budget pages.</td><td>Approved scope stops at Tier B; budget integration is a deferred follow-up spec.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- 11 -->
+      <section id="impact" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">11 · Impact summary</h2>
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
+          <div class="card-2 p-4"><div class="text-xs uppercase tracking-wider text-[var(--muted)]">Migrations</div><div class="text-lg font-semibold mt-1">0</div><div class="text-xs text-[var(--muted)] mt-1">Read-time compute; no schema change.</div></div>
+          <div class="card-2 p-4"><div class="text-xs uppercase tracking-wider text-[var(--muted)]">New packages</div><div class="text-lg font-semibold mt-1">0</div><div class="text-xs text-[var(--muted)] mt-1">Recharts/shadcn already cover the UI.</div></div>
+          <div class="card-2 p-4"><div class="text-xs uppercase tracking-wider text-[var(--muted)]">Files (Tier B)</div><div class="text-lg font-semibold mt-1">~12</div><div class="text-xs text-[var(--muted)] mt-1">2 new + ~10 modified (≈7 core in §6.1; the rest small pass-through, see §6.2). Tier A ≈ 4. Tier C +~6.</div></div>
+          <div class="card-2 p-4"><div class="text-xs uppercase tracking-wider text-[var(--muted)]">Blast radius</div><div class="text-lg font-semibold mt-1">Low</div><div class="text-xs text-[var(--muted)] mt-1">Estimate is additive &amp; isolated; actuals untouched.</div></div>
+        </div>
+        <p class="text-sm text-[var(--muted)] mt-4 max-w-3xl">
+          The change is intentionally additive: a new pure helper + a separate DTO field + reuse of existing dashed/ghost chart affordances.
+          No existing actual/billed number, alert, or budget total changes unless you choose Tier C.
+        </p>
+      </section>
+
+      <!-- 12 -->
+      <section id="scope" class="anchor mb-10">
+        <h2 class="text-2xl font-bold mb-3">12 · Explicitly out of scope</h2>
+        <ul class="risk-list ac-list text-sm text-[var(--muted)] max-w-3xl">
+          <li>Persisting a synthetic "today" row into <code>anthropic_workspace_costs</code> — rejected: it would silently leak the estimate into every SUM query, budget actuals, and alerts with no way to distinguish it.</li>
+          <li>Full-day extrapolation of the partial current day into the MTD <em>actual</em> figure (overstates spend; the run-rate covers remaining days).</li>
+          <li>Changing the annual OLS budget forecast (<span class="file-path">forecast.ts</span>) — operates on monthly period actuals, unrelated.</li>
+          <li>Backfilling estimates for past days — the estimate only ever occupies the single trailing "today" slot.</li>
+          <li><strong>Budget-layer integration (former Tier C)</strong> — feeding the estimate into <code>getRunningCostsForPeriod</code> / budget actuals / reports. Deferred to a follow-up spec.</li>
+          <li><strong>Moving alert thresholds</strong> with the estimate — <code>getActiveAlerts</code> keeps reading actual-only MTD. (The cron forecast alert benefits from the run-rate fix, but its firing logic is unchanged.)</li>
+        </ul>
+      </section>
+
+      <footer class="pt-6 border-t border-[var(--border)] text-xs text-[var(--muted)]">
+        Spec 033 · Proposal for review · grounded in: schema.ts:553-737, anthropic-sync.ts:264-435, anthropic-pricing.ts:85-117,
+        queries.ts:62-239, anthropic-global.ts:789-900, budget-utils.ts:83-143, budget.ts:612-648, utils.ts:86-93,
+        forecast-workspace.ts:41-140, cumulative-pacing-chart.tsx, twelve-month-bar-chart.tsx, vercel.json. Related: PR #105 (cost-sync 1st-of-month fix).
+        Companion mockup: <a class="link" href="mockup.html">mockup.html</a>.
+      </footer>
+
+    </div>
+  </body>
+</html>

--- a/src/actions/anthropic-global.ts
+++ b/src/actions/anthropic-global.ts
@@ -19,7 +19,6 @@ import {
   parseISO,
   subMonths,
   startOfMonth,
-  getDate,
   getDaysInMonth,
 } from "date-fns";
 import type {
@@ -37,12 +36,14 @@ import type {
   WorkspaceUser,
   ModelBreakdownRow,
 } from "@/types";
-import { getCurrentMonth, projectMonthEnd } from "@/lib/utils";
+import { formatUtcDateOnly, getCurrentMonth, projectMonthEnd } from "@/lib/utils";
 import { run as runAnthropicSync } from "@/lib/sync/sources/anthropic-workspace";
 import {
   loadDashboardKpis,
   loadSyncStatus,
   loadWorkspaceList,
+  loadTodayEstimate,
+  loadTodayEstimatesByWorkspace,
 } from "@/lib/anthropic/queries";
 
 // ---------------------------------------------------------------------------
@@ -381,6 +382,7 @@ export async function getDashboardKpis(month?: string): Promise<DashboardKpis> {
       topOverWorkspaceName: null,
       topOverWorkspaceUtilizationPct: null,
       priorMonthCents: 0,
+      todayEstimate: null,
     };
   }
   const targetMonth =
@@ -398,6 +400,10 @@ export async function getDashboardKpis(month?: string): Promise<DashboardKpis> {
 const TOP_STACKED_LIMIT = 8;
 const STACKED_OTHER_KEY = "__other__";
 const STACKED_NULL_KEY = "__default__";
+// Spec 033 — reserved series key for the trailing "today (est.)" ghost bar.
+// Mirrored as ESTIMATE_KEY in global-metrics-client.tsx (same pattern as the
+// other __*__ keys, which are intentionally duplicated client-side).
+const STACKED_ESTIMATE_KEY = "__estimated__";
 
 async function _getDailyTotalsByWorkspace(month: string): Promise<{
   rows: DailyStackedRow[];
@@ -461,6 +467,23 @@ async function _getDailyTotalsByWorkspace(month: string): Promise<{
   const rows = Array.from(dayMap.values()).sort((a, b) =>
     a.date.localeCompare(b.date)
   );
+
+  // Spec 033 — append one trailing "today (est.)" ghost row for the current
+  // month. Carried in a reserved series key so it never stacks into a real
+  // workspace and the client can render it dashed. Out of all actual rows, so
+  // it sorts last (today is the max date).
+  if (month === getCurrentMonth()) {
+    const now = new Date();
+    const estimate = await loadTodayEstimate(now);
+    if (estimate) {
+      rows.push({
+        date: formatUtcDateOnly(now),
+        perWorkspace: { [STACKED_ESTIMATE_KEY]: estimate.cents },
+        total: estimate.cents,
+        estimated: true,
+      });
+    }
+  }
 
   const topWorkspaces = ranked.slice(0, TOP_STACKED_LIMIT).map((key) => ({
     key,
@@ -831,13 +854,20 @@ async function _getWorkspaceDetail(
       ? Math.round((currentMonthCents / limitCents) * 100)
       : null;
 
-  // Projected month-end
-  const nowMonth = format(new Date(), "yyyy-MM");
+  // Projected month-end (spec 033): for the current month, add this workspace's
+  // estimate of today's spend to the numerator and count today (UTC) in the
+  // denominator so the two agree. Past months: full month, no estimate.
+  const now = new Date();
+  const isCurrentMonth = month === getCurrentMonth();
+  const todayEstimate = isCurrentMonth
+    ? (await loadTodayEstimatesByWorkspace(now)).get(workspaceId) ?? null
+    : null;
   const daysInMonth = getDaysInMonth(parseISO(monthStart));
-  const daysElapsed =
-    month === nowMonth ? Math.max(1, getDate(new Date())) : daysInMonth;
+  const daysElapsed = isCurrentMonth
+    ? Math.max(1, now.getUTCDate())
+    : daysInMonth;
   const projectedMonthEndCents = projectMonthEnd(
-    currentMonthCents,
+    currentMonthCents + (todayEstimate?.cents ?? 0),
     daysElapsed,
     daysInMonth
   );
@@ -921,6 +951,7 @@ async function _getWorkspaceDetail(
     topUsers,
     modelBreakdown,
     availableMonths: months,
+    todayEstimate,
   };
 }
 

--- a/src/actions/anthropic-users.ts
+++ b/src/actions/anthropic-users.ts
@@ -11,7 +11,6 @@ import {
   parseISO,
   subMonths,
   startOfMonth,
-  getDate,
   getDaysInMonth,
 } from "date-fns";
 import { LOCK_USER_ID } from "@/lib/anthropic-sync";
@@ -808,10 +807,13 @@ async function _getUserDetail(
       : Math.round((momDeltaCents / priorMonthCents) * 100);
 
   // Linear projection — for non-current months we treat the full month as
-  // elapsed so the projection equals the actual total.
-  const nowMonth = format(new Date(), "yyyy-MM");
+  // elapsed so the projection equals the actual total. The per-user source
+  // (anthropic_usage_metrics) already INCLUDES today's real cost — unlike the
+  // workspace cost_report source — so no "today estimate" is needed here (spec
+  // 033 scope guard: per-user pages are the source, no calibration). We only
+  // align daysElapsed to the UTC day boundary the data keys on.
   const daysElapsed =
-    month === nowMonth ? Math.max(1, getDate(new Date())) : daysInMonth;
+    month === getCurrentMonth() ? Math.max(1, new Date().getUTCDate()) : daysInMonth;
   const projectedMonthEndCents = projectMonthEnd(
     currentMonthCents,
     daysElapsed,

--- a/src/app/claude/page.tsx
+++ b/src/app/claude/page.tsx
@@ -20,7 +20,8 @@ import { OrgBillingBudgetCard } from "@/components/claude/org-credits-panel";
 import { HistoricalTrendCard } from "@/components/claude/historical-trend-card";
 import { SyncButton } from "@/components/claude/sync-button";
 import { ClaudeTabs } from "@/components/claude/claude-tabs";
-import { format, getDate, getDaysInMonth } from "date-fns";
+import { getDaysInMonth } from "date-fns";
+import { getCurrentMonth } from "@/lib/utils";
 import { Bot } from "lucide-react";
 
 export const metadata: Metadata = { title: "Claude API Spending" };
@@ -32,8 +33,10 @@ export default async function ClaudePage() {
   }
 
   const now = new Date();
-  const currentMonth = format(now, "yyyy-MM");
-  const todayDayOfMonth = getDate(now);
+  // UTC throughout — the cost tables key on UTC calendar dates, and the today
+  // estimate / projection denominator count the UTC day (spec 033).
+  const currentMonth = getCurrentMonth();
+  const todayDayOfMonth = now.getUTCDate();
   const daysInMonth = getDaysInMonth(now);
   const availableMonths = await getAvailableWorkspaceCostMonths();
 
@@ -101,6 +104,7 @@ export default async function ClaudePage() {
         budgetLimitCents={orgConfig?.billingBudgetLimitCents ?? null}
         todayDayOfMonth={todayDayOfMonth}
         daysInMonth={daysInMonth}
+        todayEstimateCents={kpis.todayEstimate?.cents ?? null}
       />
 
       <section aria-label="Organization billing">
@@ -109,6 +113,7 @@ export default async function ClaudePage() {
           orgConfig={orgConfig}
           currentMonthTotalCents={kpis.totalCents}
           projectedMonthEndCents={kpis.projectedMonthEndCents}
+          todayEstimate={kpis.todayEstimate}
         />
       </section>
 

--- a/src/app/claude/page.tsx
+++ b/src/app/claude/page.tsx
@@ -20,8 +20,7 @@ import { OrgBillingBudgetCard } from "@/components/claude/org-credits-panel";
 import { HistoricalTrendCard } from "@/components/claude/historical-trend-card";
 import { SyncButton } from "@/components/claude/sync-button";
 import { ClaudeTabs } from "@/components/claude/claude-tabs";
-import { getDaysInMonth } from "date-fns";
-import { getCurrentMonth } from "@/lib/utils";
+import { getCurrentMonth, getUtcDaysInMonth } from "@/lib/utils";
 import { Bot } from "lucide-react";
 
 export const metadata: Metadata = { title: "Claude API Spending" };
@@ -37,7 +36,7 @@ export default async function ClaudePage() {
   // estimate / projection denominator count the UTC day (spec 033).
   const currentMonth = getCurrentMonth();
   const todayDayOfMonth = now.getUTCDate();
-  const daysInMonth = getDaysInMonth(now);
+  const daysInMonth = getUtcDaysInMonth(now);
   const availableMonths = await getAvailableWorkspaceCostMonths();
 
   if (availableMonths.length === 0) {

--- a/src/app/claude/workspaces/[workspaceId]/workspace-detail-client.tsx
+++ b/src/app/claude/workspaces/[workspaceId]/workspace-detail-client.tsx
@@ -18,6 +18,7 @@ import type { WorkspaceDetail } from "@/types";
 import { AlertTriangle, TrendingDown, TrendingUp } from "lucide-react";
 import { formatCurrency } from "@/lib/utils";
 import { getDaysInMonth, parseISO } from "date-fns";
+import { totalTileCaption } from "@/components/claude/today-estimate";
 
 type Props = {
   workspaceIdParam: string;
@@ -122,10 +123,7 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
       {
         label: `Total · ${monthLabel}`,
         value: formatCurrency(detail.currentMonthCents),
-        caption:
-          detail.priorMonthCents > 0
-            ? `Prior month ${formatCurrency(detail.priorMonthCents)}`
-            : "First month with data",
+        caption: totalTileCaption(detail.todayEstimate, detail.priorMonthCents),
       },
       {
         label: "MoM Delta",
@@ -146,8 +144,10 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
         value: formatCurrency(detail.projectedMonthEndCents),
         caption:
           detail.limitCents == null
-            ? "No limit set"
-            : `${projectedPct ?? 0}% of ${formatCurrency(detail.limitCents)} limit`,
+            ? detail.todayEstimate
+              ? "Run-rate incl. est. today"
+              : "No limit set"
+            : `${projectedPct ?? 0}% of ${formatCurrency(detail.limitCents)} limit${detail.todayEstimate ? " · incl. est. today" : ""}`,
         tone: isOver ? "danger" : projectedPct != null && projectedPct >= 80 ? "warn" : "default",
         ring: isOver,
         icon: isOver ? <AlertTriangle className="size-3 text-destructive" /> : undefined,
@@ -216,6 +216,7 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
             color={detail.workspace.displayColor}
             limitCents={detail.limitCents}
             daysInMonth={getDaysInMonth(parseISO(`${month}-01`))}
+            estimatedTodayCents={detail.todayEstimate?.cents ?? null}
           />
         </CardContent>
       </Card>

--- a/src/components/claude/cumulative-pacing-chart.tsx
+++ b/src/components/claude/cumulative-pacing-chart.tsx
@@ -30,12 +30,15 @@ export function CumulativePacingChart({
   projectedEomCents,
   todayDayOfMonth,
   daysInMonth,
+  todayEstimateCents = null,
 }: {
   rows: PacingRow[];
   budgetLimitCents: number | null;
   projectedEomCents: number;
   todayDayOfMonth: number;
   daysInMonth: number;
+  /** Spec 033 — when present, anchor the projection at today using MTD + est. */
+  todayEstimateCents?: number | null;
 }) {
   const monthName = new Date().toLocaleString("en-US", { month: "long" });
 
@@ -47,9 +50,8 @@ export function CumulativePacingChart({
     );
   }
 
-  // Anchor the projection at the latest known cumulative ≤ today.
-  // Data freshness may lag — yesterday's row is a fine anchor when today's
-  // sync hasn't landed yet.
+  // Anchor the (solid) actuals at the latest known cumulative ≤ today. The
+  // cost_report source lags by a day, so this is normally yesterday.
   const sortedDays = [...rows].sort((a, b) => a.dayOfMonth - b.dayOfMonth);
   const anchorRow = [...sortedDays]
     .reverse()
@@ -57,12 +59,26 @@ export function CumulativePacingChart({
   const anchorDay = anchorRow?.dayOfMonth ?? null;
   const anchorCents = anchorRow?.current ?? null;
 
-  // Projection anchors at (anchorDay, anchorCents) and terminates at
-  // (daysInMonth, projectedEom). Only the two endpoints carry values; Recharts
-  // draws a straight line between them.
+  // Spec 033 — when we have a today estimate, move the projection anchor forward
+  // to today at (last actual cumulative + est today), so the dashed line crosses
+  // the budget at the right date instead of lagging a day behind.
+  const hasEstimate =
+    todayEstimateCents != null &&
+    todayEstimateCents > 0 &&
+    anchorCents != null &&
+    anchorDay != null &&
+    todayDayOfMonth > anchorDay;
+  const todayCumulativeCents =
+    hasEstimate && anchorCents != null ? anchorCents + todayEstimateCents! : null;
+
+  // Projection points: (anchorDay, anchorCents) keeps it continuous with the
+  // solid line; (today, anchor + est) shows the estimated bump; (daysInMonth,
+  // projectedEom) terminates it. Recharts connects them in order.
   function projectionAt(dayOfMonth: number): number | null {
     if (anchorDay == null || anchorCents == null) return null;
     if (dayOfMonth === anchorDay) return anchorCents / 100;
+    if (hasEstimate && dayOfMonth === todayDayOfMonth && todayCumulativeCents != null)
+      return todayCumulativeCents / 100;
     if (dayOfMonth === daysInMonth) return projectedEomCents / 100;
     return null;
   }
@@ -246,7 +262,11 @@ export function CumulativePacingChart({
       <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
         <ul className="flex flex-wrap items-center gap-3">
           <LineSwatch color="var(--chart-1)" label="this month" />
-          <LineSwatch color="var(--chart-1)" label="projection" dashed />
+          <LineSwatch
+            color="var(--chart-1)"
+            label={hasEstimate ? "projection · incl. est. today" : "projection"}
+            dashed
+          />
           <LineSwatch color="#a1a1aa" label={`${monthLabelOffset(1)} (prior)`} />
           <LineSwatch color="#71717a" label={monthLabelOffset(2)} />
           <LineSwatch color="#52525b" label={monthLabelOffset(3)} />

--- a/src/components/claude/global-metrics-client.tsx
+++ b/src/components/claude/global-metrics-client.tsx
@@ -69,6 +69,9 @@ type StackedSeries = {
 const ALL_WORKSPACES = "__all__";
 const OTHER_KEY = "__other__";
 const DEFAULT_KEY = "__default__";
+// Spec 033 — trailing "today (est.)" ghost bar. Mirrors STACKED_ESTIMATE_KEY in
+// anthropic-global.ts (same intentional duplication as OTHER_KEY/DEFAULT_KEY).
+const ESTIMATE_KEY = "__estimated__";
 
 type GlobalMetricsClientProps = {
   initialKpis: DashboardKpis;
@@ -148,6 +151,7 @@ export function GlobalMetricsClient({
         workspacesWithLimitCount: kpis.workspacesWithLimitCount,
         topOverWorkspaceName: kpis.topOverWorkspaceName,
         topOverWorkspaceUtilizationPct: kpis.topOverWorkspaceUtilizationPct,
+        todayEstimate: kpis.todayEstimate,
       }),
     [kpis, orgBudgetCents, selectedMonth]
   );
@@ -166,6 +170,7 @@ export function GlobalMetricsClient({
     for (const s of seriesWithColors) {
       out[s.key] = { label: s.name, color: s.color };
     }
+    out[ESTIMATE_KEY] = { label: "Today (est.)", color: "var(--chart-1)" };
     return out;
   }, [seriesWithColors]);
 
@@ -201,6 +206,12 @@ export function GlobalMetricsClient({
     [seriesWithColors, selectedWorkspace]
   );
 
+  // Spec 033 — the server appends one trailing "today (est.)" row carrying the
+  // estimate under ESTIMATE_KEY. Render its ghost bar only in the org-wide view
+  // (the estimate is a single org/total figure, not per-workspace here).
+  const showEstimate =
+    selectedWorkspace === ALL_WORKSPACES && daily.rows.some((d) => d.estimated);
+
   const chartData = useMemo(
     () =>
       daily.rows.map((d) => {
@@ -208,9 +219,12 @@ export function GlobalMetricsClient({
         for (const s of visibleSeries) {
           row[s.key] = (d.perWorkspace[s.key] ?? 0) / 100;
         }
+        if (showEstimate) {
+          row[ESTIMATE_KEY] = (d.perWorkspace[ESTIMATE_KEY] ?? 0) / 100;
+        }
         return row;
       }),
-    [daily.rows, visibleSeries]
+    [daily.rows, visibleSeries, showEstimate]
   );
 
   return (
@@ -336,6 +350,19 @@ export function GlobalMetricsClient({
                     }
                   />
                 ))}
+                {showEstimate && (
+                  <Bar
+                    dataKey={ESTIMATE_KEY}
+                    stackId="costs"
+                    name="Today (est.)"
+                    fill="var(--chart-1)"
+                    fillOpacity={0.28}
+                    stroke="var(--chart-1)"
+                    strokeOpacity={0.6}
+                    strokeDasharray="3 3"
+                    radius={[4, 4, 0, 0]}
+                  />
+                )}
               </BarChart>
             </ChartContainer>
           )}

--- a/src/components/claude/historical-trend-card.tsx
+++ b/src/components/claude/historical-trend-card.tsx
@@ -26,6 +26,8 @@ type HistoricalTrendCardProps = {
   budgetLimitCents: number | null;
   todayDayOfMonth: number;
   daysInMonth: number;
+  /** Spec 033 — anchors the pacing projection at today (MTD + est). */
+  todayEstimateCents?: number | null;
 };
 
 export function HistoricalTrendCard({
@@ -37,6 +39,7 @@ export function HistoricalTrendCard({
   budgetLimitCents,
   todayDayOfMonth,
   daysInMonth,
+  todayEstimateCents = null,
 }: HistoricalTrendCardProps) {
   const [view, setView] = useState<View>("monthly");
 
@@ -83,6 +86,7 @@ export function HistoricalTrendCard({
             projectedEomCents={projectedMonthEndCents}
             todayDayOfMonth={todayDayOfMonth}
             daysInMonth={daysInMonth}
+            todayEstimateCents={todayEstimateCents}
           />
         )}
         {view === "growing" && (

--- a/src/components/claude/kpi-strip.tsx
+++ b/src/components/claude/kpi-strip.tsx
@@ -2,6 +2,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { cn, formatCurrency } from "@/lib/utils";
 import { AlertTriangle, TrendingDown, TrendingUp } from "lucide-react";
 import type { ReactNode } from "react";
+import type { TodayEstimate } from "@/lib/anthropic/estimate-today";
+import { totalTileCaption } from "./today-estimate";
 
 export type KpiTile = {
   label: string;
@@ -85,6 +87,7 @@ export function buildOrgKpiTiles(args: {
   workspacesWithLimitCount: number;
   topOverWorkspaceName: string | null;
   topOverWorkspaceUtilizationPct: number | null;
+  todayEstimate?: TodayEstimate | null;
 }): KpiTile[] {
   const {
     month,
@@ -98,6 +101,7 @@ export function buildOrgKpiTiles(args: {
     workspacesWithLimitCount,
     topOverWorkspaceName,
     topOverWorkspaceUtilizationPct,
+    todayEstimate,
   } = args;
 
   const [year, monthNum] = month.split("-");
@@ -128,12 +132,11 @@ export function buildOrgKpiTiles(args: {
 
   const tiles: KpiTile[] = [
     {
+      // Headline stays the ACTUAL billed total (spec 033 guard — never merge the
+      // estimate into it); the estimate is surfaced as a labeled sub-line.
       label: `Total · ${monthLabel}`,
       value: formatCurrency(totalCents),
-      caption:
-        priorMonthCents > 0
-          ? `Prior month ${formatCurrency(priorMonthCents)}`
-          : "First month with data",
+      caption: totalTileCaption(todayEstimate, priorMonthCents),
     },
     {
       label: "MoM Delta",
@@ -149,10 +152,10 @@ export function buildOrgKpiTiles(args: {
       value: formatCurrency(projectedMonthEndCents),
       caption:
         orgBudgetCents == null
-          ? "No org budget set"
-          : isOverBudget
-          ? `${projectedPct}% of ${formatCurrency(orgBudgetCents)} budget`
-          : `${projectedPct ?? 0}% of ${formatCurrency(orgBudgetCents)} budget`,
+          ? todayEstimate
+            ? "Run-rate incl. est. today"
+            : "No org budget set"
+          : `${projectedPct ?? 0}% of ${formatCurrency(orgBudgetCents)} budget${todayEstimate ? " · incl. est. today" : ""}`,
       tone: isOverBudget ? "danger" : projectedPct != null && projectedPct >= 80 ? "warn" : "default",
       ring: isOverBudget,
       icon: isOverBudget ? <AlertTriangle className="size-3 text-destructive" /> : undefined,

--- a/src/components/claude/org-credits-panel.tsx
+++ b/src/components/claude/org-credits-panel.tsx
@@ -13,17 +13,22 @@ import { Input } from "@/components/ui/input";
 import { setOrgBillingBudget } from "@/actions/anthropic-global";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
+import type { TodayEstimate } from "@/lib/anthropic/estimate-today";
+import { EstChip } from "@/components/claude/today-estimate";
 
 type OrgBillingBudgetCardProps = {
   orgConfig: { billingBudgetLimitCents: number | null } | null;
   currentMonthTotalCents: number;
   projectedMonthEndCents: number;
+  /** Spec 033 — estimate of today's spend (shown alongside actuals, not merged). */
+  todayEstimate?: TodayEstimate | null;
 };
 
 export function OrgBillingBudgetCard({
   orgConfig,
   currentMonthTotalCents,
   projectedMonthEndCents,
+  todayEstimate,
 }: OrgBillingBudgetCardProps) {
   const [editing, setEditing] = useState(false);
   const [inputValue, setInputValue] = useState(
@@ -85,6 +90,12 @@ export function OrgBillingBudgetCard({
             <p className="mt-1 text-xl font-semibold tabular-nums">
               {formatCurrency(currentMonthTotalCents)}
             </p>
+            {todayEstimate && (
+              <p className="mt-1 inline-flex flex-wrap items-center gap-1 text-xs text-primary">
+                +{formatCurrency(todayEstimate.cents)} est. today
+                <EstChip estimate={todayEstimate} />
+              </p>
+            )}
             {limitCents != null && (
               <p className="mt-1 text-xs text-muted-foreground">
                 {utilizationPct ?? 0}% of {formatCurrency(limitCents)} budget

--- a/src/components/claude/today-estimate.tsx
+++ b/src/components/claude/today-estimate.tsx
@@ -1,0 +1,74 @@
+// Spec 033 — shared presentational affordances for the "estimated today" figure.
+// Always visually distinct from solid actuals: a dashed/ghost "est." chip with a
+// tooltip explaining provenance. Kept tiny and client-safe so KPI strips, the
+// org panel, and (indirectly) charts share one vocabulary.
+
+import type { ReactNode } from "react";
+import { formatCurrency } from "@/lib/utils";
+import {
+  CALIBRATION_LOOKBACK_DAYS,
+  type TodayEstimate,
+} from "@/lib/anthropic/estimate-today";
+
+function relativeAge(asOfIso: string): string {
+  const ageMin = Math.max(0, Math.floor((Date.now() - new Date(asOfIso).getTime()) / 60_000));
+  if (ageMin < 1) return "just now";
+  if (ageMin < 60) return `${ageMin}m ago`;
+  const h = Math.floor(ageMin / 60);
+  return `${h}h ago`;
+}
+
+/** Tooltip text mirroring mockup.html — provenance + the don't-reconcile caveat. */
+export function estimateTooltip(estimate: TodayEstimate): string {
+  const calibration = estimate.confident
+    ? `calibrated ×${estimate.calibration.toFixed(2)} to the last ${CALIBRATION_LOOKBACK_DAYS} billed days`
+    : "uncalibrated — not enough recent billed days to calibrate";
+  return [
+    `Estimated today: ${formatCurrency(estimate.cents)}.`,
+    `Derived from today's per-user usage (${formatCurrency(estimate.rawUserCents)}), ${calibration}.`,
+    `Updates hourly (synced ${relativeAge(estimate.asOfIso)}); replaced by the billed figure tomorrow.`,
+    `Per-user and billed totals don't reconcile exactly.`,
+  ].join(" ");
+}
+
+/** The dashed "est." chip — reuses the projection-ghost vocabulary (primary, dashed). */
+export function EstChip({ estimate }: { estimate: TodayEstimate }) {
+  return (
+    <span
+      className="inline-flex items-center rounded border border-dashed border-primary/60 bg-primary/10 px-1.5 py-0 text-[10px] font-medium text-primary"
+      title={estimateTooltip(estimate)}
+    >
+      est.
+    </span>
+  );
+}
+
+/**
+ * Caption fragment for a month-to-date / total tile: "incl. +$X est. today" with
+ * the chip. The headline value itself stays the ACTUAL total — the estimate is
+ * never merged into it (spec 033 guard); this line makes it explicit.
+ */
+export function InclEstTodayCaption({ estimate }: { estimate: TodayEstimate }) {
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      <span>incl.</span>
+      <span className="text-primary">+{formatCurrency(estimate.cents)} est. today</span>
+      <EstChip estimate={estimate} />
+    </span>
+  );
+}
+
+/**
+ * Caption for a "Total · {month}" KPI tile: the est-today sub-line when present,
+ * otherwise the prior-month / first-month fallback. Shared by the org strip and
+ * the workspace-detail strip so the two stay in lockstep.
+ */
+export function totalTileCaption(
+  estimate: TodayEstimate | null | undefined,
+  priorMonthCents: number
+): ReactNode {
+  if (estimate) return <InclEstTodayCaption estimate={estimate} />;
+  return priorMonthCents > 0
+    ? `Prior month ${formatCurrency(priorMonthCents)}`
+    : "First month with data";
+}

--- a/src/components/claude/workspace-budget-list.tsx
+++ b/src/components/claude/workspace-budget-list.tsx
@@ -17,17 +17,22 @@ import { setWorkspaceLimit } from "@/actions/anthropic-global";
 import { Sparkline } from "@/components/ui/sparkline";
 import { toast } from "sonner";
 import type { WorkspaceListItem, WorkspaceSparkline } from "@/types";
-import { cn, formatCurrency, projectMonthEnd } from "@/lib/utils";
-import { getDaysInMonth } from "date-fns";
+import {
+  cn,
+  formatCurrency,
+  getUtcDaysInMonth,
+  projectMonthEnd,
+} from "@/lib/utils";
 
 const HIDE_ZERO_STORAGE_KEY = "claude-hide-zero-workspaces";
 
 function PaceLabel({ workspace }: { workspace: WorkspaceListItem }) {
   if (workspace.limitCents == null || workspace.limitCents <= 0) return null;
   const now = new Date();
-  const daysInMonth = getDaysInMonth(now);
   // Spec 033: count today (UTC) in the denominator and add today's estimate to
   // the numerator so the pace matches the projection on the rest of the page.
+  // Days-in-month is also UTC-keyed so it can't skew at a UTC month boundary.
+  const daysInMonth = getUtcDaysInMonth(now);
   const daysElapsed = Math.max(1, now.getUTCDate());
   const spentSoFar =
     workspace.currentMonthCents + (workspace.todayEstimate?.cents ?? 0);

--- a/src/components/claude/workspace-budget-list.tsx
+++ b/src/components/claude/workspace-budget-list.tsx
@@ -18,7 +18,7 @@ import { Sparkline } from "@/components/ui/sparkline";
 import { toast } from "sonner";
 import type { WorkspaceListItem, WorkspaceSparkline } from "@/types";
 import { cn, formatCurrency, projectMonthEnd } from "@/lib/utils";
-import { getDaysInMonth, getDate } from "date-fns";
+import { getDaysInMonth } from "date-fns";
 
 const HIDE_ZERO_STORAGE_KEY = "claude-hide-zero-workspaces";
 
@@ -26,12 +26,12 @@ function PaceLabel({ workspace }: { workspace: WorkspaceListItem }) {
   if (workspace.limitCents == null || workspace.limitCents <= 0) return null;
   const now = new Date();
   const daysInMonth = getDaysInMonth(now);
-  const daysElapsed = Math.max(1, getDate(now));
-  const projected = projectMonthEnd(
-    workspace.currentMonthCents,
-    daysElapsed,
-    daysInMonth
-  );
+  // Spec 033: count today (UTC) in the denominator and add today's estimate to
+  // the numerator so the pace matches the projection on the rest of the page.
+  const daysElapsed = Math.max(1, now.getUTCDate());
+  const spentSoFar =
+    workspace.currentMonthCents + (workspace.todayEstimate?.cents ?? 0);
+  const projected = projectMonthEnd(spentSoFar, daysElapsed, daysInMonth);
   const pacePct = Math.round((projected / workspace.limitCents) * 100);
   const overPace = pacePct >= 100;
   return (

--- a/src/components/claude/workspace-daily-chart.tsx
+++ b/src/components/claude/workspace-daily-chart.tsx
@@ -7,11 +7,12 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartConfig } from "@/components/ui/chart";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, formatUtcDateOnly } from "@/lib/utils";
 import { formatCurrencyFromDollars, formatDateLong } from "@/lib/chart-format";
 
 const config: ChartConfig = {
   cost: { label: "Daily spend", color: "var(--chart-1)" },
+  estimated: { label: "Today (est.)", color: "var(--chart-1)" },
 };
 
 export function WorkspaceDailyChart({
@@ -19,6 +20,7 @@ export function WorkspaceDailyChart({
   color,
   limitCents,
   daysInMonth,
+  estimatedTodayCents,
 }: {
   dailyTotals: { date: string; costCents: number }[];
   color?: string | null;
@@ -26,18 +28,29 @@ export function WorkspaceDailyChart({
   limitCents?: number | null;
   /** Days in the selected month, used to prorate the monthly limit. */
   daysInMonth?: number;
+  /** Spec 033 — appends a ghost/dashed "today (est.)" bar when present. */
+  estimatedTodayCents?: number | null;
 }) {
-  if (dailyTotals.length === 0) {
+  if (dailyTotals.length === 0 && !estimatedTodayCents) {
     return (
       <p className="py-10 text-center text-sm text-muted-foreground">
         No daily data for this period.
       </p>
     );
   }
-  const data = dailyTotals.map((d) => ({
-    date: d.date,
-    cost: d.costCents / 100,
-  }));
+  const data: { date: string; cost: number | null; estimated: number | null }[] =
+    dailyTotals.map((d) => ({
+      date: d.date,
+      cost: d.costCents / 100,
+      estimated: null,
+    }));
+  if (estimatedTodayCents != null && estimatedTodayCents > 0) {
+    const today = formatUtcDateOnly(new Date());
+    // Replace today's slot if cost_report somehow already has it; else append.
+    const existing = data.find((d) => d.date === today);
+    if (existing) existing.estimated = estimatedTodayCents / 100;
+    else data.push({ date: today, cost: null, estimated: estimatedTodayCents / 100 });
+  }
 
   const dailyCapDollars =
     limitCents != null && daysInMonth && daysInMonth > 0
@@ -48,7 +61,7 @@ export function WorkspaceDailyChart({
   // max is below ~$5, switch to 2 decimals so ticks read e.g. "$0.50" not
   // four duplicate "$1" labels.
   const maxValue = data.reduce(
-    (acc, d) => Math.max(acc, d.cost),
+    (acc, d) => Math.max(acc, d.cost ?? 0, d.estimated ?? 0),
     dailyCapDollars ?? 0
   );
   const useFineTicks = maxValue < 5;
@@ -113,6 +126,19 @@ export function WorkspaceDailyChart({
           radius={[4, 4, 0, 0]}
           maxBarSize={56}
         />
+        {data.some((d) => d.estimated != null) && (
+          <Bar
+            dataKey="estimated"
+            name="Today (est.)"
+            fill="var(--chart-1)"
+            fillOpacity={0.28}
+            stroke="var(--chart-1)"
+            strokeOpacity={0.6}
+            strokeDasharray="3 3"
+            radius={[4, 4, 0, 0]}
+            maxBarSize={56}
+          />
+        )}
       </BarChart>
     </ChartContainer>
   );

--- a/src/lib/anthropic/estimate-today.ts
+++ b/src/lib/anthropic/estimate-today.ts
@@ -1,0 +1,77 @@
+// Spec 033 — current-day cost estimate.
+//
+// Pure, dependency-free helper. The Anthropic `cost_report` (workspace) source
+// only ever returns COMPLETE UTC days, so the workspace/global views are always
+// missing "today". The per-USER `usage_report` source, by contrast, holds a
+// real hourly-fresh cost for today. The two sources DO NOT reconcile exactly
+// (different endpoints, pricing-table drift, unmapped spend, rounding — see
+// specs/027 data-model.md:107), so we must not treat "sum of per-user today" as
+// the workspace cost. Instead we use it as a signal and CALIBRATE it against how
+// the two sources actually relate over recent complete days.
+//
+// No I/O, no `server-only` — safe to import from client components (e.g. to read
+// the TodayEstimate shape). The query/aggregation layer (queries.ts) decides
+// when the estimate is null (no today data, or the usage sync is stale).
+
+/** Complete days used to calibrate per-user → workspace cost. */
+export const CALIBRATION_LOOKBACK_DAYS = 7;
+/** Clamp band so a noisy week can't 2×/½× the figure. */
+export const CALIBRATION_MIN = 0.5;
+export const CALIBRATION_MAX = 2.0;
+
+/**
+ * The estimate carried on every DTO that exposes month-to-date cost.
+ *
+ * `null` (at the DTO level) ⇒ nothing to show — no per-user data for today, or
+ * the usage sync is stale ⇒ the UI falls back to actual-only.
+ */
+export type TodayEstimate = {
+  /** Calibrated estimate of today's spend SO FAR (cumulative to now), in cents. */
+  cents: number;
+  /** Uncalibrated per-user sum for today, in cents (shown in the tooltip). */
+  rawUserCents: number;
+  /** Ratio applied to rawUserCents (1.0 when not confident). */
+  calibration: number;
+  /** Had ≥1 recent complete day in BOTH sources to calibrate against. */
+  confident: boolean;
+  /** ISO timestamp of the per-user usage sync — drives the freshness label. */
+  asOfIso: string;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Calibrate today's per-user spend against the recent per-user↔workspace ratio.
+ *
+ * The estimate is today's spend SO FAR (cumulative to the current hour), NOT a
+ * full-day extrapolation — it is the most defensible "as up to date as possible"
+ * number. The run-rate handles the remaining days of the month.
+ */
+export function estimateTodayCostCents(input: {
+  /** SUM(usage_metrics.computed_cost_cents) WHERE date = today (real, hourly). */
+  todayUserCostCents: number;
+  /** SUM over the last N COMPLETE days, per-user source. */
+  recentUserCostCents: number;
+  /** SUM over the SAME N complete days, workspace source. */
+  recentWorkspaceCostCents: number;
+}): { estimatedTodayCents: number; calibration: number; confident: boolean } {
+  // Calibration = how much bigger the billed workspace total runs vs our
+  // per-user estimate over the recent complete days.
+  const raw =
+    input.recentUserCostCents > 0
+      ? input.recentWorkspaceCostCents / input.recentUserCostCents
+      : 1;
+  // Clamp to a sane band; fall back to 1.0 when either source is thin.
+  const calibration = clamp(raw, CALIBRATION_MIN, CALIBRATION_MAX);
+  const confident =
+    input.recentUserCostCents > 0 && input.recentWorkspaceCostCents > 0;
+  return {
+    estimatedTodayCents: Math.round(
+      input.todayUserCostCents * (confident ? calibration : 1)
+    ),
+    calibration: confident ? calibration : 1,
+    confident,
+  };
+}

--- a/src/lib/anthropic/forecast-workspace.ts
+++ b/src/lib/anthropic/forecast-workspace.ts
@@ -37,25 +37,32 @@ const MIN_HISTORY_DAYS = 3;
  * @param month       Billing month as "YYYY-MM".
  * @param today       Current time. Pass explicitly for deterministic tests.
  * @param limitCents  Monthly cap in cents, or null when no cap.
+ * @param todayEstimateCents  Spec 033 — the cost_report source has no row for
+ *                    today, which dilutes the 7-day run-rate with a phantom 0
+ *                    and drops today from MTD. When > 0 it fills today's slot
+ *                    and is added to MTD. Defaults to 0 → identical to before.
  */
 export function forecastWorkspaceMonth(
   dailyCosts: Map<string, number>,
   month: string,
   today: Date,
   limitCents: number | null,
+  todayEstimateCents = 0,
 ): WorkspaceForecast {
   const monthStart = parseISO(`${month}-01`);
   const monthEndDate = endOfMonth(monthStart);
   const daysInMonth = getDaysInMonth(monthStart);
   const daysElapsed = Math.min(daysInMonth, Math.max(1, getDate(today)));
   const daysRemaining = Math.max(0, daysInMonth - daysElapsed);
+  const todayStr = format(today, "yyyy-MM-dd");
 
   // Build dense daily series — fill missing days with 0 so averages are over
-  // calendar days, not just billed days.
+  // calendar days, not just billed days. Today has no cost_report row yet, so
+  // fall back to the per-user estimate for that single slot.
   const last30: number[] = [];
   for (let i = 29; i >= 0; i--) {
     const d = format(subDays(today, i), "yyyy-MM-dd");
-    last30.push(dailyCosts.get(d) ?? 0);
+    last30.push(dailyCosts.get(d) ?? (d === todayStr ? todayEstimateCents : 0));
   }
   const last7 = last30.slice(-7);
   const prev7 = last30.slice(-14, -7);
@@ -80,6 +87,17 @@ export function forecastWorkspaceMonth(
       mtdCents += cents;
       if (cents > 0) distinctMtdDays += 1;
     }
+  }
+  // Spec 033: cost_report lacks today — add the estimate when today is in MTD
+  // and not already billed (it won't be, but guard against double-counting).
+  if (
+    todayEstimateCents > 0 &&
+    todayStr >= mtdStart &&
+    todayStr <= mtdEnd &&
+    !dailyCosts.has(todayStr)
+  ) {
+    mtdCents += todayEstimateCents;
+    distinctMtdDays += 1;
   }
 
   const projectedMonthEndCents = mtdCents + runRate7dCents * daysRemaining;

--- a/src/lib/anthropic/forecast-workspace.ts
+++ b/src/lib/anthropic/forecast-workspace.ts
@@ -6,14 +6,7 @@
 // tracker). This one projects month-end via a 7-day trailing rate from up to
 // 30 days of daily history. Right tool for cap-based monthly alerts.
 
-import {
-  endOfMonth,
-  format,
-  getDate,
-  getDaysInMonth,
-  parseISO,
-  subDays,
-} from "date-fns";
+import { formatUtcDateOnly } from "@/lib/utils";
 
 export type WorkspaceForecast = {
   runRate7dCents: number;
@@ -49,19 +42,27 @@ export function forecastWorkspaceMonth(
   limitCents: number | null,
   todayEstimateCents = 0,
 ): WorkspaceForecast {
-  const monthStart = parseISO(`${month}-01`);
-  const monthEndDate = endOfMonth(monthStart);
-  const daysInMonth = getDaysInMonth(monthStart);
-  const daysElapsed = Math.min(daysInMonth, Math.max(1, getDate(today)));
+  // All date math is UTC — the dailyCosts keys come from cost_report (UTC
+  // calendar dates), so mixing in local-time helpers would shift "today" by a
+  // day in non-UTC runtimes (off-by-one MTD / run-rate / crossesCapOn).
+  const [year, monthNum] = month.split("-").map(Number);
+  const monthIdx = monthNum - 1;
+  const daysInMonth = new Date(Date.UTC(year, monthIdx + 1, 0)).getUTCDate();
+  const monthEndUtc = new Date(Date.UTC(year, monthIdx, daysInMonth));
+  const daysElapsed = Math.min(daysInMonth, Math.max(1, today.getUTCDate()));
   const daysRemaining = Math.max(0, daysInMonth - daysElapsed);
-  const todayStr = format(today, "yyyy-MM-dd");
+  const todayStr = formatUtcDateOnly(today);
 
   // Build dense daily series — fill missing days with 0 so averages are over
   // calendar days, not just billed days. Today has no cost_report row yet, so
   // fall back to the per-user estimate for that single slot.
   const last30: number[] = [];
   for (let i = 29; i >= 0; i--) {
-    const d = format(subDays(today, i), "yyyy-MM-dd");
+    const d = formatUtcDateOnly(
+      new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() - i)
+      )
+    );
     last30.push(dailyCosts.get(d) ?? (d === todayStr ? todayEstimateCents : 0));
   }
   const last7 = last30.slice(-7);
@@ -78,8 +79,9 @@ export function forecastWorkspaceMonth(
       ? null
       : Math.round(((last7Total - prev7Total) / prev7Total) * 100);
 
-  const mtdStart = format(monthStart, "yyyy-MM-dd");
-  const mtdEnd = format(today < monthEndDate ? today : monthEndDate, "yyyy-MM-dd");
+  const mtdStart = `${month}-01`;
+  const monthEndStr = formatUtcDateOnly(monthEndUtc);
+  const mtdEnd = todayStr < monthEndStr ? todayStr : monthEndStr;
   let mtdCents = 0;
   let distinctMtdDays = 0;
   for (const [date, cents] of dailyCosts) {
@@ -141,10 +143,15 @@ export function forecastWorkspaceMonth(
   if (willOvershoot && runRate7dCents > 0) {
     const centsToReachCap = limitCents - mtdCents;
     const daysToReachCap = Math.ceil(centsToReachCap / runRate7dCents);
-    const crossDate = new Date(today);
-    crossDate.setDate(crossDate.getDate() + daysToReachCap);
-    const clamped = crossDate > monthEndDate ? monthEndDate : crossDate;
-    crossesCapOn = format(clamped, "yyyy-MM-dd");
+    const crossDate = new Date(
+      Date.UTC(
+        today.getUTCFullYear(),
+        today.getUTCMonth(),
+        today.getUTCDate() + daysToReachCap
+      )
+    );
+    const clamped = crossDate > monthEndUtc ? monthEndUtc : crossDate;
+    crossesCapOn = formatUtcDateOnly(clamped);
   }
 
   return {

--- a/src/lib/anthropic/queries.ts
+++ b/src/lib/anthropic/queries.ts
@@ -13,14 +13,18 @@ import { eq, sql } from "drizzle-orm";
 import {
   endOfMonth,
   format,
-  getDate,
   getDaysInMonth,
   parseISO,
   startOfMonth,
   subDays,
   subMonths,
 } from "date-fns";
-import { projectMonthEnd } from "@/lib/utils";
+import { formatUtcDateOnly, getCurrentMonth, projectMonthEnd } from "@/lib/utils";
+import {
+  CALIBRATION_LOOKBACK_DAYS,
+  estimateTodayCostCents,
+  type TodayEstimate,
+} from "@/lib/anthropic/estimate-today";
 import type {
   DashboardKpis,
   SyncStatus,
@@ -56,6 +60,164 @@ export async function loadSyncStatus(): Promise<SyncStatus> {
 }
 
 // ---------------------------------------------------------------------------
+// Today estimate (spec 033)
+//
+// The workspace/global cost_report source only has COMPLETE UTC days, so it is
+// always missing today. We derive a calibrated estimate of today's spend from
+// the hourly per-user usage source and carry it as a SEPARATE field — never
+// merged into actuals. Computed here (uncached) so the cron evaluator gets a
+// fresh value and the cached dashboard actions inherit the existing cadence.
+// ---------------------------------------------------------------------------
+
+type EstimateComponents = {
+  todayUserCents: number;
+  recentUserCents: number;
+  recentWorkspaceCents: number;
+};
+
+type TodayEstimateInputs = {
+  /** Per-user usage sync completion (sentinel row) — drives freshness/null. */
+  asOf: Date | null;
+  global: EstimateComponents;
+  byWorkspace: Map<string | null, EstimateComponents>;
+};
+
+/**
+ * One round-trip of the raw inputs for the today estimate, both globally and
+ * per resolved workspace. Recent window is the last CALIBRATION_LOOKBACK_DAYS
+ * COMPLETE UTC days, i.e. [today − N, today − 1].
+ */
+async function loadTodayEstimateInputs(now: Date): Promise<TodayEstimateInputs> {
+  const todayStr = formatUtcDateOnly(now);
+  const recentEnd = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1)
+  );
+  const recentStart = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - CALIBRATION_LOOKBACK_DAYS
+    )
+  );
+  const recentStartStr = formatUtcDateOnly(recentStart);
+  const recentEndStr = formatUtcDateOnly(recentEnd);
+
+  const [todayUserRows, recentUserRows, recentWsRows, sentinelRow] =
+    await Promise.all([
+      db.execute<{ ws: string | null; cents: number }>(sql`
+        SELECT s.resolved_workspace_id AS ws,
+               COALESCE(SUM(m.computed_cost_cents), 0)::bigint AS cents
+        FROM anthropic_usage_metrics m
+        JOIN anthropic_sync_status s ON s.user_id = m.user_id
+        WHERE m.date = ${todayStr}::date
+        GROUP BY s.resolved_workspace_id
+      `),
+      db.execute<{ ws: string | null; cents: number }>(sql`
+        SELECT s.resolved_workspace_id AS ws,
+               COALESCE(SUM(m.computed_cost_cents), 0)::bigint AS cents
+        FROM anthropic_usage_metrics m
+        JOIN anthropic_sync_status s ON s.user_id = m.user_id
+        WHERE m.date >= ${recentStartStr}::date AND m.date <= ${recentEndStr}::date
+        GROUP BY s.resolved_workspace_id
+      `),
+      db.execute<{ ws: string | null; cents: number }>(sql`
+        SELECT workspace_id AS ws,
+               COALESCE(SUM(cost_cents), 0)::bigint AS cents
+        FROM anthropic_workspace_costs
+        WHERE date >= ${recentStartStr}::date AND date <= ${recentEndStr}::date
+        GROUP BY workspace_id
+      `),
+      db.query.anthropicSyncStatus.findFirst({
+        where: eq(anthropicSyncStatus.userId, SYNC_SENTINEL_USER_ID),
+      }),
+    ]);
+
+  const byWorkspace = new Map<string | null, EstimateComponents>();
+  const ensure = (ws: string | null): EstimateComponents => {
+    let c = byWorkspace.get(ws);
+    if (!c) {
+      c = { todayUserCents: 0, recentUserCents: 0, recentWorkspaceCents: 0 };
+      byWorkspace.set(ws, c);
+    }
+    return c;
+  };
+  const global: EstimateComponents = {
+    todayUserCents: 0,
+    recentUserCents: 0,
+    recentWorkspaceCents: 0,
+  };
+
+  for (const r of todayUserRows.rows) {
+    const cents = Number(r.cents ?? 0);
+    ensure(r.ws ?? null).todayUserCents += cents;
+    global.todayUserCents += cents;
+  }
+  for (const r of recentUserRows.rows) {
+    const cents = Number(r.cents ?? 0);
+    ensure(r.ws ?? null).recentUserCents += cents;
+    global.recentUserCents += cents;
+  }
+  for (const r of recentWsRows.rows) {
+    const cents = Number(r.cents ?? 0);
+    ensure(r.ws ?? null).recentWorkspaceCents += cents;
+    global.recentWorkspaceCents += cents;
+  }
+
+  return { asOf: sentinelRow?.lastSyncCompletedAt ?? null, global, byWorkspace };
+}
+
+/**
+ * Build a TodayEstimate from raw components, or null when there is nothing
+ * trustworthy to show: no per-user data for today, or the usage sync is stale
+ * (older than STALE_MINUTES). The UI falls back to actual-only on null.
+ */
+function buildTodayEstimate(
+  c: EstimateComponents,
+  asOf: Date | null,
+  now: Date
+): TodayEstimate | null {
+  if (!asOf) return null;
+  if (now.getTime() - asOf.getTime() > STALE_MINUTES * 60_000) return null;
+  if (c.todayUserCents <= 0) return null;
+  const { estimatedTodayCents, calibration, confident } = estimateTodayCostCents(
+    {
+      todayUserCostCents: c.todayUserCents,
+      recentUserCostCents: c.recentUserCents,
+      recentWorkspaceCostCents: c.recentWorkspaceCents,
+    }
+  );
+  if (estimatedTodayCents <= 0) return null;
+  return {
+    cents: estimatedTodayCents,
+    rawUserCents: c.todayUserCents,
+    calibration,
+    confident,
+    asOfIso: asOf.toISOString(),
+  };
+}
+
+/** Calibrated estimate of the org-wide spend so far today, or null. */
+export async function loadTodayEstimate(
+  now: Date = new Date()
+): Promise<TodayEstimate | null> {
+  const { asOf, global } = await loadTodayEstimateInputs(now);
+  return buildTodayEstimate(global, asOf, now);
+}
+
+/** Per-workspace today estimates (only workspaces with a non-null estimate). */
+export async function loadTodayEstimatesByWorkspace(
+  now: Date = new Date()
+): Promise<Map<string | null, TodayEstimate>> {
+  const { asOf, byWorkspace } = await loadTodayEstimateInputs(now);
+  const out = new Map<string | null, TodayEstimate>();
+  for (const [ws, c] of byWorkspace) {
+    const est = buildTodayEstimate(c, asOf, now);
+    if (est) out.set(ws, est);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // loadDashboardKpis
 // ---------------------------------------------------------------------------
 
@@ -81,11 +243,23 @@ export async function loadDashboardKpis(month: string): Promise<DashboardKpis> {
       ? null
       : Math.round((momDeltaCents / priorMonthCents) * 100);
 
-  const nowMonth = format(new Date(), "yyyy-MM");
+  // Projection (spec 033): for the current month, count today in the
+  // denominator (UTC day) AND add today's estimate to the numerator so the two
+  // agree — otherwise the numerator skips today while the denominator counts it
+  // (under-projects all month, projects 0 on the 1st). Past months: full month.
+  const now = new Date();
+  const isCurrentMonth = month === getCurrentMonth();
+  const todayEstimate = isCurrentMonth ? await loadTodayEstimate(now) : null;
   const daysInMonth = getDaysInMonth(parseISO(monthStart));
-  const daysElapsed =
-    month === nowMonth ? Math.max(1, getDate(new Date())) : daysInMonth;
-  const projectedMonthEndCents = projectMonthEnd(totalCents, daysElapsed, daysInMonth);
+  const daysElapsed = isCurrentMonth
+    ? Math.max(1, now.getUTCDate())
+    : daysInMonth;
+  const spentSoFar = totalCents + (todayEstimate?.cents ?? 0);
+  const projectedMonthEndCents = projectMonthEnd(
+    spentSoFar,
+    daysElapsed,
+    daysInMonth
+  );
 
   const overRows = await db.execute(sql`
     SELECT
@@ -133,6 +307,7 @@ export async function loadDashboardKpis(month: string): Promise<DashboardKpis> {
     topOverWorkspaceName: overCount > 0 ? topName : null,
     topOverWorkspaceUtilizationPct: overCount > 0 ? topPct : null,
     priorMonthCents,
+    todayEstimate,
   };
 }
 
@@ -183,6 +358,10 @@ export async function loadWorkspaceList(): Promise<WorkspaceListItem[]> {
       w.name ASC
   `);
 
+  // Per-workspace today estimate (separate field; never folded into the actual
+  // currentMonthCents or utilizationPct). The list is always the current month.
+  const estimates = await loadTodayEstimatesByWorkspace();
+
   return rows.rows.map((r) => {
     const currentMonthCents = Number(r.current_month_cents ?? 0);
     const limitCents = r.limit_cents != null ? Number(r.limit_cents) : null;
@@ -190,8 +369,9 @@ export async function loadWorkspaceList(): Promise<WorkspaceListItem[]> {
       limitCents != null && limitCents > 0
         ? Math.round((currentMonthCents / limitCents) * 100)
         : null;
+    const workspaceId = r.workspace_id as string | null;
     return {
-      workspaceId: r.workspace_id as string | null,
+      workspaceId,
       name: r.name as string,
       isDefault: r.is_default as boolean,
       isArchived: r.is_archived as boolean,
@@ -199,6 +379,7 @@ export async function loadWorkspaceList(): Promise<WorkspaceListItem[]> {
       limitCents,
       utilizationPct,
       displayColor: (r.display_color as string | null) ?? null,
+      todayEstimate: estimates.get(workspaceId) ?? null,
     };
   });
 }

--- a/src/lib/teams/evaluator.ts
+++ b/src/lib/teams/evaluator.ts
@@ -11,6 +11,7 @@ import {
   loadDashboardKpis,
   loadSyncStatus,
   loadWorkspaceList,
+  loadTodayEstimatesByWorkspace,
 } from "@/lib/anthropic/queries";
 import {
   forecastWorkspaceMonth,
@@ -69,19 +70,27 @@ export async function evaluateAndPostTeamsAlerts(opts?: {
     return { posted: 1, skipped: ["digest_skipped_stale"] };
   }
 
-  const [kpis, workspaces, priorState, costHistory] = await Promise.all([
-    loadDashboardKpis(month),
-    loadWorkspaceList(),
-    readAlertState(month),
-    loadCostHistory(now, FORECAST_LOOKBACK_DAYS),
-  ]);
+  const [kpis, workspaces, priorState, costHistory, todayEstimates] =
+    await Promise.all([
+      loadDashboardKpis(month),
+      loadWorkspaceList(),
+      readAlertState(month),
+      loadCostHistory(now, FORECAST_LOOKBACK_DAYS),
+      loadTodayEstimatesByWorkspace(now),
+    ]);
 
   // Compute forecasts purely from the pre-loaded cost history (no DB calls).
+  // Spec 033: feed each workspace's today estimate so the run-rate and MTD
+  // aren't diluted by the missing-today gap (cost_report has no row for today).
   const forecastByKey = new Map<string, WorkspaceForecast>();
   for (const w of workspaces) {
     if (w.currentMonthCents === 0 && w.limitCents === null) continue;
     const daily = costHistory.get(w.workspaceId) ?? new Map();
-    forecastByKey.set(keyFor(w.workspaceId), forecastWorkspaceMonth(daily, month, now, w.limitCents));
+    const estCents = todayEstimates.get(w.workspaceId)?.cents ?? 0;
+    forecastByKey.set(
+      keyFor(w.workspaceId),
+      forecastWorkspaceMonth(daily, month, now, w.limitCents, estCents),
+    );
   }
 
   const workspacesByKey = new Map<string, WorkspaceListItem>();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -121,6 +121,18 @@ export function formatDateOnly(d: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+/**
+ * Format a Date to its UTC ISO date-only string (yyyy-MM-dd). Use this — not
+ * `formatDateOnly` (local) — when comparing against the Anthropic cost tables,
+ * which key calendar dates in UTC.
+ */
+export function formatUtcDateOnly(d: Date): string {
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 // Sentinel values for faceted filters on nullable columns.
 export const NO_CIRCLE_SENTINEL = "__no_circle__";
 export const NO_PROFILE_SENTINEL = "__no_profile__";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -133,6 +133,15 @@ export function formatUtcDateOnly(d: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+/**
+ * Number of days in the UTC calendar month of `d`. Use this — not date-fns
+ * `getDaysInMonth(d)` (local month) — when `daysElapsed` / the spend data are
+ * keyed to UTC, so the projection denominator can't skew at a UTC month boundary.
+ */
+export function getUtcDaysInMonth(d: Date): number {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
+}
+
 // Sentinel values for faceted filters on nullable columns.
 export const NO_CIRCLE_SENTINEL = "__no_circle__";
 export const NO_PROFILE_SENTINEL = "__no_profile__";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import type { InferSelectModel, InferInsertModel } from "drizzle-orm";
+import type { TodayEstimate } from "@/lib/anthropic/estimate-today";
 import type {
   users,
   aiTools,
@@ -557,6 +558,10 @@ export interface GlobalCostDashboardData {
 
 // Spec 026 — Claude page redesign
 
+// Spec 033 — calibrated estimate of today's (incomplete) spend. `null` ⇒ no
+// per-user data for today or the usage sync is stale ⇒ fall back to actual-only.
+export type { TodayEstimate } from "@/lib/anthropic/estimate-today";
+
 export interface DashboardKpis {
   totalCents: number;
   momDeltaCents: number;
@@ -567,12 +572,16 @@ export interface DashboardKpis {
   topOverWorkspaceName: string | null;
   topOverWorkspaceUtilizationPct: number | null;
   priorMonthCents: number;
+  /** Spec 033 — estimate of today's spend so far (separate from totalCents). */
+  todayEstimate: TodayEstimate | null;
 }
 
 export interface DailyStackedRow {
   date: string;
   perWorkspace: Record<string, number>;
   total: number;
+  /** Spec 033 — true for the synthetic trailing "today (est.)" row. */
+  estimated?: boolean;
 }
 
 export interface StackedSeries {
@@ -655,6 +664,8 @@ export interface WorkspaceDetail {
   topUsers: WorkspaceUser[];
   modelBreakdown: ModelBreakdownRow[];
   availableMonths: string[];
+  /** Spec 033 — workspace's estimate of today's spend (separate field). */
+  todayEstimate: TodayEstimate | null;
 }
 
 export interface WorkspaceListItem {
@@ -666,6 +677,8 @@ export interface WorkspaceListItem {
   limitCents: number | null;
   utilizationPct: number | null;
   displayColor: string | null;
+  /** Spec 033 — workspace's estimate of today's spend (separate field). */
+  todayEstimate: TodayEstimate | null;
 }
 
 export interface WorkspaceAlert {

--- a/tests/unit/anthropic-global-kpis.test.ts
+++ b/tests/unit/anthropic-global-kpis.test.ts
@@ -23,6 +23,63 @@ describe("projectMonthEnd", () => {
   });
 });
 
+describe("Projection with today estimate (spec 033 — mirrors loadDashboardKpis)", () => {
+  // spentSoFar = actual MTD (complete days) + today's estimate; daysElapsed
+  // counts today (UTC day). This is the model loadDashboardKpis / _getWorkspaceDetail use.
+  function project(
+    mtdActualCents: number,
+    estTodayCents: number,
+    daysElapsed: number,
+    daysInMonth: number
+  ) {
+    return projectMonthEnd(mtdActualCents + estTodayCents, daysElapsed, daysInMonth);
+  }
+
+  it("1st of the month: actual is $0 but the estimate yields a non-zero projection", () => {
+    // Before the fix this projected $0 (numerator skipped today, denominator counted it).
+    // Day 1 of 30, $0 billed, $1,180 est today → $35,400 projected.
+    expect(project(0, 118_000, 1, 30)).toBe(30 * 118_000);
+  });
+
+  it("mid-month: matches the hand-calc of (actual + est) / dayOfMonth * daysInMonth", () => {
+    // $42,320 actual + $1,640 est on day 12 of 30.
+    expect(project(4_232_000, 164_000, 12, 30)).toBe(
+      Math.round(((4_232_000 + 164_000) / 12) * 30)
+    );
+  });
+
+  it("a null/zero estimate leaves the projection at the actual-only run-rate", () => {
+    expect(project(4_232_000, 0, 12, 30)).toBe(projectMonthEnd(4_232_000, 12, 30));
+  });
+
+  it("past months are unaffected (full month elapsed, no estimate)", () => {
+    expect(project(5_000_000, 0, 30, 30)).toBe(5_000_000);
+  });
+});
+
+describe("Alerts & running costs stay actual-only (spec 033 invariant)", () => {
+  // getActiveAlerts (alerts.ts) and getRunningCostsForPeriod (budget-utils.ts)
+  // must NEVER fold in the estimate. Their math reads actual cents only.
+  function utilization(actualMtdCents: number, limitCents: number) {
+    return Math.round((actualMtdCents / limitCents) * 100);
+  }
+  function runningCost(actualBreakdownCents: number[]) {
+    return actualBreakdownCents.reduce((sum, c) => sum + c, 0);
+  }
+
+  it("utilization is computed from actual MTD only — an estimate cannot push it over 80%", () => {
+    const actualMtd = 7_900; // 79% of $100
+    const limit = 10_000;
+    // Even with a large today estimate sitting in a separate field, utilization
+    // is unchanged because the function never reads it.
+    expect(utilization(actualMtd, limit)).toBe(79);
+  });
+
+  it("running cost sums actual workspace costs only", () => {
+    expect(runningCost([100_00, 250_00, 0])).toBe(350_00);
+  });
+});
+
 describe("MoM math (mirrors getDashboardKpis)", () => {
   function mom(curr: number, prior: number) {
     const delta = curr - prior;

--- a/tests/unit/anthropic/estimate-today.test.ts
+++ b/tests/unit/anthropic/estimate-today.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  CALIBRATION_MAX,
+  CALIBRATION_MIN,
+  estimateTodayCostCents,
+} from "@/lib/anthropic/estimate-today";
+
+describe("estimateTodayCostCents", () => {
+  it("applies the calibration ratio of workspace/per-user to today's per-user spend", () => {
+    // Workspace billed 1.2× our per-user estimate over recent complete days.
+    const r = estimateTodayCostCents({
+      todayUserCostCents: 1_000,
+      recentUserCostCents: 10_000,
+      recentWorkspaceCostCents: 12_000,
+    });
+    expect(r.confident).toBe(true);
+    expect(r.calibration).toBeCloseTo(1.2, 5);
+    expect(r.estimatedTodayCents).toBe(1_200); // round(1000 * 1.2)
+  });
+
+  it("clamps a high ratio to CALIBRATION_MAX so a noisy week can't blow up the figure", () => {
+    const r = estimateTodayCostCents({
+      todayUserCostCents: 1_000,
+      recentUserCostCents: 1_000,
+      recentWorkspaceCostCents: 9_000, // raw ratio 9.0 → clamp to 2.0
+    });
+    expect(r.calibration).toBe(CALIBRATION_MAX);
+    expect(r.estimatedTodayCents).toBe(2_000);
+  });
+
+  it("clamps a low ratio to CALIBRATION_MIN", () => {
+    const r = estimateTodayCostCents({
+      todayUserCostCents: 1_000,
+      recentUserCostCents: 10_000,
+      recentWorkspaceCostCents: 1_000, // raw ratio 0.1 → clamp to 0.5
+    });
+    expect(r.calibration).toBe(CALIBRATION_MIN);
+    expect(r.estimatedTodayCents).toBe(500);
+  });
+
+  it("falls back to ×1 (not confident) when there is no recent per-user data", () => {
+    const r = estimateTodayCostCents({
+      todayUserCostCents: 1_500,
+      recentUserCostCents: 0,
+      recentWorkspaceCostCents: 5_000,
+    });
+    expect(r.confident).toBe(false);
+    expect(r.calibration).toBe(1);
+    expect(r.estimatedTodayCents).toBe(1_500); // uncalibrated per-user sum
+  });
+
+  it("falls back to ×1 (not confident) when there is no recent workspace data", () => {
+    const r = estimateTodayCostCents({
+      todayUserCostCents: 1_500,
+      recentUserCostCents: 8_000,
+      recentWorkspaceCostCents: 0,
+    });
+    expect(r.confident).toBe(false);
+    expect(r.calibration).toBe(1);
+    expect(r.estimatedTodayCents).toBe(1_500);
+  });
+
+  it("returns 0 when there is no per-user spend today (query layer maps this to null)", () => {
+    const r = estimateTodayCostCents({
+      todayUserCostCents: 0,
+      recentUserCostCents: 10_000,
+      recentWorkspaceCostCents: 12_000,
+    });
+    expect(r.estimatedTodayCents).toBe(0);
+  });
+
+  it("rounds the calibrated estimate to whole cents", () => {
+    const r = estimateTodayCostCents({
+      todayUserCostCents: 333,
+      recentUserCostCents: 1_000,
+      recentWorkspaceCostCents: 1_500, // ratio 1.5
+    });
+    expect(r.estimatedTodayCents).toBe(500); // round(333 * 1.5 = 499.5)
+  });
+
+  it("keeps the in-band ratio exactly (no clamping at the boundary)", () => {
+    const r = estimateTodayCostCents({
+      todayUserCostCents: 2_000,
+      recentUserCostCents: 10_000,
+      recentWorkspaceCostCents: 5_000, // ratio 0.5 == CALIBRATION_MIN
+    });
+    expect(r.calibration).toBe(0.5);
+    expect(r.estimatedTodayCents).toBe(1_000);
+  });
+});

--- a/tests/unit/teams/cards.test.ts
+++ b/tests/unit/teams/cards.test.ts
@@ -17,6 +17,7 @@ const baseWorkspace: WorkspaceListItem = {
   limitCents: 5_000_00,
   utilizationPct: 102,
   displayColor: null,
+  todayEstimate: null,
 };
 
 const baseForecast: WorkspaceForecast = {
@@ -38,6 +39,7 @@ const baseKpis: DashboardKpis = {
   topOverWorkspaceName: "research-claude",
   topOverWorkspaceUtilizationPct: 102,
   priorMonthCents: 16_920_00,
+  todayEstimate: null,
 };
 
 const baseSync: SyncStatus = {

--- a/tests/unit/teams/evaluator-diff.test.ts
+++ b/tests/unit/teams/evaluator-diff.test.ts
@@ -17,6 +17,7 @@ function ws(over: Partial<WorkspaceListItem> = {}): WorkspaceListItem {
     limitCents: 1_000_00,
     utilizationPct: 0,
     displayColor: null,
+    todayEstimate: null,
     ...over,
   };
 }

--- a/tests/unit/teams/forecast-workspace.test.ts
+++ b/tests/unit/teams/forecast-workspace.test.ts
@@ -108,4 +108,16 @@ describe("forecastWorkspaceMonth", () => {
     const omitted = forecastWorkspaceMonth(daily, month, today, 5000_00);
     expect(explicitZero).toEqual(omitted);
   });
+
+  // Regression: cost_report keys dates in UTC. At 23:30 UTC on May 31, a UTC+
+  // runtime is already on June 1 locally — the forecast must still key "today"
+  // to the UTC day (May 31) so the estimate counts toward the right month.
+  it("keys 'today' in UTC at a month boundary, not local time", () => {
+    const lateMayUtc = new Date("2026-05-31T23:30:00Z");
+    const f = forecastWorkspaceMonth(new Map(), "2026-05", lateMayUtc, null, 300_00);
+    // UTC day 31 of 31 → daysRemaining 0 → projected == MTD == the estimate.
+    // (If "today" were taken as local June 1, the estimate would fall outside
+    // May's MTD window and projected would be 0.)
+    expect(f.projectedMonthEndCents).toBe(300_00);
+  });
 });

--- a/tests/unit/teams/forecast-workspace.test.ts
+++ b/tests/unit/teams/forecast-workspace.test.ts
@@ -76,4 +76,36 @@ describe("forecastWorkspaceMonth", () => {
     expect(f.status).toBe("at_risk");
     expect(f.crossesCapOn).toBeNull();
   });
+
+  // Spec 033 — today estimate fills the missing cost_report slot.
+  it("fills today's missing slot with the estimate, lifting the 7-day run-rate", () => {
+    // 7 complete days before today @ $100, NO today row in cost_report.
+    const daily = new Map<string, number>();
+    for (let i = 1; i <= 7; i++) daily.set(daysBefore(i), 100_00);
+
+    const without = forecastWorkspaceMonth(daily, month, today, null);
+    const withEst = forecastWorkspaceMonth(daily, month, today, null, 700_00);
+
+    // last7 = [today-6..today-1, today]; today is 0 without, 700_00 with.
+    expect(without.runRate7dCents).toBe(Math.round(600_00 / 7));
+    expect(withEst.runRate7dCents).toBe(Math.round(1_300_00 / 7));
+    expect(withEst.projectedMonthEndCents).toBeGreaterThan(
+      without.projectedMonthEndCents,
+    );
+  });
+
+  it("does not double-count the estimate when cost_report already has today", () => {
+    const daily = build(Array(8).fill(100_00)); // includes a real today row
+    const without = forecastWorkspaceMonth(daily, month, today, null);
+    const withEst = forecastWorkspaceMonth(daily, month, today, null, 999_00);
+    expect(withEst.runRate7dCents).toBe(without.runRate7dCents);
+    expect(withEst.projectedMonthEndCents).toBe(without.projectedMonthEndCents);
+  });
+
+  it("defaulting the estimate to 0 preserves the original behavior", () => {
+    const daily = build(Array(14).fill(50_00));
+    const explicitZero = forecastWorkspaceMonth(daily, month, today, 5000_00, 0);
+    const omitted = forecastWorkspaceMonth(daily, month, today, 5000_00);
+    expect(explicitZero).toEqual(omitted);
+  });
 });


### PR DESCRIPTION
## Summary

Anthropic's `cost_report` (workspace / global) source only ever returns **complete UTC days**, so the Claude dashboard's month-to-date totals and month-end projections were always running a day behind — and **empty for the whole current month until the 2nd** (the gap PR #103 deliberately skips on the 1st). Meanwhile we already hold a real, hourly-fresh per-**user** cost for today.

Spec 033 surfaces a clearly-labelled, **calibrated "estimated today"** figure so MTD totals and projections are accurate from hour one — especially near month end, where budget decisions get made. Two issues, one PR:

1. **Projection denominator off-by-one** — `projectMonthEnd` counted today in the denominator while MTD (from `cost_report`) excluded it, so it under-projected all month and projected **$0 on the 1st**. Fixed at all four callers.
2. **No current-day figure** — derive a calibrated estimate of today's spend from per-user usage and show it as a distinct, dashed/ghost value.

Tier B scope, three phases (data → maths → UI). **0 migrations, 0 new packages.**

## How it works

- **`estimate-today.ts`** (new, pure, unit-tested): `estimateTodayCostCents` calibrates today's per-user sum against how `cost_report` related to per-user over the last 7 complete days (ratio clamped 0.5–2.0; falls back to ×1 when thin). The two sources are documented as *not reconciling exactly*, so the estimate is a calibrated signal, never treated as the billed total.
- **`queries.ts`**: today-estimate query helpers (global + per-workspace via `resolved_workspace_id`), threaded onto the `DashboardKpis` / `WorkspaceListItem` / `WorkspaceDetail` DTOs as a **separate field**. `totalCents` is byte-for-byte unchanged. Returns `null` (UI falls back to actual-only) when there's no per-user data today or the usage sync is stale.
- **Projection**: `spentSoFar = MTD actual + est today`, `daysElapsed = UTC day`. The user-detail page gets only the UTC alignment (its per-user MTD already includes today — it *is* the source, no calibration).
- **`forecast-workspace.ts`**: an optional today-estimate fills the missing `cost_report` slot so the cron Teams run-rate/MTD isn't diluted by a phantom $0; the evaluator passes per-workspace estimates. Default `0` ⇒ identical prior behaviour.
- **UI**: reuses the existing ghost/dashed projection vocabulary — `est.` chip + tooltip and "incl. est. today" sub-labels on the KPI strip & org panel, a ghost "today (est.)" bar on the daily charts, and the cumulative-pacing projection re-anchored at today.

## Scope guards (held)

- **Alerts** (`getActiveAlerts`) and **budget running-costs** (`getRunningCostsForPeriod`) stay **actual-only** — the estimate never moves a threshold or inflates a billed total.
- The estimate is a separate field, never merged into `totalCents` / any SUM query.

## Verification — Neon branch `wt/fix-sync-first-of-month` (real data, literally the 1st)

End-to-end (DB → query → DTO → SSR + hydrated UI), authenticated as the seeded agent admin:

| Surface | Result |
| --- | --- |
| Org KPI strip | Total `$0.00` + `$112.61 est. today` (dashed `est.` chip); Projected `$3,378.30` = "97% of $3,500 budget · incl. est. today" — math exact (11,261¢ × 30 ÷ 1) |
| 1st-of-month win | June `cost_report` empty (MTD $0) → estimate turns a would-be `$0 / —` into a real, calibrated number |
| Daily chart | single dashed ghost "today (est.)" bar |
| Workspace detail | `boost-starter-1`: `+$45.43 est. today` (own calibration ~0.945) · "95% of $700 limit · incl. est. today"; default workspace (no today usage) → null → $0 |
| Freshness | a "Stale" workspace-sync pill coexists with a live estimate — the estimate rides the *usage* sync |

`pnpm lint` + `pnpm typecheck` clean; **382 unit tests pass** (new: helper calibration/clamp/fallback/rounding, forecast est-fill/no-double-count, projection 1st-of-month + actual-only invariants).

See `specs/033-current-day-cost-estimate/implementation-notes.html` for design decisions, deviations, and two items flagged for your confirmation (the cron Teams forecast now includes the estimate; dashboard estimate freshness follows the existing cache cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
