### PR TITLE
feat(035): Scenarios section + API→Subscription calculator

### DIFF
--- a/specs/035-scenario-calculators/implementation-plan.html
+++ b/specs/035-scenario-calculators/implementation-plan.html
@@ -1,0 +1,530 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Implementation Plan — Scenarios section &amp; API→Subscription calculator (035)</title>
+  <style>
+    :root {
+      --bg: #0b0d12;
+      --bg-elev: #11141b;
+      --bg-card: #161a24;
+      --border: #232938;
+      --border-strong: #2f3850;
+      --fg: #e7ebf3;
+      --fg-muted: #9aa3b5;
+      --fg-dim: #6b7488;
+      --accent: #f0a072;        /* clay — matches the prototype accent */
+      --accent-2: #7dd3fc;
+      --good: #86efac;
+      --warn: #fcd34d;
+      --bad: #fca5a5;
+      --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); font-family: var(--sans); line-height: 1.55; }
+    body { padding: 48px 24px 96px; }
+    main { max-width: 1100px; margin: 0 auto; }
+    h1, h2, h3, h4 { font-weight: 600; letter-spacing: -0.01em; }
+    h1 { font-size: 32px; margin: 0 0 8px; }
+    h2 { font-size: 22px; margin: 52px 0 16px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+    h3 { font-size: 17px; margin: 0 0 6px; }
+    h4 { font-size: 13px; margin: 16px 0 6px; color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.08em; }
+    p { margin: 0 0 12px; }
+    a { color: var(--accent); }
+    code { font-family: var(--mono); font-size: 0.88em; background: var(--bg-elev); padding: 1px 5px; border-radius: 4px; border: 1px solid var(--border); }
+    pre { font-family: var(--mono); font-size: 12.5px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; overflow-x: auto; line-height: 1.5; }
+    pre code { background: transparent; border: 0; padding: 0; font-size: inherit; }
+    .lede { color: var(--fg-muted); font-size: 16px; max-width: 820px; }
+    .meta { color: var(--fg-dim); font-size: 13px; margin-top: 8px; font-family: var(--mono); }
+    .badge { display: inline-block; font-size: 11px; font-family: var(--mono); padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border-strong); color: var(--fg-muted); background: var(--bg-elev); }
+    .badge.good { color: var(--good); border-color: rgba(134,239,172,0.3); }
+    .badge.warn { color: var(--warn); border-color: rgba(252,211,77,0.3); }
+    .badge.accent { color: var(--accent); border-color: rgba(240,160,114,0.35); }
+    .card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin: 16px 0; }
+    .card.accent { border-left: 3px solid var(--accent); }
+    .card.accent-2 { border-left: 3px solid var(--accent-2); }
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+    @media (max-width: 760px) { .grid-2, .grid-3 { grid-template-columns: 1fr; } }
+    .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+    .row.between { justify-content: space-between; }
+    .flow { font-family: var(--mono); font-size: 12.5px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 10px; padding: 16px; white-space: pre; overflow-x: auto; color: var(--fg-muted); }
+    .flow .em { color: var(--fg); }
+    .flow .ok { color: var(--good); }
+    .flow .accent { color: var(--accent); }
+    ul { padding-left: 20px; margin: 8px 0 12px; }
+    li { margin: 4px 0; }
+    li.pro::marker { content: "+ "; color: var(--good); font-weight: 700; }
+    li.con::marker { content: "− "; color: var(--bad); font-weight: 700; }
+    li.note::marker { content: "› "; color: var(--fg-dim); }
+    li.check::marker { content: "\2610  "; color: var(--fg-muted); }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; margin: 12px 0; }
+    th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+    th { color: var(--fg-muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; background: var(--bg-elev); }
+    td code { white-space: nowrap; }
+    .pill { display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 11.5px; font-family: var(--mono); }
+    .pill.good { background: rgba(134,239,172,0.12); color: var(--good); }
+    .pill.warn { background: rgba(252,211,77,0.12); color: var(--warn); }
+    .pill.new { background: rgba(240,160,114,0.14); color: var(--accent); }
+    .pill.neutral { background: var(--bg-elev); color: var(--fg-muted); border: 1px solid var(--border); }
+    .callout { border: 1px solid var(--border-strong); border-left: 3px solid var(--warn); background: rgba(252,211,77,0.04); padding: 14px 16px; border-radius: 8px; margin: 16px 0; font-size: 14px; }
+    .callout.info { border-left-color: var(--accent-2); background: rgba(125,211,252,0.04); }
+    .callout.accent { border-left-color: var(--accent); background: rgba(240,160,114,0.05); }
+    .phase { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin: 24px 0; }
+    .phase-head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--border); }
+    .phase-head h3 { font-size: 20px; margin: 0; }
+    .phase-meta { color: var(--fg-dim); font-family: var(--mono); font-size: 12px; }
+    .toc { columns: 2; column-gap: 32px; font-size: 14px; }
+    @media (max-width: 760px) { .toc { columns: 1; } }
+    .toc a { display: block; padding: 3px 0; color: var(--fg-muted); text-decoration: none; }
+    .toc a:hover { color: var(--accent); }
+    footer { color: var(--fg-dim); font-size: 12.5px; margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--border); font-family: var(--mono); }
+    .k { color: var(--accent-2); }
+    .s { color: var(--good); }
+    .c { color: var(--fg-dim); font-style: italic; }
+  </style>
+</head>
+<body>
+<main>
+
+<header>
+  <div class="row" style="margin-bottom: 16px;">
+    <span class="badge">Implementation plan</span>
+    <span class="badge">spec/035-scenario-calculators</span>
+    <span class="badge accent">Draft — pending approval</span>
+  </div>
+  <h1>Scenarios section &amp; the API&nbsp;→&nbsp;Subscription calculator</h1>
+  <p class="lede">
+    Turn the standalone cost prototype into a real, live-data feature of the AI Developer Hub: a new
+    <strong>Scenarios</strong> nav section whose first inhabitant is the <strong>API&nbsp;→&nbsp;Subscription
+    migration calculator</strong>. The section is built as an extensible registry so a second (and third)
+    calculator can be added later without touching the first.
+  </p>
+  <p class="lede">
+    The interactive reference — same math, same controls — lives in
+    <a href="./prototype.html">prototype.html</a>. That doc is the <em>what</em>; this is the
+    <em>how</em>, wired into the app's real architecture (Server Components → server actions → Drizzle,
+    shadcn primitives, design tokens).
+  </p>
+  <p class="meta">Drafted 2026-06-09 · author: T. Studer · branch: <code>035-scenario-calculators</code> · estimate: ~3–4 dev days</p>
+</header>
+
+<div class="callout info" style="margin-top: 24px;">
+  <strong>Reference prototype.</strong> <a href="./prototype.html">prototype.html</a> is the validated single-file
+  version generated from live Neon data (project <code>broad-shadow-82397229</code>, window 27&nbsp;Feb&nbsp;–&nbsp;9&nbsp;Jun&nbsp;2026).
+  Its numbers were cross-checked against <code>anthropic_usage_metrics</code> and a Node re-computation. The app version
+  must reproduce those figures exactly when fed the same data.
+</div>
+
+<h2 id="toc">Contents</h2>
+<div class="toc card">
+  <a href="#goal">1 · Goal &amp; scope</a>
+  <a href="#what">2 · What the first calculator does</a>
+  <a href="#data">3 · Data sources (no schema change)</a>
+  <a href="#arch">4 · Architecture &amp; routing</a>
+  <a href="#engine">5 · The pure calculation engine</a>
+  <a href="#registry">6 · Extensibility contract (future calculators)</a>
+  <a href="#phases">7 · Phasing (file-level)</a>
+  <a href="#manifest">8 · File manifest</a>
+  <a href="#design">9 · Design &amp; component mapping</a>
+  <a href="#risks">10 · Risks &amp; decisions</a>
+  <a href="#questions">11 · Open questions</a>
+  <a href="#accept">12 · Acceptance checklist</a>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="goal">1 · Goal &amp; scope</h2>
+
+<div class="card accent">
+  <h4>In scope</h4>
+  <ul>
+    <li class="note">A new top-level <strong>Scenarios</strong> section (sidebar entry, admin-only) at <code>/scenarios</code>.</li>
+    <li class="note">An <strong>index page</strong> listing available calculators, driven by a registry — so adding calculator #2 is a one-line registry entry + its own route.</li>
+    <li class="note">The first calculator at <code>/scenarios/api-subscription</code>, fed by <strong>live</strong> data (Anthropic usage + license assignments + seat prices), reproducing the prototype's KPIs, scenario cards, comparison bars, and per-user mapping table.</li>
+    <li class="note">A <strong>pure, tested calculation module</strong> shared by server (initial render) and client (live re-compute on control changes).</li>
+  </ul>
+  <h4>Out of scope (this spec)</h4>
+  <ul>
+    <li class="con">Any DB schema change — the feature is read-only over existing tables.</li>
+    <li class="con">The second calculator itself (only the seams that let it slot in).</li>
+    <li class="con">Persisting/sharing saved scenario presets, CSV/PDF export — noted as follow-ups, not built now.</li>
+    <li class="con">Currency conversion (USD→CHF) — see <a href="#risks">risks</a>; deferred unless requested.</li>
+  </ul>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="what">2 · What the first calculator does</h2>
+
+<p>
+  Every user holding a <strong>Claude Console</strong> (Anthropic API) license key is a metered, pay-as-you-go
+  consumer. The calculator maps each one onto a flat Claude <strong>Standard</strong> or <strong>Premium</strong>
+  seat and compares the projected bill against today's API spend, under four scenarios:
+</p>
+<ul>
+  <li class="note"><strong>Metered API (baseline)</strong> — sum of each user's actual API spend on the chosen basis.</li>
+  <li class="note"><strong>All → Standard</strong> — every user on the cheapest seat.</li>
+  <li class="note"><strong>All → Premium</strong> — every user on the top seat.</li>
+  <li class="note"><strong>Right-sized</strong> — users whose API spend ≥ a threshold get Premium; the rest get Standard.</li>
+</ul>
+<p>Live, recomputing controls: <code>Standard $/mo</code>, <code>Premium $/mo</code>, <code>Premium threshold</code> (slider),
+  <code>usage basis</code> (avg of complete months / latest / peak / specific month), and
+  <code>population</code> (all keys vs. active only). Sortable per-user table with a
+  <code>Δ&nbsp;seat&nbsp;−&nbsp;API</code> column (green = seat cheaper than burn, clay = seat over-pays a light key).</p>
+
+<div class="callout accent">
+  <strong>Numbers it must hit on current data</strong> (all 47 keys, avg of complete months Mar/Apr/May 2026,
+  threshold = $125): baseline <code>$3,041/mo</code>, all-Standard <code>$1,175/mo</code>,
+  all-Premium <code>$5,875/mo</code>, right-sized <code>$2,075/mo</code> (9 Premium + 38 Standard) →
+  <span class="s">$966/mo (32%) saving</span> vs. API. These are the regression anchors for the unit tests.
+</div>
+
+<!-- ============================================================ -->
+<h2 id="data">3 · Data sources (no schema change)</h2>
+
+<table>
+  <thead><tr><th>Table</th><th>Role in the calculator</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>license_assignments</code></td>
+      <td>The <strong>population</strong>. API users = rows where <code>tool_id =</code> the <em>Claude Console</em> tool
+        <em>and</em> <code>api_key_encrypted IS NOT NULL</code> (47 today; 43 active). One row per user (dedupe by
+        <code>row_number()</code>, preferring active + latest <code>assigned_at</code>). Carries <code>status</code>,
+        <code>workspace</code>, and the internal boost tier (context only).</td>
+    </tr>
+    <tr>
+      <td><code>anthropic_usage_metrics</code></td>
+      <td>The <strong>spend</strong>. <code>computed_cost_cents</code> per user/day/model, summed by
+        <code>to_char(date,'YYYY-MM')</code> into a per-user monthly map.</td>
+    </tr>
+    <tr>
+      <td><code>access_tiers</code> + <code>ai_tools</code></td>
+      <td>The <strong>seat prices</strong>. The <em>Claude</em> subscription tool's two active tiers supply the
+        defaults: <code>Standard Seat = 2500¢</code>, <code>Premium Seat = 12500¢</code>. Read live (lowest active
+        tier = Standard, highest = Premium) so config edits flow through automatically.</td>
+    </tr>
+    <tr>
+      <td><code>users</code></td>
+      <td>Display name, email, status, discipline (for the table + any future grouping).</td>
+    </tr>
+  </tbody>
+</table>
+
+<h4>Tool resolution — don't hardcode IDs</h4>
+<p>The prototype hardcoded tool ids (Claude Console = 2, Claude = 3). The app must resolve by
+  <strong>vendor + name</strong> to survive reseeded/other environments:</p>
+<pre><code><span class="c">// API tool: vendor 'Anthropic', name 'Claude Console'  (the one whose assignments carry api keys)</span>
+<span class="c">// Seat tool: vendor 'Anthropic', name 'Claude'          (its access_tiers = Standard/Premium)</span></code></pre>
+
+<h4>Complete vs. partial months</h4>
+<p>The prototype baked in "Mar/Apr/May are complete." The app computes it: a month is <em>complete</em> when its last
+  calendar day is strictly before today (UTC) <em>and</em> the dataset's earliest date is on/before that month's first
+  day (so a month the org joined mid-way isn't treated as full). The current month is always <em>partial</em>. This
+  matches the standing fact that Anthropic's <code>cost_report</code> only returns complete UTC days. The default basis
+  averages the complete months; partial months are shown in the table (muted, "MTD") but excluded from the run-rate.</p>
+
+<h4>Validated aggregation query (reference)</h4>
+<pre><code>WITH console AS (
+  SELECT la.user_id, la.status, la.workspace, at.name AS tier_name,
+         row_number() OVER (PARTITION BY la.user_id
+           ORDER BY (la.status='active') DESC, la.assigned_at DESC) rn
+  FROM license_assignments la
+  JOIN access_tiers at ON at.id = la.tier_id
+  WHERE la.tool_id = :claudeConsoleToolId
+    AND la.api_key_encrypted IS NOT NULL
+)
+SELECT u.id, u.name, u.email, u.discipline, c.status, c.workspace, c.tier_name,
+       to_char(m.date,'YYYY-MM') AS month, SUM(m.computed_cost_cents) AS cents
+FROM console c
+JOIN users u ON u.id = c.user_id
+LEFT JOIN anthropic_usage_metrics m ON m.user_id = c.user_id
+WHERE c.rn = 1
+GROUP BY u.id, u.name, u.email, u.discipline, c.status, c.workspace, c.tier_name, 2
+ORDER BY u.name;</code></pre>
+<p class="c">Implemented with the Drizzle query builder in <code>lib/scenarios/queries.ts</code>; raw SQL shown only for clarity.</p>
+
+<!-- ============================================================ -->
+<h2 id="arch">4 · Architecture &amp; routing</h2>
+
+<div class="card">
+  <div class="flow"><span class="accent">/scenarios</span>                         <span class="em">index — registry-driven cards (server component)</span>
+   │
+   └── <span class="accent">/scenarios/api-subscription</span>      <span class="em">page.tsx (server) → requireAdmin + load dataset</span>
+                  │
+                  └── api-subscription-client.tsx   <span class="c">"use client" — controls + live recompute</span>
+                                 │ imports
+                                 ▼
+        <span class="k">lib/scenarios/api-subscription.ts</span>   <span class="c">pure calc engine (no React, no db)</span>
+        <span class="k">lib/scenarios/queries.ts</span>          <span class="c">Drizzle reads (server only)</span>
+        <span class="k">lib/scenarios/registry.ts</span>         <span class="c">calculator catalogue (slug/title/status)</span>
+  </div>
+</div>
+
+<p>The split mirrors the existing <code>/claude</code> feature: a server <code>page.tsx</code> does
+  <code>requireAdmin()</code>, awaits the dataset via a <code>"use server"</code> action, and hands plain serializable
+  data to a <code>"use client"</code> component. The novelty is the <strong>pure engine in <code>lib/</code></strong>
+  (no <code>"use server"</code>, no React) so the <em>same</em> functions run on the server for first paint and in the
+  browser on every slider drag — guaranteeing the displayed totals can't drift from the tested ones.</p>
+
+<div class="grid-2">
+  <div class="card accent-2">
+    <h4>Why a registry, not just two routes</h4>
+    <p>The user wants more calculators later. A <code>registry.ts</code> list is the single source of truth for the
+      index cards, the optional section tab strip, and "coming soon" placeholders. Adding calculator #2 =
+      append one entry + create its route folder. No edits to calculator #1.</p>
+  </div>
+  <div class="card accent-2">
+    <h4>Caching</h4>
+    <p>The dataset query is wrapped in <code>unstable_cache</code> tagged <code>scenarios:api-subscription</code>,
+      revalidated by the Anthropic usage sync (same hook that already revalidates <code>/claude</code>) and on a short
+      TTL. The page is dynamic (admin-gated) so it's never statically cached at the route level.</p>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="engine">5 · The pure calculation engine</h2>
+
+<p>File: <code>src/lib/scenarios/api-subscription.ts</code>. No imports from <code>db</code>, <code>react</code>, or
+  <code>next</code> — only types and plain math. Fully unit-tested.</p>
+
+<pre><code><span class="c">// ---- inputs the UI controls map onto ----</span>
+export type UsageBasis =
+  | "avgComplete"      <span class="c">// mean of complete months (default)</span>
+  | "latestComplete"   <span class="c">// most recent complete month</span>
+  | "peakComplete"     <span class="c">// max single complete month</span>
+  | { month: string }; <span class="c">// a specific 'YYYY-MM'</span>
+
+export type ScenarioInputs = {
+  standardCents: number;
+  premiumCents: number;
+  premiumThresholdCents: number;  <span class="c">// usage &gt;= threshold ⇒ Premium</span>
+  basis: UsageBasis;
+  population: "all" | "active";
+};
+
+<span class="c">// ---- per-user shape coming out of queries.ts ----</span>
+export type ApiUser = {
+  userId: number; name: string; email: string;
+  status: "active" | "inactive";
+  workspace: string | null; internalTier: string | null;
+  monthly: Record&lt;string, number&gt;;   <span class="c">// 'YYYY-MM' -&gt; cents</span>
+};
+
+export type ApiSubscriptionDataset = {
+  users: ApiUser[];
+  completeMonths: string[];           <span class="c">// sorted asc</span>
+  partialMonths: string[];
+  defaultStandardCents: number;       <span class="c">// from access_tiers</span>
+  defaultPremiumCents: number;
+  generatedAt: string;                <span class="c">// ISO; stamped by caller</span>
+};
+
+<span class="c">// ---- pure functions (the testable core) ----</span>
+export function usageForUser(u: ApiUser, ds: ApiSubscriptionDataset, basis: UsageBasis): number;
+export function mapSeat(usageCents: number, i: ScenarioInputs):
+  { tier: "standard" | "premium"; seatCents: number };
+export function computeScenarios(ds: ApiSubscriptionDataset, i: ScenarioInputs): {
+  rows: Array&lt;{ user: ApiUser; usageCents: number; tier: "standard" | "premium";
+                seatCents: number; deltaCents: number }&gt;;
+  baselineCents: number;
+  allStandardCents: number;
+  allPremiumCents: number;
+  rightSizedCents: number;
+  premiumCount: number;
+  standardCount: number;
+};</code></pre>
+
+<p>The client component holds only the <code>ScenarioInputs</code> in React state; everything rendered (cards, bars,
+  table, verdict line) is derived by calling <code>computeScenarios(dataset, inputs)</code> on each render. No duplicated
+  arithmetic in JSX.</p>
+
+<!-- ============================================================ -->
+<h2 id="registry">6 · Extensibility contract (future calculators)</h2>
+
+<pre><code><span class="c">// src/lib/scenarios/registry.ts</span>
+export type ScenarioStatus = "live" | "soon";
+export type ScenarioMeta = {
+  slug: string;            <span class="c">// URL segment under /scenarios</span>
+  title: string;
+  blurb: string;           <span class="c">// one line for the index card</span>
+  icon: LucideIcon;
+  status: ScenarioStatus;
+};
+
+export const SCENARIOS: ScenarioMeta[] = [
+  { slug: "api-subscription", title: "API → Subscription migration",
+    blurb: "Map metered Anthropic API users onto flat Standard/Premium seats.",
+    icon: ArrowLeftRight, status: "live" },
+  { slug: "budget-forecast", title: "Budget / Cost Forecast Simulation",
+    blurb: "Project spend forward and simulate budget outcomes.",
+    icon: LineChart, status: "soon" },   <span class="c">// calculator #2 — stubbed now, built later</span>
+];</code></pre>
+
+<p>A new calculator slots in by: (1) appending a <code>ScenarioMeta</code>; (2) adding
+  <code>src/app/scenarios/&lt;slug&gt;/page.tsx</code> + client; (3) optionally its own loader in
+  <code>queries.ts</code> and pure module. The index page and tab strip render straight off <code>SCENARIOS</code>;
+  <code>status: "soon"</code> entries render as non-clickable "coming soon" cards.</p>
+
+<!-- ============================================================ -->
+<h2 id="phases">7 · Phasing (file-level)</h2>
+
+<div class="phase">
+  <div class="phase-head"><h3>Phase 0 — Section scaffolding</h3><span class="phase-meta">~0.5 day</span></div>
+  <ul>
+    <li class="check">Add <code>{ title: "Scenarios", href: "/scenarios", roles: ["admin"] }</code> to <code>navItems</code> in
+      <code>src/components/app-sidebar.tsx</code> (place after <em>Reports</em>).</li>
+    <li class="check">Create <code>src/lib/scenarios/registry.ts</code> with the <code>ScenarioMeta</code> type + one live entry.</li>
+    <li class="check">Create <code>src/app/scenarios/page.tsx</code> — server component, <code>requireAdmin()</code>, renders a
+      grid of shadcn <code>Card</code>s from <code>SCENARIOS</code> (live → <code>Link</code>; soon → disabled).</li>
+    <li class="check">Optional <code>src/components/scenarios/scenario-tabs.tsx</code> (mirrors <code>claude-tabs.tsx</code>) —
+      only rendered once ≥2 live calculators exist.</li>
+  </ul>
+</div>
+
+<div class="phase">
+  <div class="phase-head"><h3>Phase 1 — Data layer</h3><span class="phase-meta">~1 day</span></div>
+  <ul>
+    <li class="check"><code>src/lib/scenarios/types.ts</code> — the dataset &amp; input types (or co-locate in the engine file).</li>
+    <li class="check"><code>src/lib/scenarios/queries.ts</code> — <code>getApiSubscriptionDataset()</code>: resolve the two tools
+      by vendor+name, run the aggregation query via Drizzle, classify complete/partial months, read seat-price defaults
+      from <code>access_tiers</code>, return <code>ApiSubscriptionDataset</code>. Guard the empty/zero-tool cases.</li>
+    <li class="check"><code>src/actions/scenarios.ts</code> — <code>"use server"</code>; <code>requireAdmin()</code> then the
+      cached loader (<code>unstable_cache</code>, tag <code>scenarios:api-subscription</code>).</li>
+    <li class="check">Integration test seam: a fixture dataset object reused by unit tests + the client storybook-ish manual check.</li>
+  </ul>
+</div>
+
+<div class="phase">
+  <div class="phase-head"><h3>Phase 2 — Calculator page &amp; UI</h3><span class="phase-meta">~1.5 days</span></div>
+  <ul>
+    <li class="check"><code>src/lib/scenarios/api-subscription.ts</code> — the pure engine (§5). Write tests first (TDD anchors from §2).</li>
+    <li class="check">Threshold control: a <strong>styled native <code>&lt;input type="range"&gt;</code></strong> (accent fill, mono readout).
+      <code>@radix-ui/react-slider</code> is not installed; a native range adds no dependency and reads as a mechanical
+      instrument — on-brand for Nothing. Revisit a Radix slider only if richer keyboard semantics are needed.</li>
+    <li class="check"><code>src/app/scenarios/api-subscription/page.tsx</code> — server: <code>requireAdmin()</code>, await
+      action, compute the default scenario server-side for first paint, pass <code>dataset</code> + defaults to client.</li>
+    <li class="check"><code>src/app/scenarios/api-subscription/api-subscription-client.tsx</code> — <code>"use client"</code>:
+      controls → <code>ScenarioInputs</code> state → <code>computeScenarios()</code> → KPI strip, four scenario
+      <code>Card</code>s, comparison bars (<code>segmented-bar</code> or simple token-styled divs), verdict line, and the
+      sortable per-user <code>Table</code> with <code>Sparkline</code> month trends and the Δ column.</li>
+    <li class="check">Empty state (no API users / no usage yet) and loading via <code>Suspense</code> + <code>LoadingState</code>.</li>
+  </ul>
+</div>
+
+<div class="phase">
+  <div class="phase-head"><h3>Phase 3 — Polish &amp; a11y</h3><span class="phase-meta">~0.5 day</span></div>
+  <ul>
+    <li class="check">Design-token pass (no hardcoded hex; use <code>text-ink</code>, <code>muted-foreground</code>,
+      <code>destructive</code>, etc.). Mono uppercase labels to match the house dashboard look — <em>not</em> the
+      prototype's standalone editorial palette.</li>
+    <li class="check">Capacity caveat: badge/tooltip on users whose API basis spend ≫ a Standard seat under the
+      all-Standard scenario ("a $25 seat may not cover this workload").</li>
+    <li class="check">Keyboard + SR labels on slider/select/toggle; column-sort buttons announce direction; responsive
+      table scroll on mobile.</li>
+    <li class="check"><code>pnpm lint</code> (zero warnings), <code>pnpm typecheck</code>, <code>pnpm format</code>.</li>
+  </ul>
+</div>
+
+<div class="phase">
+  <div class="phase-head"><h3>Phase 4 — Tests</h3><span class="phase-meta">~0.5 day</span></div>
+  <ul>
+    <li class="check"><code>tests/unit/scenarios/api-subscription.test.ts</code> — <code>usageForUser</code> (each basis),
+      <code>mapSeat</code> (threshold boundary: <code>usage == threshold</code> ⇒ Premium), <code>computeScenarios</code>
+      totals against the §2 fixture anchors (3041 / 1175 / 5875 / 2075).</li>
+    <li class="check">Month-classification unit test (current month partial; mid-join month partial).</li>
+    <li class="check">Optional <code>tests/integration/scenarios/dataset.test.ts</code> — <code>getApiSubscriptionDataset()</code>
+      against the real DB (gated like other integration tests).</li>
+    <li class="check">Optional Playwright smoke: <code>/scenarios</code> shows the card; calculator renders 47 rows;
+      moving the threshold changes the right-sized total.</li>
+  </ul>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="manifest">8 · File manifest</h2>
+
+<table>
+  <thead><tr><th>File</th><th></th><th>Purpose</th></tr></thead>
+  <tbody>
+    <tr><td><code>src/app/scenarios/page.tsx</code></td><td><span class="pill new">new</span></td><td>Section index; registry-driven calculator cards.</td></tr>
+    <tr><td><code>src/app/scenarios/api-subscription/page.tsx</code></td><td><span class="pill new">new</span></td><td>Calculator server page — auth, dataset load, first-paint scenario.</td></tr>
+    <tr><td><code>src/app/scenarios/api-subscription/api-subscription-client.tsx</code></td><td><span class="pill new">new</span></td><td>Interactive client UI (controls, cards, bars, table).</td></tr>
+    <tr><td><code>src/lib/scenarios/registry.ts</code></td><td><span class="pill new">new</span></td><td>Calculator catalogue (slug/title/blurb/icon/status).</td></tr>
+    <tr><td><code>src/lib/scenarios/types.ts</code></td><td><span class="pill new">new</span></td><td>Dataset &amp; input types (or fold into engine).</td></tr>
+    <tr><td><code>src/lib/scenarios/queries.ts</code></td><td><span class="pill new">new</span></td><td><code>getApiSubscriptionDataset()</code> — Drizzle reads, month classification, seat-price defaults.</td></tr>
+    <tr><td><code>src/lib/scenarios/api-subscription.ts</code></td><td><span class="pill new">new</span></td><td>Pure calc engine (basis, mapSeat, computeScenarios).</td></tr>
+    <tr><td><code>src/actions/scenarios.ts</code></td><td><span class="pill new">new</span></td><td><code>"use server"</code> wrapper: requireAdmin + cached loader.</td></tr>
+    <tr><td><code>src/components/scenarios/scenario-tabs.tsx</code></td><td><span class="pill new">opt</span></td><td>Section tab strip — when ≥2 live calculators.</td></tr>
+    <tr><td><code>src/components/app-sidebar.tsx</code></td><td><span class="pill warn">edit</span></td><td>Add the <em>Scenarios</em> nav item (admin).</td></tr>
+    <tr><td><code>tests/unit/scenarios/api-subscription.test.ts</code></td><td><span class="pill new">new</span></td><td>Engine unit tests with regression anchors.</td></tr>
+    <tr><td><code>CLAUDE.md</code></td><td><span class="pill warn">edit</span></td><td>"Recent Changes" line for 035 (auto-gen convention).</td></tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2 id="design">9 · Design &amp; component mapping</h2>
+
+<table>
+  <thead><tr><th>Prototype element</th><th>App implementation</th></tr></thead>
+  <tbody>
+    <tr><td>KPI strip</td><td>Reuse the <code>kpi-strip</code> pattern from <code>components/claude</code>, or shadcn <code>Card</code>s with mono labels.</td></tr>
+    <tr><td>Controls (prices / threshold / basis / population)</td><td><code>Input</code> (number), styled native <code>range</code>, <code>Select</code>, and a two-button segmented toggle (mechanical control, not <code>switch</code>).</td></tr>
+    <tr><td>Four scenario cards + verdict</td><td>shadcn <code>Card</code> + <code>Badge</code>; verdict is a token-styled callout.</td></tr>
+    <tr><td>Horizontal comparison bars</td><td><code>components/ui/segmented-bar</code> (already in the kit).</td></tr>
+    <tr><td>Per-month mini-trend</td><td><code>components/ui/sparkline</code>.</td></tr>
+    <tr><td>Per-user table (sortable, Δ column)</td><td>shadcn <code>Table</code>; sort via local state or TanStack Table (already a dep). Money via <code>formatCurrency()</code> from <code>lib/utils</code>.</td></tr>
+    <tr><td>Standalone editorial theme (Fraunces/clay/ivory)</td><td><strong>Dropped</strong> — the app page uses the <strong>Nothing design system</strong> (spec 028 tokens): <code>font-mono</code> ALL-CAPS labels, <code>text-ink</code>/<code>muted-foreground</code>/<code>faint</code> greyscale hierarchy, red <code>destructive</code> as the single interrupt, <code>SegmentedBar</code> for the comparison viz, optics/spacing over borders. The editorial look stays in the prototype only.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2 id="risks">10 · Risks &amp; decisions</h2>
+
+<table>
+  <thead><tr><th>Topic</th><th>Decision / mitigation</th></tr></thead>
+  <tbody>
+    <tr><td>Seat prices — live vs editable</td><td><strong>Both.</strong> Default the price inputs from <code>access_tiers</code> (live), but keep them editable for what-if modelling. A "reset to live" affordance restores defaults.</td></tr>
+    <tr><td>Capacity realism</td><td>"All → Standard" can look deceptively cheap; a $25 seat won't cover a $287/mo user. Surface a per-user warning + a footnote. The right-sized scenario is the honest default.</td></tr>
+    <tr><td>Partial months</td><td>Computed dynamically (current month + mid-join months excluded from run-rate). Aligns with Anthropic complete-UTC-day behaviour.</td></tr>
+    <tr><td>Currency</td><td>Figures are USD as billed by Anthropic; <code>formatCurrency()</code> drives display. No FX conversion this spec (open question below).</td></tr>
+    <tr><td>Tool resolution</td><td>Resolve by vendor+name, not hardcoded ids; fail soft to an empty state if the Claude/Claude Console tools aren't present.</td></tr>
+    <tr><td>Role &amp; data sensitivity</td><td>Admin-only (matches <code>/claude</code>, <code>/reports</code>). No API-key material is read — only aggregate spend &amp; assignment metadata.</td></tr>
+    <tr><td>Performance</td><td>~47 users × few months — one indexed aggregation. Cached; negligible.</td></tr>
+    <tr><td>Number parity</td><td>Shared pure engine + unit anchors prevent client/server drift and lock the prototype's figures.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2 id="questions">11 · Decisions (resolved)</h2>
+<div class="card accent">
+  <ul>
+    <li class="pro"><strong>Design system: Nothing</strong> (spec 028 tokens) — confirmed via <code>/nothing-design</code>.</li>
+    <li class="pro"><strong>Calculator #2 = Budget / Cost Forecast Simulation</strong> — stubbed now as a <code>status:"soon"</code> registry card; built in a later spec.</li>
+    <li class="pro"><strong>Seat prices</strong> — live defaults from <code>access_tiers</code>, editable for what-if, with a "reset to live" affordance.</li>
+    <li class="pro"><strong>Default population</strong> — all 47 keys; toggle to active-only.</li>
+    <li class="pro"><strong>Currency</strong> — USD via <code>formatCurrency()</code>; CHF/FX is a follow-up.</li>
+    <li class="pro"><strong>Default threshold</strong> — $125 (Premium break-even).</li>
+    <li class="note"><strong>Saved presets / export</strong> — deferred to a follow-up.</li>
+  </ul>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="accept">12 · Acceptance checklist</h2>
+<ul>
+  <li class="check"><em>Scenarios</em> appears in the admin sidebar; non-admins are redirected.</li>
+  <li class="check"><code>/scenarios</code> lists the API→Subscription calculator (registry-driven).</li>
+  <li class="check"><code>/scenarios/api-subscription</code> renders all 47 live API users with correct per-month spend.</li>
+  <li class="check">Default view reproduces the §2 anchor figures exactly.</li>
+  <li class="check">Slider / price / basis / population controls recompute cards, bars, verdict, and table live.</li>
+  <li class="check">Δ column colours and capacity warnings behave as specified.</li>
+  <li class="check"><code>lint</code> / <code>typecheck</code> / <code>format</code> clean; unit tests green with regression anchors.</li>
+  <li class="check">Adding a second calculator requires no edits to the first (registry + new route only).</li>
+</ul>
+
+<footer>
+  AI Developer Hub · spec/035-scenario-calculators · implementation plan · drafted 2026-06-09 · companion: prototype.html
+</footer>
+
+</main>
+</body>
+</html>

--- a/specs/035-scenario-calculators/prototype.html
+++ b/specs/035-scenario-calculators/prototype.html
@@ -1,0 +1,557 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>API → Subscription Migration Model · AI Developer Hub</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,900&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --paper:#FBF7EE;
+    --paper-2:#F4EDE0;
+    --panel:#FFFDF8;
+    --ink:#231D17;
+    --ink-soft:#736A5C;
+    --ink-faint:#9C9384;
+    --line:#E3D9C7;
+    --line-strong:#D2C5AC;
+    --clay:#BF5A37;        /* premium / over-cost */
+    --clay-deep:#9C4427;
+    --clay-wash:#F0DACE;
+    --slate:#3F6470;       /* standard */
+    --slate-wash:#DCE7E8;
+    --green:#4C7350;       /* savings */
+    --green-wash:#DCE7D8;
+    --gold:#B98908;
+    --shadow:0 1px 0 rgba(35,29,23,.04), 0 14px 34px -22px rgba(35,29,23,.45);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{
+    margin:0;
+    font-family:"Hanken Grotesk",system-ui,sans-serif;
+    color:var(--ink);
+    background:var(--paper);
+    background-image:
+      radial-gradient(60vw 40vw at 88% -8%, rgba(191,90,55,.07), transparent 60%),
+      radial-gradient(50vw 50vw at -10% 110%, rgba(63,100,112,.06), transparent 55%);
+    background-attachment:fixed;
+    -webkit-font-smoothing:antialiased;
+    line-height:1.5;
+  }
+  /* paper grain */
+  body::before{
+    content:"";position:fixed;inset:0;pointer-events:none;z-index:0;opacity:.04;mix-blend-mode:multiply;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  }
+  .wrap{position:relative;z-index:1;max-width:1240px;margin:0 auto;padding:0 28px 96px}
+  .mono{font-family:"JetBrains Mono",ui-monospace,monospace;font-variant-numeric:tabular-nums}
+  .eyebrow{font-family:"JetBrains Mono",monospace;font-size:11px;letter-spacing:.28em;text-transform:uppercase;color:var(--clay-deep);font-weight:500}
+
+  /* ---------- Header ---------- */
+  header{padding:54px 0 26px;border-bottom:1px solid var(--line-strong)}
+  .head-top{display:flex;justify-content:space-between;align-items:flex-start;gap:24px;flex-wrap:wrap}
+  h1{
+    font-family:"Fraunces",serif;font-optical-sizing:auto;
+    font-weight:900;font-size:clamp(34px,5.4vw,64px);line-height:.98;letter-spacing:-.015em;
+    margin:14px 0 0;max-width:15ch;
+  }
+  h1 em{font-style:italic;font-weight:500;color:var(--clay)}
+  .lede{margin:18px 0 0;max-width:62ch;font-size:16.5px;color:var(--ink-soft)}
+  .stamp{
+    text-align:right;font-family:"JetBrains Mono",monospace;font-size:11.5px;line-height:1.9;
+    color:var(--ink-soft);border:1px solid var(--line);background:var(--panel);
+    padding:12px 16px;border-radius:3px;white-space:nowrap;box-shadow:var(--shadow)
+  }
+  .stamp b{color:var(--ink)}
+
+  /* ---------- KPI strip ---------- */
+  .kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:0;margin:30px 0 8px;border:1px solid var(--line-strong);border-radius:4px;overflow:hidden;background:var(--panel);box-shadow:var(--shadow)}
+  .kpi{padding:20px 22px;border-right:1px solid var(--line)}
+  .kpi:last-child{border-right:0}
+  .kpi .lbl{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-faint);font-weight:600}
+  .kpi .val{font-family:"Fraunces",serif;font-weight:600;font-size:30px;margin-top:8px;letter-spacing:-.01em}
+  .kpi .sub{font-size:12.5px;color:var(--ink-soft);margin-top:3px}
+  .kpi .val.mono{font-family:"JetBrains Mono",monospace;font-size:26px}
+
+  section{margin-top:52px}
+  .sec-head{display:flex;align-items:baseline;gap:14px;margin-bottom:18px}
+  .sec-head h2{font-family:"Fraunces",serif;font-weight:600;font-size:24px;margin:0;letter-spacing:-.01em}
+  .sec-head .rule{flex:1;height:1px;background:var(--line-strong)}
+  .sec-head .n{font-family:"JetBrains Mono",monospace;font-size:12px;color:var(--clay-deep)}
+
+  /* ---------- Controls ---------- */
+  .controls{
+    position:sticky;top:0;z-index:30;
+    background:rgba(251,247,238,.86);backdrop-filter:blur(10px);
+    border:1px solid var(--line-strong);border-radius:5px;padding:18px 22px;margin-top:24px;
+    box-shadow:var(--shadow);
+    display:grid;grid-template-columns:repeat(2,minmax(170px,1fr)) 1.6fr 1.3fr;gap:22px 28px;align-items:end;
+  }
+  .ctrl label{display:block;font-size:11px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-faint);font-weight:600;margin-bottom:7px}
+  .field{display:flex;align-items:center;gap:8px;border:1px solid var(--line-strong);background:var(--panel);border-radius:4px;padding:0 12px;height:42px}
+  .field span.pre{color:var(--ink-faint);font-family:"JetBrains Mono",monospace}
+  .field input{border:0;background:transparent;font-family:"JetBrains Mono",monospace;font-size:16px;color:var(--ink);width:100%;outline:none}
+  select{
+    width:100%;height:42px;border:1px solid var(--line-strong);background:var(--panel);border-radius:4px;
+    padding:0 12px;font-family:"Hanken Grotesk",sans-serif;font-size:14.5px;color:var(--ink);cursor:pointer;outline:none
+  }
+  .thresh .row{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:7px}
+  .thresh .row .v{font-family:"JetBrains Mono",monospace;font-weight:700;color:var(--clay-deep)}
+  input[type=range]{width:100%;accent-color:var(--clay);height:24px;cursor:pointer}
+  .split-note{font-size:12px;color:var(--ink-soft);margin-top:6px}
+  .split-note b.p{color:var(--clay-deep)} .split-note b.s{color:var(--slate)}
+  .toggle{display:flex;border:1px solid var(--line-strong);border-radius:4px;overflow:hidden;height:42px}
+  .toggle button{flex:1;border:0;background:var(--panel);font-family:inherit;font-size:13px;color:var(--ink-soft);cursor:pointer;padding:0 8px;font-weight:600;letter-spacing:.02em}
+  .toggle button.on{background:var(--ink);color:var(--paper)}
+  .toggle button+button{border-left:1px solid var(--line-strong)}
+
+  /* ---------- Verdict ---------- */
+  .verdict{margin-top:26px;border-left:3px solid var(--clay);background:var(--panel);padding:18px 22px;border-radius:0 4px 4px 0;font-size:17px;box-shadow:var(--shadow)}
+  .verdict b{font-weight:700}
+  .verdict .save{color:var(--green);font-weight:700}
+  .verdict .cost{color:var(--clay-deep);font-weight:700}
+
+  /* ---------- Scenario cards ---------- */
+  .scenarios{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-top:24px}
+  .card{position:relative;border:1px solid var(--line-strong);border-radius:6px;background:var(--panel);padding:20px 20px 18px;box-shadow:var(--shadow);overflow:hidden}
+  .card::before{content:"";position:absolute;inset:0 0 auto 0;height:4px}
+  .card.baseline::before{background:var(--ink)}
+  .card.std::before{background:var(--slate)}
+  .card.prem::before{background:var(--clay)}
+  .card.hybrid::before{background:linear-gradient(90deg,var(--slate),var(--clay))}
+  .card .tag{font-size:11px;letter-spacing:.13em;text-transform:uppercase;font-weight:700;color:var(--ink-faint)}
+  .card h3{font-family:"Fraunces",serif;font-weight:600;font-size:19px;margin:5px 0 14px;letter-spacing:-.01em}
+  .card .big{font-family:"JetBrains Mono",monospace;font-weight:700;font-size:27px;letter-spacing:-.02em}
+  .card .big small{font-size:13px;color:var(--ink-faint);font-weight:500}
+  .card .annual{font-family:"JetBrains Mono",monospace;font-size:13.5px;color:var(--ink-soft);margin-top:4px}
+  .card .delta{margin-top:13px;padding-top:12px;border-top:1px dashed var(--line-strong);font-size:13.5px;font-weight:600}
+  .card .delta.save{color:var(--green)} .card .delta.cost{color:var(--clay-deep)} .card .delta.flat{color:var(--ink-faint)}
+  .card .mix{font-size:12px;color:var(--ink-soft);margin-top:7px}
+
+  /* ---------- Bar comparison ---------- */
+  .bars{border:1px solid var(--line-strong);border-radius:6px;background:var(--panel);padding:24px 26px;margin-top:24px;box-shadow:var(--shadow)}
+  .bar-row{display:grid;grid-template-columns:150px 1fr 150px;align-items:center;gap:16px;margin:13px 0}
+  .bar-row .name{font-size:13.5px;font-weight:600}
+  .bar-row .name small{display:block;color:var(--ink-faint);font-weight:500;font-size:11.5px}
+  .track{height:26px;background:var(--paper-2);border-radius:3px;overflow:hidden;position:relative}
+  .fill{height:100%;border-radius:3px;transition:width .5s cubic-bezier(.22,.61,.36,1)}
+  .fill.baseline{background:repeating-linear-gradient(45deg,var(--ink),var(--ink) 7px,#3a322a 7px,#3a322a 14px)}
+  .fill.std{background:var(--slate)} .fill.prem{background:var(--clay)}
+  .fill.hybrid{background:linear-gradient(90deg,var(--slate),var(--clay))}
+  .bar-row .amt{font-family:"JetBrains Mono",monospace;font-size:14px;font-weight:700;text-align:right}
+  .bar-row .amt small{display:block;font-weight:400;color:var(--ink-soft);font-size:11.5px}
+
+  /* ---------- Table ---------- */
+  .table-wrap{border:1px solid var(--line-strong);border-radius:6px;overflow:hidden;box-shadow:var(--shadow);background:var(--panel)}
+  .scroll{overflow-x:auto}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;min-width:880px}
+  thead th{
+    position:sticky;top:0;background:var(--paper-2);text-align:right;padding:13px 14px;
+    font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-soft);font-weight:700;
+    border-bottom:1px solid var(--line-strong);cursor:pointer;white-space:nowrap;user-select:none
+  }
+  thead th:first-child,thead th.l{text-align:left}
+  thead th:hover{color:var(--clay-deep)}
+  thead th .arr{opacity:.4;font-size:9px}
+  thead th.sorted .arr{opacity:1;color:var(--clay-deep)}
+  tbody td{padding:12px 14px;text-align:right;border-bottom:1px solid var(--line);white-space:nowrap}
+  tbody td:first-child,tbody td.l{text-align:left}
+  tbody tr:hover{background:var(--paper-2)}
+  tbody tr:last-child td{border-bottom:0}
+  .uname{font-weight:600;color:var(--ink)}
+  .umeta{font-size:11.5px;color:var(--ink-faint);margin-top:1px}
+  .num{font-family:"JetBrains Mono",monospace;font-variant-numeric:tabular-nums}
+  .muted{color:var(--ink-faint)}
+  .basis{font-weight:700}
+  .pill{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.04em;padding:3px 9px;border-radius:999px;text-transform:uppercase}
+  .pill.std{background:var(--slate-wash);color:var(--slate)}
+  .pill.prem{background:var(--clay-wash);color:var(--clay-deep)}
+  .pill.inactive{background:#EBE4D6;color:var(--ink-faint)}
+  .pill.active{background:var(--green-wash);color:var(--green)}
+  td.delta.save{color:var(--green);font-weight:700}
+  td.delta.cost{color:var(--clay-deep);font-weight:700}
+  tfoot td{padding:14px;background:var(--paper-2);font-weight:700;border-top:2px solid var(--line-strong);text-align:right}
+  tfoot td.l{text-align:left;font-family:"Fraunces",serif;font-size:15px}
+
+  /* ---------- Notes ---------- */
+  .notes{margin-top:46px;border-top:1px solid var(--line-strong);padding-top:24px;columns:2;column-gap:42px;font-size:13.5px;color:var(--ink-soft)}
+  .notes h4{font-family:"Fraunces",serif;color:var(--ink);font-size:15px;margin:0 0 8px}
+  .notes p{margin:0 0 14px;break-inside:avoid}
+  .notes code{font-family:"JetBrains Mono",monospace;font-size:12px;background:var(--paper-2);padding:1px 5px;border-radius:3px;color:var(--clay-deep)}
+  footer{margin-top:40px;font-family:"JetBrains Mono",monospace;font-size:11.5px;color:var(--ink-faint);text-align:center;letter-spacing:.04em}
+
+  @media(max-width:1000px){
+    .kpis{grid-template-columns:repeat(2,1fr)} .kpi:nth-child(2){border-right:0}
+    .controls{grid-template-columns:1fr 1fr} .scenarios{grid-template-columns:1fr 1fr}
+    .notes{columns:1}
+    .bar-row{grid-template-columns:110px 1fr 96px}
+  }
+  @media(max-width:620px){
+    .kpis{grid-template-columns:1fr}.kpi{border-right:0}
+    .controls,.scenarios{grid-template-columns:1fr}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header>
+    <div class="head-top">
+      <div>
+        <div class="eyebrow">Cost Model · Anthropic API → Claude Seats</div>
+        <h1>If every API key became a <em>subscription seat</em>.</h1>
+      </div>
+      <div class="stamp" id="stamp"></div>
+    </div>
+    <p class="lede">Every user holding a <b>Claude&nbsp;Console</b> (Anthropic API) key is a pay‑as‑you‑go consumer. This model maps each one onto a flat <b>Standard</b> or <b>Premium</b> Claude seat and compares the bill against today's metered API spend. Every input below is live — set seat prices, slide the heavy‑user threshold, and the scenarios recompute.</p>
+  </header>
+
+  <div class="kpis" id="kpis"></div>
+
+  <!-- CONTROLS -->
+  <div class="controls">
+    <div class="ctrl">
+      <label>Standard seat / mo</label>
+      <div class="field"><span class="pre">$</span><input id="stdPrice" type="number" min="0" step="1" value="25"></div>
+    </div>
+    <div class="ctrl">
+      <label>Premium seat / mo</label>
+      <div class="field"><span class="pre">$</span><input id="premPrice" type="number" min="0" step="1" value="125"></div>
+    </div>
+    <div class="ctrl thresh">
+      <div class="row"><label style="margin:0">Premium threshold — API spend ≥</label><span class="v" id="threshVal">$125</span></div>
+      <input id="thresh" type="range" min="0" max="300" step="5" value="125">
+      <div class="split-note" id="splitNote"></div>
+    </div>
+    <div class="ctrl">
+      <label>Usage basis</label>
+      <select id="basis">
+        <option value="avg3">Avg of Mar–May 2026 (run‑rate)</option>
+        <option value="m05">May 2026 (latest full month)</option>
+        <option value="m04">April 2026</option>
+        <option value="m03">March 2026</option>
+        <option value="max3">Peak full month (Mar/Apr/May)</option>
+      </select>
+      <label style="margin-top:14px">Population</label>
+      <div class="toggle" id="popToggle">
+        <button data-pop="all" class="on">All 47 keys</button>
+        <button data-pop="active">Active only (43)</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="verdict" id="verdict"></div>
+
+  <!-- SCENARIOS -->
+  <section>
+    <div class="sec-head"><span class="n">01</span><h2>Scenarios</h2><div class="rule"></div></div>
+    <div class="scenarios" id="scenarios"></div>
+
+    <div class="bars" id="bars"></div>
+  </section>
+
+  <!-- TABLE -->
+  <section>
+    <div class="sec-head"><span class="n">02</span><h2>Per‑user mapping</h2><div class="rule"></div></div>
+    <div class="table-wrap"><div class="scroll">
+      <table id="tbl">
+        <thead>
+          <tr>
+            <th class="l" data-k="name">User <span class="arr">▲▼</span></th>
+            <th data-k="status">Status <span class="arr">▲▼</span></th>
+            <th data-k="m03">Mar <span class="arr">▲▼</span></th>
+            <th data-k="m04">Apr <span class="arr">▲▼</span></th>
+            <th data-k="m05">May <span class="arr">▲▼</span></th>
+            <th data-k="jun">Jun·MTD <span class="arr">▲▼</span></th>
+            <th data-k="usage" class="sorted">API basis <span class="arr">▲▼</span></th>
+            <th data-k="rec">Seat <span class="arr">▲▼</span></th>
+            <th data-k="sub">Seat $/mo <span class="arr">▲▼</span></th>
+            <th data-k="delta">Δ seat − API <span class="arr">▲▼</span></th>
+          </tr>
+        </thead>
+        <tbody id="tbody"></tbody>
+        <tfoot id="tfoot"></tfoot>
+      </table>
+    </div></div>
+  </section>
+
+  <!-- NOTES -->
+  <div class="notes">
+    <h4>What you're looking at</h4>
+    <p>The population is the <b>47 Claude Console license assignments that carry an Anthropic API key</b> (tool <code>Claude Console</code>). These are the metered, pay‑as‑you‑go users — distinct from the <code>Claude</code> subscription tool, whose two seat tiers (Standard&nbsp;$25, Premium&nbsp;$125) supply the default prices here.</p>
+
+    <h4>Where the money comes from</h4>
+    <p>API spend is the real <code>computed_cost_cents</code> recorded per user per day in <code>anthropic_usage_metrics</code>, summed by month. Data runs <b>27&nbsp;Feb&nbsp;→&nbsp;9&nbsp;Jun&nbsp;2026</b>. February (2 days) and June (partial) are excluded from the run‑rate; <b>Mar/Apr/May are the only complete months</b>, so the default basis averages them.</p>
+
+    <h4>How a seat is assigned</h4>
+    <p>A user is mapped to <b>Premium</b> when their API basis spend is <b>at or above the threshold</b> slider, otherwise <b>Standard</b>. Raising the threshold pushes more people onto cheaper Standard seats. The <i>right‑sized</i> scenario bills each user their mapped seat; <i>all‑Standard</i> and <i>all‑Premium</i> ignore the threshold.</p>
+
+    <h4>Reading Δ seat − API</h4>
+    <p>For each user, <code>Δ = seat price − their API spend</code>. <span style="color:var(--green);font-weight:700">Green</span> means the flat seat is <i>cheaper</i> than what they burn on the API (a saving); <span style="color:var(--clay-deep);font-weight:700">clay</span> means the seat costs <i>more</i> than their metered usage — typically light or dormant keys.</p>
+
+    <h4>Caveats</h4>
+    <p>Figures are in <b>USD</b> as billed by Anthropic; seat prices are whatever you type. A flat seat assumes comparable capability/quota to the user's API usage — verify that a Standard seat actually covers a heavy user's workload before migrating. Currency conversion, taxes, and annual‑commit discounts are not modelled. 4 keys are <i>inactive</i> and only count when the population toggle is set to “All”.</p>
+  </div>
+
+  <footer id="footer"></footer>
+</div>
+
+<script>
+/* ----- Raw data: 47 Claude Console (API-key) assignments -----
+   m = [March, April, May, June-MTD] computed_cost_cents; t = all-time cents */
+const USERS = [
+ {id:17,n:"Lorenz Pfiffner",e:"lorenz.pfiffner@unic.com",s:"inactive",w:"boost-starter-3",bt:"leader",m:[25937,34602,25652,0],t:86294},
+ {id:12,n:"Jan Steffen",e:"jan.steffen@unic.com",s:"inactive",w:"boost-starter-2",bt:"leader",m:[15086,21937,20423,1465],t:58911},
+ {id:101,n:"Dechapon Bunpia",e:"dechapon.bunpia@unic.com",s:"active",w:"boost-starter-5",bt:"leader",m:[7257,20230,25464,4719],t:57670},
+ {id:6,n:"Roland Kołodziej",e:"roland.kolodziej@unic.com",s:"active",w:"boost-starter-1",bt:"leader",m:[8975,17610,24578,7465],t:58999},
+ {id:9,n:"Amrullo Olimov",e:"amrullo.olimov@unic.com",s:"active",w:"boost-starter-1",bt:"leader",m:[13754,17503,17238,1250],t:50255},
+ {id:26,n:"Robin Löffel",e:"robin.loeffel@unic.com",s:"active",w:"boost-expert-1",bt:"leader",m:[14738,10091,20758,5333],t:50920},
+ {id:36,n:"Mario Thiele",e:"mario.thiele@unic.com",s:"active",w:"boost-starter-5",bt:"starter",m:[13904,31090,0,0],t:44994},
+ {id:35,n:"David Däster",e:"david.daester@unic.com",s:"active",w:"boost-starter-5",bt:"leader",m:[16432,2282,25791,7098],t:51603},
+ {id:16,n:"Michał Bychawski",e:"michal.bychawski@unic.com",s:"active",w:"boost-starter-2",bt:"leader",m:[12412,18205,12352,1062],t:44232},
+ {id:7,n:"Felipe Monteiro de Carvalho",e:"f.monteirodecarvalho@unic.com",s:"active",w:"boost-starter-1",bt:"leader",m:[6816,13419,14447,4555],t:39419},
+ {id:31,n:"Ina Widmer",e:"ina.widmer@unic.com",s:"active",w:"boost-starter-4",bt:"expert",m:[15919,17757,0,0],t:33676},
+ {id:8,n:"Lukas Heilmann",e:"lukas.heilmann@unic.com",s:"active",w:"boost-starter-1",bt:"expert",m:[11072,5215,12781,3036],t:32619},
+ {id:24,n:"Katarzyna Pietraszko",e:"katarzyna.pietraszko@unic.com",s:"active",w:"boost-starter-4",bt:"expert",m:[10643,8329,9258,1709],t:29939},
+ {id:78,n:"Christoph Dubach",e:"christoph.dubach@unic.com",s:"inactive",w:"boost-starter-6",bt:"leader",m:[917,9679,16188,0],t:26784},
+ {id:18,n:"Gerald Wilhelm",e:"gerald.wilhelm@unic.com",s:"active",w:"boost-starter-3",bt:"leader",m:[7998,6811,11566,1887],t:28262},
+ {id:113,n:"Piotr Palej",e:"piotr.palej@unic.com",s:"active",w:"boost-starter-6",bt:"expert",m:[8675,8639,8073,0],t:25387},
+ {id:80,n:"Remo vonArx",e:"remo.vonarx@unic.com",s:"active",w:"boost-starter-6",bt:"expert",m:[670,9080,11848,0],t:21598},
+ {id:32,n:"Monika Kwiatek",e:"monika.kwiatek@unic.com",s:"active",w:"boost-starter-4",bt:"expert",m:[8086,8673,2260,6407],t:25426},
+ {id:33,n:"Roman Domke",e:"roman.domke@unic.com",s:"inactive",w:"boost-starter-4",bt:"expert",m:[97,7640,9403,7079],t:24219},
+ {id:21,n:"Marek Pierzchala",e:"marek.pierzchala@unic.com",s:"active",w:"boost-starter-3",bt:"advanced",m:[4826,6693,4269,1895],t:19542},
+ {id:13,n:"Oliver Ladner",e:"oliver.ladner@unic.com",s:"active",w:"boost-starter-2",bt:"expert",m:[2713,6098,6316,1905],t:17041},
+ {id:115,n:"Tomasz Wołowiec",e:"tomasz.wolowiec@unic.com",s:"active",w:"boost-starter-7",bt:"expert",m:[0,6601,7880,2504],t:16985},
+ {id:19,n:"Joanna Bałanda",e:"joanna.balanda@unic.com",s:"active",w:"boost-starter-3",bt:"leader",m:[670,5421,7795,0],t:13886},
+ {id:37,n:"Corinne Wydler-Roelli",e:"c.wydler-roelli@unic.com",s:"active",w:"boost-starter-5",bt:"starter",m:[4416,5693,3725,149],t:13983},
+ {id:20,n:"Balbina Trepka",e:"balbina.trepka@unic.com",s:"active",w:"boost-starter-3",bt:"advanced",m:[8864,2246,2373,0],t:13483},
+ {id:114,n:"Cédric Zeier",e:"cedric.zeier@unic.com",s:"active",w:"boost-starter-7",bt:"expert",m:[372,8484,3664,1274],t:13794},
+ {id:75,n:"Janick Kunz",e:"janick.kunz@unic.com",s:"active",w:"boost-starter-9",bt:"starter",m:[0,0,10223,0],t:10223},
+ {id:62,n:"Lukas Schiffmann",e:"lukas.schiffmann@unic.com",s:"active",w:"boost-starter-6",bt:"expert",m:[373,5538,4241,624],t:10776},
+ {id:11,n:"Robert Schumann",e:"robert.schumann@unic.com",s:"active",w:"boost-starter-2",bt:"starter",m:[5590,3430,635,512],t:10821},
+ {id:29,n:"Martin Kriegler",e:"martin.kriegler@unic.com",s:"active",w:"boost-starter-4",bt:"advanced",m:[2675,544,5684,24],t:8927},
+ {id:96,n:"Igor Galenchik",e:"igor.galenchik@unic.com",s:"active",w:"boost-starter-7",bt:"advanced",m:[754,3183,3901,1124],t:8962},
+ {id:14,n:"Fredi Bach",e:"fredi.bach@unic.com",s:"active",w:"boost-starter-2",bt:"advanced",m:[2231,3029,1885,182],t:7327},
+ {id:73,n:"Fridolin Jackstadt",e:"fridolin.jackstadt@unic.com",s:"active",w:"boost-starter-8",bt:"advanced",m:[0,0,4900,0],t:4900},
+ {id:92,n:"Agnieszka Skarupinska",e:"a.skarupinska@unic.com",s:"active",w:"boost-starter-8",bt:"starter",m:[0,644,3250,0],t:3894},
+ {id:34,n:"Patricia Gomez",e:"patricia.gomez@unic.com",s:"active",w:"boost-starter-5",bt:"advanced",m:[80,2163,1424,48],t:3715},
+ {id:131,n:"Silvia Monti",e:"silvia.monti@unic.com",s:"active",w:"boost-starter-6",bt:"starter",m:[27,733,2796,5377],t:8933},
+ {id:51,n:"Johannes Riese",e:"johannes.riese@unic.com",s:"active",w:"boost-starter-7",bt:"starter",m:[0,1310,2144,18],t:3472},
+ {id:103,n:"Alexander Farkas",e:"alexander.farkas@unic.com",s:"active",w:"boost-starter-8",bt:"starter",m:[0,0,3036,999],t:4035},
+ {id:54,n:"Branko Markovic",e:"branko.markovic@unic.com",s:"active",w:"boost-starter-8",bt:"starter",m:[0,0,366,0],t:366},
+ {id:135,n:"Nicolas Suter",e:"nicolas.suter@unic.com",s:"active",w:"boost-starter-7",bt:"starter",m:[0,0,259,0],t:259},
+ {id:22,n:"Marcin Zalewski",e:"marcin.zalewski@unic.com",s:"active",w:"boost-starter-9",bt:"starter",m:[0,0,0,51],t:51},
+ {id:3,n:"Mathias Indermühle",e:"mathias.indermuehle@unic.com",s:"active",w:"boost-starter-1",bt:"starter",m:[0,0,0,0],t:0},
+ {id:106,n:"Natalia Pokusa",e:"natalia.pokusa@unic.com",s:"active",w:"boost-starter-9",bt:"starter",m:[0,0,0,375],t:375},
+ {id:82,n:"Artur Oberski",e:"artur.oberski@unic.com",s:"active",w:"boost-starter-9",bt:"starter",m:[0,0,0,10342],t:10342},
+ {id:55,n:"Maciej Pochciał",e:"maciej.pochcial@unic.com",s:"active",w:"boost-starter-8",bt:"starter",m:[0,0,0,0],t:0},
+ {id:57,n:"Raphael Eymann",e:"raphael.eymann@unic.com",s:"active",w:"boost-starter-9",bt:"starter",m:[0,0,0,0],t:0},
+ {id:2,n:"Tobias Studer",e:"tobias.studer@unic.com",s:"active",w:"Automations",bt:"advanced",m:[0,0,1,1],t:2},
+];
+
+/* ---------- formatters ---------- */
+const usd0 = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:0});
+const usd2 = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',minimumFractionDigits:2,maximumFractionDigits:2});
+const $c0 = c => usd0.format(c/100);
+const $c2 = c => usd2.format(c/100);
+const $cAuto = c => Math.abs(c) >= 100000 ? $c0(c) : $c2(c);
+
+/* ---------- state ---------- */
+const state = { stdPrice:2500, premPrice:12500, thresh:12500, basis:'avg3', pop:'all',
+                sortK:'usage', sortDir:-1 };
+
+/* basis usage in cents for a user */
+function usage(u){
+  const [a,b,c]=u.m;
+  switch(state.basis){
+    case 'm03':return a; case 'm04':return b; case 'm05':return c;
+    case 'max3':return Math.max(a,b,c);
+    default:return Math.round((a+b+c)/3); // avg3
+  }
+}
+function pool(){ return state.pop==='active' ? USERS.filter(u=>u.s==='active') : USERS.slice(); }
+
+/* ---------- render ---------- */
+function render(){
+  const list = pool();
+  const n = list.length;
+  let baseline=0, hybrid=0, nPrem=0, nStd=0;
+  const rows = list.map(u=>{
+    const use = usage(u);
+    const prem = use >= state.thresh;
+    const seat = prem ? state.premPrice : state.stdPrice;
+    baseline += use; hybrid += seat;
+    if(prem) nPrem++; else nStd++;
+    return {u, use, prem, seat, delta: seat-use};
+  });
+  const allStd = n*state.stdPrice;
+  const allPrem = n*state.premPrice;
+
+  /* ---- KPIs (fixed run-rate context, independent of pop toggle uses full set) ---- */
+  const fullAvg = USERS.reduce((s,u)=>s+Math.round((u.m[0]+u.m[1]+u.m[2])/3),0);
+  document.getElementById('kpis').innerHTML = `
+    <div class="kpi"><div class="lbl">API keys in scope</div><div class="val">${n}<small style="font-size:14px;color:var(--ink-faint)"> / 47</small></div><div class="sub">${state.pop==='active'?'active assignments':'all assignments (4 inactive)'}</div></div>
+    <div class="kpi"><div class="lbl">Current API run‑rate</div><div class="val mono">${$c0(baseline)}</div><div class="sub">per month · ${basisLabel()}</div></div>
+    <div class="kpi"><div class="lbl">Annualised API spend</div><div class="val mono">${$c0(baseline*12)}</div><div class="sub">${$c0(baseline)} × 12</div></div>
+    <div class="kpi"><div class="lbl">Heavy users ≥ ${$c0(state.thresh)}</div><div class="val">${nPrem}</div><div class="sub">${nStd} fit a Standard seat</div></div>`;
+
+  /* ---- split note ---- */
+  document.getElementById('splitNote').innerHTML =
+    `<b class="p">${nPrem} → Premium</b> &nbsp;·&nbsp; <b class="s">${nStd} → Standard</b>`;
+
+  /* ---- scenario cards ---- */
+  const scen = [
+    {cls:'baseline',tag:'Today',name:'Metered API',m:baseline,mix:`${n} pay‑as‑you‑go keys`},
+    {cls:'std',tag:'Flat',name:'All → Standard',m:allStd,mix:`${n} × ${$c0(state.stdPrice)}`},
+    {cls:'prem',tag:'Flat',name:'All → Premium',m:allPrem,mix:`${n} × ${$c0(state.premPrice)}`},
+    {cls:'hybrid',tag:'Right‑sized',name:'Threshold mix',m:hybrid,mix:`${nPrem} Prem + ${nStd} Std`},
+  ];
+  document.getElementById('scenarios').innerHTML = scen.map(s=>{
+    let d='', dcls='flat';
+    if(s.cls!=='baseline'){
+      const diff=s.m-baseline;
+      if(diff<-0.5){dcls='save';d=`▼ ${$c0(-diff)}/mo saved`;}
+      else if(diff>0.5){dcls='cost';d=`▲ ${$c0(diff)}/mo more`;}
+      else d='— same as API';
+    } else d=`baseline · ${$c0(s.m*12)}/yr`;
+    return `<div class="card ${s.cls}">
+      <div class="tag">${s.tag}</div><h3>${s.name}</h3>
+      <div class="big">${$c0(s.m)}<small> /mo</small></div>
+      <div class="annual">${$c0(s.m*12)} / year</div>
+      <div class="delta ${dcls}">${d}</div>
+      <div class="mix">${s.mix}</div>
+    </div>`;
+  }).join('');
+
+  /* ---- bars ---- */
+  const maxM = Math.max(baseline,allStd,allPrem,hybrid,1);
+  const barRows = [
+    {cls:'baseline',name:'Metered API',sub:'today',m:baseline},
+    {cls:'std',name:'All Standard',sub:`${n}×${$c0(state.stdPrice)}`,m:allStd},
+    {cls:'prem',name:'All Premium',sub:`${n}×${$c0(state.premPrice)}`,m:allPrem},
+    {cls:'hybrid',name:'Right‑sized',sub:`${nPrem}P · ${nStd}S`,m:hybrid},
+  ];
+  document.getElementById('bars').innerHTML = barRows.map(b=>`
+    <div class="bar-row">
+      <div class="name">${b.name}<small>${b.sub}</small></div>
+      <div class="track"><div class="fill ${b.cls}" style="width:${(b.m/maxM*100).toFixed(1)}%"></div></div>
+      <div class="amt">${$c0(b.m)}<small>${$c0(b.m*12)}/yr</small></div>
+    </div>`).join('');
+
+  /* ---- verdict ---- */
+  const bestFlat = Math.min(allStd,hybrid);
+  const diffHy = baseline-hybrid;
+  let v;
+  if(diffHy>0.5){
+    v=`Moving all <b>${n}</b> API users to right‑sized seats (<b>${nPrem}</b> Premium + <b>${nStd}</b> Standard) costs <b>${$c0(hybrid)}/mo</b> — a <span class="save">${$c0(diffHy)}/mo (${(diffHy/baseline*100).toFixed(0)}%) saving</span> against the ${$c0(baseline)}/mo API run‑rate, or <span class="save">${$c0(diffHy*12)}/year</span>.`;
+  } else if(diffHy<-0.5){
+    v=`Right‑sized seats would cost <span class="cost">${$c0(-diffHy)}/mo (${(-diffHy/baseline*100).toFixed(0)}%) more</span> than today's ${$c0(baseline)}/mo API spend — at these prices the metered API is cheaper. Lower the seat prices or raise the threshold to flip this.`;
+  } else {
+    v=`Right‑sized seats land at <b>${$c0(hybrid)}/mo</b>, essentially matching the ${$c0(baseline)}/mo API run‑rate.`;
+  }
+  document.getElementById('verdict').innerHTML = v;
+
+  /* ---- table ---- */
+  rows.sort(cmp);
+  const tb = document.getElementById('tbody');
+  tb.innerHTML = rows.map((r,i)=>{
+    const u=r.u;
+    const dcls = r.delta< -0.5?'save':(r.delta>0.5?'cost':'');
+    const dtxt = r.delta< -0.5?`−${$cAuto(-r.delta)}`:(r.delta>0.5?`+${$cAuto(r.delta)}`:`—`);
+    return `<tr>
+      <td class="l"><div class="uname">${u.n}</div><div class="umeta">${u.w} · boost‑${u.bt}</div></td>
+      <td><span class="pill ${u.s}">${u.s}</span></td>
+      <td class="num muted">${u.m[0]?$c2(u.m[0]):'·'}</td>
+      <td class="num muted">${u.m[1]?$c2(u.m[1]):'·'}</td>
+      <td class="num muted">${u.m[2]?$c2(u.m[2]):'·'}</td>
+      <td class="num muted">${u.m[3]?$c2(u.m[3]):'·'}</td>
+      <td class="num basis">${$c2(r.use)}</td>
+      <td><span class="pill ${r.prem?'prem':'std'}">${r.prem?'Premium':'Standard'}</span></td>
+      <td class="num">${$c0(r.seat)}</td>
+      <td class="num delta ${dcls}">${dtxt}</td>
+    </tr>`;
+  }).join('');
+
+  document.getElementById('tfoot').innerHTML = `<tr>
+    <td class="l">Totals · ${n} keys</td><td></td>
+    <td class="num">${$c0(sum(rows,r=>r.u.m[0]))}</td>
+    <td class="num">${$c0(sum(rows,r=>r.u.m[1]))}</td>
+    <td class="num">${$c0(sum(rows,r=>r.u.m[2]))}</td>
+    <td class="num">${$c0(sum(rows,r=>r.u.m[3]))}</td>
+    <td class="num">${$c0(baseline)}</td>
+    <td class="num">${nPrem}P/${nStd}S</td>
+    <td class="num">${$c0(hybrid)}</td>
+    <td class="num ${hybrid<baseline?'delta save':'delta cost'}">${hybrid<baseline?'−':'+'}${$c0(Math.abs(hybrid-baseline))}</td>
+  </tr>`;
+
+  markSortedHeader();
+}
+function sum(rows,f){return rows.reduce((s,r)=>s+f(r),0);}
+function basisLabel(){
+  return {avg3:'avg Mar–May',m05:'May 2026',m04:'Apr 2026',m03:'Mar 2026',max3:'peak month'}[state.basis];
+}
+
+/* ---------- sorting ---------- */
+function cmp(A,B){
+  const d=state.sortDir, k=state.sortK;
+  const get=(r)=>{
+    switch(k){
+      case 'name':return r.u.n.toLowerCase();
+      case 'status':return r.u.s;
+      case 'm03':return r.u.m[0]; case 'm04':return r.u.m[1];
+      case 'm05':return r.u.m[2]; case 'jun':return r.u.m[3];
+      case 'usage':return r.use; case 'sub':return r.seat;
+      case 'rec':return r.prem?1:0; case 'delta':return r.delta;
+      default:return r.use;
+    }
+  };
+  const a=get(A), b=get(B);
+  if(a<b)return -1*d; if(a>b)return 1*d; return 0;
+}
+function markSortedHeader(){
+  document.querySelectorAll('#tbl thead th').forEach(th=>{
+    const on = th.dataset.k===state.sortK;
+    th.classList.toggle('sorted', on);
+    const arr = th.querySelector('.arr');
+    if(arr) arr.textContent = on ? (state.sortDir<0 ? '▼' : '▲') : '▲▼';
+  });
+}
+
+/* ---------- wire up ---------- */
+function setPrice(){
+  state.stdPrice = Math.max(0,Math.round((+document.getElementById('stdPrice').value||0)*100));
+  state.premPrice = Math.max(0,Math.round((+document.getElementById('premPrice').value||0)*100));
+  render();
+}
+document.getElementById('stdPrice').addEventListener('input',setPrice);
+document.getElementById('premPrice').addEventListener('input',setPrice);
+document.getElementById('thresh').addEventListener('input',e=>{
+  state.thresh = (+e.target.value)*100;
+  document.getElementById('threshVal').textContent = '$'+(+e.target.value);
+  render();
+});
+document.getElementById('basis').addEventListener('change',e=>{state.basis=e.target.value;render();});
+document.querySelectorAll('#popToggle button').forEach(b=>b.addEventListener('click',()=>{
+  document.querySelectorAll('#popToggle button').forEach(x=>x.classList.remove('on'));
+  b.classList.add('on'); state.pop=b.dataset.pop; render();
+}));
+document.querySelectorAll('#tbl thead th').forEach(th=>th.addEventListener('click',()=>{
+  const k=th.dataset.k;
+  if(state.sortK===k){state.sortDir*=-1;}
+  else{state.sortK=k; state.sortDir = (k==='name'||k==='status')?1:-1;}
+  render();
+}));
+
+/* stamp + footer */
+document.getElementById('stamp').innerHTML =
+  `DATA WINDOW<br><b>27 Feb – 9 Jun 2026</b><br>complete months: <b>Mar·Apr·May</b><br>source: anthropic_usage_metrics`;
+document.getElementById('footer').textContent =
+  'AI Developer Hub · API→Subscription cost model · figures in USD · generated 2026-06-09 from live Neon data (project broad-shadow-82397229)';
+
+render();
+</script>
+</body>
+</html>

