### PR TITLE
fix(mobile): optimize responsive layouts across screens

### DIFF
--- a/src/app/assignments/assignments-client.tsx
+++ b/src/app/assignments/assignments-client.tsx
@@ -18,7 +18,13 @@ import type { UpdateAssignmentInput } from "@/lib/validators";
 import { DataTable, arrayIncludesFilterFn } from "@/components/data-table";
 import { StatusText, useInlineStatus } from "@/components/ui/status-text";
 import { UserCombobox } from "@/components/user-combobox";
-import { formatCurrency, formatDate, cn, formatDateOnly, NO_WORKSPACE_SENTINEL } from "@/lib/utils";
+import {
+  formatCurrency,
+  formatDate,
+  cn,
+  formatDateOnly,
+  NO_WORKSPACE_SENTINEL,
+} from "@/lib/utils";
 import type { AiTool, User, AccessTier } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -289,7 +295,7 @@ function EditAssignmentDialog({
                           variant="outline"
                           className={cn(
                             "w-full justify-start text-left font-normal",
-                            !field.value && "text-muted-foreground"
+                            !field.value && "text-muted-foreground",
                           )}
                         >
                           <CalendarIcon className="mr-2 size-4" />
@@ -303,7 +309,9 @@ function EditAssignmentDialog({
                       <Calendar
                         mode="single"
                         captionLayout="dropdown"
-                        selected={field.value ? parseISO(field.value) : undefined}
+                        selected={
+                          field.value ? parseISO(field.value) : undefined
+                        }
                         onSelect={(date) => {
                           if (date) {
                             field.onChange(formatDateOnly(date));
@@ -452,68 +460,76 @@ function AssignmentRowActions({
         </TooltipTrigger>
         <TooltipContent>View</TooltipContent>
       </Tooltip>
-      {isAdmin && assignment.status === "active" && assignment.source === "copilot-sync" && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Badge variant="outline" className="ml-1 cursor-default text-xs text-muted-foreground">
-              Managed by sync
-            </Badge>
-          </TooltipTrigger>
-          <TooltipContent>
-            This assignment is managed by Copilot sync and cannot be edited or revoked manually.
-          </TooltipContent>
-        </Tooltip>
-      )}
-      {isAdmin && assignment.status === "active" && assignment.source !== "copilot-sync" && (
-        <>
-          <EditAssignmentDialog assignment={assignment} onSaved={onSaved} />
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    aria-label={`More actions for ${assignment.user.name}'s assignment`}
-                  >
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent>More actions</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                variant="destructive"
-                onSelect={() => setShowRevokeDialog(true)}
+      {isAdmin &&
+        assignment.status === "active" &&
+        assignment.source === "copilot-sync" && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge
+                variant="outline"
+                className="ml-1 cursor-default text-xs text-muted-foreground"
               >
-                <Ban className="size-4" />
-                Revoke
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <AlertDialog
-            open={showRevokeDialog}
-            onOpenChange={setShowRevokeDialog}
-          >
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Revoke this assignment?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will revoke {assignment.user.name}&apos;s license for{" "}
-                  {assignment.tool.name}.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction onClick={() => onRevoke(assignment.id)}>
+                Managed by sync
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent>
+              This assignment is managed by Copilot sync and cannot be edited or
+              revoked manually.
+            </TooltipContent>
+          </Tooltip>
+        )}
+      {isAdmin &&
+        assignment.status === "active" &&
+        assignment.source !== "copilot-sync" && (
+          <>
+            <EditAssignmentDialog assignment={assignment} onSaved={onSaved} />
+            <DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      aria-label={`More actions for ${assignment.user.name}'s assignment`}
+                    >
+                      <MoreHorizontal className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent>More actions</TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  variant="destructive"
+                  onSelect={() => setShowRevokeDialog(true)}
+                >
+                  <Ban className="size-4" />
                   Revoke
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </>
-      )}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <AlertDialog
+              open={showRevokeDialog}
+              onOpenChange={setShowRevokeDialog}
+            >
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Revoke this assignment?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will revoke {assignment.user.name}&apos;s license for{" "}
+                    {assignment.tool.name}.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={() => onRevoke(assignment.id)}>
+                    Revoke
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </>
+        )}
     </div>
   );
 }
@@ -523,7 +539,7 @@ function AssignmentRowActions({
 function getColumns(
   isAdmin: boolean,
   onRevoke: (id: number) => void,
-  onSaved: () => void
+  onSaved: () => void,
 ): ColumnDef<AssignmentRow>[] {
   return [
     {
@@ -565,9 +581,7 @@ function getColumns(
       cell: ({ row }) => (
         <div className="flex items-center gap-1.5">
           <Badge
-            variant={
-              row.original.status === "active" ? "default" : "secondary"
-            }
+            variant={row.original.status === "active" ? "default" : "secondary"}
           >
             {row.original.status}
           </Badge>
@@ -591,7 +605,11 @@ function getColumns(
       ),
       filterFn: arrayIncludesFilterFn,
       cell: ({ row }) => (
-        <Badge variant={row.original.source === "copilot-sync" ? "outline" : "secondary"}>
+        <Badge
+          variant={
+            row.original.source === "copilot-sync" ? "outline" : "secondary"
+          }
+        >
           {row.original.source === "copilot-sync" ? "Copilot Sync" : "Manual"}
         </Badge>
       ),
@@ -673,24 +691,29 @@ export function AssignmentsClient({
   const [assigning, setAssigning] = useState(false);
 
   const handleRefresh = useCallback(() => router.refresh(), [router]);
-  const handleRevoke = useCallback(async (id: number) => {
-    const result = await revokeLicense({ id });
-    if (result.success) {
-      status.ok("Revoked");
-      router.refresh();
-    } else {
-      status.error(result.error);
-    }
-  }, [router, status]);
+  const handleRevoke = useCallback(
+    async (id: number) => {
+      const result = await revokeLicense({ id });
+      if (result.success) {
+        status.ok("Revoked");
+        router.refresh();
+      } else {
+        status.error(result.error);
+      }
+    },
+    [router, status],
+  );
   const columns = useMemo(
     () => getColumns(isAdmin, handleRevoke, handleRefresh),
-    [isAdmin, handleRevoke, handleRefresh]
+    [isAdmin, handleRevoke, handleRefresh],
   );
 
   const facetedFilters = useMemo(() => {
     const toolNames = [...new Set(assignments.map((a) => a.tool.name))].sort();
     const tierNames = [...new Set(assignments.map((a) => a.tier.name))].sort();
-    const workspaces = [...new Set(assignments.map((a) => a.workspace ?? NO_WORKSPACE_SENTINEL))].sort();
+    const workspaces = [
+      ...new Set(assignments.map((a) => a.workspace ?? NO_WORKSPACE_SENTINEL)),
+    ].sort();
 
     return [
       {
@@ -709,7 +732,7 @@ export function AssignmentsClient({
         options: workspaces.map((w) =>
           w === NO_WORKSPACE_SENTINEL
             ? { label: "No Workspace", value: NO_WORKSPACE_SENTINEL }
-            : { label: w, value: w }
+            : { label: w, value: w },
         ),
       },
       ...STATIC_ASSIGNMENT_FILTERS,
@@ -721,9 +744,7 @@ export function AssignmentsClient({
     setSelectedTierId("");
     if (toolId) {
       const tool = await getToolWithTiers(Number(toolId));
-      setAvailableTiers(
-        tool?.accessTiers.filter((t) => t.isActive) ?? []
-      );
+      setAvailableTiers(tool?.accessTiers.filter((t) => t.isActive) ?? []);
     } else {
       setAvailableTiers([]);
     }
@@ -752,15 +773,17 @@ export function AssignmentsClient({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-3xl font-medium tracking-tight text-ink">License Assignments</h1>
+          <h1 className="text-3xl font-medium tracking-tight text-ink">
+            License Assignments
+          </h1>
           <p className="text-muted-foreground">
             Track user-to-tool license assignments
           </p>
         </div>
         {isAdmin && (
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <StatusText status={status.status} />
             <Button asChild variant="outline">
               <Link href="/assignments/import">Bulk Import</Link>
@@ -772,71 +795,71 @@ export function AssignmentsClient({
                   Assign License
                 </Button>
               </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Assign License</DialogTitle>
-              </DialogHeader>
-              <div className="space-y-4">
-                <div>
-                  <label className="text-sm font-medium">User</label>
-                  <UserCombobox
-                    users={users}
-                    value={selectedUserId}
-                    onSelect={setSelectedUserId}
-                  />
-                </div>
-                <div>
-                  <label className="text-sm font-medium">Tool</label>
-                  <Select
-                    value={selectedToolId}
-                    onValueChange={handleToolChange}
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Assign License</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <div>
+                    <label className="text-sm font-medium">User</label>
+                    <UserCombobox
+                      users={users}
+                      value={selectedUserId}
+                      onSelect={setSelectedUserId}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">Tool</label>
+                    <Select
+                      value={selectedToolId}
+                      onValueChange={handleToolChange}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select tool" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {tools.map((t) => (
+                          <SelectItem key={t.id} value={String(t.id)}>
+                            {t.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium">Tier</label>
+                    <Select
+                      value={selectedTierId}
+                      onValueChange={setSelectedTierId}
+                      disabled={availableTiers.length === 0}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select tier" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {availableTiers.map((t) => (
+                          <SelectItem key={t.id} value={String(t.id)}>
+                            {t.name} — {formatCurrency(t.monthlyCostCents)}/mo
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Button
+                    onClick={handleAssign}
+                    disabled={
+                      !selectedUserId ||
+                      !selectedToolId ||
+                      !selectedTierId ||
+                      assigning
+                    }
+                    className="w-full"
                   >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select tool" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {tools.map((t) => (
-                        <SelectItem key={t.id} value={String(t.id)}>
-                          {t.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    {assigning ? "Assigning..." : "Assign License"}
+                  </Button>
                 </div>
-                <div>
-                  <label className="text-sm font-medium">Tier</label>
-                  <Select
-                    value={selectedTierId}
-                    onValueChange={setSelectedTierId}
-                    disabled={availableTiers.length === 0}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select tier" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableTiers.map((t) => (
-                        <SelectItem key={t.id} value={String(t.id)}>
-                          {t.name} — {formatCurrency(t.monthlyCostCents)}/mo
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <Button
-                  onClick={handleAssign}
-                  disabled={
-                    !selectedUserId ||
-                    !selectedToolId ||
-                    !selectedTierId ||
-                    assigning
-                  }
-                  className="w-full"
-                >
-                  {assigning ? "Assigning..." : "Assign License"}
-                </Button>
-              </div>
-            </DialogContent>
-          </Dialog>
+              </DialogContent>
+            </Dialog>
           </div>
         )}
       </div>

--- a/src/app/claude/users/[userId]/user-detail-client.tsx
+++ b/src/app/claude/users/[userId]/user-detail-client.tsx
@@ -47,7 +47,8 @@ export function UserDetailClient({ userId, initial }: Props) {
         <span className="text-muted-foreground">— no spend last month</span>
       ) : detail.momDeltaPct >= 0 ? (
         <span className="inline-flex items-center gap-1 text-foreground">
-          <TrendingUp className="size-3" /> +{detail.momDeltaPct}% vs prior month
+          <TrendingUp className="size-3" /> +{detail.momDeltaPct}% vs prior
+          month
         </span>
       ) : (
         <span className="inline-flex items-center gap-1 text-foreground">
@@ -103,7 +104,9 @@ export function UserDetailClient({ userId, initial }: Props) {
             value={month}
             onChange={handleMonthChange}
             months={
-              detail.availableMonths.length > 0 ? detail.availableMonths : [month]
+              detail.availableMonths.length > 0
+                ? detail.availableMonths
+                : [month]
             }
           />
           {isPending && <InlineSpinner />}
@@ -120,25 +123,29 @@ export function UserDetailClient({ userId, initial }: Props) {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">
-            Daily cost · {monthLabel}
-          </CardTitle>
+          <CardTitle className="text-base">Daily cost · {monthLabel}</CardTitle>
         </CardHeader>
         <CardContent>
-          <WorkspaceDailyChart dailyTotals={detail.dailyTotals} limitCents={null} />
+          <WorkspaceDailyChart
+            dailyTotals={detail.dailyTotals}
+            limitCents={null}
+          />
         </CardContent>
       </Card>
 
       <div className="grid gap-4 lg:grid-cols-2">
-        <Card>
+        <Card className="min-w-0">
           <CardHeader>
             <CardTitle className="text-base">Model breakdown</CardTitle>
           </CardHeader>
           <CardContent>
-            <WorkspaceModelBreakdown rows={detail.modelBreakdown} scopeLabel="User" />
+            <WorkspaceModelBreakdown
+              rows={detail.modelBreakdown}
+              scopeLabel="User"
+            />
           </CardContent>
         </Card>
-        <Card>
+        <Card className="min-w-0">
           <CardHeader>
             <CardTitle className="text-base">Top dates this month</CardTitle>
           </CardHeader>

--- a/src/app/claude/users/page.tsx
+++ b/src/app/claude/users/page.tsx
@@ -32,7 +32,9 @@ export const metadata: Metadata = { title: "Claude Console · Users" };
 // back to the current month cleanly instead of being silently passed through.
 const MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
 
-type SearchParamsPromise = Promise<Record<string, string | string[] | undefined>>;
+type SearchParamsPromise = Promise<
+  Record<string, string | string[] | undefined>
+>;
 
 export default async function ClaudeUsersPage({
   searchParams,
@@ -121,8 +123,12 @@ export default async function ClaudeUsersPage({
       <TopUsersCard users={list.users} />
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <CostDistributionHistogram buckets={distribution} />
-        <UserTopMoversChips movers={movers} />
+        <div className="min-w-0">
+          <CostDistributionHistogram buckets={distribution} />
+        </div>
+        <div className="min-w-0">
+          <UserTopMoversChips movers={movers} />
+        </div>
       </div>
 
       <Card>
@@ -143,8 +149,8 @@ function UsersEmptyState() {
       <UsersIcon className="mb-4 size-12 text-muted-foreground" />
       <h2 className="mb-2 text-xl font-semibold">No user-level data yet</h2>
       <p className="mb-6 max-w-sm text-center text-muted-foreground">
-        User-level data will appear after the first sync. You can trigger a
-        sync manually.
+        User-level data will appear after the first sync. You can trigger a sync
+        manually.
       </p>
       <SyncButton />
     </div>

--- a/src/app/claude/workspaces/[workspaceId]/workspace-detail-client.tsx
+++ b/src/app/claude/workspaces/[workspaceId]/workspace-detail-client.tsx
@@ -32,7 +32,7 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
   const [isPending, startTransition] = useTransition();
   const [editing, setEditing] = useState(false);
   const [limitInput, setLimitInput] = useState(
-    detail.limitCents != null ? String(detail.limitCents / 100) : ""
+    detail.limitCents != null ? String(detail.limitCents / 100) : "",
   );
   const [savingLimit, savingTransition] = useTransition();
   const status = useInlineStatus();
@@ -78,16 +78,19 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
         <span className="text-muted-foreground">— no spend last month</span>
       ) : detail.momDeltaPct >= 0 ? (
         <span className="inline-flex items-center gap-1 text-foreground">
-          <TrendingUp className="size-3" /> +{detail.momDeltaPct}% vs prior month
+          <TrendingUp className="size-3" /> +{detail.momDeltaPct}% vs prior
+          month
         </span>
       ) : (
         <span className="inline-flex items-center gap-1 text-muted-foreground">
-          <TrendingDown className="size-3" /> {detail.momDeltaPct}% vs prior month
+          <TrendingDown className="size-3" /> {detail.momDeltaPct}% vs prior
+          month
         </span>
       );
 
     const isOver =
-      detail.limitCents != null && detail.projectedMonthEndCents > detail.limitCents;
+      detail.limitCents != null &&
+      detail.projectedMonthEndCents > detail.limitCents;
     const projectedPct =
       detail.limitCents != null && detail.limitCents > 0
         ? Math.round((detail.projectedMonthEndCents / detail.limitCents) * 100)
@@ -97,7 +100,11 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
       detail.limitCents == null
         ? {
             label: "Utilization",
-            value: <span className="text-base text-muted-foreground">No limit set</span>,
+            value: (
+              <span className="text-base text-muted-foreground">
+                No limit set
+              </span>
+            ),
             caption: (
               <Button
                 size="sm"
@@ -117,8 +124,8 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
               (detail.utilizationPct ?? 0) >= 100
                 ? "danger"
                 : (detail.utilizationPct ?? 0) >= 80
-                ? "warn"
-                : "default",
+                  ? "warn"
+                  : "default",
           };
 
     return [
@@ -138,8 +145,8 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
           detail.momDeltaPct === null
             ? "default"
             : detail.momDeltaPct >= 0
-            ? "success"
-            : "danger",
+              ? "success"
+              : "danger",
       },
       {
         label: "Projected Month-End",
@@ -150,9 +157,15 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
               ? "Run-rate incl. est. today"
               : "No limit set"
             : `${projectedPct ?? 0}% of ${formatCurrency(detail.limitCents)} limit${detail.todayEstimate ? " · incl. est. today" : ""}`,
-        tone: isOver ? "danger" : projectedPct != null && projectedPct >= 80 ? "warn" : "default",
+        tone: isOver
+          ? "danger"
+          : projectedPct != null && projectedPct >= 80
+            ? "warn"
+            : "default",
         ring: isOver,
-        icon: isOver ? <AlertTriangle className="size-3 text-destructive" /> : undefined,
+        icon: isOver ? (
+          <AlertTriangle className="size-3 text-destructive" />
+        ) : undefined,
       },
       utilizationTile,
     ];
@@ -165,7 +178,11 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
           <MonthPicker
             value={month}
             onChange={handleMonthChange}
-            months={detail.availableMonths.length > 0 ? detail.availableMonths : [month]}
+            months={
+              detail.availableMonths.length > 0
+                ? detail.availableMonths
+                : [month]
+            }
           />
           {isPending && <InlineSpinner />}
         </div>
@@ -182,10 +199,19 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
                 onChange={(e) => setLimitInput(e.target.value)}
                 autoFocus
               />
-              <Button size="sm" onClick={handleSaveLimit} disabled={savingLimit}>
+              <Button
+                size="sm"
+                onClick={handleSaveLimit}
+                disabled={savingLimit}
+              >
                 {savingLimit ? "Saving…" : "Save"}
               </Button>
-              <Button size="sm" variant="ghost" onClick={() => setEditing(false)} disabled={savingLimit}>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setEditing(false)}
+                disabled={savingLimit}
+              >
                 Cancel
               </Button>
               <StatusText status={status.status} />
@@ -220,7 +246,7 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
       </Card>
 
       <div className="grid gap-4 lg:grid-cols-2">
-        <Card>
+        <Card className="min-w-0">
           <CardHeader>
             <CardTitle className="text-base">Top users this month</CardTitle>
           </CardHeader>
@@ -228,7 +254,7 @@ export function WorkspaceDetailClient({ workspaceIdParam, initial }: Props) {
             <WorkspaceTopUsers users={detail.topUsers} />
           </CardContent>
         </Card>
-        <Card>
+        <Card className="min-w-0">
           <CardHeader>
             <CardTitle className="text-base">Model breakdown</CardTitle>
           </CardHeader>

--- a/src/app/copilot/analytics/page.tsx
+++ b/src/app/copilot/analytics/page.tsx
@@ -18,7 +18,11 @@ export default async function CopilotAnalyticsPage() {
 
   if (!result.success) {
     return (
-      <Card><CardContent className="py-12 text-center"><p className="text-muted-foreground">{result.error}</p></CardContent></Card>
+      <Card>
+        <CardContent className="py-12 text-center">
+          <p className="text-muted-foreground">{result.error}</p>
+        </CardContent>
+      </Card>
     );
   }
 
@@ -33,7 +37,16 @@ export default async function CopilotAnalyticsPage() {
           <CardContent className="py-12 text-center space-y-3">
             <BarChart3 className="size-12 mx-auto text-muted-foreground" />
             <h3 className="text-lg font-medium">No analytics data yet</h3>
-            <p className="text-sm text-muted-foreground">Enable Copilot sync in <Link href="/settings/integrations" className="underline text-primary">Settings</Link> to start collecting usage analytics.</p>
+            <p className="text-sm text-muted-foreground">
+              Enable Copilot sync in{" "}
+              <Link
+                href="/settings/integrations"
+                className="underline text-primary"
+              >
+                Settings
+              </Link>{" "}
+              to start collecting usage analytics.
+            </p>
           </CardContent>
         </Card>
       </div>
@@ -44,8 +57,12 @@ export default async function CopilotAnalyticsPage() {
     <div className="space-y-6">
       <MetricsFreshnessCard freshness={freshness} />
       <div className="grid gap-6 lg:grid-cols-2">
-        <LanguageChart data={data.byLanguage} />
-        <EditorChart data={data.byEditor} />
+        <div className="min-w-0">
+          <LanguageChart data={data.byLanguage} />
+        </div>
+        <div className="min-w-0">
+          <EditorChart data={data.byEditor} />
+        </div>
       </div>
       <ActivityDistribution data={data.activityDistribution} />
     </div>

--- a/src/app/copilot/copilot-tab-bar.tsx
+++ b/src/app/copilot/copilot-tab-bar.tsx
@@ -15,7 +15,11 @@ export function CopilotTabBar() {
   const pathname = usePathname();
 
   return (
-    <div className="flex gap-1 border-b" role="tablist" aria-label="Copilot sections">
+    <div
+      className="flex gap-1 border-b overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      role="tablist"
+      aria-label="Copilot sections"
+    >
       {tabs.map((tab) => {
         const isActive =
           tab.href === "/copilot"
@@ -28,10 +32,10 @@ export function CopilotTabBar() {
             role="tab"
             aria-selected={isActive}
             className={cn(
-              "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+              "shrink-0 whitespace-nowrap px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
               isActive
                 ? "border-primary text-primary"
-                : "border-transparent text-muted-foreground hover:text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
             )}
           >
             {tab.label}

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -29,9 +29,11 @@ export default async function InvoicesPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-medium tracking-tight text-ink">Invoices</h1>
-        <div className="flex items-center gap-2">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-3xl font-medium tracking-tight text-ink">
+          Invoices
+        </h1>
+        <div className="flex flex-wrap items-center gap-2">
           <Button variant="outline" asChild>
             <Link href="/invoices/bulk">Bulk Upload</Link>
           </Button>

--- a/src/app/reports/reports-nav.tsx
+++ b/src/app/reports/reports-nav.tsx
@@ -14,7 +14,7 @@ export function ReportsNav() {
 
   return (
     <div
-      className="flex gap-1 border-b"
+      className="flex gap-1 border-b overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       role="tablist"
       aria-label="Reports sections"
     >
@@ -30,10 +30,10 @@ export function ReportsNav() {
             role="tab"
             aria-selected={isActive}
             className={cn(
-              "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+              "shrink-0 whitespace-nowrap px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
               isActive
                 ? "border-primary text-primary"
-                : "border-transparent text-muted-foreground hover:text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
             )}
           >
             {tab.label}

--- a/src/app/requests/[id]/request-detail-client.tsx
+++ b/src/app/requests/[id]/request-detail-client.tsx
@@ -115,7 +115,7 @@ export function RequestDetailClient({
         <CardHeader>
           <CardTitle>Requester</CardTitle>
         </CardHeader>
-        <CardContent className="grid grid-cols-[160px_1fr] gap-y-2 gap-x-4 text-sm">
+        <CardContent className="grid grid-cols-1 gap-y-1 text-sm sm:grid-cols-[160px_1fr] sm:gap-y-2 sm:gap-x-4">
           <span className="text-muted-foreground">Name</span>
           <span>{detail.requesterName}</span>
           <span className="text-muted-foreground">Email</span>
@@ -123,7 +123,10 @@ export function RequestDetailClient({
           <span className="text-muted-foreground">Hub user</span>
           <span>
             {detail.requesterUserId !== null ? (
-              <Link href={`/users/${detail.requesterUserId}`} className="text-primary hover:underline">
+              <Link
+                href={`/users/${detail.requesterUserId}`}
+                className="text-primary hover:underline"
+              >
                 Matched (user #{detail.requesterUserId})
               </Link>
             ) : (
@@ -166,12 +169,15 @@ export function RequestDetailClient({
       </Card>
 
       {/* Sent messages (audit) */}
-      {(detail.approvalMessageMd || detail.completionMessageMd || detail.decisionNote) && (
+      {(detail.approvalMessageMd ||
+        detail.completionMessageMd ||
+        detail.decisionNote) && (
         <Card>
           <CardHeader>
             <CardTitle>Sent messages</CardTitle>
             <CardDescription>
-              Audit log of what the Hub posted to the Teams channel + group chat.
+              Audit log of what the Hub posted to the Teams channel + group
+              chat.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -205,11 +211,11 @@ export function RequestDetailClient({
 
       {/* Action bar */}
       {(isPending || isApproved || canCancel) && (
-        <div className="flex justify-between items-center rounded-md border bg-muted/40 p-4">
+        <div className="flex flex-col gap-3 rounded-md border bg-muted/40 p-4 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-muted-foreground">
             Any admin can act on this request. First-write-wins.
           </p>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <StatusText status={status.status} />
             {canCancel && (
               <Button variant="ghost" onClick={() => setCancelOpen(true)}>
@@ -218,7 +224,10 @@ export function RequestDetailClient({
             )}
             {isPending && (
               <>
-                <Button variant="destructive" onClick={() => setRejectOpen(true)}>
+                <Button
+                  variant="destructive"
+                  onClick={() => setRejectOpen(true)}
+                >
                   Reject
                 </Button>
                 <Button onClick={() => setApproveOpen(true)}>Approve</Button>
@@ -293,7 +302,7 @@ function FormPayloadList({
 }) {
   const entries = Object.entries(payload);
   return (
-    <dl className="grid grid-cols-[160px_1fr] gap-y-2 gap-x-4 text-sm">
+    <dl className="grid grid-cols-1 gap-y-1 text-sm sm:grid-cols-[160px_1fr] sm:gap-y-2 sm:gap-x-4">
       <dt className="text-muted-foreground">Tool</dt>
       <dd>{toolName}</dd>
       {tierName && (
@@ -347,8 +356,8 @@ function MessageBlock({
   return (
     <div className="rounded-md border-l-4 border-l-primary/60 bg-muted/40 p-3">
       <p className="text-xs text-muted-foreground mb-2">
-        <span className="font-medium">{kind}</span> · {actorName ?? "(unknown)"} ·{" "}
-        {at ? format(at, "yyyy-MM-dd HH:mm") : "—"}
+        <span className="font-medium">{kind}</span> · {actorName ?? "(unknown)"}{" "}
+        · {at ? format(at, "yyyy-MM-dd HH:mm") : "—"}
       </p>
       <div
         className="text-sm prose-sm dark:prose-invert"
@@ -359,9 +368,7 @@ function MessageBlock({
 }
 
 function prettifyKey(key: string): string {
-  return key
-    .replace(/_/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+  return key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 function stringifyValue(v: unknown): string {

--- a/src/app/settings/license-templates/templates-client.tsx
+++ b/src/app/settings/license-templates/templates-client.tsx
@@ -5,7 +5,10 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Plus, Pencil } from "lucide-react";
-import type { MessageTemplateRow, ToolWithTiers } from "@/actions/license-templates";
+import type {
+  MessageTemplateRow,
+  ToolWithTiers,
+} from "@/actions/license-templates";
 import { TemplateEditorDialog } from "./template-editor-dialog";
 
 interface Props {
@@ -44,12 +47,17 @@ export function TemplatesClient({ templates, toolsWithTiers }: Props) {
     kind: "approval" | "completion";
   }) {
     const existing = templates.find(
-      (t) => t.toolId === args.toolId && t.tierId === args.tierId && t.kind === args.kind,
+      (t) =>
+        t.toolId === args.toolId &&
+        t.tierId === args.tierId &&
+        t.kind === args.kind,
     );
     setEditor({
       ...args,
       existingId: existing?.id ?? null,
-      bodyMd: existing?.bodyMd ?? defaultBody(args.kind, args.toolName, args.tierName),
+      bodyMd:
+        existing?.bodyMd ??
+        defaultBody(args.kind, args.toolName, args.tierName),
     });
   }
 
@@ -114,7 +122,9 @@ export function TemplatesClient({ templates, toolsWithTiers }: Props) {
                   </h4>
                   {tool.tiers.map((tier) =>
                     (["approval", "completion"] as const).map((kind) => {
-                      const row = rows.find((r) => r.tierId === tier.id && r.kind === kind);
+                      const row = rows.find(
+                        (r) => r.tierId === tier.id && r.kind === kind,
+                      );
                       return (
                         <TemplateRow
                           key={`tier-${tier.id}-${kind}`}
@@ -166,12 +176,12 @@ function TemplateRow(props: {
     ? props.bodyMd.replace(/\s+/g, " ").slice(0, 80)
     : null;
   return (
-    <div className="flex items-center gap-3 rounded-md border bg-card px-3 py-2 text-sm">
+    <div className="flex flex-col items-start gap-2 rounded-md border bg-card px-3 py-2 text-sm sm:flex-row sm:items-center sm:gap-3">
       <span
         className={
           props.tierIsDefault
-            ? "text-muted-foreground italic w-40"
-            : "font-medium w-40"
+            ? "text-muted-foreground italic w-full sm:w-40"
+            : "font-medium w-full sm:w-40"
         }
       >
         {props.tierLabel}
@@ -187,10 +197,14 @@ function TemplateRow(props: {
       >
         {props.kindLabel}
       </Badge>
-      <span className="flex-1 truncate font-mono text-xs text-muted-foreground">
+      <span className="w-full min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
         {snippet ?? <span className="italic">no template set</span>}
       </span>
-      <Button size="sm" variant={snippet ? "outline" : "default"} onClick={props.onEdit}>
+      <Button
+        size="sm"
+        variant={snippet ? "outline" : "default"}
+        onClick={props.onEdit}
+      >
         {snippet ? (
           <>
             <Pencil className="size-3" />

--- a/src/app/settings/settings-nav.tsx
+++ b/src/app/settings/settings-nav.tsx
@@ -4,9 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 
-const baseTabs = [
-  { label: "Appearance", href: "/settings/appearance" },
-];
+const baseTabs = [{ label: "Appearance", href: "/settings/appearance" }];
 
 const adminTabs = [
   { label: "Integrations", href: "/settings/integrations" },
@@ -21,16 +19,19 @@ export function SettingsNav({ isAdmin }: { isAdmin: boolean }) {
   const tabs = isAdmin ? [...baseTabs, ...adminTabs] : baseTabs;
 
   return (
-    <nav className="flex gap-2 border-b" aria-label="Settings navigation">
+    <nav
+      className="flex gap-2 border-b overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      aria-label="Settings navigation"
+    >
       {tabs.map((tab) => (
         <Link
           key={tab.href}
           href={tab.href}
           className={cn(
-            "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+            "shrink-0 whitespace-nowrap px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
             pathname === tab.href
               ? "border-primary text-primary"
-              : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/50"
+              : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/50",
           )}
         >
           {tab.label}

--- a/src/app/settings/sync/github-member-sync-sheet.tsx
+++ b/src/app/settings/sync/github-member-sync-sheet.tsx
@@ -9,12 +9,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Table,
   TableBody,
@@ -422,7 +417,7 @@ function ResolutionSummaryPanel({
   return (
     <div className="rounded-md border bg-muted/30 p-3 space-y-2">
       <p className="text-sm font-medium">Resolution Summary</p>
-      <div className="grid grid-cols-5 gap-2 text-center">
+      <div className="grid grid-cols-3 gap-2 text-center sm:grid-cols-5">
         <div>
           <p className="text-lg font-mono tabular-nums">{summary.imported}</p>
           <p className="text-[10px] text-muted-foreground">
@@ -452,9 +447,7 @@ function ResolutionSummaryPanel({
           </p>
         </div>
         <div>
-          <p className="text-lg font-mono tabular-nums">
-            {summary.unresolved}
-          </p>
+          <p className="text-lg font-mono tabular-nums">{summary.unresolved}</p>
           <p className="text-[10px] text-muted-foreground">Unresolved</p>
         </div>
       </div>
@@ -560,7 +553,10 @@ function UnmatchedGitHubResolutionList({
   const suggestionsMap = useMemo(() => {
     const map = new Map<string, ReturnType<typeof computeMatchSuggestions>>();
     for (const member of members) {
-      map.set(member.githubLogin, computeMatchSuggestions(member, unmatchedSystemUsers));
+      map.set(
+        member.githubLogin,
+        computeMatchSuggestions(member, unmatchedSystemUsers),
+      );
     }
     return map;
   }, [members, unmatchedSystemUsers]);

--- a/src/app/users/[id]/user-detail-client.tsx
+++ b/src/app/users/[id]/user-detail-client.tsx
@@ -11,21 +11,36 @@ import { updateUserSchema, type UpdateUserInput } from "@/lib/validators";
 import { assignLicense, revokeLicense } from "@/actions/assignments";
 import { getTools, getToolWithTiers } from "@/actions/tools";
 import { formatCurrency, formatDate } from "@/lib/utils";
-import type { User, ChangeHistoryRecord, CostData, AiTool, AccessTier } from "@/types";
+import type {
+  User,
+  ChangeHistoryRecord,
+  CostData,
+  AiTool,
+  AccessTier,
+} from "@/types";
 import { AdminCostSection } from "@/components/profile/admin-cost-section";
-import { DISCIPLINES, DISCIPLINE_ICON, DISCIPLINE_LABEL, asDiscipline } from "@/lib/disciplines";
-import { Github, ExternalLink, BookOpen, KeyRound, Plus, RotateCcw, Eye, EyeOff } from "lucide-react";
+import {
+  DISCIPLINES,
+  DISCIPLINE_ICON,
+  DISCIPLINE_LABEL,
+  asDiscipline,
+} from "@/lib/disciplines";
+import {
+  Github,
+  ExternalLink,
+  BookOpen,
+  KeyRound,
+  Plus,
+  RotateCcw,
+  Eye,
+  EyeOff,
+} from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Form,
   FormControl,
@@ -227,18 +242,18 @@ export function UserDetailClient({
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-medium tracking-tight text-ink">{user.name}</h1>
-          <p className="text-muted-foreground">{user.email}</p>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-3xl font-medium tracking-tight text-ink break-words">
+            {user.name}
+          </h1>
+          <p className="text-muted-foreground break-words">{user.email}</p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <Badge variant="outline" className="capitalize">
             {user.role}
           </Badge>
-          <Badge
-            variant={user.status === "active" ? "default" : "secondary"}
-          >
+          <Badge variant={user.status === "active" ? "default" : "secondary"}>
             {user.status}
           </Badge>
           <Badge variant="outline" className="gap-1">
@@ -307,8 +322,7 @@ export function UserDetailClient({
                   )}
                 </div>
                 <p className="text-xs text-muted-foreground pt-1">
-                  Last synced{" "}
-                  {formatDate(githubProfile.lastSyncedAt)}
+                  Last synced {formatDate(githubProfile.lastSyncedAt)}
                 </p>
               </div>
             </div>
@@ -360,7 +374,13 @@ export function UserDetailClient({
                     <FormItem>
                       <FormLabel>Circle (optional)</FormLabel>
                       <FormControl>
-                        <Input {...field} value={field.value ?? ""} onChange={(e) => field.onChange(e.target.value || null)} />
+                        <Input
+                          {...field}
+                          value={field.value ?? ""}
+                          onChange={(e) =>
+                            field.onChange(e.target.value || null)
+                          }
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -458,7 +478,7 @@ export function UserDetailClient({
                     </FormItem>
                   )}
                 />
-                <div className="flex gap-3">
+                <div className="flex flex-wrap items-center gap-3">
                   <Button type="submit" disabled={form.formState.isSubmitting}>
                     Save Changes
                   </Button>
@@ -552,9 +572,7 @@ export function UserDetailClient({
                   </Link>
                   <div className="flex items-center gap-2">
                     <Badge
-                      variant={
-                        a.status === "active" ? "default" : "secondary"
-                      }
+                      variant={a.status === "active" ? "default" : "secondary"}
                     >
                       {a.status}
                     </Badge>
@@ -567,46 +585,64 @@ export function UserDetailClient({
                         Revoke
                       </Button>
                     )}
-                    {isAdmin && a.status !== "active" && a.tool.status === "active" && (
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={reactivatingId === a.id}
-                          >
-                            <RotateCcw className="mr-1 size-3" />
-                            {reactivatingId === a.id ? "Reactivating..." : "Reactivate"}
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>
-                              Reactivate this license?
-                            </AlertDialogTitle>
-                            <AlertDialogDescription asChild>
-                              <div className="space-y-2">
-                                <p>
-                                  This will create a new active license assignment
-                                  for <strong>{user.name}</strong>:
-                                </p>
-                                <ul className="list-disc pl-5 text-sm">
-                                  <li>Tool: <strong>{a.tool.name}</strong></li>
-                                  <li>Tier: <strong>{a.tier.name}</strong></li>
-                                  <li>Cost: <strong>{formatCurrency(a.costAtAssignmentCents)}/mo</strong></li>
-                                </ul>
-                              </div>
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction onClick={() => handleReactivate(a)}>
-                              Reactivate
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    )}
+                    {isAdmin &&
+                      a.status !== "active" &&
+                      a.tool.status === "active" && (
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              disabled={reactivatingId === a.id}
+                            >
+                              <RotateCcw className="mr-1 size-3" />
+                              {reactivatingId === a.id
+                                ? "Reactivating..."
+                                : "Reactivate"}
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                Reactivate this license?
+                              </AlertDialogTitle>
+                              <AlertDialogDescription asChild>
+                                <div className="space-y-2">
+                                  <p>
+                                    This will create a new active license
+                                    assignment for <strong>{user.name}</strong>:
+                                  </p>
+                                  <ul className="list-disc pl-5 text-sm">
+                                    <li>
+                                      Tool: <strong>{a.tool.name}</strong>
+                                    </li>
+                                    <li>
+                                      Tier: <strong>{a.tier.name}</strong>
+                                    </li>
+                                    <li>
+                                      Cost:{" "}
+                                      <strong>
+                                        {formatCurrency(
+                                          a.costAtAssignmentCents,
+                                        )}
+                                        /mo
+                                      </strong>
+                                    </li>
+                                  </ul>
+                                </div>
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => handleReactivate(a)}
+                              >
+                                Reactivate
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      )}
                   </div>
                 </div>
               ))}
@@ -620,10 +656,13 @@ export function UserDetailClient({
       </Card>
 
       {/* Assign License Dialog */}
-      <Dialog open={assignDialogOpen} onOpenChange={(open) => {
-        if (!open) resetAssignDialogState();
-        setAssignDialogOpen(open);
-      }}>
+      <Dialog
+        open={assignDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) resetAssignDialogState();
+          setAssignDialogOpen(open);
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Assign License to {user.name}</DialogTitle>
@@ -631,16 +670,26 @@ export function UserDetailClient({
           <div className="space-y-4">
             <div>
               <label className="text-sm font-medium">Tool</label>
-              <Select value={selectedToolId} onValueChange={handleToolChange} disabled={loadingTools}>
+              <Select
+                value={selectedToolId}
+                onValueChange={handleToolChange}
+                disabled={loadingTools}
+              >
                 <SelectTrigger>
-                  <SelectValue placeholder={loadingTools ? "Loading tools..." : "Select tool"} />
+                  <SelectValue
+                    placeholder={
+                      loadingTools ? "Loading tools..." : "Select tool"
+                    }
+                  />
                 </SelectTrigger>
                 <SelectContent>
-                  {tools.filter((t) => t.status === "active").map((t) => (
-                    <SelectItem key={t.id} value={String(t.id)}>
-                      {t.name}
-                    </SelectItem>
-                  ))}
+                  {tools
+                    .filter((t) => t.status === "active")
+                    .map((t) => (
+                      <SelectItem key={t.id} value={String(t.id)}>
+                        {t.name}
+                      </SelectItem>
+                    ))}
                 </SelectContent>
               </Select>
             </div>
@@ -664,7 +713,9 @@ export function UserDetailClient({
               </Select>
             </div>
             <div>
-              <label className="text-sm font-medium">Workspace (optional)</label>
+              <label className="text-sm font-medium">
+                Workspace (optional)
+              </label>
               <Input
                 placeholder="e.g. team-alpha"
                 maxLength={200}
@@ -703,11 +754,11 @@ export function UserDetailClient({
             </div>
           </div>
           <DialogFooter>
-            <StatusText status={assignStatus.status} className="mr-auto self-center" />
-            <Button
-              variant="outline"
-              onClick={closeAssignDialog}
-            >
+            <StatusText
+              status={assignStatus.status}
+              className="mr-auto self-center"
+            />
+            <Button variant="outline" onClick={closeAssignDialog}>
               Cancel
             </Button>
             <Button
@@ -720,7 +771,11 @@ export function UserDetailClient({
         </DialogContent>
       </Dialog>
 
-      <AdminCostSection userId={user.id} initialData={costData} availableMonths={costAvailableMonths} />
+      <AdminCostSection
+        userId={user.id}
+        initialData={costData}
+        availableMonths={costAvailableMonths}
+      />
 
       <Card>
         <CardHeader>
@@ -730,10 +785,7 @@ export function UserDetailClient({
           {history.length > 0 ? (
             <div className="space-y-3">
               {history.map((record) => (
-                <div
-                  key={record.id}
-                  className="flex items-start gap-3 text-sm"
-                >
+                <div key={record.id} className="flex items-start gap-3 text-sm">
                   <span className="text-muted-foreground whitespace-nowrap">
                     {formatDate(record.createdAt)}
                   </span>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -16,20 +16,25 @@ export default async function UsersPage() {
   return (
     <AuthGuard requiredRole="admin">
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <div className="flex items-center gap-3">
-              <h1 className="text-3xl font-medium tracking-tight text-ink">Users</h1>
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-3xl font-medium tracking-tight text-ink">
+                Users
+              </h1>
               {pendingCount > 0 && (
                 <Badge variant="secondary">
-                  {pendingCount} user{pendingCount !== 1 ? "s" : ""} pending setup
+                  {pendingCount} user{pendingCount !== 1 ? "s" : ""} pending
+                  setup
                 </Badge>
               )}
             </div>
-            <p className="text-muted-foreground">Manage company user directory</p>
+            <p className="text-muted-foreground">
+              Manage company user directory
+            </p>
           </div>
           {isAdmin && (
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <Button variant="outline" asChild>
                 <a href="/api/export/users" download>
                   <Download className="mr-2 size-4" />
@@ -48,7 +53,11 @@ export default async function UsersPage() {
             </div>
           )}
         </div>
-        <UsersTable data={userList} isAdmin={isAdmin} pendingCount={pendingCount} />
+        <UsersTable
+          data={userList}
+          isAdmin={isAdmin}
+          pendingCount={pendingCount}
+        />
       </div>
     </AuthGuard>
   );

--- a/src/components/claude/global-metrics-client.tsx
+++ b/src/components/claude/global-metrics-client.tsx
@@ -24,11 +24,7 @@ import {
   getDailyTotalsByWorkspace,
   getDashboardKpis,
 } from "@/actions/anthropic-global";
-import type {
-  DailyStackedRow,
-  DashboardKpis,
-  SyncStatus,
-} from "@/types";
+import type { DailyStackedRow, DashboardKpis, SyncStatus } from "@/types";
 import { formatCurrency } from "@/lib/utils";
 import { formatDateLong, shareOfTotalFormatter } from "@/lib/chart-format";
 import { KpiStrip, buildOrgKpiTiles } from "@/components/claude/kpi-strip";
@@ -57,7 +53,7 @@ function seriesColor(
   key: string,
   displayColor: string | null,
   stackIdx: number,
-  useDbColors: boolean
+  useDbColors: boolean,
 ): string {
   // "Use workspace colors" on → the workspace's own hue (still capped at ≤5
   // stacked segments, so even the colour mode stays legible).
@@ -102,7 +98,8 @@ export function GlobalMetricsClient({
   const [kpis, setKpis] = useState<DashboardKpis>(initialKpis);
   const [daily, setDaily] = useState(initialDaily);
   const [selectedMonth, setSelectedMonth] = useState<string>(initialMonth);
-  const [selectedWorkspace, setSelectedWorkspace] = useState<string>(ALL_WORKSPACES);
+  const [selectedWorkspace, setSelectedWorkspace] =
+    useState<string>(ALL_WORKSPACES);
   const [useDbColors, setUseDbColors] = useState<boolean>(false);
   const [isPending, startTransition] = useTransition();
 
@@ -114,10 +111,7 @@ export function GlobalMetricsClient({
     if (saved === "true") setUseDbColors(true);
   }, []);
   useEffect(() => {
-    localStorage.setItem(
-      "claude-dashboard:useDbColors",
-      String(useDbColors)
-    );
+    localStorage.setItem("claude-dashboard:useDbColors", String(useDbColors));
   }, [useDbColors]);
 
   // Honor the ?workspace=<id> query param when returning from the
@@ -160,22 +154,22 @@ export function GlobalMetricsClient({
         topOverWorkspaceUtilizationPct: kpis.topOverWorkspaceUtilizationPct,
         todayEstimate: kpis.todayEstimate,
       }),
-    [kpis, orgBudgetCents, selectedMonth]
+    [kpis, orgBudgetCents, selectedMonth],
   );
 
   // Full server-provided series (top N + "Other") — used for the dropdown's
   // filter options so any top workspace can still be isolated.
   const allSeries = useMemo(
     () => daily.topWorkspaces.map((s) => ({ ...s })),
-    [daily.topWorkspaces]
+    [daily.topWorkspaces],
   );
   const seriesKeys = useMemo(
     () => new Set(allSeries.map((s) => s.key)),
-    [allSeries]
+    [allSeries],
   );
   const filterableOptions = useMemo(
     () => workspaceOptions.filter((w) => seriesKeys.has(w.key)),
-    [workspaceOptions, seriesKeys]
+    [workspaceOptions, seriesKeys],
   );
 
   // Fall back to "All workspaces" if a previously-selected workspace dropped
@@ -237,11 +231,11 @@ export function GlobalMetricsClient({
 
   const stackedTopCount = useMemo(
     () => stackedSeries.filter((s) => s.key !== OTHER_KEY).length,
-    [stackedSeries]
+    [stackedSeries],
   );
   const stackedHasOther = useMemo(
     () => stackedSeries.some((s) => s.key === OTHER_KEY),
-    [stackedSeries]
+    [stackedSeries],
   );
 
   const chartConfig = useMemo<ChartConfig>(() => {
@@ -278,7 +272,7 @@ export function GlobalMetricsClient({
         }
         return row;
       }),
-    [daily.rows, stackedSeries, showEstimate]
+    [daily.rows, stackedSeries, showEstimate],
   );
 
   return (
@@ -294,7 +288,7 @@ export function GlobalMetricsClient({
             value={selectedWorkspace}
             onValueChange={setSelectedWorkspace}
           >
-            <SelectTrigger className="w-[220px]">
+            <SelectTrigger className="w-full sm:w-[220px]">
               <SelectValue placeholder="All workspaces" />
             </SelectTrigger>
             <SelectContent>
@@ -331,7 +325,9 @@ export function GlobalMetricsClient({
                   ? `Stacked · top ${stackedTopCount} workspaces${stackedHasOther ? " + Other" : ""}`
                   : "Single workspace · filtered view"}
                 {" · "}
-                <span className="tabular-nums">{formatCurrency(kpis.totalCents)}</span>{" "}
+                <span className="tabular-nums">
+                  {formatCurrency(kpis.totalCents)}
+                </span>{" "}
                 this period
               </p>
             </div>
@@ -356,7 +352,10 @@ export function GlobalMetricsClient({
               No data for this period.
             </p>
           ) : (
-            <ChartContainer config={chartConfig} className="min-h-[320px] w-full">
+            <ChartContainer
+              config={chartConfig}
+              className="min-h-[320px] w-full"
+            >
               <BarChart data={chartData} accessibilityLayer>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} />
                 <XAxis

--- a/src/components/claude/workspace-budget-list.tsx
+++ b/src/components/claude/workspace-budget-list.tsx
@@ -2,12 +2,7 @@
 
 import { useEffect, useMemo, useState, useTransition } from "react";
 import Link from "next/link";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -76,7 +71,7 @@ function SparklineDeltaLabel({
   const last = months[months.length - 1].totalCents;
   const windowMonths = calendarMonthsCovered(
     months[0].month,
-    months[months.length - 1].month
+    months[months.length - 1].month,
   );
   if (first === 0 && last === 0) {
     return <span className="text-[10px] text-muted-foreground">flat</span>;
@@ -90,7 +85,7 @@ function SparklineDeltaLabel({
     <span
       className={cn(
         "text-[10px]",
-        big ? "text-warning font-medium" : "text-muted-foreground"
+        big ? "text-warning font-medium" : "text-muted-foreground",
       )}
     >
       {big ? "▲ " : ""}
@@ -108,7 +103,7 @@ type WorkspaceBudgetRowProps = {
 function WorkspaceBudgetRow({ workspace, sparkline }: WorkspaceBudgetRowProps) {
   const [editing, setEditing] = useState(false);
   const [inputValue, setInputValue] = useState(
-    workspace.limitCents != null ? String(workspace.limitCents / 100) : ""
+    workspace.limitCents != null ? String(workspace.limitCents / 100) : "",
   );
   const [isPending, startTransition] = useTransition();
   const status = useInlineStatus();
@@ -121,7 +116,10 @@ function WorkspaceBudgetRow({ workspace, sparkline }: WorkspaceBudgetRowProps) {
           ? null
           : Math.round(dollars * 100);
       try {
-        const result = await setWorkspaceLimit(workspace.workspaceId, limitCents);
+        const result = await setWorkspaceLimit(
+          workspace.workspaceId,
+          limitCents,
+        );
         if (result.success) {
           status.ok("Saved");
           setEditing(false);
@@ -214,7 +212,7 @@ function WorkspaceBudgetRow({ workspace, sparkline }: WorkspaceBudgetRowProps) {
         <SparklineDeltaLabel months={sparkline?.months ?? []} />
       </div>
 
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
         {editing ? (
           <>
             <div className="flex items-center gap-1">
@@ -246,7 +244,11 @@ function WorkspaceBudgetRow({ workspace, sparkline }: WorkspaceBudgetRowProps) {
           </>
         ) : (
           <>
-            <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setEditing(true)}
+            >
               {workspace.limitCents != null ? "Edit limit" : "Set limit"}
             </Button>
             <StatusText status={status.status} />
@@ -290,7 +292,8 @@ export function WorkspaceBudgetList({
   }, [hideZero, hydrated]);
 
   const { visible, hidden } = useMemo(() => {
-    if (!hideZero) return { visible: workspaces, hidden: [] as WorkspaceListItem[] };
+    if (!hideZero)
+      return { visible: workspaces, hidden: [] as WorkspaceListItem[] };
     const v: WorkspaceListItem[] = [];
     const h: WorkspaceListItem[] = [];
     for (const w of workspaces) {

--- a/src/components/dashboard/admin/spend-trend-card.tsx
+++ b/src/components/dashboard/admin/spend-trend-card.tsx
@@ -36,7 +36,10 @@ const chartConfig: ChartConfig = {
   api: { label: "Anthropic API (running)", color: "var(--chart-2)" },
 };
 
-export function SpendTrendCard({ spendSeries, billedYtdCents }: SpendTrendCardProps) {
+export function SpendTrendCard({
+  spendSeries,
+  billedYtdCents,
+}: SpendTrendCardProps) {
   if (spendSeries.length === 0) {
     return null;
   }
@@ -50,7 +53,7 @@ export function SpendTrendCard({ spendSeries, billedYtdCents }: SpendTrendCardPr
 
   const totalApi = spendSeries.reduce(
     (s, p) => s + (p.isForecast ? 0 : p.apiCents),
-    0
+    0,
   );
   const totalLicensesYtd = billedYtdCents;
   const grandTotal = totalLicensesYtd + totalApi || 1;
@@ -62,10 +65,8 @@ export function SpendTrendCard({ spendSeries, billedYtdCents }: SpendTrendCardPr
   const billedMonths = spendSeries.filter((p) => !p.isForecast);
   const avgMonthlyActual =
     billedMonths.length > 0
-      ? billedMonths.reduce(
-          (s, p) => s + p.licensesCents + p.apiCents,
-          0
-        ) / billedMonths.length
+      ? billedMonths.reduce((s, p) => s + p.licensesCents + p.apiCents, 0) /
+        billedMonths.length
       : 0;
 
   return (
@@ -73,17 +74,20 @@ export function SpendTrendCard({ spendSeries, billedYtdCents }: SpendTrendCardPr
       <CardHeader>
         <CardTitle>Spend over time</CardTitle>
         <CardDescription>
-          Stacked monthly cost · Licenses (billed) + Anthropic API (running) · last 12
-          months
+          Stacked monthly cost · Licenses (billed) + Anthropic API (running) ·
+          last 12 months
         </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="grid gap-6 lg:grid-cols-[1fr_220px]">
           <ChartContainer
             config={chartConfig}
-            className="h-[260px] w-full"
+            className="h-[260px] w-full min-w-0"
           >
-            <BarChart data={data} margin={{ top: 16, right: 16, left: 0, bottom: 0 }}>
+            <BarChart
+              data={data}
+              margin={{ top: 16, right: 16, left: 0, bottom: 0 }}
+            >
               <CartesianGrid vertical={false} strokeDasharray="3 3" />
               <XAxis
                 dataKey="month"
@@ -121,7 +125,11 @@ export function SpendTrendCard({ spendSeries, billedYtdCents }: SpendTrendCardPr
                   />
                 }
               />
-              <Bar dataKey="licenses" stackId="actual" fill="var(--color-licenses)">
+              <Bar
+                dataKey="licenses"
+                stackId="actual"
+                fill="var(--color-licenses)"
+              >
                 {data.map((d, i) => (
                   <Cell
                     key={`lic-${i}`}
@@ -197,7 +205,9 @@ function LegendRow({
       </span>
       <div className="text-right">
         <p className="tabular-nums">{value}</p>
-        <p className="text-[10px] text-muted-foreground tabular-nums">{share}%</p>
+        <p className="text-[10px] text-muted-foreground tabular-nums">
+          {share}%
+        </p>
       </div>
     </div>
   );

--- a/src/components/dashboard/viewer/my-usage-card.tsx
+++ b/src/components/dashboard/viewer/my-usage-card.tsx
@@ -47,7 +47,11 @@ export function MyUsageCard({
   uncachedInputTokens,
   cacheSavingsCents,
 }: MyUsageCardProps) {
-  if (!cost.available || !cost.dailyBreakdown || cost.dailyBreakdown.length === 0) {
+  if (
+    !cost.available ||
+    !cost.dailyBreakdown ||
+    cost.dailyBreakdown.length === 0
+  ) {
     return (
       <Card>
         <CardHeader>
@@ -79,7 +83,9 @@ export function MyUsageCard({
 
   const totalCacheInput = cacheReadTokens + uncachedInputTokens;
   const cacheHitRate =
-    totalCacheInput > 0 ? Math.round((cacheReadTokens / totalCacheInput) * 100) : 0;
+    totalCacheInput > 0
+      ? Math.round((cacheReadTokens / totalCacheInput) * 100)
+      : 0;
 
   return (
     <Card>
@@ -91,24 +97,43 @@ export function MyUsageCard({
       </CardHeader>
       <CardContent>
         <div className="grid gap-5 lg:grid-cols-[1fr_180px]">
-          <div>
+          <div className="min-w-0">
             <p className="text-3xl font-semibold tabular-nums">
               {formatCurrency(cost.monthlyTotalCents)}
             </p>
             <p className="text-[11px] text-muted-foreground">
               Month to date
-              {cost.latestDataDate ? ` · data through ${cost.latestDataDate}` : ""}
+              {cost.latestDataDate
+                ? ` · data through ${cost.latestDataDate}`
+                : ""}
             </p>
 
             <ChartContainer
               config={chartConfig}
               className="mt-3 h-[160px] w-full"
             >
-              <AreaChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+              <AreaChart
+                data={data}
+                margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+              >
                 <defs>
-                  <linearGradient id="viewerSpendArea" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="var(--chart-1)" stopOpacity={0.45} />
-                    <stop offset="100%" stopColor="var(--chart-1)" stopOpacity={0} />
+                  <linearGradient
+                    id="viewerSpendArea"
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
+                    <stop
+                      offset="0%"
+                      stopColor="var(--chart-1)"
+                      stopOpacity={0.45}
+                    />
+                    <stop
+                      offset="100%"
+                      stopColor="var(--chart-1)"
+                      stopOpacity={0}
+                    />
                   </linearGradient>
                 </defs>
                 <CartesianGrid vertical={false} strokeDasharray="3 3" />

--- a/src/components/profile/cost-tracking-section.tsx
+++ b/src/components/profile/cost-tracking-section.tsx
@@ -41,16 +41,20 @@ export function CostTrackingSection({
         modelTotals.set(m.model, (modelTotals.get(m.model) ?? 0) + m.costCents);
       }
     }
-    const top = Array.from(modelTotals.entries()).sort((a, b) => b[1] - a[1])[0];
+    const top = Array.from(modelTotals.entries()).sort(
+      (a, b) => b[1] - a[1],
+    )[0];
     if (!top) return "—";
     const match = top[0].match(/claude-(\w+)/);
-    return match ? match[1].charAt(0).toUpperCase() + match[1].slice(1) : top[0];
+    return match
+      ? match[1].charAt(0).toUpperCase() + match[1].slice(1)
+      : top[0];
   }, [costData.dailyBreakdown]);
 
   const peakDayLabel = useMemo(() => {
     if (costData.dailyBreakdown.length === 0) return "—";
     const peak = costData.dailyBreakdown.reduce((max, day) =>
-      day.totalCents > max.totalCents ? day : max
+      day.totalCents > max.totalCents ? day : max,
     );
     const d = new Date(peak.date + "T00:00:00");
     return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
@@ -106,12 +110,12 @@ export function CostTrackingSection({
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <CardTitle className="flex items-center gap-2 text-lg">
             <DollarSign className="size-5" />
             Claude API Costs
           </CardTitle>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <StatusText status={status.status} />
             <MonthPicker
               value={selectedMonth}
@@ -173,15 +177,11 @@ export function CostTrackingSection({
             </div>
             <div className="rounded-lg border p-3">
               <p className="text-sm text-muted-foreground">Top Model</p>
-              <p className="text-lg font-semibold truncate">
-                {topModelName}
-              </p>
+              <p className="text-lg font-semibold truncate">{topModelName}</p>
             </div>
             <div className="rounded-lg border p-3">
               <p className="text-sm text-muted-foreground">Peak Day</p>
-              <p className="text-lg font-semibold">
-                {peakDayLabel}
-              </p>
+              <p className="text-lg font-semibold">{peakDayLabel}</p>
             </div>
           </div>
         )}

--- a/src/components/profile/month-picker.tsx
+++ b/src/components/profile/month-picker.tsx
@@ -37,7 +37,7 @@ export function MonthPicker({ value, onChange, months }: MonthPickerProps) {
 
   return (
     <Select value={value} onValueChange={onChange}>
-      <SelectTrigger className="w-[200px]">
+      <SelectTrigger className="w-full sm:w-[200px]">
         <SelectValue placeholder="Select month" />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
Fix horizontal-overflow and cramped layouts on narrow (≈375px) viewports
that surfaced after the Nothing redesign.

Root cause of the reported Claude user-detail bug: the `lg:grid-cols-2`
card grids holding the wide `whitespace-nowrap` model-breakdown table had
grid cells defaulting to `min-width:auto`, so the table's intrinsic width
expanded the track (and the whole page) past the viewport instead of
letting the table's own `overflow-x-auto` engage. Add `min-w-0` to those
cells on the Claude user/workspace detail pages and the users list.

Other fixes:
- Make Settings / Copilot / Reports tab bars scroll horizontally instead
  of overflowing the viewport.
- Stack page headers and wrap action-button groups on mobile (Users,
  Invoices, Assignments, User detail, Request detail, profile cost card).
- Collapse fixed two-column definition grids and the dense grid-cols-5
  sync summary to single/fewer columns on mobile.
- MonthPicker / workspace select go full-width below sm; license-template
  rows stack; budget edit controls wrap.
- Harden dashboard chart cells with `min-w-0` to prevent mid-width overflow.

https://claude.ai/code/session_01Cdqk8njUrmV66qC9GGF6Ad