--- a/src/actions/scenarios.ts
+++ b/src/actions/scenarios.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { unstable_cache } from "next/cache";
+import { requireAdmin } from "@/lib/auth-helpers";
+import { getApiSubscriptionDataset } from "@/lib/scenarios/queries";
+import type { ApiSubscriptionDataset } from "@/lib/scenarios/types";
+
+// Cached behind the same revalidation cadence as the Anthropic usage data.
+// Tag: revalidate with `revalidateTag("scenarios:api-subscription")` from the
+// Anthropic usage sync when fresher numbers are needed sooner than the TTL.
+const loadCached = unstable_cache(
+  () => getApiSubscriptionDataset(),
+  ["scenarios:api-subscription:v1"],
+  { tags: ["scenarios:api-subscription"], revalidate: 3600 },
+);
+
+export async function loadApiSubscriptionDataset(): Promise<ApiSubscriptionDataset> {
+  const admin = await requireAdmin();
+  if (!admin) throw new Error("Unauthorized");
+  return loadCached();
+}

--- a/src/app/scenarios/api-subscription/api-subscription-client.tsx
+++ b/src/app/scenarios/api-subscription/api-subscription-client.tsx
@@ -1,0 +1,834 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ArrowDown, ArrowUp, ChevronsUpDown, RotateCcw } from "lucide-react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Card, CardContent } from "@/components/ui/card";
+import { SegmentedBar } from "@/components/ui/segmented-bar";
+import { cn, formatCurrency } from "@/lib/utils";
+import { formatUSD0 } from "@/lib/chart-format";
+import {
+  computeScenarios,
+  type Population,
+  type ScenarioInputs,
+  type ScenarioRow,
+  type UsageBasis,
+} from "@/lib/scenarios/api-subscription";
+import type { ApiSubscriptionDataset } from "@/lib/scenarios/types";
+
+// Headline/aggregate figures use whole-dollar formatUSD0; per-user cells keep
+// 2-decimal precision via formatCurrency.
+
+function monthLabel(ym: string, withYear: boolean): string {
+  const [y, m] = ym.split("-").map(Number);
+  const mon = new Date(Date.UTC(y, m - 1, 1)).toLocaleString("en-US", {
+    month: "short",
+    timeZone: "UTC",
+  });
+  return withYear ? `${mon} '${String(y).slice(2)}` : mon;
+}
+
+function toBasis(key: string): UsageBasis {
+  if (key.startsWith("month:")) return { month: key.slice(6) };
+  return key as Exclude<UsageBasis, object>;
+}
+
+function basisLabel(key: string, ds: ApiSubscriptionDataset): string {
+  if (key.startsWith("month:")) return monthLabel(key.slice(6), true);
+  if (key === "latestComplete") return "latest complete month";
+  if (key === "peakComplete") return "peak complete month";
+  return `avg of ${ds.completeMonths.length} complete months`;
+}
+
+type SortKey = "name" | "status" | "usage" | "tier" | "seat" | "delta";
+
+export function ApiSubscriptionClient({
+  dataset,
+}: {
+  dataset: ApiSubscriptionDataset;
+}) {
+  const [standardDollars, setStandardDollars] = useState(
+    dataset.defaultStandardCents / 100,
+  );
+  const [premiumDollars, setPremiumDollars] = useState(
+    dataset.defaultPremiumCents / 100,
+  );
+  const [thresholdDollars, setThresholdDollars] = useState(
+    Math.round(dataset.defaultPremiumCents / 100),
+  );
+  const [basisKey, setBasisKey] = useState("avgComplete");
+  const [population, setPopulation] = useState<Population>("all");
+  const [sort, setSort] = useState<{ key: SortKey; dir: 1 | -1 }>({
+    key: "usage",
+    dir: -1,
+  });
+
+  const inputs: ScenarioInputs = useMemo(
+    () => ({
+      standardCents: Math.max(0, Math.round(standardDollars * 100)),
+      premiumCents: Math.max(0, Math.round(premiumDollars * 100)),
+      premiumThresholdCents: Math.max(0, Math.round(thresholdDollars * 100)),
+      basis: toBasis(basisKey),
+      population,
+    }),
+    [standardDollars, premiumDollars, thresholdDollars, basisKey, population],
+  );
+
+  const result = useMemo(
+    () => computeScenarios(dataset, inputs),
+    [dataset, inputs],
+  );
+
+  const activeCount = useMemo(
+    () => dataset.users.filter((u) => u.status === "active").length,
+    [dataset.users],
+  );
+
+  const displayMonths = useMemo(
+    () => [...dataset.completeMonths, ...dataset.partialMonths].sort(),
+    [dataset.completeMonths, dataset.partialMonths],
+  );
+  const partialSet = useMemo(
+    () => new Set(dataset.partialMonths),
+    [dataset.partialMonths],
+  );
+  const spanMultiYear = useMemo(
+    () => new Set(displayMonths.map((m) => m.slice(0, 4))).size > 1,
+    [displayMonths],
+  );
+
+  // Per-month column totals for the table footer, in a single pass over the
+  // population (avoids re-scanning all rows once per column on every render).
+  const monthColumnSums = useMemo(() => {
+    const sums: Record<string, number> = {};
+    for (const row of result.rows) {
+      for (const m of displayMonths) {
+        sums[m] = (sums[m] ?? 0) + (row.user.monthly[m] ?? 0);
+      }
+    }
+    return sums;
+  }, [result.rows, displayMonths]);
+
+  const sortedRows = useMemo(() => {
+    const { key, dir } = sort;
+    const val = (r: ScenarioRow): string | number => {
+      switch (key) {
+        case "name":
+          return r.user.name.toLowerCase();
+        case "status":
+          return r.user.status;
+        case "tier":
+          return r.tier === "premium" ? 1 : 0;
+        case "seat":
+          return r.seatCents;
+        case "delta":
+          return r.deltaCents;
+        default:
+          return r.usageCents;
+      }
+    };
+    return [...result.rows].sort((a, b) => {
+      const x = val(a);
+      const y = val(b);
+      if (x < y) return -1 * dir;
+      if (x > y) return 1 * dir;
+      return 0;
+    });
+  }, [result.rows, sort]);
+
+  function toggleSort(key: SortKey) {
+    setSort((prev) =>
+      prev.key === key
+        ? { key, dir: prev.dir === 1 ? -1 : 1 }
+        : { key, dir: key === "name" || key === "status" ? 1 : -1 },
+    );
+  }
+
+  function reset() {
+    setStandardDollars(dataset.defaultStandardCents / 100);
+    setPremiumDollars(dataset.defaultPremiumCents / 100);
+    setThresholdDollars(Math.round(dataset.defaultPremiumCents / 100));
+    setBasisKey("avgComplete");
+    setPopulation("all");
+  }
+
+  const saving = result.baselineCents - result.rightSizedCents; // + = saving
+  const savesMoney = saving > 0;
+  const savingPct =
+    result.baselineCents > 0
+      ? Math.round((Math.abs(saving) / result.baselineCents) * 100)
+      : 0;
+  const savingSign = savesMoney ? "−" : "+";
+  const verdictPhrase = savesMoney
+    ? `a ${savingPct}% cut from`
+    : `${savingPct}% above`;
+
+  // Single source for the four scenarios — drives both the cards and the bars.
+  const scenarios = [
+    {
+      tag: "Today",
+      title: "Metered API",
+      barLabel: "Metered API",
+      barSub: "today",
+      cents: result.baselineCents,
+      mix: `${result.count} pay-as-you-go keys`,
+      isBaseline: true,
+    },
+    {
+      tag: "Flat",
+      title: "All → Standard",
+      barLabel: "All Standard",
+      barSub: `${result.count} seats`,
+      cents: result.allStandardCents,
+      mix: `${result.count} × ${formatUSD0(inputs.standardCents)}`,
+      isBaseline: false,
+    },
+    {
+      tag: "Flat",
+      title: "All → Premium",
+      barLabel: "All Premium",
+      barSub: `${result.count} seats`,
+      cents: result.allPremiumCents,
+      mix: `${result.count} × ${formatUSD0(inputs.premiumCents)}`,
+      isBaseline: false,
+    },
+    {
+      tag: "Right-sized",
+      title: "Threshold mix",
+      barLabel: "Right-sized",
+      barSub: `${result.premiumCount}P · ${result.standardCount}S`,
+      cents: result.rightSizedCents,
+      mix: `${result.premiumCount} Premium · ${result.standardCount} Standard`,
+      isBaseline: false,
+    },
+  ];
+  const maxBar = Math.max(...scenarios.map((s) => s.cents), 1);
+
+  const basisOptions = [
+    {
+      v: "avgComplete",
+      l: `Avg · ${dataset.completeMonths.length} complete mo`,
+    },
+    {
+      v: "latestComplete",
+      l: `Latest · ${
+        dataset.completeMonths.length
+          ? monthLabel(
+              dataset.completeMonths[dataset.completeMonths.length - 1],
+              spanMultiYear,
+            )
+          : "—"
+      }`,
+    },
+    { v: "peakComplete", l: "Peak complete month" },
+    ...dataset.completeMonths.map((m) => ({
+      v: `month:${m}`,
+      l: monthLabel(m, true),
+    })),
+  ];
+
+  return (
+    <div className="space-y-6">
+      {/* CONTROLS — the instrument panel */}
+      <Card>
+        <CardContent className="p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+              Assumptions
+            </span>
+            <button
+              type="button"
+              onClick={reset}
+              className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <RotateCcw className="size-3" aria-hidden /> Reset to live
+            </button>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
+            <PriceField
+              id="std-price"
+              label="Standard seat"
+              value={standardDollars}
+              onChange={setStandardDollars}
+            />
+            <PriceField
+              id="prem-price"
+              label="Premium seat"
+              value={premiumDollars}
+              onChange={setPremiumDollars}
+            />
+
+            <div>
+              <div className="flex items-baseline justify-between">
+                <ControlLabel htmlFor="threshold">
+                  Premium threshold ≥
+                </ControlLabel>
+                <span className="font-mono text-sm tabular-nums text-ink">
+                  {formatUSD0(inputs.premiumThresholdCents)}
+                </span>
+              </div>
+              <input
+                id="threshold"
+                type="range"
+                min={0}
+                max={300}
+                step={5}
+                value={thresholdDollars}
+                onChange={(e) => setThresholdDollars(Number(e.target.value))}
+                className="mt-3 w-full cursor-pointer"
+                style={{ accentColor: "var(--ink)" }}
+                aria-label="Premium threshold, dollars per month"
+              />
+              <p className="mt-1.5 font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
+                <span className="text-ink">{result.premiumCount}</span> Premium
+                · <span className="text-ink">{result.standardCount}</span>{" "}
+                Standard
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <ControlLabel htmlFor="basis">Usage basis</ControlLabel>
+                <Select value={basisKey} onValueChange={setBasisKey}>
+                  <SelectTrigger id="basis" className="mt-2 w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {basisOptions.map((o) => (
+                      <SelectItem key={o.v} value={o.v}>
+                        {o.l}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <ControlLabel>Population</ControlLabel>
+                <div className="mt-2 inline-flex w-full overflow-hidden rounded-[6px] border border-input">
+                  <ToggleButton
+                    active={population === "all"}
+                    onClick={() => setPopulation("all")}
+                  >
+                    All {dataset.users.length}
+                  </ToggleButton>
+                  <ToggleButton
+                    active={population === "active"}
+                    onClick={() => setPopulation("active")}
+                  >
+                    Active {activeCount}
+                  </ToggleButton>
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* KPIs */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Kpi
+          label="Keys in scope"
+          value={
+            <>
+              {result.count}
+              <span className="text-base text-faint">
+                {" "}
+                / {dataset.users.length}
+              </span>
+            </>
+          }
+          sub={
+            population === "active"
+              ? "active assignments"
+              : `all keys · ${dataset.users.length - activeCount} inactive`
+          }
+        />
+        <Kpi
+          label="Current API run-rate"
+          value={formatUSD0(result.baselineCents)}
+          sub={`per month · ${basisLabel(basisKey, dataset)}`}
+        />
+        <Kpi
+          label="Annualised API spend"
+          value={formatUSD0(result.baselineCents * 12)}
+          sub={`${formatUSD0(result.baselineCents)} × 12`}
+        />
+        <Kpi
+          label={`Heavy users ≥ ${formatUSD0(inputs.premiumThresholdCents)}`}
+          value={result.premiumCount}
+          sub={`${result.standardCount} fit a Standard seat`}
+        />
+      </div>
+
+      {/* VERDICT — the one expressive moment */}
+      <div
+        className={cn(
+          "flex flex-col gap-1 border-l-2 bg-card px-5 py-4",
+          savesMoney ? "border-ink" : "border-destructive",
+        )}
+      >
+        <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+          Right-sized verdict
+        </p>
+        <p
+          className={cn(
+            "font-display text-3xl tabular-nums",
+            savesMoney ? "text-ink" : "text-destructive",
+          )}
+        >
+          {savingSign}
+          {formatUSD0(Math.abs(saving) * 12)}
+          <span className="ml-2 font-mono text-sm text-muted-foreground">
+            / year
+          </span>
+        </p>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          Moving all {result.count} API users to {result.premiumCount} Premium +{" "}
+          {result.standardCount} Standard seats costs{" "}
+          <span className="text-ink">
+            {formatUSD0(result.rightSizedCents)}/mo
+          </span>{" "}
+          — {verdictPhrase} the {formatUSD0(result.baselineCents)}/mo API
+          run-rate.
+        </p>
+      </div>
+
+      {/* SCENARIO CARDS */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {scenarios.map((s) => {
+          const delta = s.cents - result.baselineCents;
+          return (
+            <Card key={s.title}>
+              <CardContent className="p-5">
+                <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-faint">
+                  {s.tag}
+                </p>
+                <p className="mt-0.5 text-sm font-medium text-ink">{s.title}</p>
+                <p className="mt-3 font-mono text-2xl tabular-nums tracking-tight text-ink">
+                  {formatUSD0(s.cents)}
+                  <span className="text-sm text-faint"> /mo</span>
+                </p>
+                <p className="mt-1 font-mono text-xs tabular-nums text-muted-foreground">
+                  {formatUSD0(s.cents * 12)} / yr
+                </p>
+                <div className="mt-3 border-t border-border pt-2.5 text-xs font-medium">
+                  {s.isBaseline ? (
+                    <span className="text-muted-foreground">baseline</span>
+                  ) : Math.abs(delta) < 50 ? (
+                    <span className="text-muted-foreground">≈ same as API</span>
+                  ) : delta < 0 ? (
+                    <span className="text-success">
+                      ▼ {formatUSD0(-delta)}/mo saved
+                    </span>
+                  ) : (
+                    <span className="text-destructive">
+                      ▲ {formatUSD0(delta)}/mo more
+                    </span>
+                  )}
+                </div>
+                <p className="mt-2 text-[11px] text-muted-foreground">
+                  {s.mix}
+                </p>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* COMPARISON BARS */}
+      <Card>
+        <CardContent className="space-y-3 p-5">
+          <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            Monthly cost comparison
+          </p>
+          {scenarios.map((s) => (
+            <div
+              key={s.barLabel}
+              className="grid grid-cols-[112px_1fr_auto] items-center gap-3 sm:grid-cols-[140px_1fr_auto]"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-[13px] font-medium text-ink">
+                  {s.barLabel}
+                </p>
+                <p className="font-mono text-[10px] uppercase tracking-wide text-faint">
+                  {s.barSub}
+                </p>
+              </div>
+              <SegmentedBar
+                value={s.cents / maxBar}
+                segments={28}
+                ariaLabel={`${s.barLabel}: ${formatUSD0(s.cents)} per month`}
+              />
+              <div className="text-right">
+                <p className="font-mono text-sm tabular-nums text-ink">
+                  {formatUSD0(s.cents)}
+                </p>
+                <p className="font-mono text-[10px] tabular-nums text-faint">
+                  {formatUSD0(s.cents * 12)}/yr
+                </p>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* PER-USER TABLE */}
+      <Card>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table className="min-w-[820px]">
+              <TableHeader>
+                <TableRow>
+                  <SortableHead
+                    label="User"
+                    k="name"
+                    sort={sort}
+                    onSort={toggleSort}
+                    align="left"
+                  />
+                  <SortableHead
+                    label="Status"
+                    k="status"
+                    sort={sort}
+                    onSort={toggleSort}
+                  />
+                  {displayMonths.map((m) => (
+                    <TableHead
+                      key={m}
+                      className="text-right"
+                      title={
+                        partialSet.has(m) ? "partial month (month-to-date)" : m
+                      }
+                    >
+                      <span
+                        className={cn(
+                          "font-mono text-[10px] uppercase tracking-wide",
+                          partialSet.has(m) && "text-faint",
+                        )}
+                      >
+                        {monthLabel(m, spanMultiYear)}
+                        {partialSet.has(m) ? "·" : ""}
+                      </span>
+                    </TableHead>
+                  ))}
+                  <SortableHead
+                    label="API basis"
+                    k="usage"
+                    sort={sort}
+                    onSort={toggleSort}
+                  />
+                  <SortableHead
+                    label="Seat"
+                    k="tier"
+                    sort={sort}
+                    onSort={toggleSort}
+                  />
+                  <SortableHead
+                    label="Seat $/mo"
+                    k="seat"
+                    sort={sort}
+                    onSort={toggleSort}
+                  />
+                  <SortableHead
+                    label="Δ seat − API"
+                    k="delta"
+                    sort={sort}
+                    onSort={toggleSort}
+                  />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedRows.map((r) => (
+                  <TableRow key={r.user.userId}>
+                    <TableCell>
+                      <div className="font-medium text-ink">{r.user.name}</div>
+                      <div className="font-mono text-[11px] text-faint">
+                        {r.user.workspace ?? "—"}
+                        {r.user.internalTier ? ` · ${r.user.internalTier}` : ""}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <span
+                        className={cn(
+                          "font-mono text-[11px] uppercase tracking-wide",
+                          r.user.status === "active"
+                            ? "text-ink"
+                            : "text-faint",
+                        )}
+                      >
+                        {r.user.status}
+                      </span>
+                    </TableCell>
+                    {displayMonths.map((m) => {
+                      const cents = r.user.monthly[m] ?? 0;
+                      return (
+                        <TableCell
+                          key={m}
+                          className="text-right font-mono text-xs tabular-nums text-muted-foreground"
+                        >
+                          {cents ? formatCurrency(cents) : "·"}
+                        </TableCell>
+                      );
+                    })}
+                    <TableCell className="text-right font-mono text-sm tabular-nums font-medium text-ink">
+                      {formatCurrency(r.usageCents)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <SeatPill tier={r.tier} />
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-sm tabular-nums text-ink">
+                      {formatUSD0(r.seatCents)}
+                    </TableCell>
+                    <TableCell
+                      className={cn(
+                        "text-right font-mono text-sm tabular-nums",
+                        r.deltaCents < 0
+                          ? "text-success"
+                          : r.deltaCents > 0
+                            ? "text-destructive"
+                            : "text-faint",
+                      )}
+                    >
+                      {r.deltaCents === 0
+                        ? "—"
+                        : `${r.deltaCents < 0 ? "−" : "+"}${formatCurrency(
+                            Math.abs(r.deltaCents),
+                          )}`}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+              <TableFooter>
+                <TableRow>
+                  <TableCell className="font-medium">
+                    Totals · {result.count} keys
+                  </TableCell>
+                  <TableCell />
+                  {displayMonths.map((m) => (
+                    <TableCell
+                      key={m}
+                      className="text-right font-mono text-xs tabular-nums"
+                    >
+                      {formatUSD0(monthColumnSums[m] ?? 0)}
+                    </TableCell>
+                  ))}
+                  <TableCell className="text-right font-mono text-sm tabular-nums">
+                    {formatUSD0(result.baselineCents)}
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-xs tabular-nums text-muted-foreground">
+                    {result.premiumCount}P / {result.standardCount}S
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-sm tabular-nums">
+                    {formatUSD0(result.rightSizedCents)}
+                  </TableCell>
+                  <TableCell
+                    className={cn(
+                      "text-right font-mono text-sm tabular-nums",
+                      savesMoney ? "text-success" : "text-destructive",
+                    )}
+                  >
+                    {savingSign}
+                    {formatUSD0(Math.abs(saving))}
+                  </TableCell>
+                </TableRow>
+              </TableFooter>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <p className="font-mono text-[11px] text-faint">
+        Figures in USD as billed by Anthropic · spend from
+        anthropic_usage_metrics · complete months:{" "}
+        {dataset.completeMonths.map((m) => monthLabel(m, true)).join(" · ") ||
+          "none yet"}{" "}
+        · data assembled {new Date(dataset.generatedAt).toLocaleString()}
+      </p>
+    </div>
+  );
+}
+
+/* ---------------------------------- bits --------------------------------- */
+
+function ControlLabel({
+  children,
+  htmlFor,
+}: {
+  children: React.ReactNode;
+  htmlFor?: string;
+}) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+    >
+      {children}
+    </label>
+  );
+}
+
+function PriceField({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div>
+      <ControlLabel htmlFor={id}>{label}</ControlLabel>
+      <div className="mt-2 flex h-10 items-center gap-1.5 rounded-[6px] border border-input bg-card px-3 focus-within:border-ink">
+        <span className="font-mono text-sm text-muted-foreground">$</span>
+        <input
+          id={id}
+          type="number"
+          min={0}
+          step={1}
+          value={value}
+          onChange={(e) =>
+            onChange(
+              e.target.value === "" ? 0 : Math.max(0, Number(e.target.value)),
+            )
+          }
+          className="w-full bg-transparent font-mono text-base tabular-nums text-ink outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        />
+        <span className="font-mono text-[10px] uppercase tracking-wider text-faint">
+          /mo
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function ToggleButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "flex-1 px-2 py-2 font-mono text-[11px] uppercase tracking-[0.08em] transition-colors",
+        active
+          ? "bg-ink text-background"
+          : "bg-card text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  sub,
+}: {
+  label: React.ReactNode;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+          {label}
+        </p>
+        <p className="mt-2 font-mono text-2xl tabular-nums tracking-tight text-ink">
+          {value}
+        </p>
+        {sub ? (
+          <p className="mt-1 text-xs text-muted-foreground">{sub}</p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SeatPill({ tier }: { tier: "standard" | "premium" }) {
+  return (
+    <span
+      className={cn(
+        "inline-block rounded-[4px] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em]",
+        tier === "premium"
+          ? "border border-ink text-ink"
+          : "border border-input text-muted-foreground",
+      )}
+    >
+      {tier}
+    </span>
+  );
+}
+
+function SortableHead({
+  label,
+  k,
+  sort,
+  onSort,
+  align = "right",
+}: {
+  label: string;
+  k: SortKey;
+  sort: { key: SortKey; dir: 1 | -1 };
+  onSort: (k: SortKey) => void;
+  align?: "left" | "right";
+}) {
+  const active = sort.key === k;
+  return (
+    <TableHead
+      aria-sort={
+        active ? (sort.dir === 1 ? "ascending" : "descending") : "none"
+      }
+      className={align === "left" ? "text-left" : "text-right"}
+    >
+      <button
+        type="button"
+        onClick={() => onSort(k)}
+        className={cn(
+          "inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-wide transition-colors hover:text-foreground",
+          align === "left" ? "flex-row" : "flex-row-reverse",
+          active ? "text-ink" : "text-muted-foreground",
+        )}
+      >
+        {label}
+        {active ? (
+          sort.dir === 1 ? (
+            <ArrowUp className="size-3" aria-hidden />
+          ) : (
+            <ArrowDown className="size-3" aria-hidden />
+          )
+        ) : (
+          <ChevronsUpDown className="size-3 opacity-40" aria-hidden />
+        )}
+      </button>
+    </TableHead>
+  );
+}

--- a/src/app/scenarios/api-subscription/api-subscription-client.tsx
+++ b/src/app/scenarios/api-subscription/api-subscription-client.tsx
@@ -112,6 +112,9 @@ export function ApiSubscriptionClient({
     () => new Set(displayMonths.map((m) => m.slice(0, 4))).size > 1,
     [displayMonths],
   );
+  // The most recent month is the current (month-to-date) one; an earlier partial
+  // month is partial because data collection started mid-month, not because it's MTD.
+  const latestMonth = displayMonths[displayMonths.length - 1];
 
   // Per-month column totals for the table footer, in a single pass over the
   // population (avoids re-scanning all rows once per column on every render).
@@ -169,15 +172,44 @@ export function ApiSubscriptionClient({
   }
 
   const saving = result.baselineCents - result.rightSizedCents; // + = saving
-  const savesMoney = saving > 0;
+  const savingState: "saves" | "costs" | "flat" =
+    saving > 0 ? "saves" : saving < 0 ? "costs" : "flat";
+  // Percentage is undefined when there's no baseline spend to compare against.
   const savingPct =
     result.baselineCents > 0
       ? Math.round((Math.abs(saving) / result.baselineCents) * 100)
-      : 0;
-  const savingSign = savesMoney ? "−" : "+";
-  const verdictPhrase = savesMoney
-    ? `a ${savingPct}% cut from`
-    : `${savingPct}% above`;
+      : null;
+  const savingSign =
+    savingState === "saves" ? "−" : savingState === "costs" ? "+" : "";
+  const verdictPhrase =
+    savingState === "flat"
+      ? "the same as"
+      : savingState === "saves"
+        ? savingPct !== null
+          ? `a ${savingPct}% cut from`
+          : "less than"
+        : savingPct !== null
+          ? `${savingPct}% above`
+          : "more than";
+  // Tone classes per state — flat (equal cost) reads neutral, not negative.
+  const verdictBorder =
+    savingState === "saves"
+      ? "border-ink"
+      : savingState === "costs"
+        ? "border-destructive"
+        : "border-border";
+  const verdictText =
+    savingState === "saves"
+      ? "text-ink"
+      : savingState === "costs"
+        ? "text-destructive"
+        : "text-muted-foreground";
+  const deltaText =
+    savingState === "saves"
+      ? "text-success"
+      : savingState === "costs"
+        ? "text-destructive"
+        : "text-faint";
 
   // Single source for the four scenarios — drives both the cards and the bars.
   const scenarios = [
@@ -381,18 +413,13 @@ export function ApiSubscriptionClient({
       <div
         className={cn(
           "flex flex-col gap-1 border-l-2 bg-card px-5 py-4",
-          savesMoney ? "border-ink" : "border-destructive",
+          verdictBorder,
         )}
       >
         <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
           Right-sized verdict
         </p>
-        <p
-          className={cn(
-            "font-display text-3xl tabular-nums",
-            savesMoney ? "text-ink" : "text-destructive",
-          )}
-        >
+        <p className={cn("font-display text-3xl tabular-nums", verdictText)}>
           {savingSign}
           {formatUSD0(Math.abs(saving) * 12)}
           <span className="ml-2 font-mono text-sm text-muted-foreground">
@@ -514,7 +541,11 @@ export function ApiSubscriptionClient({
                       key={m}
                       className="text-right"
                       title={
-                        partialSet.has(m) ? "partial month (month-to-date)" : m
+                        !partialSet.has(m)
+                          ? m
+                          : m === latestMonth
+                            ? "Current month — month-to-date, excluded from the run-rate"
+                            : "Partial month — data collection started mid-month, excluded from the run-rate"
                       }
                     >
                       <span
@@ -641,7 +672,7 @@ export function ApiSubscriptionClient({
                   <TableCell
                     className={cn(
                       "text-right font-mono text-sm tabular-nums",
-                      savesMoney ? "text-success" : "text-destructive",
+                      deltaText,
                     )}
                   >
                     {savingSign}

--- a/src/app/scenarios/api-subscription/page.tsx
+++ b/src/app/scenarios/api-subscription/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+import { loadApiSubscriptionDataset } from "@/actions/scenarios";
+import { ApiSubscriptionClient } from "./api-subscription-client";
+
+export const metadata: Metadata = { title: "API → Subscription · Scenarios" };
+
+export default async function ApiSubscriptionScenarioPage() {
+  const dataset = await loadApiSubscriptionDataset();
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-3">
+        <Link
+          href="/scenarios"
+          className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="size-3.5" aria-hidden /> Scenarios
+        </Link>
+        <div>
+          <h1 className="text-2xl font-medium tracking-tight text-ink">
+            API → Subscription Migration
+          </h1>
+          <p className="max-w-2xl text-muted-foreground">
+            Every Claude Console (Anthropic API) key is a metered, pay-as-you-go
+            consumer. Map each onto a flat Standard or Premium seat and compare
+            the bill against today&apos;s spend.
+          </p>
+        </div>
+      </header>
+
+      {dataset.users.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ApiSubscriptionClient dataset={dataset} />
+      )}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-[14px] border border-border bg-card p-10 text-center">
+      <p className="font-mono text-sm uppercase tracking-[0.16em] text-muted-foreground">
+        [ NO API USERS ]
+      </p>
+      <p className="mx-auto mt-3 max-w-md text-sm text-muted-foreground">
+        No Claude Console license keys were found. Assign API keys to users and
+        run an Anthropic usage sync to populate this model.
+      </p>
+    </div>
+  );
+}

--- a/src/app/scenarios/layout.tsx
+++ b/src/app/scenarios/layout.tsx
@@ -1,0 +1,19 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+
+/**
+ * Admin gate for the whole /scenarios subtree (mirrors the copilot/reports
+ * section layouts). Individual pages render their own headers.
+ */
+export default async function ScenariosLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session?.user || session.user.role !== "admin") {
+    redirect("/login");
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/scenarios/page.tsx
+++ b/src/app/scenarios/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+import { SCENARIOS, type ScenarioMeta } from "@/lib/scenarios/registry";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+export const metadata: Metadata = { title: "Scenarios" };
+
+export default function ScenariosPage() {
+  return (
+    <div className="space-y-10">
+      <header className="space-y-2">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+          Cost modelling
+        </p>
+        <h1 className="text-2xl font-medium tracking-tight text-ink">
+          Scenarios
+        </h1>
+        <p className="max-w-2xl text-muted-foreground">
+          What-if calculators for AI tooling spend. Model a change against live
+          data before you commit to it.
+        </p>
+      </header>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {SCENARIOS.map((scenario) => (
+          <ScenarioCard key={scenario.slug} scenario={scenario} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ScenarioCard({ scenario }: { scenario: ScenarioMeta }) {
+  const { icon: Icon, title, blurb, status, slug } = scenario;
+  const live = status === "live";
+
+  const card = (
+    <Card
+      className={cn(
+        "group h-full transition-colors",
+        live ? "hover:border-ink" : "opacity-55",
+      )}
+    >
+      <CardContent className="flex h-full flex-col gap-3 p-5">
+        <div className="flex items-center justify-between">
+          <Icon className="size-5 text-ink" strokeWidth={1.5} aria-hidden />
+          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            {live ? "Live" : "Soon"}
+          </span>
+        </div>
+        <h2 className="text-base font-medium text-ink">{title}</h2>
+        <p className="text-sm text-muted-foreground">{blurb}</p>
+        {live ? (
+          <span className="mt-auto inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-ink">
+            Open
+            <ArrowRight
+              className="size-3.5 transition-transform group-hover:translate-x-0.5"
+              aria-hidden
+            />
+          </span>
+        ) : (
+          <span className="mt-auto font-mono text-[11px] uppercase tracking-[0.14em] text-faint">
+            In planning
+          </span>
+        )}
+      </CardContent>
+    </Card>
+  );
+
+  if (!live) return card;
+
+  return (
+    <Link
+      href={`/scenarios/${slug}`}
+      className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      {card}
+    </Link>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -24,10 +24,15 @@ const navItems: NavItem[] = [
   { title: "Requests", href: "/requests", roles: ["admin"] },
   { title: "Budget", href: "/budget", roles: ["admin"] },
   { title: "Reports", href: "/reports", roles: ["admin"] },
+  { title: "Scenarios", href: "/scenarios", roles: ["admin"] },
   { title: "Copilot", href: "/copilot", roles: ["admin"] },
   { title: "Claude Console", href: "/claude", roles: ["admin"] },
   { title: "Invoices", href: "/invoices", roles: ["admin"] },
-  { title: "Settings", href: "/settings/appearance", roles: ["admin", "viewer"] },
+  {
+    title: "Settings",
+    href: "/settings/appearance",
+    roles: ["admin", "viewer"],
+  },
 ];
 
 function initialsOf(name: string | null): string {
@@ -50,7 +55,10 @@ function isItemActive(pathname: string, href: string): boolean {
 function Brand() {
   return (
     <div className="flex items-center gap-2">
-      <span className="size-2.5 rounded-full bg-destructive" aria-hidden="true" />
+      <span
+        className="size-2.5 rounded-full bg-destructive"
+        aria-hidden="true"
+      />
       <span className="font-mono text-sm tracking-[0.14em] uppercase text-ink">
         AI·HUB
       </span>
@@ -81,7 +89,7 @@ function NavLinks({
               "relative rounded-[4px] px-2 py-2.5 font-mono text-xs tracking-[0.1em] uppercase transition-colors",
               active
                 ? "text-ink"
-                : "text-muted-foreground hover:text-foreground"
+                : "text-muted-foreground hover:text-foreground",
             )}
           >
             {active ? (
@@ -115,7 +123,9 @@ function Footer({
           {initialsOf(userName)}
         </span>
         <span className="flex min-w-0 flex-col">
-          <span className="truncate text-[13px] text-foreground">{userName}</span>
+          <span className="truncate text-[13px] text-foreground">
+            {userName}
+          </span>
           <span className="font-mono text-[11px] tracking-[0.1em] uppercase text-muted-foreground capitalize">
             {userRole}
           </span>
@@ -184,7 +194,11 @@ export function AppSidebar({
 
       {/* Mobile drawer */}
       {mobileOpen ? (
-        <div className="fixed inset-0 z-50 md:hidden" role="dialog" aria-modal="true">
+        <div
+          className="fixed inset-0 z-50 md:hidden"
+          role="dialog"
+          aria-modal="true"
+        >
           <button
             type="button"
             aria-label="Close navigation"

--- a/src/lib/chart-format.ts
+++ b/src/lib/chart-format.ts
@@ -25,6 +25,17 @@ export function formatUSDCompact(cents: number): string {
   return `${sign}$${abs.toFixed(2)}`;
 }
 
+const usd0 = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+/** Whole-dollar USD from integer cents — "$3,041". For headline/aggregate figures. */
+export function formatUSD0(cents: number): string {
+  return usd0.format(cents / 100);
+}
+
 /** Accepts a fraction 0..1 — e.g. 0.42 → "42%". */
 export function formatPercent(fraction: number, digits = 1): string {
   return `${(fraction * 100).toFixed(digits)}%`;

--- a/src/lib/scenarios/api-subscription.ts
+++ b/src/lib/scenarios/api-subscription.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure calculation engine for the API → Subscription migration scenario.
+ *
+ * No imports from `react`, `next`, or `@/lib/db` — only plain math and the
+ * data types. This module runs identically on the server (initial render) and
+ * in the browser (every control change), which guarantees the figures shown to
+ * the user cannot drift from the ones covered by the unit tests.
+ */
+
+import type { ApiSubscriptionDataset, ApiUser } from "./types";
+
+/** Which slice of history a user's "current spend" is read from. */
+export type UsageBasis =
+  | "avgComplete" // mean across all complete months (default)
+  | "latestComplete" // the most recent complete month
+  | "peakComplete" // the single highest complete month
+  | { month: string }; // a specific 'YYYY-MM'
+
+export type Population = "all" | "active";
+
+export type ScenarioInputs = {
+  standardCents: number;
+  premiumCents: number;
+  /** usage >= threshold ⇒ Premium seat, otherwise Standard. */
+  premiumThresholdCents: number;
+  basis: UsageBasis;
+  population: Population;
+};
+
+export type SeatTier = "standard" | "premium";
+
+export type ScenarioRow = {
+  user: ApiUser;
+  usageCents: number;
+  tier: SeatTier;
+  seatCents: number;
+  /** seatCents − usageCents. Negative ⇒ the flat seat is cheaper than the user's API burn (a saving). */
+  deltaCents: number;
+};
+
+export type ScenarioResult = {
+  rows: ScenarioRow[];
+  count: number;
+  baselineCents: number; // metered API spend (sum of usage)
+  allStandardCents: number; // everyone on a Standard seat
+  allPremiumCents: number; // everyone on a Premium seat
+  rightSizedCents: number; // threshold-based mix
+  premiumCount: number;
+  standardCount: number;
+};
+
+/** The user's representative monthly spend (cents) under the chosen basis. */
+export function usageForUser(
+  user: ApiUser,
+  dataset: ApiSubscriptionDataset,
+  basis: UsageBasis,
+): number {
+  const monthly = user.monthly;
+
+  if (typeof basis === "object") {
+    return monthly[basis.month] ?? 0;
+  }
+
+  const months = dataset.completeMonths;
+  if (months.length === 0) return 0;
+
+  if (basis === "latestComplete") {
+    return monthly[months[months.length - 1]] ?? 0;
+  }
+
+  const values = months.map((m) => monthly[m] ?? 0);
+
+  if (basis === "peakComplete") {
+    return values.reduce((max, v) => (v > max ? v : max), 0);
+  }
+
+  // avgComplete
+  const sum = values.reduce((a, b) => a + b, 0);
+  return Math.round(sum / months.length);
+}
+
+/** Map a monthly spend onto the seat tier it qualifies for. */
+export function mapSeat(
+  usageCents: number,
+  inputs: ScenarioInputs,
+): { tier: SeatTier; seatCents: number } {
+  const tier: SeatTier =
+    usageCents >= inputs.premiumThresholdCents ? "premium" : "standard";
+  return {
+    tier,
+    seatCents: tier === "premium" ? inputs.premiumCents : inputs.standardCents,
+  };
+}
+
+/** Compute all four scenario totals plus the per-user mapping rows. */
+export function computeScenarios(
+  dataset: ApiSubscriptionDataset,
+  inputs: ScenarioInputs,
+): ScenarioResult {
+  const pool =
+    inputs.population === "active"
+      ? dataset.users.filter((u) => u.status === "active")
+      : dataset.users;
+
+  let baselineCents = 0;
+  let rightSizedCents = 0;
+  let premiumCount = 0;
+
+  const rows: ScenarioRow[] = pool.map((user) => {
+    const usageCents = usageForUser(user, dataset, inputs.basis);
+    const { tier, seatCents } = mapSeat(usageCents, inputs);
+    baselineCents += usageCents;
+    rightSizedCents += seatCents;
+    if (tier === "premium") premiumCount += 1;
+    return {
+      user,
+      usageCents,
+      tier,
+      seatCents,
+      deltaCents: seatCents - usageCents,
+    };
+  });
+
+  const count = pool.length;
+  return {
+    rows,
+    count,
+    baselineCents,
+    allStandardCents: count * inputs.standardCents,
+    allPremiumCents: count * inputs.premiumCents,
+    rightSizedCents,
+    premiumCount,
+    standardCount: count - premiumCount,
+  };
+}
+
+/**
+ * Split a sorted-ascending list of `'YYYY-MM'` months into complete vs partial.
+ * The current month is always partial; the earliest month is partial when data
+ * collection began mid-month (`minDate` not the 1st) — mirroring Anthropic's
+ * complete-UTC-day reporting. Pure so it can be unit-tested and reused by other
+ * scenario calculators.
+ */
+export function classifyMonths(
+  months: string[],
+  minDate: string | null,
+  currentMonth: string,
+): { completeMonths: string[]; partialMonths: string[] } {
+  const earliestMonth = months[0];
+  const earliestIsDayOne = !!minDate && minDate.slice(-2) === "01";
+  const completeMonths: string[] = [];
+  const partialMonths: string[] = [];
+  for (const mo of months) {
+    if (mo === currentMonth || (mo === earliestMonth && !earliestIsDayOne)) {
+      partialMonths.push(mo);
+    } else {
+      completeMonths.push(mo);
+    }
+  }
+  return { completeMonths, partialMonths };
+}

--- a/src/lib/scenarios/queries.ts
+++ b/src/lib/scenarios/queries.ts
@@ -1,0 +1,188 @@
+import { db } from "@/lib/db";
+import {
+  accessTiers,
+  aiTools,
+  anthropicUsageMetrics,
+  licenseAssignments,
+  users,
+} from "@/lib/db/schema";
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { classifyMonths } from "./api-subscription";
+import type { ApiSubscriptionDataset, ApiUser } from "./types";
+
+// Tools are resolved by vendor + name rather than hardcoded ids so the loader
+// survives reseeded / per-environment databases.
+const ANTHROPIC = "Anthropic";
+const API_TOOL_NAME = "Claude Console"; // assignments here carry the API keys
+const SEAT_TOOL_NAME = "Claude"; // its access_tiers are the Standard/Premium seats
+
+const FALLBACK_STANDARD_CENTS = 2500;
+const FALLBACK_PREMIUM_CENTS = 12500;
+
+function emptyDataset(
+  defaultStandardCents = FALLBACK_STANDARD_CENTS,
+  defaultPremiumCents = FALLBACK_PREMIUM_CENTS,
+): ApiSubscriptionDataset {
+  return {
+    users: [],
+    completeMonths: [],
+    partialMonths: [],
+    defaultStandardCents,
+    defaultPremiumCents,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Assemble the full dataset for the API → Subscription calculator from live
+ * tables. Read-only; no schema dependencies beyond the existing columns.
+ */
+export async function getApiSubscriptionDataset(): Promise<ApiSubscriptionDataset> {
+  // 1. Resolve the two Anthropic tools.
+  const tools = await db
+    .select({ id: aiTools.id, name: aiTools.name })
+    .from(aiTools)
+    .where(eq(aiTools.vendor, ANTHROPIC));
+
+  const apiTool = tools.find((t) => t.name === API_TOOL_NAME);
+  const seatTool = tools.find((t) => t.name === SEAT_TOOL_NAME);
+
+  // 2. Seat-price defaults from the subscription tool's active tiers. Match by
+  //    name ("Standard" / "Premium") so a third tier or a price inversion can't
+  //    silently mis-pick; fall back to lowest=Standard / highest=Premium by cost.
+  let defaultStandardCents = FALLBACK_STANDARD_CENTS;
+  let defaultPremiumCents = FALLBACK_PREMIUM_CENTS;
+  if (seatTool) {
+    const seatTiers = await db
+      .select({ name: accessTiers.name, cents: accessTiers.monthlyCostCents })
+      .from(accessTiers)
+      .where(
+        and(
+          eq(accessTiers.toolId, seatTool.id),
+          eq(accessTiers.isActive, true),
+        ),
+      );
+    if (seatTiers.length > 0) {
+      const byCost = [...seatTiers].sort((a, b) => a.cents - b.cents);
+      const standard = seatTiers.find((t) => /standard/i.test(t.name));
+      const premium = seatTiers.find((t) => /premium/i.test(t.name));
+      defaultStandardCents = standard?.cents ?? byCost[0].cents;
+      defaultPremiumCents = premium?.cents ?? byCost[byCost.length - 1].cents;
+    }
+  }
+
+  if (!apiTool) return emptyDataset(defaultStandardCents, defaultPremiumCents);
+
+  // 3. API users = Claude Console assignments that carry an API key.
+  const assignmentRows = await db
+    .select({
+      userId: licenseAssignments.userId,
+      status: licenseAssignments.status,
+      workspace: licenseAssignments.workspace,
+      assignedAt: licenseAssignments.assignedAt,
+      tierName: accessTiers.name,
+      name: users.name,
+      email: users.email,
+      discipline: users.discipline,
+    })
+    .from(licenseAssignments)
+    .innerJoin(accessTiers, eq(accessTiers.id, licenseAssignments.tierId))
+    .innerJoin(users, eq(users.id, licenseAssignments.userId))
+    .where(
+      and(
+        eq(licenseAssignments.toolId, apiTool.id),
+        isNotNull(licenseAssignments.apiKeyEncrypted),
+      ),
+    );
+
+  if (assignmentRows.length === 0) {
+    return emptyDataset(defaultStandardCents, defaultPremiumCents);
+  }
+
+  // One assignment per user: prefer active, then most-recently assigned.
+  const byUser = new Map<number, (typeof assignmentRows)[number]>();
+  for (const row of assignmentRows) {
+    const existing = byUser.get(row.userId);
+    if (!existing) {
+      byUser.set(row.userId, row);
+      continue;
+    }
+    const rank =
+      (row.status === "active" ? 1 : 0) -
+        (existing.status === "active" ? 1 : 0) ||
+      row.assignedAt.getTime() - existing.assignedAt.getTime();
+    if (rank > 0) byUser.set(row.userId, row);
+  }
+  const userIds = [...byUser.keys()];
+
+  // 4. Per-user monthly spend + earliest usage date.
+  const usageRows = await db
+    .select({
+      userId: anthropicUsageMetrics.userId,
+      month: sql<string>`to_char(${anthropicUsageMetrics.date}, 'YYYY-MM')`,
+      cents: sql<number>`sum(${anthropicUsageMetrics.computedCostCents})::int`,
+    })
+    .from(anthropicUsageMetrics)
+    .where(inArray(anthropicUsageMetrics.userId, userIds))
+    .groupBy(
+      anthropicUsageMetrics.userId,
+      sql`to_char(${anthropicUsageMetrics.date}, 'YYYY-MM')`,
+    );
+
+  const minRows = await db
+    .select({ minDate: sql<string | null>`min(${anthropicUsageMetrics.date})` })
+    .from(anthropicUsageMetrics)
+    .where(inArray(anthropicUsageMetrics.userId, userIds));
+  const minDate = minRows[0]?.minDate ?? null;
+
+  const monthlyByUser = new Map<number, Record<string, number>>();
+  const allMonths = new Set<string>();
+  for (const r of usageRows) {
+    allMonths.add(r.month);
+    const map = monthlyByUser.get(r.userId) ?? {};
+    map[r.month] = Number(r.cents) || 0;
+    monthlyByUser.set(r.userId, map);
+  }
+
+  // 5. Classify months into complete vs partial (see classifyMonths).
+  const months = [...allMonths].sort();
+  const currentMonth = new Date().toISOString().slice(0, 7); // 'YYYY-MM' (UTC)
+  const { completeMonths, partialMonths } = classifyMonths(
+    months,
+    minDate,
+    currentMonth,
+  );
+
+  // 6. Build the user list, sorted by avg-complete-month spend desc for a
+  //    deterministic SSR order (the client re-sorts on demand).
+  const avgComplete = (monthly: Record<string, number>) =>
+    completeMonths.length
+      ? completeMonths.reduce((s, mo) => s + (monthly[mo] ?? 0), 0) /
+        completeMonths.length
+      : 0;
+
+  const userList: ApiUser[] = userIds
+    .map((id) => {
+      const a = byUser.get(id)!;
+      return {
+        userId: id,
+        name: a.name,
+        email: a.email,
+        discipline: a.discipline ?? null,
+        status: a.status === "active" ? "active" : "inactive",
+        workspace: a.workspace ?? null,
+        internalTier: a.tierName ?? null,
+        monthly: monthlyByUser.get(id) ?? {},
+      } satisfies ApiUser;
+    })
+    .sort((x, y) => avgComplete(y.monthly) - avgComplete(x.monthly));
+
+  return {
+    users: userList,
+    completeMonths,
+    partialMonths,
+    defaultStandardCents,
+    defaultPremiumCents,
+    generatedAt: new Date().toISOString(),
+  };
+}

--- a/src/lib/scenarios/registry.ts
+++ b/src/lib/scenarios/registry.ts
@@ -1,0 +1,40 @@
+import type { LucideIcon } from "lucide-react";
+import { ArrowLeftRight, LineChart } from "lucide-react";
+
+/**
+ * Catalogue of scenario calculators. Single source of truth for the index
+ * cards and (later) the section tab strip. Add a calculator by appending an
+ * entry here and creating its route under `src/app/scenarios/<slug>/`.
+ */
+export type ScenarioStatus = "live" | "soon";
+
+export type ScenarioMeta = {
+  slug: string;
+  title: string;
+  blurb: string;
+  icon: LucideIcon;
+  status: ScenarioStatus;
+};
+
+export const SCENARIOS: ScenarioMeta[] = [
+  {
+    slug: "api-subscription",
+    title: "API → Subscription Migration",
+    blurb:
+      "Map metered Anthropic API users onto flat Standard / Premium seats and model the bill under four scenarios.",
+    icon: ArrowLeftRight,
+    status: "live",
+  },
+  {
+    slug: "budget-forecast",
+    title: "Budget / Cost Forecast Simulation",
+    blurb:
+      "Project spend forward from historical run-rate and simulate budget outcomes across the fiscal year.",
+    icon: LineChart,
+    status: "soon",
+  },
+];
+
+export function getScenario(slug: string): ScenarioMeta | undefined {
+  return SCENARIOS.find((s) => s.slug === slug);
+}

--- a/src/lib/scenarios/types.ts
+++ b/src/lib/scenarios/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared data shapes for the Scenarios section (spec 035).
+ *
+ * These types are intentionally framework-free (no React, no Drizzle) so the
+ * pure calculation engine in `api-subscription.ts` can be imported on both the
+ * server (first paint) and the client (live re-compute) without dragging in
+ * server-only modules.
+ */
+
+/** One API-key user (a Claude Console license assignment) + their monthly spend. */
+export type ApiUser = {
+  userId: number;
+  name: string;
+  email: string;
+  discipline: string | null;
+  status: "active" | "inactive";
+  /** Anthropic workspace label carried on the assignment, if any. */
+  workspace: string | null;
+  /** Internal boost-tier the user is allocated to (context only). */
+  internalTier: string | null;
+  /** Map of `'YYYY-MM'` -> spend in cents (computed_cost_cents). */
+  monthly: Record<string, number>;
+};
+
+/** Everything the calculator needs, assembled server-side from live data. */
+export type ApiSubscriptionDataset = {
+  users: ApiUser[];
+  /** Complete calendar months with data, sorted ascending. */
+  completeMonths: string[];
+  /** Partial months — current month + a mid-join first month — sorted ascending. */
+  partialMonths: string[];
+  /** Default Standard seat price (cents), read live from access_tiers. */
+  defaultStandardCents: number;
+  /** Default Premium seat price (cents), read live from access_tiers. */
+  defaultPremiumCents: number;
+  /** ISO timestamp of when the dataset was assembled. */
+  generatedAt: string;
+};

--- a/tests/unit/scenarios/api-subscription.test.ts
+++ b/tests/unit/scenarios/api-subscription.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyMonths,
+  computeScenarios,
+  mapSeat,
+  usageForUser,
+  type ScenarioInputs,
+} from "@/lib/scenarios/api-subscription";
+import type { ApiSubscriptionDataset, ApiUser } from "@/lib/scenarios/types";
+
+/**
+ * Real per-user spend (cents) for the three complete months Mar/Apr/May 2026,
+ * captured from anthropic_usage_metrics on 2026-06-09. These lock the engine to
+ * the figures validated in the prototype (specs/035 prototype.html):
+ *   baseline $3,041 · all-Standard $1,175 · all-Premium $5,875 · right-sized $2,075.
+ * Tuple: [userId, status, mar, apr, may]
+ */
+const REAL: Array<[number, "active" | "inactive", number, number, number]> = [
+  [17, "inactive", 25937, 34602, 25652],
+  [12, "inactive", 15086, 21937, 20423],
+  [101, "active", 7257, 20230, 25464],
+  [6, "active", 8975, 17610, 24578],
+  [9, "active", 13754, 17503, 17238],
+  [26, "active", 14738, 10091, 20758],
+  [36, "active", 13904, 31090, 0],
+  [35, "active", 16432, 2282, 25791],
+  [16, "active", 12412, 18205, 12352],
+  [7, "active", 6816, 13419, 14447],
+  [31, "active", 15919, 17757, 0],
+  [8, "active", 11072, 5215, 12781],
+  [24, "active", 10643, 8329, 9258],
+  [78, "inactive", 917, 9679, 16188],
+  [18, "active", 7998, 6811, 11566],
+  [113, "active", 8675, 8639, 8073],
+  [80, "active", 670, 9080, 11848],
+  [32, "active", 8086, 8673, 2260],
+  [33, "inactive", 97, 7640, 9403],
+  [21, "active", 4826, 6693, 4269],
+  [13, "active", 2713, 6098, 6316],
+  [115, "active", 0, 6601, 7880],
+  [19, "active", 670, 5421, 7795],
+  [37, "active", 4416, 5693, 3725],
+  [20, "active", 8864, 2246, 2373],
+  [114, "active", 372, 8484, 3664],
+  [75, "active", 0, 0, 10223],
+  [62, "active", 373, 5538, 4241],
+  [11, "active", 5590, 3430, 635],
+  [29, "active", 2675, 544, 5684],
+  [96, "active", 754, 3183, 3901],
+  [14, "active", 2231, 3029, 1885],
+  [73, "active", 0, 0, 4900],
+  [92, "active", 0, 644, 3250],
+  [34, "active", 80, 2163, 1424],
+  [131, "active", 27, 733, 2796],
+  [51, "active", 0, 1310, 2144],
+  [103, "active", 0, 0, 3036],
+  [54, "active", 0, 0, 366],
+  [135, "active", 0, 0, 259],
+  [22, "active", 0, 0, 0],
+  [3, "active", 0, 0, 0],
+  [106, "active", 0, 0, 0],
+  [82, "active", 0, 0, 0],
+  [55, "active", 0, 0, 0],
+  [57, "active", 0, 0, 0],
+  [2, "active", 0, 0, 1],
+];
+
+function realDataset(): ApiSubscriptionDataset {
+  const users: ApiUser[] = REAL.map(([id, status, mar, apr, may]) => ({
+    userId: id,
+    name: `User ${id}`,
+    email: `u${id}@example.com`,
+    discipline: "developer",
+    status,
+    workspace: null,
+    internalTier: null,
+    monthly: { "2026-03": mar, "2026-04": apr, "2026-05": may },
+  }));
+  return {
+    users,
+    completeMonths: ["2026-03", "2026-04", "2026-05"],
+    partialMonths: [],
+    defaultStandardCents: 2500,
+    defaultPremiumCents: 12500,
+    generatedAt: "2026-06-09T00:00:00.000Z",
+  };
+}
+
+const baseInputs: ScenarioInputs = {
+  standardCents: 2500,
+  premiumCents: 12500,
+  premiumThresholdCents: 12500,
+  basis: "avgComplete",
+  population: "all",
+};
+
+describe("usageForUser", () => {
+  const ds = realDataset();
+  const user: ApiUser = {
+    userId: 1,
+    name: "x",
+    email: "x",
+    discipline: null,
+    status: "active",
+    workspace: null,
+    internalTier: null,
+    monthly: { "2026-03": 300, "2026-04": 600, "2026-05": 900 },
+  };
+
+  it("avgComplete is the mean of complete months, rounded", () => {
+    expect(usageForUser(user, ds, "avgComplete")).toBe(600);
+  });
+
+  it("rounds the average to the nearest cent", () => {
+    const u = {
+      ...user,
+      monthly: { "2026-03": 100, "2026-04": 100, "2026-05": 101 },
+    };
+    expect(usageForUser(u, ds, "avgComplete")).toBe(100); // 301/3 = 100.33 -> 100
+  });
+
+  it("latestComplete returns the most recent complete month", () => {
+    expect(usageForUser(user, ds, "latestComplete")).toBe(900);
+  });
+
+  it("peakComplete returns the single highest complete month", () => {
+    const u = {
+      ...user,
+      monthly: { "2026-03": 900, "2026-04": 200, "2026-05": 500 },
+    };
+    expect(usageForUser(u, ds, "peakComplete")).toBe(900);
+  });
+
+  it("a specific month basis reads exactly that month", () => {
+    expect(usageForUser(user, ds, { month: "2026-04" })).toBe(600);
+    expect(usageForUser(user, ds, { month: "2099-01" })).toBe(0);
+  });
+
+  it("returns 0 when there are no complete months", () => {
+    const empty = { ...ds, completeMonths: [] };
+    expect(usageForUser(user, empty, "avgComplete")).toBe(0);
+  });
+});
+
+describe("mapSeat", () => {
+  it("assigns Premium when usage is at or above the threshold (boundary inclusive)", () => {
+    expect(mapSeat(12500, baseInputs)).toEqual({
+      tier: "premium",
+      seatCents: 12500,
+    });
+  });
+
+  it("assigns Standard just below the threshold", () => {
+    expect(mapSeat(12499, baseInputs)).toEqual({
+      tier: "standard",
+      seatCents: 2500,
+    });
+  });
+});
+
+describe("computeScenarios — regression anchors on live data", () => {
+  const ds = realDataset();
+
+  it("matches the prototype figures for all 47 keys at a $125 threshold", () => {
+    const r = computeScenarios(ds, baseInputs);
+    expect(r.count).toBe(47);
+    expect(r.baselineCents).toBe(304140); // $3,041.40/mo run-rate
+    expect(r.allStandardCents).toBe(117500); // $1,175
+    expect(r.allPremiumCents).toBe(587500); // $5,875
+    expect(r.rightSizedCents).toBe(207500); // $2,075 (9 Premium + 38 Standard)
+    expect(r.premiumCount).toBe(9);
+    expect(r.standardCount).toBe(38);
+  });
+
+  it("filters to the active population (43 keys)", () => {
+    const r = computeScenarios(ds, { ...baseInputs, population: "active" });
+    expect(r.count).toBe(43);
+    expect(r.baselineCents).toBe(241620); // $2,416.20
+    expect(r.premiumCount).toBe(7);
+    expect(r.rightSizedCents).toBe(177500); // 7×$125 + 36×$25 = $1,775
+  });
+
+  it("all-Standard / all-Premium scale linearly with editable prices", () => {
+    const r = computeScenarios(ds, {
+      ...baseInputs,
+      standardCents: 3000,
+      premiumCents: 10000,
+    });
+    expect(r.allStandardCents).toBe(47 * 3000);
+    expect(r.allPremiumCents).toBe(47 * 10000);
+  });
+
+  it("a higher threshold pushes more users onto Standard", () => {
+    const low = computeScenarios(ds, {
+      ...baseInputs,
+      premiumThresholdCents: 5000,
+    });
+    const high = computeScenarios(ds, {
+      ...baseInputs,
+      premiumThresholdCents: 30000,
+    });
+    expect(low.premiumCount).toBeGreaterThan(high.premiumCount);
+  });
+
+  it("per-user delta = seat − usage (negative means the seat is cheaper)", () => {
+    const r = computeScenarios(ds, baseInputs);
+    for (const row of r.rows) {
+      expect(row.deltaCents).toBe(row.seatCents - row.usageCents);
+    }
+  });
+});
+
+describe("classifyMonths", () => {
+  const months = ["2026-02", "2026-03", "2026-04", "2026-05", "2026-06"];
+
+  it("marks the current month and a mid-month start as partial", () => {
+    const r = classifyMonths(months, "2026-02-27", "2026-06");
+    expect(r.completeMonths).toEqual(["2026-03", "2026-04", "2026-05"]);
+    expect(r.partialMonths).toEqual(["2026-02", "2026-06"]);
+  });
+
+  it("treats the earliest month as complete when data starts on the 1st", () => {
+    const r = classifyMonths(months, "2026-02-01", "2026-06");
+    expect(r.completeMonths).toEqual([
+      "2026-02",
+      "2026-03",
+      "2026-04",
+      "2026-05",
+    ]);
+    expect(r.partialMonths).toEqual(["2026-06"]);
+  });
+
+  it("treats the earliest month as partial when minDate is unknown (null)", () => {
+    const r = classifyMonths(["2026-03", "2026-04"], null, "2026-04");
+    expect(r.completeMonths).toEqual([]);
+    expect(r.partialMonths).toEqual(["2026-03", "2026-04"]);
+  });
+
+  it("never double-counts when earliest === current", () => {
+    const r = classifyMonths(["2026-06"], "2026-06-15", "2026-06");
+    expect(r.completeMonths).toEqual([]);
+    expect(r.partialMonths).toEqual(["2026-06"]);
+  });
+});


### PR DESCRIPTION
## What

Adds a new admin-only **Scenarios** section — a home for what-if cost calculators — and its first calculator, **API → Subscription Migration**.

The calculator takes every user holding a Claude Console (Anthropic API) key and models what it would cost to move them onto flat **Standard** / **Premium** Claude seats, comparing four scenarios (metered API baseline, all-Standard, all-Premium, threshold-based right-sizing) against live spend. Seat prices, the Premium threshold, the usage basis, and the population are all live, recomputing controls.

The section is built on an **extensible registry** — the index and (future) section nav render from `SCENARIOS`. Calculator #2, **Budget / Cost Forecast Simulation**, is stubbed as a "soon" card so it slots in with just a registry entry + route.

## How

- **Pure engine** `src/lib/scenarios/api-subscription.ts` (no React/DB) — shared by the server (first paint) and client (live recompute), so displayed figures can't drift from the tested ones. `classifyMonths` is extracted and unit-tested.
- **Live loader** `src/lib/scenarios/queries.ts` — resolves the API/seat tools by vendor+name (no hardcoded IDs), reads seat-price defaults from `access_tiers` by name, aggregates `anthropic_usage_metrics` per user/month, classifies complete vs partial months. No schema changes.
- **Server action** `src/actions/scenarios.ts` — `requireAdmin` + cached loader.
- **UI** — Nothing design system (existing tokens/components: `Card`, `Table`, `SegmentedBar`, mono labels). Admin gate lives in a section `layout.tsx` (matches copilot/reports).
- Adds `formatUSD0` to `src/lib/chart-format.ts`.

## Verification

- `pnpm typecheck` ✓ · ESLint clean on changed files ✓
- `pnpm vitest run tests/unit/scenarios` ✓ — 17 tests, including regression anchors locked to the validated prototype figures ($3,041 baseline · $1,175 all-Standard · $5,875 all-Premium · $2,075 right-sized) and `classifyMonths` cases.
- Rendered end-to-end against live data (both pages HTTP 200, full per-user table).

## Notes

- Spec docs (plan + validated prototype) under `specs/035-scenario-calculators/`.
- All figures are USD (Anthropic's billing currency); no FX conversion.
- Read-only feature; no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)