### PR TITLE
feat(035): API threshold — keep light keys on metered API

### DIFF
--- a/specs/035-scenario-calculators/api-threshold-implementation-plan.html
+++ b/specs/035-scenario-calculators/api-threshold-implementation-plan.html
@@ -1,0 +1,484 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Implementation Plan — API threshold (keep light keys metered) · 035</title>
+  <style>
+    :root {
+      --bg: #0b0d12;
+      --bg-elev: #11141b;
+      --bg-card: #161a24;
+      --border: #232938;
+      --border-strong: #2f3850;
+      --fg: #e7ebf3;
+      --fg-muted: #9aa3b5;
+      --fg-dim: #6b7488;
+      --accent: #f0a072;        /* clay — matches the prototype accent */
+      --accent-2: #7dd3fc;
+      --good: #86efac;
+      --warn: #fcd34d;
+      --bad: #fca5a5;
+      --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); font-family: var(--sans); line-height: 1.55; }
+    body { padding: 48px 24px 96px; }
+    main { max-width: 1100px; margin: 0 auto; }
+    h1, h2, h3, h4 { font-weight: 600; letter-spacing: -0.01em; }
+    h1 { font-size: 32px; margin: 0 0 8px; }
+    h2 { font-size: 22px; margin: 52px 0 16px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+    h3 { font-size: 17px; margin: 0 0 6px; }
+    h4 { font-size: 13px; margin: 16px 0 6px; color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.08em; }
+    p { margin: 0 0 12px; }
+    a { color: var(--accent); }
+    code { font-family: var(--mono); font-size: 0.88em; background: var(--bg-elev); padding: 1px 5px; border-radius: 4px; border: 1px solid var(--border); }
+    pre { font-family: var(--mono); font-size: 12.5px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; overflow-x: auto; line-height: 1.5; }
+    pre code { background: transparent; border: 0; padding: 0; font-size: inherit; }
+    .lede { color: var(--fg-muted); font-size: 16px; max-width: 820px; }
+    .meta { color: var(--fg-dim); font-size: 13px; margin-top: 8px; font-family: var(--mono); }
+    .badge { display: inline-block; font-size: 11px; font-family: var(--mono); padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border-strong); color: var(--fg-muted); background: var(--bg-elev); }
+    .badge.good { color: var(--good); border-color: rgba(134,239,172,0.3); }
+    .badge.warn { color: var(--warn); border-color: rgba(252,211,77,0.3); }
+    .badge.accent { color: var(--accent); border-color: rgba(240,160,114,0.35); }
+    .card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin: 16px 0; }
+    .card.accent { border-left: 3px solid var(--accent); }
+    .card.accent-2 { border-left: 3px solid var(--accent-2); }
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+    @media (max-width: 760px) { .grid-2, .grid-3 { grid-template-columns: 1fr; } }
+    .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+    .row.between { justify-content: space-between; }
+    .flow { font-family: var(--mono); font-size: 12.5px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 10px; padding: 16px; white-space: pre; overflow-x: auto; color: var(--fg-muted); }
+    .flow .em { color: var(--fg); }
+    .flow .ok { color: var(--good); }
+    .flow .accent { color: var(--accent); }
+    ul { padding-left: 20px; margin: 8px 0 12px; }
+    li { margin: 4px 0; }
+    li.pro::marker { content: "+ "; color: var(--good); font-weight: 700; }
+    li.con::marker { content: "− "; color: var(--bad); font-weight: 700; }
+    li.note::marker { content: "› "; color: var(--fg-dim); }
+    li.check::marker { content: "\2610  "; color: var(--fg-muted); }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; margin: 12px 0; }
+    th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+    th { color: var(--fg-muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; background: var(--bg-elev); }
+    td code { white-space: nowrap; }
+    .pill { display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 11.5px; font-family: var(--mono); }
+    .pill.good { background: rgba(134,239,172,0.12); color: var(--good); }
+    .pill.warn { background: rgba(252,211,77,0.12); color: var(--warn); }
+    .pill.new { background: rgba(240,160,114,0.14); color: var(--accent); }
+    .pill.neutral { background: var(--bg-elev); color: var(--fg-muted); border: 1px solid var(--border); }
+    .callout { border: 1px solid var(--border-strong); border-left: 3px solid var(--warn); background: rgba(252,211,77,0.04); padding: 14px 16px; border-radius: 8px; margin: 16px 0; font-size: 14px; }
+    .callout.info { border-left-color: var(--accent-2); background: rgba(125,211,252,0.04); }
+    .callout.accent { border-left-color: var(--accent); background: rgba(240,160,114,0.05); }
+    .callout.bad { border-left-color: var(--bad); background: rgba(252,165,165,0.05); }
+    .phase { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin: 24px 0; }
+    .phase-head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--border); }
+    .phase-head h3 { font-size: 20px; margin: 0; }
+    .phase-meta { color: var(--fg-dim); font-family: var(--mono); font-size: 12px; }
+    .toc { columns: 2; column-gap: 32px; font-size: 14px; }
+    @media (max-width: 760px) { .toc { columns: 1; } }
+    .toc a { display: block; padding: 3px 0; color: var(--fg-muted); text-decoration: none; }
+    .toc a:hover { color: var(--accent); }
+    footer { color: var(--fg-dim); font-size: 12.5px; margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--border); font-family: var(--mono); }
+    .k { color: var(--accent-2); }
+    .s { color: var(--good); }
+    .c { color: var(--fg-dim); font-style: italic; }
+    .del { color: var(--bad); text-decoration: line-through; }
+    .add { color: var(--good); }
+    .band { display: flex; width: 100%; height: 40px; border-radius: 8px; overflow: hidden; border: 1px solid var(--border); font-family: var(--mono); font-size: 11px; margin: 14px 0 6px; }
+    .band > div { display: flex; align-items: center; justify-content: center; color: var(--bg); font-weight: 600; letter-spacing: 0.04em; }
+    .band .api { background: var(--fg-dim); flex: 0 0 22%; }
+    .band .std { background: var(--accent-2); flex: 1; }
+    .band .prem { background: var(--accent); flex: 0 0 30%; }
+    .band-scale { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 11px; color: var(--fg-dim); }
+  </style>
+</head>
+<body>
+<main>
+
+<header>
+  <div class="row" style="margin-bottom: 16px;">
+    <span class="badge">Implementation plan</span>
+    <span class="badge">spec/035-scenario-calculators</span>
+    <span class="badge accent">Increment · pending approval</span>
+  </div>
+  <h1>API threshold — keep light keys on metered API</h1>
+  <p class="lede">
+    A focused enhancement to the shipped <strong>API&nbsp;→&nbsp;Subscription</strong> calculator
+    (<a href="./implementation-plan.html">original plan</a>, <a href="./prototype.html">prototype</a>).
+    Today the <em>right-sized</em> scenario forces every key onto a flat seat — even someone burning $3/mo gets a $25
+    Standard seat, which <em>costs more</em> than leaving them on the API. This adds a lower
+    <strong>API threshold</strong>: below it, a key stays on pay-as-you-go metered API. It mirrors the existing
+    <strong>Premium threshold</strong> and <strong>defaults to $25</strong> — the price of a Standard seat, i.e. the
+    break-even point below which a seat can never pay off.
+  </p>
+  <p class="lede">
+    The result is a genuine three-band right-sizing — <span class="c">API · Standard · Premium</span> — and a
+    right-sized total that is now provably ≤ the metered baseline.
+  </p>
+  <p class="meta">Drafted 2026-06-09 · author: T. Studer · feature 035 increment · estimate: ~0.5–1 dev day</p>
+</header>
+
+<div class="callout info" style="margin-top: 24px;">
+  <strong>Scope.</strong> This is an increment to a <em>merged</em> feature (PR #113). It touches the pure engine, the
+  client controls/table, and the unit tests. <strong>No DB schema change, no new route, no new dependency.</strong> It
+  <em>does</em> change the calculator's default headline figures — see <a href="#anchors">§6 Regression anchors</a>.
+</div>
+
+<h2 id="toc">Contents</h2>
+<div class="toc card">
+  <a href="#goal">1 · Goal &amp; scope</a>
+  <a href="#model">2 · The three-band model</a>
+  <a href="#engine">3 · Engine changes</a>
+  <a href="#ui">4 · UI changes</a>
+  <a href="#defaults">5 · Defaults, clamping &amp; data</a>
+  <a href="#anchors">6 · Regression anchors (numbers change)</a>
+  <a href="#manifest">7 · File manifest</a>
+  <a href="#phases">8 · Phasing</a>
+  <a href="#risks">9 · Risks &amp; decisions</a>
+  <a href="#accept">10 · Acceptance checklist</a>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="goal">1 · Goal &amp; scope</h2>
+
+<div class="card accent">
+  <h4>In scope</h4>
+  <ul>
+    <li class="note">A new <strong>API threshold</strong> input (slider) in the calculator's assumptions panel,
+      <strong>default $25</strong> (= the live Standard seat price).</li>
+    <li class="note">Engine support for a third seat outcome — <code>"api"</code> — meaning <em>keep this key metered</em>;
+      its right-sized cost is the user's own API spend, not a seat price.</li>
+    <li class="note">The <em>right-sized</em> scenario, its card, bar, verdict, KPI, and the per-user table all become
+      three-way (<span class="c">API · Standard · Premium</span>).</li>
+    <li class="note">Updated unit tests + new regression anchors locking the new default figures.</li>
+  </ul>
+  <h4>Out of scope</h4>
+  <ul>
+    <li class="con">Any DB schema change — still read-only over existing tables.</li>
+    <li class="con">Applying the API floor to the <em>All&nbsp;→&nbsp;Standard</em> / <em>All&nbsp;→&nbsp;Premium</em>
+      scenarios — those stay deliberately naïve as contrast baselines (see <a href="#risks">§9</a>).</li>
+    <li class="con">Re-deriving the prototype's editorial numbers — the standalone <code>prototype.html</code> may be
+      refreshed later; not required for this increment.</li>
+  </ul>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="model">2 · The three-band model</h2>
+
+<p>
+  Each key's representative monthly spend (<code>usageForUser</code> under the chosen basis) now falls into one of three
+  bands, decided by two thresholds. With both thresholds at their break-even defaults:
+</p>
+
+<div class="band" aria-hidden="true">
+  <div class="api">API · metered</div>
+  <div class="std">STANDARD seat</div>
+  <div class="prem">PREMIUM seat</div>
+</div>
+<div class="band-scale">
+  <span>$0</span>
+  <span>↑ API threshold ($25)</span>
+  <span>↑ Premium threshold ($125)</span>
+  <span>$300+</span>
+</div>
+
+<table>
+  <thead><tr><th>Band</th><th>Condition (monthly spend <code>U</code>)</th><th>Right-sized cost for that key</th></tr></thead>
+  <tbody>
+    <tr><td><span class="pill neutral">API</span></td><td><code>U &lt; apiThreshold</code></td>
+      <td><strong>= U</strong> (stays metered — no seat). A $25 seat can't beat a $3 burn, so don't migrate them.</td></tr>
+    <tr><td><span class="pill" style="background:rgba(125,211,252,.14);color:var(--accent-2)">Standard</span></td>
+      <td><code>apiThreshold ≤ U &lt; premiumThreshold</code></td><td><code>standardCents</code></td></tr>
+    <tr><td><span class="pill new">Premium</span></td><td><code>U ≥ premiumThreshold</code></td><td><code>premiumCents</code></td></tr>
+  </tbody>
+</table>
+
+<div class="callout accent">
+  <strong>Why $25 is the right default.</strong> The API threshold defaults to the <em>Standard seat price</em>. Below
+  that, the cheapest seat already costs more than the key's entire metered bill — converting it is pure waste. Pairing
+  this with the Premium threshold's existing $125 default (the Premium seat price) makes the right-sized scenario the
+  true <em>cost-minimising</em> assignment: every key lands on whichever of {metered API, Standard, Premium} is cheapest
+  for it. Consequently <strong>right-sized ≤ baseline always</strong> (at default thresholds) — the previous version
+  could come out <em>above</em> baseline on a light-skewed population.
+</div>
+
+<p class="c">Boundaries are inclusive of the seat, matching the existing Premium convention: <code>U == apiThreshold</code>
+  ⇒ Standard (tie goes to the seat); <code>U == premiumThreshold</code> ⇒ Premium.</p>
+
+<!-- ============================================================ -->
+<h2 id="engine">3 · Engine changes</h2>
+<p>File: <code>src/lib/scenarios/api-subscription.ts</code> — pure, no React/db. Three small edits.</p>
+
+<h4>3.1 Types — add the band + the input</h4>
+<pre><code><span class="add">export type SeatTier = "api" | "standard" | "premium";</span>   <span class="c">// was: "standard" | "premium"</span>
+
+export type ScenarioInputs = {
+  standardCents: number;
+  premiumCents: number;
+  premiumThresholdCents: number;       <span class="c">// usage &gt;= ⇒ Premium</span>
+  <span class="add">apiThresholdCents: number;</span>           <span class="c">// usage &lt;  ⇒ stay on metered API</span>
+  basis: UsageBasis;
+  population: Population;
+};
+
+export type ScenarioResult = {
+  rows: ScenarioRow[];
+  count: number;
+  baselineCents: number;
+  allStandardCents: number;
+  allPremiumCents: number;
+  rightSizedCents: number;
+  premiumCount: number;
+  standardCount: number;
+  <span class="add">apiCount: number;</span>                    <span class="c">// keys kept metered</span>
+};</code></pre>
+
+<h4>3.2 <code>mapSeat</code> — three-way, Premium-first so any threshold order is sane</h4>
+<pre><code>export function mapSeat(
+  usageCents: number,
+  inputs: ScenarioInputs,
+): { tier: SeatTier; seatCents: number } {
+  <span class="add">if (usageCents &gt;= inputs.premiumThresholdCents)
+    return { tier: "premium", seatCents: inputs.premiumCents };
+  if (usageCents &lt; inputs.apiThresholdCents)
+    return { tier: "api", seatCents: usageCents };   // metered — pays its own burn
+  return { tier: "standard", seatCents: inputs.standardCents };</span>
+}</code></pre>
+<p class="c">Setting <code>seatCents = usageCents</code> for the API band is the key trick: the per-user
+  <code>deltaCents (= seatCents − usageCents)</code> becomes <strong>0</strong> (the table shows “—”, no change), and the
+  <code>seatCents</code> column still sums to <code>rightSizedCents</code> in the footer.</p>
+
+<h4>3.3 <code>computeScenarios</code> — tally the third band</h4>
+<pre><code>let premiumCount = 0;<span class="add">  let apiCount = 0;</span>
+<span class="c">// inside pool.map → after const { tier, seatCents } = mapSeat(...)</span>
+if (tier === "premium") premiumCount += 1;<span class="add">
+else if (tier === "api") apiCount += 1;</span>
+<span class="c">// rightSizedCents += seatCents  ← unchanged; API rows add their own usage</span>
+
+return {
+  /* …unchanged… */
+  premiumCount,
+  <span class="add">apiCount,</span>
+  standardCount: count - premiumCount<span class="add"> - apiCount</span>,
+};</code></pre>
+<p><code>baselineCents</code>, <code>allStandardCents</code>, <code>allPremiumCents</code>, <code>usageForUser</code> and
+  <code>classifyMonths</code> are <strong>untouched</strong>. The All&nbsp;→&nbsp;Standard / All&nbsp;→&nbsp;Premium
+  totals stay naïve by design.</p>
+
+<!-- ============================================================ -->
+<h2 id="ui">4 · UI changes</h2>
+<p>File: <code>src/app/scenarios/api-subscription/api-subscription-client.tsx</code>.</p>
+
+<h4>4.1 New state + input wiring</h4>
+<pre><code>const [apiThresholdDollars, setApiThresholdDollars] = useState(
+  Math.round(dataset.defaultStandardCents / 100),   <span class="c">// $25 on live data</span>
+);
+<span class="c">// fold into the existing useMemo ScenarioInputs:</span>
+apiThresholdCents: Math.max(0, Math.round(apiThresholdDollars * 100)),
+<span class="c">// reset(): setApiThresholdDollars(Math.round(dataset.defaultStandardCents / 100));</span></code></pre>
+
+<h4>4.2 The control — a second slider, paired with the Premium one</h4>
+<p>To keep the 4-column instrument panel, group <strong>both</strong> sliders in one “Seat thresholds” cell: the API
+  floor stacked above the Premium ceiling, with a three-way mix readout below. Two native
+  <code>&lt;input type="range"&gt;</code>s (no new dependency — consistent with the original decision). The API slider:
+  <code>min 0 · max 100 · step 5</code>, accent-filled, mono readout, <code>aria-label="API threshold, keep keys below
+  this metered"</code>.</p>
+<pre><code><span class="c">// readout under the pair — replaces the old 2-way line</span>
+&lt;span className="text-faint"&gt;{result.apiCount}&lt;/span&gt; API ·
+&lt;span className="text-ink"&gt;{result.standardCount}&lt;/span&gt; Standard ·
+&lt;span className="text-ink"&gt;{result.premiumCount}&lt;/span&gt; Premium</code></pre>
+
+<h4>4.3 Clamp — API floor must not exceed the Premium ceiling</h4>
+<pre><code>function onApiThreshold(v: number) {
+  setApiThresholdDollars(Math.min(v, thresholdDollars));        <span class="c">// can't pass Premium</span>
+}
+function onPremiumThreshold(v: number) {
+  setThresholdDollars(v);
+  if (apiThresholdDollars &gt; v) setApiThresholdDollars(v);       <span class="c">// drag the floor down with it</span>
+}</code></pre>
+
+<h4>4.4 Right-sized scenario card / bar / verdict / KPI</h4>
+<ul>
+  <li class="note"><strong>Scenario card &amp; bar</strong> (the “Threshold mix” / “Right-sized” entry): <code>barSub</code>
+    and <code>mix</code> become <code>{apiCount}A · {standardCount}S · {premiumCount}P</code> and
+    <code>{premiumCount} Premium · {standardCount} Standard · {apiCount} metered API</code>.</li>
+  <li class="note"><strong>Verdict line</strong>: “Moving {count} keys to {premiumCount} Premium + {standardCount}
+    Standard seats and keeping <span class="add">{apiCount} light keys metered</span> costs {rightSized}/mo — {phrase}
+    the {baseline}/mo API run-rate.” The save/cost tone logic is unchanged.</li>
+  <li class="note"><strong>KPI #4</strong> “Heavy users ≥ threshold” → repurpose to the three-way split, or keep it and
+    add the mix to the threshold readout. Minimal: leave the KPI, surface <code>apiCount</code> in the readout (4.2).</li>
+</ul>
+
+<h4>4.5 Per-user table</h4>
+<ul>
+  <li class="note"><code>SeatPill</code> gains an <code>"api"</code> variant — a muted/dashed pill labelled
+    <code>API</code> (greyscale, distinct from the outlined Standard/Premium pills). Keep it in the Nothing palette
+    (<code>text-faint</code> / dashed <code>border-input</code>).</li>
+  <li class="note"><strong>Seat $/mo</strong> cell for API rows shows the metered figure (<code>= API basis</code>) so the
+    footer total still equals <code>rightSizedCents</code>; the <strong>Δ seat − API</strong> cell shows “—” (delta 0).</li>
+  <li class="note">Footer mix string: <code>{premiumCount}P / {standardCount}S / {apiCount} API</code>.</li>
+  <li class="note">Sort key <code>"tier"</code>: rank <code>api &lt; standard &lt; premium</code> (e.g. 0/1/2) so the
+    column sorts cleanly across all three.</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2 id="defaults">5 · Defaults, clamping &amp; data</h2>
+<table>
+  <thead><tr><th>Concern</th><th>Decision</th></tr></thead>
+  <tbody>
+    <tr><td>Default value</td><td><code>apiThresholdCents = dataset.defaultStandardCents</code> ($25 on live data). “Reset
+      to live” restores it alongside the seat prices. Independent of the Standard <em>price</em> input thereafter (same
+      pattern the Premium threshold already follows).</td></tr>
+    <tr><td>Data / schema</td><td>None. <code>defaultStandardCents</code> already rides on <code>ApiSubscriptionDataset</code>
+      from <code>access_tiers</code> — no query change in <code>queries.ts</code>.</td></tr>
+    <tr><td>Ordering invariant</td><td>UI clamps <code>apiThreshold ≤ premiumThreshold</code> (§4.3). The engine is robust
+      regardless (Premium-first), so a bad order can never produce a negative/empty count.</td></tr>
+    <tr><td>Zero floor</td><td><code>apiThreshold = 0</code> ⇒ no key is ever kept metered ⇒ exactly the pre-increment
+      behaviour. The feature is a strict superset; $0 reproduces the old numbers.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2 id="anchors">6 · Regression anchors (these change)</h2>
+<div class="callout bad">
+  <strong>Heads-up: the default headline numbers move.</strong> Because the API threshold defaults to $25 (not $0), the
+  shipped tests asserting <code>rightSizedCents === 207500</code> (all) and <code>=== 177500</code> (active)
+  <strong>will fail and must be updated</strong>. This is the intended behaviour change, recomputed on the same
+  2026-06-09 live fixture (avg of Mar/Apr/May complete months):
+</div>
+
+<table>
+  <thead><tr><th>Population</th><th>Mix (API · Std · Prem)</th><th>Right-sized /mo</th><th>vs metered baseline</th></tr></thead>
+  <tbody>
+    <tr><td><strong>All 47 keys</strong></td><td>16 · 22 · 9</td>
+      <td><code>177591</code> <span class="c">($1,775.91)</span> <span class="del">was 207500</span></td>
+      <td>baseline <code>304140</code> → <span class="s">−$1,265.49/mo (42%)</span> <span class="c">(was 32%)</span></td></tr>
+    <tr><td><strong>Active 43</strong></td><td>16 · 20 · 7</td>
+      <td><code>147591</code> <span class="c">($1,475.91)</span> <span class="del">was 177500</span></td>
+      <td>baseline <code>241620</code> → <span class="s">−$940.29/mo (39%)</span></td></tr>
+  </tbody>
+</table>
+<p class="c">Verified by re-running the engine logic over the existing <code>REAL[]</code> fixture in
+  <code>tests/unit/scenarios/api-subscription.test.ts</code>. <code>baselineCents</code>,
+  <code>allStandardCents</code> (117500), <code>allPremiumCents</code> (587500) and <code>premiumCount</code> (9 / 7) are
+  unchanged — only the right-sized split and total move. The 38 old “Standard” keys now split <strong>22 Standard + 16
+  metered API</strong>; the 16 metered keys contribute <code>$100.91/mo</code> of real spend (not 16 × $25 = $400).</p>
+
+<h4>New / updated test cases</h4>
+<ul>
+  <li class="check"><code>mapSeat</code> band boundaries: <code>2499 ⇒ api (seatCents 2499)</code>,
+    <code>2500 ⇒ standard</code>, <code>12499 ⇒ standard</code>, <code>12500 ⇒ premium</code> — all at
+    <code>apiThresholdCents 2500</code>.</li>
+  <li class="check"><code>computeScenarios</code> default anchors → <code>{ apiCount:16, standardCount:22, premiumCount:9,
+    rightSizedCents:177591 }</code>; active → <code>{16, 20, 7, 147591}</code>.</li>
+  <li class="check"><code>apiThresholdCents: 0</code> reproduces the legacy figures (<code>207500</code> / <code>177500</code>)
+    — proves the superset property.</li>
+  <li class="check">API row invariants: <code>tier==="api" ⇒ seatCents === usageCents ⇒ deltaCents === 0</code>; footer
+    <code>Σ seatCents === rightSizedCents</code>.</li>
+  <li class="check">Update <code>baseInputs</code> in the test file to include <code>apiThresholdCents</code> (set 0 where a
+    test means to preserve old behaviour, 2500 where it asserts the new defaults).</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2 id="manifest">7 · File manifest</h2>
+<table>
+  <thead><tr><th>File</th><th></th><th>Change</th></tr></thead>
+  <tbody>
+    <tr><td><code>src/lib/scenarios/api-subscription.ts</code></td><td><span class="pill warn">edit</span></td>
+      <td><code>SeatTier</code> + <code>"api"</code>; <code>apiThresholdCents</code> on <code>ScenarioInputs</code>;
+        <code>apiCount</code> on <code>ScenarioResult</code>; three-way <code>mapSeat</code>; tally in
+        <code>computeScenarios</code>.</td></tr>
+    <tr><td><code>src/app/scenarios/api-subscription/api-subscription-client.tsx</code></td><td><span class="pill warn">edit</span></td>
+      <td>API-threshold state + slider, clamp, three-way readouts (card/bar/verdict/KPI/table footer), API
+        <code>SeatPill</code> variant, tier sort ranking.</td></tr>
+    <tr><td><code>tests/unit/scenarios/api-subscription.test.ts</code></td><td><span class="pill warn">edit</span></td>
+      <td><code>baseInputs</code> + new band/anchor/superset cases (§6).</td></tr>
+    <tr><td><code>src/lib/scenarios/queries.ts</code></td><td><span class="pill neutral">none</span></td>
+      <td>No change — <code>defaultStandardCents</code> already supplied.</td></tr>
+    <tr><td><code>src/lib/scenarios/types.ts</code></td><td><span class="pill neutral">none</span></td>
+      <td>No change — dataset shape unchanged.</td></tr>
+    <tr><td><code>specs/035-scenario-calculators/prototype.html</code></td><td><span class="pill new">opt</span></td>
+      <td>Optional later refresh to show the three-band split; not required.</td></tr>
+    <tr><td><code>CLAUDE.md</code></td><td><span class="pill warn">edit</span></td><td>“Recent Changes” line for the increment.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2 id="phases">8 · Phasing</h2>
+
+<div class="phase">
+  <div class="phase-head"><h3>Phase 1 — Engine + tests (TDD)</h3><span class="phase-meta">~0.25 day</span></div>
+  <ul>
+    <li class="check">Add the type changes (§3.1); update <code>baseInputs</code> &amp; write the new anchor/boundary/superset
+      tests (§6) <em>first</em> — they should fail.</li>
+    <li class="check">Implement three-way <code>mapSeat</code> + the <code>apiCount</code> tally (§3.2–3.3) until green.</li>
+    <li class="check"><code>pnpm test tests/unit/scenarios</code> — anchors 177591 / 147591 pass.</li>
+  </ul>
+</div>
+
+<div class="phase">
+  <div class="phase-head"><h3>Phase 2 — Client UI</h3><span class="phase-meta">~0.25–0.5 day</span></div>
+  <ul>
+    <li class="check">State + input + clamp (§4.1, 4.3); paired-slider control (§4.2).</li>
+    <li class="check">Three-way readouts: card <code>mix</code>/<code>barSub</code>, verdict, KPI, table footer (§4.4).</li>
+    <li class="check">API <code>SeatPill</code> variant + tier sort ranking + “—” delta / metered seat cell (§4.5).</li>
+  </ul>
+</div>
+
+<div class="phase">
+  <div class="phase-head"><h3>Phase 3 — Polish &amp; gates</h3><span class="phase-meta">~0.1 day</span></div>
+  <ul>
+    <li class="check">a11y: slider <code>aria-label</code>, keyboard reach, SR-sane mix readout.</li>
+    <li class="check">Design-token pass on the API pill / band viz (Nothing greyscale; no hardcoded hex).</li>
+    <li class="check"><code>pnpm lint</code> (zero warnings), <code>pnpm typecheck</code>, <code>pnpm format</code>.</li>
+  </ul>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="risks">9 · Risks &amp; decisions</h2>
+<table>
+  <thead><tr><th>Topic</th><th>Decision / mitigation</th></tr></thead>
+  <tbody>
+    <tr><td><strong>Default figures shift</strong></td><td>Intended. Documented in §6 with recomputed anchors; the $0
+      superset test pins the legacy numbers so the change is auditable.</td></tr>
+    <tr><td>Should All→Standard adopt the floor?</td><td><strong>No.</strong> Those two cards are naïve “everyone on one
+      seat” baselines — their job is to show the waste the right-sized mix avoids. Only the right-sized scenario gets the
+      floor.</td></tr>
+    <tr><td>Threshold ordering</td><td>UI clamps <code>api ≤ premium</code>; engine is Premium-first so it never breaks
+      even if fed an inverted pair (defensive).</td></tr>
+    <tr><td>“API” seat cost = usage</td><td>Makes delta 0 and keeps the footer total honest. The Seat&nbsp;$/mo cell
+      duplicating the API-basis cell is acceptable signal (“no change”); a “metered” text label is an alternative.</td></tr>
+    <tr><td>Capacity caveat still holds</td><td>The all-Standard warning (“a $25 seat may not cover a $287 user”) is
+      unaffected; the API floor is about the <em>bottom</em> of the distribution, not the top.</td></tr>
+    <tr><td>Naming</td><td>“API threshold” (keep-below-metered) reads symmetrically with “Premium threshold”
+      (promote-above). Confirm the label wording with the user if “metered floor” is preferred.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2 id="accept">10 · Acceptance checklist</h2>
+<ul>
+  <li class="check">An <strong>API threshold</strong> control appears, defaulting to $25 (live Standard price); “Reset to
+    live” restores it.</li>
+  <li class="check">Keys below the threshold render as <code>API</code> seats, contribute their metered spend (not a seat
+    price) to the right-sized total, and show a “—” delta.</li>
+  <li class="check">Right-sized card/bar/verdict/KPI/table all read three-way (API · Standard · Premium).</li>
+  <li class="check">Dragging the API threshold up moves keys API→Standard and re-totals live; it can never exceed the
+    Premium threshold.</li>
+  <li class="check">Default view reproduces the §6 anchors (47 → 16·22·9 → $1,775.91/mo; active → 16·20·7 →
+    $1,475.91/mo); <code>apiThreshold=0</code> reproduces the legacy $2,075 / $1,775.</li>
+  <li class="check"><code>lint</code> / <code>typecheck</code> / <code>format</code> clean; unit tests green with the new
+    anchors.</li>
+</ul>
+
+<footer>
+  AI Developer Hub · spec/035-scenario-calculators · API-threshold increment · drafted 2026-06-09 · companions:
+  implementation-plan.html · prototype.html
+</footer>
+
+</main>
+</body>
+</html>

--- a/specs/035-scenario-calculators/implementation-notes.html
+++ b/specs/035-scenario-calculators/implementation-notes.html
@@ -262,6 +262,20 @@
       (a <code>verdictLead</code> string); verified: <code>count 0</code> → "Right-sizing the 0 API users costs …",
       <code>count 1</code> → singular "user".</li>
   </ul>
+  <p><strong>Pass 3</strong> (re-review of pass 2) — two more, both fixed:</p>
+  <ul>
+    <li><strong>Seat $/mo precision mismatch</strong> — API rows carry cents-precise metered spend, but the "Seat $/mo"
+      cell used whole-dollar <code>formatUSD0</code> while "API basis" used <code>formatCurrency</code> — so the same
+      value could read <code>$24</code> vs <code>$23.82</code> beside a <code>—</code> delta. API rows now use
+      <code>formatCurrency</code> too; verified in-browser the two cells match exactly (e.g. $23.82 = $23.82, Δ —).
+      Whole-dollar seat prices keep <code>formatUSD0</code>.</li>
+    <li><strong>Misleading sort comment</strong> — <code>TIER_SORT_ORDER</code> was annotated "cheapest → priciest",
+      but it's a tier-escalation order (API → Standard → Premium), not a cost order. Reworded to say so and cross-ref
+      <code>mapSeat</code>.</li>
+  </ul>
+  <p class="c">After pass 3 the loop is converging on increasingly minor points (display precision, comment wording),
+    each typically about the previous fix. All six findings across three passes are fixed, replied, and resolved; CI is
+    green on every commit. Concluding the review loop here — the PR is open for human review.</p>
 </div>
 
 <footer id="result-footer">

--- a/specs/035-scenario-calculators/implementation-notes.html
+++ b/specs/035-scenario-calculators/implementation-notes.html
@@ -238,6 +238,22 @@
   </ul>
 </div>
 
+<h2>6 · AI review round (Copilot) — addressed</h2>
+<div class="card">
+  <p>GitHub Copilot's review raised two (both fair, both fixed):</p>
+  <ul>
+    <li><strong><code>mapSeat</code> JSDoc said "cheapest viable option"</strong> — but the function is purely
+      threshold-based; away from the default thresholds a tier can be assigned even when another would cost less.
+      Reworded the doc to state the three threshold rules explicitly and to note that the cost-minimising reading only
+      holds at the break-even defaults.</li>
+    <li><strong>Verdict sentence was internally inconsistent for <code>apiCount &gt; 0</code></strong> — "Moving 47 users
+      to 9 Premium + 22 Standard seats and keeping 16 metered" reads as 47 → 31 seats. Reworded to a true partition via
+      a small <code>joinParts()</code> helper, omitting empty groups. Verified in-browser across all three mixes:
+      default → "9 Premium, 22 Standard, and 16 kept on metered API"; API floor $0 → "9 Premium and 38 Standard";
+      Standard-empty clamp → "32 Premium and 15 kept on metered API" (each sums to 47).</li>
+  </ul>
+</div>
+
 <footer id="result-footer">
   AI Developer Hub · 035 API-threshold increment · notes drafted 2026-06-09 · implemented, gates green, reviewed, simplified.
 </footer>

--- a/specs/035-scenario-calculators/implementation-notes.html
+++ b/specs/035-scenario-calculators/implementation-notes.html
@@ -238,9 +238,9 @@
   </ul>
 </div>
 
-<h2>6 · AI review round (Copilot) — addressed</h2>
+<h2>6 · AI review (Copilot) — addressed across two passes</h2>
 <div class="card">
-  <p>GitHub Copilot's review raised two (both fair, both fixed):</p>
+  <p><strong>Pass 1</strong> raised two (both fair, both fixed):</p>
   <ul>
     <li><strong><code>mapSeat</code> JSDoc said "cheapest viable option"</strong> — but the function is purely
       threshold-based; away from the default thresholds a tier can be assigned even when another would cost less.
@@ -251,6 +251,16 @@
       a small <code>joinParts()</code> helper, omitting empty groups. Verified in-browser across all three mixes:
       default → "9 Premium, 22 Standard, and 16 kept on metered API"; API floor $0 → "9 Premium and 38 Standard";
       Standard-empty clamp → "32 Premium and 15 kept on metered API" (each sums to 47).</li>
+  </ul>
+  <p><strong>Pass 2</strong> (re-review of the pass-1 fix) caught two follow-ons, both fixed:</p>
+  <ul>
+    <li><strong>Stale field doc</strong> — the <code>premiumThresholdCents</code> JSDoc still said "otherwise
+      Standard", which the new API tier makes wrong. Reworded to "below it the key is Standard or, under
+      <code>apiThresholdCents</code>, the metered API tier (see mapSeat)".</li>
+    <li><strong>Empty-population copy</strong> — when <code>count === 0</code> (population = active with no active keys,
+      reachable via the toggle) the verdict rendered dangling "— —". The breakdown interjection is now conditional
+      (a <code>verdictLead</code> string); verified: <code>count 0</code> → "Right-sizing the 0 API users costs …",
+      <code>count 1</code> → singular "user".</li>
   </ul>
 </div>
 

--- a/specs/035-scenario-calculators/implementation-notes.html
+++ b/specs/035-scenario-calculators/implementation-notes.html
@@ -1,0 +1,247 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Implementation Notes — API threshold (035 increment)</title>
+  <style>
+    :root {
+      --bg: #0b0d12; --bg-elev: #11141b; --bg-card: #161a24; --border: #232938; --border-strong: #2f3850;
+      --fg: #e7ebf3; --fg-muted: #9aa3b5; --fg-dim: #6b7488; --accent: #f0a072; --accent-2: #7dd3fc;
+      --good: #86efac; --warn: #fcd34d; --bad: #fca5a5;
+      --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); font-family: var(--sans); line-height: 1.55; }
+    body { padding: 48px 24px 96px; }
+    main { max-width: 1000px; margin: 0 auto; }
+    h1 { font-size: 30px; margin: 0 0 8px; font-weight: 600; letter-spacing: -0.01em; }
+    h2 { font-size: 20px; margin: 44px 0 14px; padding-bottom: 8px; border-bottom: 1px solid var(--border); font-weight: 600; }
+    h3 { font-size: 15px; margin: 18px 0 4px; font-weight: 600; }
+    p { margin: 0 0 12px; }
+    code { font-family: var(--mono); font-size: 0.88em; background: var(--bg-elev); padding: 1px 5px; border-radius: 4px; border: 1px solid var(--border); }
+    .lede { color: var(--fg-muted); font-size: 16px; max-width: 800px; }
+    .meta { color: var(--fg-dim); font-size: 13px; margin-top: 8px; font-family: var(--mono); }
+    .badge { display: inline-block; font-size: 11px; font-family: var(--mono); padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border-strong); color: var(--fg-muted); background: var(--bg-elev); }
+    .badge.accent { color: var(--accent); border-color: rgba(240,160,114,0.35); }
+    .badge.good { color: var(--good); border-color: rgba(134,239,172,0.3); }
+    .card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 20px 22px; margin: 14px 0; }
+    .note { border-left: 3px solid var(--accent-2); padding: 4px 0 4px 16px; margin: 14px 0; }
+    .note.dec { border-color: var(--accent-2); }
+    .note.dev { border-color: var(--warn); }
+    .note.trade { border-color: var(--good); }
+    .note.q { border-color: var(--bad); }
+    .tag { font-family: var(--mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--fg-dim); }
+    ul { padding-left: 20px; margin: 6px 0 12px; }
+    li { margin: 4px 0; }
+    table { width: 100%; border-collapse: collapse; font-size: 13.5px; margin: 12px 0; }
+    th, td { text-align: left; padding: 8px 11px; border-bottom: 1px solid var(--border); vertical-align: top; }
+    th { color: var(--fg-muted); font-weight: 500; font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.05em; background: var(--bg-elev); }
+    .k { color: var(--accent-2); } .s { color: var(--good); } .c { color: var(--fg-dim); font-style: italic; }
+    footer { color: var(--fg-dim); font-size: 12.5px; margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--border); font-family: var(--mono); }
+  </style>
+</head>
+<body>
+<main>
+<header>
+  <div style="margin-bottom:14px;">
+    <span class="badge accent">Implementation notes</span>
+    <span class="badge">035 · API threshold</span>
+    <span class="badge good" id="status-badge">Status: implemented · gates green · review pass</span>
+  </div>
+  <h1>Implementation notes — API threshold</h1>
+  <p class="lede">
+    What diverged from, or was interpreted beyond, <a href="./api-threshold-implementation-plan.html">the plan</a>
+    while building it. A running log; updated as the work proceeds.
+  </p>
+  <p class="meta">Started 2026-06-09 · feature 035 increment · branch 036-budget-forecast-simulation (worktree api-subscription-calc)</p>
+</header>
+
+<h2>1 · Design decisions (spec was ambiguous / left to judgement)</h2>
+
+<div class="note dec">
+  <p class="tag">Decision · control layout</p>
+  <h3>Both thresholds share one "Seat thresholds" cell</h3>
+  <p>The plan offered the API floor as "a second slider, paired with the Premium one" but left the exact panel layout
+    open. I kept the 4-column instrument panel by stacking the API-floor slider above the Premium-ceiling slider in the
+    cell that previously held the Premium slider alone, with a single three-way <code>API · Standard · Premium</code>
+    readout below the pair. No new grid column; the cell just grows taller.</p>
+</div>
+
+<div class="note dec">
+  <p class="tag">Decision · label wording</p>
+  <h3>Slider labelled <code>Keep on API &lt;</code> (not "API threshold")</h3>
+  <p>Reads symmetrically against the existing <code>Premium threshold ≥</code> and states the behaviour directly
+    (keys below stay on API). The plan flagged the wording as unconfirmed — see open questions.</p>
+</div>
+
+<div class="note dec">
+  <p class="tag">Decision · "api" seat cost</p>
+  <h3>A metered key's <code>seatCents</code> = its own usage</h3>
+  <p>So its per-user <code>deltaCents</code> is exactly 0 (the table shows "—", i.e. no change), and the
+    <code>seatCents</code> column still foots to <code>rightSizedCents</code>. This is the plan's stated trick; I kept it
+    rather than special-casing API rows out of the footer total.</p>
+</div>
+
+<div class="note dec">
+  <p class="tag">Decision · slider range</p>
+  <h3>API slider is <code>$0–$100, step $5</code></h3>
+  <p>The Premium slider spans <code>$0–$300</code>; the API floor only needs the low end (its sole job is to catch keys
+    cheaper than a seat). $25 default is reachable at step 5. The UI clamps the floor to ≤ the Premium ceiling.</p>
+</div>
+
+<div class="note dec">
+  <p class="tag">Decision · default sourcing</p>
+  <h3>Default = live Standard seat price, then independent</h3>
+  <p>Initialised from <code>dataset.defaultStandardCents</code> ($25 on live data) and restored by "Reset to live", but
+    thereafter a free, independent control — mirroring how the Premium threshold relates to the Premium price.</p>
+</div>
+
+<h2>2 · Deviations (intentional departures)</h2>
+
+<div class="note dev">
+  <p class="tag">Deviation · test anchors</p>
+  <h3>Default-input regression anchors were rewritten, not preserved</h3>
+  <p>Because the API threshold defaults to <code>$25</code> (not 0), the shipped tests asserting
+    <code>rightSizedCents === 207500</code> (all) / <code>177500</code> (active) no longer describe the default. I
+    <em>rewrote</em> those two tests to the new three-band anchors (<span class="s">177591</span> = 16·22·9;
+    <span class="s">147591</span> = 16·20·7) and added a separate <code>apiThresholdCents: 0</code> "superset" test that
+    pins the old <code>207500 / 177500</code> figures. Net: the legacy numbers are still asserted, just under the input
+    that produces them. This is the intended behaviour change called out in plan §6.</p>
+</div>
+
+<div class="note dev">
+  <p class="tag">Deviation · scope guard</p>
+  <h3>The API floor applies only to the right-sized scenario</h3>
+  <p><em>All → Standard</em> and <em>All → Premium</em> stay deliberately naïve (everyone on one seat) as contrast
+    baselines. The floor is the whole point of the right-sized column, so applying it elsewhere would erase the
+    comparison the page exists to make.</p>
+</div>
+
+<h2>3 · Tradeoffs (alternatives considered)</h2>
+
+<div class="note trade">
+  <p class="tag">Tradeoff · control widget</p>
+  <h3>Two native range sliders vs a dual-thumb Radix slider</h3>
+  <p>A single dual-thumb range would express the API–Premium band most directly, but <code>@radix-ui/react-slider</code>
+    isn't installed and the original 035 decision was explicitly "native range, no new dependency, reads as a mechanical
+    instrument." Two stacked native sliders honour that and avoid a dependency; the cost is two thumbs instead of one
+    band. Revisit only if a true band control is wanted.</p>
+</div>
+
+<div class="note trade">
+  <p class="tag">Tradeoff · "Seat $/mo" cell for API rows</p>
+  <h3>Show the metered dollar amount vs a "metered" text label</h3>
+  <p>For an API-retained key the Seat $/mo cell shows its metered figure — which duplicates the "API basis" column. The
+    alternative (a "metered" word) reads cleaner but breaks the column's footer sum. I kept the number so the column
+    keeps footing to <code>rightSizedCents</code>; the "—" in the Δ column already signals "no change". Easy to flip if
+    you prefer the label.</p>
+</div>
+
+<div class="note trade">
+  <p class="tag">Tradeoff · mapSeat ordering</p>
+  <h3>Premium-first branch order</h3>
+  <p>Checking <code>premium</code> before the API floor makes the function robust to an inverted threshold pair (floor
+    above ceiling) — it can never emit a negative or impossible count even though the UI also clamps to prevent that
+    state. Costs nothing; buys defensiveness.</p>
+</div>
+
+<h2>4 · Open questions (please confirm / revise)</h2>
+
+<div class="note q">
+  <p class="tag">Question · wording</p>
+  <h3>Is <code>Keep on API &lt;</code> the label you want?</h3>
+  <p>Alternatives: "API threshold", "Metered floor", "Min spend for a seat". Happy to change — it's a one-line edit.</p>
+</div>
+
+<div class="note q">
+  <p class="tag">Question · spec folder vs new number</p>
+  <h3>Both the plan and these notes live under <code>specs/035-scenario-calculators/</code></h3>
+  <p>Filed as a 035 increment beside the original plan/prototype. If you'd rather track this as its own numbered spec,
+    say so and I'll move them.</p>
+</div>
+
+<div class="note q">
+  <p class="tag">Question · prototype refresh</p>
+  <h3>The standalone <code>prototype.html</code> still shows the old two-band numbers</h3>
+  <p>Left untouched (it's the editorial reference, not shipped). Want it refreshed to the three-band split, or is the
+    app + this notes file enough?</p>
+</div>
+
+<h2>5 · Verification &amp; <code>/simplify</code> outcome</h2>
+
+<div class="card">
+  <h3>Gates (run twice — after implementation, and again after cleanup)</h3>
+  <table>
+    <thead><tr><th>Gate</th><th>Result</th></tr></thead>
+    <tbody>
+      <tr><td><code>pnpm test</code> (scenario suite)</td><td class="s">22 passed</td></tr>
+      <tr><td><code>pnpm typecheck</code></td><td class="s">clean</td></tr>
+      <tr><td><code>pnpm lint</code></td><td class="s">No ESLint warnings or errors (—max-warnings 0)</td></tr>
+    </tbody>
+  </table>
+  <p class="c">Regression anchors observed exactly: all-47 right-sized = <strong>177591</strong> (16 API · 22 Standard ·
+    9 Premium); active-43 = <strong>147591</strong> (16 · 20 · 7); <code>apiThreshold:0</code> superset = <strong>207500</strong>.
+    A 4-way adversarial review (engine math, test coverage, UI completeness, quality/a11y/tokens) returned pass on all
+    four dimensions; the one minor nit (a baseInputs comment) was applied.</p>
+
+  <h3>Environment note (not a code issue)</h3>
+  <p><code>pnpm lint</code> prints two benign Next.js CLI notices: a <code>next lint</code> deprecation message, and a
+    "multiple lockfiles / inferred workspace root" warning — the worktree has its own <code>pnpm-lock.yaml</code>
+    alongside the repo-root one. ESLint itself is clean. Flagged only so the extra console text isn't a surprise.</p>
+
+  <h3>Browser verification (Playwright + agent session, worktree on :3001)</h3>
+  <p>Drove the live page against the preview DB — whose data matches the test fixture, so the on-screen figures equal
+    the unit anchors:</p>
+  <table>
+    <thead><tr><th>State</th><th>Readout</th><th>Right-sized verdict</th></tr></thead>
+    <tbody>
+      <tr><td>Default ($25 floor / $125)</td><td>16 API · 22 Standard · 9 Premium</td>
+        <td class="s">$1,776/mo · 42% cut · 16 API pills in table</td></tr>
+      <tr><td>API floor → $0</td><td>0 API · 38 Standard · 9 Premium</td>
+        <td>$2,075/mo · 32% cut · verdict correctly omits the "keeping N keys" clause</td></tr>
+      <tr><td>API floor → $100</td><td>36 API · 2 Standard · 9 Premium</td><td>$2,408/mo · 36 API pills</td></tr>
+      <tr><td>Premium → $20 (clamp test)</td><td>15 API · 0 Standard · 32 Premium</td>
+        <td class="s">API floor auto-followed 100 → 20 ✓ · cost state turns red (+34%)</td></tr>
+    </tbody>
+  </table>
+  <p class="c">One console message: a React hydration warning about <code>caret-color: transparent</code> on the
+    <em>unchanged</em> <code>PriceField</code> number inputs (<code>std-price</code> / <code>prem-price</code>) — these
+    are outside this diff, so the warning is pre-existing/environmental (browser-injected inline style), not introduced
+    by the API-threshold change. Not fixed here (out of scope).</p>
+
+  <h3><code>/simplify</code> — applied</h3>
+  <ul>
+    <li><strong>Extracted <code>&lt;ThresholdSlider&gt;</code></strong> — the API and Premium slider blocks were ~45 lines
+      of near-identical JSX; now one local component, called twice. (Flagged independently by the reuse + simplification
+      passes.)</li>
+    <li><strong><code>SEAT_PILL</code> lookup record</strong> — <code>SeatPill</code> no longer special-cases
+      <code>tier === "api"</code>; all three tiers render from one <code>Record&lt;SeatTier, {className,label}&gt;</code>,
+      making the tier set first-class. (Altitude + simplification.)</li>
+    <li><strong><code>TIER_SORT_ORDER</code> constant</strong> — replaced the nested-ternary magic numbers in the table
+      sort with a named <code>Record&lt;SeatTier, number&gt;</code> (api 0 · standard 1 · premium 2). (Altitude +
+      simplification.)</li>
+  </ul>
+
+  <h3><code>/simplify</code> — skipped (with reason)</h3>
+  <ul>
+    <li><strong>Swap SeatPill for the shared <code>Badge</code></strong> — would change the deliberate "Nothing" mono/pill
+      visuals on pre-existing code; out of this increment's intent.</li>
+    <li><strong>Hoist <code>clamp()</code> into <code>lib/utils</code></strong> — touches files outside the diff; the inline
+      <code>Math.min</code> is already minimal.</li>
+    <li><strong>A <code>formatSeatMix()</code> helper</strong> — the three readouts use intentionally different orderings
+      and separators (bar <code>16A·22S·9P</code>, footer <code>9P/22S/16A</code>, prose); unifying adds parameters, not
+      clarity.</li>
+    <li><strong>Engine-side <code>validateScenarioInputs()</code></strong> — the floor≤ceiling invariant is a UI concern;
+      <code>mapSeat</code> is already Premium-first and robust to any ordering, so this would be gold-plating.</li>
+  </ul>
+</div>
+
+<footer id="result-footer">
+  AI Developer Hub · 035 API-threshold increment · notes drafted 2026-06-09 · implemented, gates green, reviewed, simplified.
+</footer>
+
+</main>
+</body>
+</html>

--- a/src/app/scenarios/api-subscription/api-subscription-client.tsx
+++ b/src/app/scenarios/api-subscription/api-subscription-client.tsx
@@ -57,6 +57,13 @@ function basisLabel(key: string, ds: ApiSubscriptionDataset): string {
   return `avg of ${ds.completeMonths.length} complete months`;
 }
 
+/** Oxford-comma join: ["a"]→"a"; ["a","b"]→"a and b"; ["a","b","c"]→"a, b, and c". */
+function joinParts(parts: string[]): string {
+  if (parts.length <= 1) return parts[0] ?? "";
+  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
+  return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`;
+}
+
 type SortKey = "name" | "status" | "usage" | "tier" | "seat" | "delta";
 
 // Seat-tier presentation kept in one place so the three-tier model stays
@@ -253,6 +260,16 @@ export function ApiSubscriptionClient({
       : savingState === "costs"
         ? "text-destructive"
         : "text-faint";
+
+  // The right-sized population as a partition, omitting empty groups, so the
+  // verdict reads correctly for any mix (including when Standard or API is empty).
+  const seatBreakdown = joinParts(
+    [
+      result.premiumCount > 0 ? `${result.premiumCount} Premium` : null,
+      result.standardCount > 0 ? `${result.standardCount} Standard` : null,
+      result.apiCount > 0 ? `${result.apiCount} kept on metered API` : null,
+    ].filter((part): part is string => part !== null),
+  );
 
   // Single source for the four scenarios — drives both the cards and the bars.
   const scenarios = [
@@ -469,18 +486,12 @@ export function ApiSubscriptionClient({
           </span>
         </p>
         <p className="max-w-3xl text-sm text-muted-foreground">
-          Moving {result.count} API users to {result.premiumCount} Premium +{" "}
-          {result.standardCount} Standard seats
-          {result.apiCount > 0
-            ? ` and keeping ${result.apiCount} light ${
-                result.apiCount === 1 ? "key" : "keys"
-              } on metered API`
-            : ""}{" "}
-          costs{" "}
+          Right-sizing the {result.count} API{" "}
+          {result.count === 1 ? "user" : "users"} — {seatBreakdown} — costs{" "}
           <span className="text-ink">
             {formatUSD0(result.rightSizedCents)}/mo
-          </span>{" "}
-          — {verdictPhrase} the {formatUSD0(result.baselineCents)}/mo API
+          </span>
+          , {verdictPhrase} the {formatUSD0(result.baselineCents)}/mo API
           run-rate.
         </p>
       </div>

--- a/src/app/scenarios/api-subscription/api-subscription-client.tsx
+++ b/src/app/scenarios/api-subscription/api-subscription-client.tsx
@@ -270,6 +270,13 @@ export function ApiSubscriptionClient({
       result.apiCount > 0 ? `${result.apiCount} kept on metered API` : null,
     ].filter((part): part is string => part !== null),
   );
+  // Drop the breakdown interjection when there's nothing to list (e.g.
+  // population=active with no active keys) so the copy never shows dangling
+  // dashes ("— —").
+  const verdictLead =
+    `Right-sizing the ${result.count} API ${
+      result.count === 1 ? "user" : "users"
+    }` + (seatBreakdown ? ` — ${seatBreakdown} —` : "");
 
   // Single source for the four scenarios — drives both the cards and the bars.
   const scenarios = [
@@ -486,8 +493,7 @@ export function ApiSubscriptionClient({
           </span>
         </p>
         <p className="max-w-3xl text-sm text-muted-foreground">
-          Right-sizing the {result.count} API{" "}
-          {result.count === 1 ? "user" : "users"} — {seatBreakdown} — costs{" "}
+          {verdictLead} costs{" "}
           <span className="text-ink">
             {formatUSD0(result.rightSizedCents)}/mo
           </span>

--- a/src/app/scenarios/api-subscription/api-subscription-client.tsx
+++ b/src/app/scenarios/api-subscription/api-subscription-client.tsx
@@ -28,6 +28,7 @@ import {
   type Population,
   type ScenarioInputs,
   type ScenarioRow,
+  type SeatTier,
   type UsageBasis,
 } from "@/lib/scenarios/api-subscription";
 import type { ApiSubscriptionDataset } from "@/lib/scenarios/types";
@@ -58,6 +59,26 @@ function basisLabel(key: string, ds: ApiSubscriptionDataset): string {
 
 type SortKey = "name" | "status" | "usage" | "tier" | "seat" | "delta";
 
+// Seat-tier presentation kept in one place so the three-tier model stays
+// first-class: sort rank (cheapest → priciest) and per-tier pill styling.
+const TIER_SORT_ORDER: Record<SeatTier, number> = {
+  api: 0,
+  standard: 1,
+  premium: 2,
+};
+
+const SEAT_PILL: Record<SeatTier, { className: string; label: string }> = {
+  api: {
+    className: "border border-dashed border-input text-faint",
+    label: "API",
+  },
+  standard: {
+    className: "border border-input text-muted-foreground",
+    label: "standard",
+  },
+  premium: { className: "border border-ink text-ink", label: "premium" },
+};
+
 export function ApiSubscriptionClient({
   dataset,
 }: {
@@ -72,6 +93,9 @@ export function ApiSubscriptionClient({
   const [thresholdDollars, setThresholdDollars] = useState(
     Math.round(dataset.defaultPremiumCents / 100),
   );
+  const [apiThresholdDollars, setApiThresholdDollars] = useState(
+    Math.round(dataset.defaultStandardCents / 100),
+  );
   const [basisKey, setBasisKey] = useState("avgComplete");
   const [population, setPopulation] = useState<Population>("all");
   const [sort, setSort] = useState<{ key: SortKey; dir: 1 | -1 }>({
@@ -84,10 +108,18 @@ export function ApiSubscriptionClient({
       standardCents: Math.max(0, Math.round(standardDollars * 100)),
       premiumCents: Math.max(0, Math.round(premiumDollars * 100)),
       premiumThresholdCents: Math.max(0, Math.round(thresholdDollars * 100)),
+      apiThresholdCents: Math.max(0, Math.round(apiThresholdDollars * 100)),
       basis: toBasis(basisKey),
       population,
     }),
-    [standardDollars, premiumDollars, thresholdDollars, basisKey, population],
+    [
+      standardDollars,
+      premiumDollars,
+      thresholdDollars,
+      apiThresholdDollars,
+      basisKey,
+      population,
+    ],
   );
 
   const result = useMemo(
@@ -137,7 +169,7 @@ export function ApiSubscriptionClient({
         case "status":
           return r.user.status;
         case "tier":
-          return r.tier === "premium" ? 1 : 0;
+          return TIER_SORT_ORDER[r.tier];
         case "seat":
           return r.seatCents;
         case "delta":
@@ -163,10 +195,21 @@ export function ApiSubscriptionClient({
     );
   }
 
+  // The API floor can never sit above the Premium ceiling. Lowering Premium drags
+  // the floor down with it; raising the floor stops at the current Premium value.
+  function onApiThreshold(value: number) {
+    setApiThresholdDollars(Math.min(value, thresholdDollars));
+  }
+  function onPremiumThreshold(value: number) {
+    setThresholdDollars(value);
+    setApiThresholdDollars((prev) => Math.min(prev, value));
+  }
+
   function reset() {
     setStandardDollars(dataset.defaultStandardCents / 100);
     setPremiumDollars(dataset.defaultPremiumCents / 100);
     setThresholdDollars(Math.round(dataset.defaultPremiumCents / 100));
+    setApiThresholdDollars(Math.round(dataset.defaultStandardCents / 100));
     setBasisKey("avgComplete");
     setPopulation("all");
   }
@@ -244,9 +287,9 @@ export function ApiSubscriptionClient({
       tag: "Right-sized",
       title: "Threshold mix",
       barLabel: "Right-sized",
-      barSub: `${result.premiumCount}P · ${result.standardCount}S`,
+      barSub: `${result.apiCount}A · ${result.standardCount}S · ${result.premiumCount}P`,
       cents: result.rightSizedCents,
-      mix: `${result.premiumCount} Premium · ${result.standardCount} Standard`,
+      mix: `${result.premiumCount} Premium · ${result.standardCount} Standard · ${result.apiCount} metered API`,
       isBaseline: false,
     },
   ];
@@ -307,31 +350,30 @@ export function ApiSubscriptionClient({
               onChange={setPremiumDollars}
             />
 
-            <div>
-              <div className="flex items-baseline justify-between">
-                <ControlLabel htmlFor="threshold">
-                  Premium threshold ≥
-                </ControlLabel>
-                <span className="font-mono text-sm tabular-nums text-ink">
-                  {formatUSD0(inputs.premiumThresholdCents)}
-                </span>
-              </div>
-              <input
-                id="threshold"
-                type="range"
-                min={0}
-                max={300}
-                step={5}
-                value={thresholdDollars}
-                onChange={(e) => setThresholdDollars(Number(e.target.value))}
-                className="mt-3 w-full cursor-pointer"
-                style={{ accentColor: "var(--ink)" }}
-                aria-label="Premium threshold, dollars per month"
+            <div className="space-y-4">
+              <ThresholdSlider
+                id="api-threshold"
+                label="Keep on API <"
+                cents={inputs.apiThresholdCents}
+                value={apiThresholdDollars}
+                max={100}
+                onChange={onApiThreshold}
+                ariaLabel="API threshold — keep keys spending below this on metered API"
               />
-              <p className="mt-1.5 font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
-                <span className="text-ink">{result.premiumCount}</span> Premium
-                · <span className="text-ink">{result.standardCount}</span>{" "}
-                Standard
+              <ThresholdSlider
+                id="threshold"
+                label="Premium threshold ≥"
+                cents={inputs.premiumThresholdCents}
+                value={thresholdDollars}
+                max={300}
+                onChange={onPremiumThreshold}
+                ariaLabel="Premium threshold, dollars per month"
+              />
+              <p className="font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
+                <span className="text-faint">{result.apiCount}</span> API ·{" "}
+                <span className="text-ink">{result.standardCount}</span> Standard
+                · <span className="text-ink">{result.premiumCount}</span>{" "}
+                Premium
               </p>
             </div>
 
@@ -405,7 +447,7 @@ export function ApiSubscriptionClient({
         <Kpi
           label={`Heavy users ≥ ${formatUSD0(inputs.premiumThresholdCents)}`}
           value={result.premiumCount}
-          sub={`${result.standardCount} fit a Standard seat`}
+          sub={`${result.standardCount} on Standard · ${result.apiCount} kept on API`}
         />
       </div>
 
@@ -427,8 +469,14 @@ export function ApiSubscriptionClient({
           </span>
         </p>
         <p className="max-w-3xl text-sm text-muted-foreground">
-          Moving all {result.count} API users to {result.premiumCount} Premium +{" "}
-          {result.standardCount} Standard seats costs{" "}
+          Moving {result.count} API users to {result.premiumCount} Premium +{" "}
+          {result.standardCount} Standard seats
+          {result.apiCount > 0
+            ? ` and keeping ${result.apiCount} light ${
+                result.apiCount === 1 ? "key" : "keys"
+              } on metered API`
+            : ""}{" "}
+          costs{" "}
           <span className="text-ink">
             {formatUSD0(result.rightSizedCents)}/mo
           </span>{" "}
@@ -664,7 +712,8 @@ export function ApiSubscriptionClient({
                     {formatUSD0(result.baselineCents)}
                   </TableCell>
                   <TableCell className="text-right font-mono text-xs tabular-nums text-muted-foreground">
-                    {result.premiumCount}P / {result.standardCount}S
+                    {result.premiumCount}P / {result.standardCount}S /{" "}
+                    {result.apiCount}A
                   </TableCell>
                   <TableCell className="text-right font-mono text-sm tabular-nums">
                     {formatUSD0(result.rightSizedCents)}
@@ -712,6 +761,47 @@ function ControlLabel({
     >
       {children}
     </label>
+  );
+}
+
+function ThresholdSlider({
+  id,
+  label,
+  cents,
+  value,
+  max,
+  onChange,
+  ariaLabel,
+}: {
+  id: string;
+  label: string;
+  cents: number;
+  value: number;
+  max: number;
+  onChange: (v: number) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between">
+        <ControlLabel htmlFor={id}>{label}</ControlLabel>
+        <span className="font-mono text-sm tabular-nums text-ink">
+          {formatUSD0(cents)}
+        </span>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={0}
+        max={max}
+        step={5}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="mt-3 w-full cursor-pointer"
+        style={{ accentColor: "var(--ink)" }}
+        aria-label={ariaLabel}
+      />
+    </div>
   );
 }
 
@@ -804,17 +894,16 @@ function Kpi({
   );
 }
 
-function SeatPill({ tier }: { tier: "standard" | "premium" }) {
+function SeatPill({ tier }: { tier: SeatTier }) {
+  const { className, label } = SEAT_PILL[tier];
   return (
     <span
       className={cn(
         "inline-block rounded-[4px] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em]",
-        tier === "premium"
-          ? "border border-ink text-ink"
-          : "border border-input text-muted-foreground",
+        className,
       )}
     >
-      {tier}
+      {label}
     </span>
   );
 }

--- a/src/app/scenarios/api-subscription/api-subscription-client.tsx
+++ b/src/app/scenarios/api-subscription/api-subscription-client.tsx
@@ -67,7 +67,8 @@ function joinParts(parts: string[]): string {
 type SortKey = "name" | "status" | "usage" | "tier" | "seat" | "delta";
 
 // Seat-tier presentation kept in one place so the three-tier model stays
-// first-class: sort rank (cheapest → priciest) and per-tier pill styling.
+// first-class: sort rank (tier escalation API → Standard → Premium, not a cost
+// ordering — see mapSeat) and per-tier pill styling.
 const TIER_SORT_ORDER: Record<SeatTier, number> = {
   api: 0,
   standard: 1,
@@ -690,7 +691,12 @@ export function ApiSubscriptionClient({
                       <SeatPill tier={r.tier} />
                     </TableCell>
                     <TableCell className="text-right font-mono text-sm tabular-nums text-ink">
-                      {formatUSD0(r.seatCents)}
+                      {/* API rows carry cents-precise metered spend; match the
+                          API-basis cell's precision so Δ "—" reads consistently.
+                          Whole-dollar seat prices stay on formatUSD0. */}
+                      {r.tier === "api"
+                        ? formatCurrency(r.seatCents)
+                        : formatUSD0(r.seatCents)}
                     </TableCell>
                     <TableCell
                       className={cn(

--- a/src/lib/scenarios/api-subscription.ts
+++ b/src/lib/scenarios/api-subscription.ts
@@ -21,7 +21,7 @@ export type Population = "all" | "active";
 export type ScenarioInputs = {
   standardCents: number;
   premiumCents: number;
-  /** usage >= threshold ⇒ Premium seat, otherwise Standard. */
+  /** usage >= threshold ⇒ Premium; below it the key is Standard or, under apiThresholdCents, the metered API tier (see mapSeat). */
   premiumThresholdCents: number;
   /** usage < threshold ⇒ keep the key on metered API (no seat migration). */
   apiThresholdCents: number;

--- a/src/lib/scenarios/api-subscription.ts
+++ b/src/lib/scenarios/api-subscription.ts
@@ -23,11 +23,13 @@ export type ScenarioInputs = {
   premiumCents: number;
   /** usage >= threshold ⇒ Premium seat, otherwise Standard. */
   premiumThresholdCents: number;
+  /** usage < threshold ⇒ keep the key on metered API (no seat migration). */
+  apiThresholdCents: number;
   basis: UsageBasis;
   population: Population;
 };
 
-export type SeatTier = "standard" | "premium";
+export type SeatTier = "api" | "standard" | "premium";
 
 export type ScenarioRow = {
   user: ApiUser;
@@ -47,6 +49,7 @@ export type ScenarioResult = {
   rightSizedCents: number; // threshold-based mix
   premiumCount: number;
   standardCount: number;
+  apiCount: number; // keys kept on metered API (usage below the API threshold)
 };
 
 /** The user's representative monthly spend (cents) under the chosen basis. */
@@ -79,17 +82,24 @@ export function usageForUser(
   return Math.round(sum / months.length);
 }
 
-/** Map a monthly spend onto the seat tier it qualifies for. */
+/**
+ * Map a monthly spend onto the cheapest viable option among
+ * {metered API, Standard seat, Premium seat}. Premium-first so the bands stay
+ * sane even if the thresholds are dragged out of order; the "api" tier carries
+ * the user's own spend as its `seatCents`, so it contributes its real burn to
+ * the right-sized total and nets a zero delta against the metered baseline.
+ */
 export function mapSeat(
   usageCents: number,
   inputs: ScenarioInputs,
 ): { tier: SeatTier; seatCents: number } {
-  const tier: SeatTier =
-    usageCents >= inputs.premiumThresholdCents ? "premium" : "standard";
-  return {
-    tier,
-    seatCents: tier === "premium" ? inputs.premiumCents : inputs.standardCents,
-  };
+  if (usageCents >= inputs.premiumThresholdCents) {
+    return { tier: "premium", seatCents: inputs.premiumCents };
+  }
+  if (usageCents < inputs.apiThresholdCents) {
+    return { tier: "api", seatCents: usageCents };
+  }
+  return { tier: "standard", seatCents: inputs.standardCents };
 }
 
 /** Compute all four scenario totals plus the per-user mapping rows. */
@@ -105,6 +115,7 @@ export function computeScenarios(
   let baselineCents = 0;
   let rightSizedCents = 0;
   let premiumCount = 0;
+  let apiCount = 0;
 
   const rows: ScenarioRow[] = pool.map((user) => {
     const usageCents = usageForUser(user, dataset, inputs.basis);
@@ -112,6 +123,7 @@ export function computeScenarios(
     baselineCents += usageCents;
     rightSizedCents += seatCents;
     if (tier === "premium") premiumCount += 1;
+    else if (tier === "api") apiCount += 1;
     return {
       user,
       usageCents,
@@ -130,7 +142,8 @@ export function computeScenarios(
     allPremiumCents: count * inputs.premiumCents,
     rightSizedCents,
     premiumCount,
-    standardCount: count - premiumCount,
+    standardCount: count - premiumCount - apiCount,
+    apiCount,
   };
 }
 

--- a/src/lib/scenarios/api-subscription.ts
+++ b/src/lib/scenarios/api-subscription.ts
@@ -83,11 +83,20 @@ export function usageForUser(
 }
 
 /**
- * Map a monthly spend onto the cheapest viable option among
- * {metered API, Standard seat, Premium seat}. Premium-first so the bands stay
- * sane even if the thresholds are dragged out of order; the "api" tier carries
- * the user's own spend as its `seatCents`, so it contributes its real burn to
- * the right-sized total and nets a zero delta against the metered baseline.
+ * Assign a monthly spend to a tier by threshold:
+ *   - `usage >= premiumThresholdCents` → Premium
+ *   - `usage <  apiThresholdCents`     → stay on metered API (no seat)
+ *   - otherwise                        → Standard
+ *
+ * Premium is tested first so the bands stay well-defined even if the two
+ * thresholds are dragged out of order. The "api" tier carries the user's own
+ * spend as its `seatCents`, so it contributes its real burn to the right-sized
+ * total and nets a zero delta against the metered baseline.
+ *
+ * These are policy thresholds, not a price comparison: at the default thresholds
+ * (API floor = Standard price, Premium threshold = Premium price) the rules
+ * coincide with the cheapest option per key, but dragged away from the defaults
+ * a tier can be assigned even when another would cost less.
  */
 export function mapSeat(
   usageCents: number,

--- a/tests/unit/scenarios/api-subscription.test.ts
+++ b/tests/unit/scenarios/api-subscription.test.ts
@@ -90,6 +90,7 @@ const baseInputs: ScenarioInputs = {
   standardCents: 2500,
   premiumCents: 12500,
   premiumThresholdCents: 12500,
+  apiThresholdCents: 2500, // $25 — keys burning below this (a Standard seat) stay on metered API
   basis: "avgComplete",
   population: "all",
 };
@@ -143,15 +144,34 @@ describe("usageForUser", () => {
 });
 
 describe("mapSeat", () => {
-  it("assigns Premium when usage is at or above the threshold (boundary inclusive)", () => {
+  it("assigns Premium when usage is at or above the Premium threshold (boundary inclusive)", () => {
     expect(mapSeat(12500, baseInputs)).toEqual({
       tier: "premium",
       seatCents: 12500,
     });
   });
 
-  it("assigns Standard just below the threshold", () => {
+  it("assigns Standard just below the Premium threshold", () => {
     expect(mapSeat(12499, baseInputs)).toEqual({
+      tier: "standard",
+      seatCents: 2500,
+    });
+  });
+
+  it("assigns Standard at the API threshold (boundary inclusive of the seat)", () => {
+    expect(mapSeat(2500, baseInputs)).toEqual({
+      tier: "standard",
+      seatCents: 2500,
+    });
+  });
+
+  it("keeps a key metered below the API threshold (seatCents = its own burn)", () => {
+    expect(mapSeat(2499, baseInputs)).toEqual({ tier: "api", seatCents: 2499 });
+    expect(mapSeat(0, baseInputs)).toEqual({ tier: "api", seatCents: 0 });
+  });
+
+  it("with apiThreshold 0 no key is ever kept metered (legacy two-band behaviour)", () => {
+    expect(mapSeat(0, { ...baseInputs, apiThresholdCents: 0 })).toEqual({
       tier: "standard",
       seatCents: 2500,
     });
@@ -161,23 +181,36 @@ describe("mapSeat", () => {
 describe("computeScenarios — regression anchors on live data", () => {
   const ds = realDataset();
 
-  it("matches the prototype figures for all 47 keys at a $125 threshold", () => {
+  it("three-band right-sizing on all 47 keys ($25 API floor, $125 Premium)", () => {
     const r = computeScenarios(ds, baseInputs);
     expect(r.count).toBe(47);
-    expect(r.baselineCents).toBe(304140); // $3,041.40/mo run-rate
-    expect(r.allStandardCents).toBe(117500); // $1,175
-    expect(r.allPremiumCents).toBe(587500); // $5,875
+    expect(r.baselineCents).toBe(304140); // $3,041.40/mo run-rate (unchanged)
+    expect(r.allStandardCents).toBe(117500); // $1,175 (unchanged — naïve baseline)
+    expect(r.allPremiumCents).toBe(587500); // $5,875 (unchanged — naïve baseline)
+    // 9 Premium + 22 Standard + 16 metered API ($100.91 of real burn)
+    expect(r.rightSizedCents).toBe(177591); // $1,775.91
+    expect(r.premiumCount).toBe(9);
+    expect(r.standardCount).toBe(22);
+    expect(r.apiCount).toBe(16);
+  });
+
+  it("apiThreshold 0 reproduces the legacy two-band figures (superset property)", () => {
+    const r = computeScenarios(ds, { ...baseInputs, apiThresholdCents: 0 });
     expect(r.rightSizedCents).toBe(207500); // $2,075 (9 Premium + 38 Standard)
     expect(r.premiumCount).toBe(9);
     expect(r.standardCount).toBe(38);
+    expect(r.apiCount).toBe(0);
   });
 
-  it("filters to the active population (43 keys)", () => {
+  it("filters to the active population (43 keys), three-band", () => {
     const r = computeScenarios(ds, { ...baseInputs, population: "active" });
     expect(r.count).toBe(43);
-    expect(r.baselineCents).toBe(241620); // $2,416.20
+    expect(r.baselineCents).toBe(241620); // $2,416.20 (unchanged)
     expect(r.premiumCount).toBe(7);
-    expect(r.rightSizedCents).toBe(177500); // 7×$125 + 36×$25 = $1,775
+    expect(r.standardCount).toBe(20);
+    expect(r.apiCount).toBe(16);
+    // 7×$125 + 20×$25 + $100.91 metered = $1,475.91
+    expect(r.rightSizedCents).toBe(147591);
   });
 
   it("all-Standard / all-Premium scale linearly with editable prices", () => {
@@ -207,6 +240,19 @@ describe("computeScenarios — regression anchors on live data", () => {
     for (const row of r.rows) {
       expect(row.deltaCents).toBe(row.seatCents - row.usageCents);
     }
+  });
+
+  it("metered-API rows carry their own burn as seat cost and net a zero delta", () => {
+    const r = computeScenarios(ds, baseInputs);
+    const apiRows = r.rows.filter((row) => row.tier === "api");
+    expect(apiRows.length).toBe(16);
+    for (const row of apiRows) {
+      expect(row.seatCents).toBe(row.usageCents);
+      expect(row.deltaCents).toBe(0);
+    }
+    // the seat column still foots to the right-sized total
+    const seatSum = r.rows.reduce((s, row) => s + row.seatCents, 0);
+    expect(seatSum).toBe(r.rightSizedCents);
   });
 });
 


### PR DESCRIPTION
## What & why

The API→Subscription calculator's **right-sized** scenario used to force *every* key onto a flat seat — even a key burning $3/mo got a $25 Standard seat, which costs **more** than leaving it on the API. This adds a lower **API threshold**: below it, a key stays on pay-as-you-go metered API.

It mirrors the existing **Premium threshold** and **defaults to $25** — the Standard seat price, i.e. the break-even below which a seat can never pay off. The result is a genuine three-band right-sizing (**API · Standard · Premium**) and a right-sized total that is now provably ≤ the metered baseline at default thresholds.

## Changes

- **Engine** (`src/lib/scenarios/api-subscription.ts`): `SeatTier` gains `"api"`; `ScenarioInputs.apiThresholdCents`; `ScenarioResult.apiCount`. `mapSeat` is Premium-first; an `"api"` key carries its own spend as `seatCents` (zero delta, still foots the right-sized total). `standardCount = count − premiumCount − apiCount`.
- **Client** (`api-subscription-client.tsx`): a second slider paired with the Premium one (clamped so the floor can't exceed the ceiling); three-way readouts across the threshold cell, KPI, verdict (which omits the "keeping N keys" clause when none are metered), scenario card, comparison bar, and table footer; a new `API` `SeatPill` variant. `/simplify` pass extracted a `ThresholdSlider` component and `SEAT_PILL` / `TIER_SORT_ORDER` lookups.
- **Tests**: boundary cases + three-band anchors, plus an `apiThreshold = 0` superset test pinning the legacy figures.

**No schema change** — read-only over existing tables. No new dependency.

## Regression anchors (recomputed on the 2026-06-09 fixture)

| Population | API · Std · Prem | Right-sized /mo | vs baseline |
|---|---|---|---|
| All 47 | 16 · 22 · 9 | **$1,775.91** (was $2,075) | **−42%** (was 32%) |
| Active 43 | 16 · 20 · 7 | **$1,475.91** | −39% |
| `apiThreshold=0` (superset) | 0 · 38 · 9 | $2,075 | legacy, pinned in tests |

Note: the default headline figures **intentionally change** because the floor defaults to $25 — the two shipped anchors were updated and a superset test preserves the old numbers.

## Verification

- `pnpm test` (22 passed) · `pnpm typecheck` clean · `pnpm lint` clean (`--max-warnings 0`).
- 4-way adversarial review (engine math / test coverage / UI completeness / quality+a11y+tokens) → all pass.
- **In-browser** (Playwright, agent session): default renders **16 API · 22 Standard · 9 Premium → $1,776/mo, 42% cut**; dragging the floor to $0 reverts to legacy 38-Standard; clamp confirmed (Premium → $20 drags the floor down); 16 `API` pills in the table.

## Docs & open questions

Plan + running notes under `specs/035-scenario-calculators/` (`api-threshold-implementation-plan.html`, `implementation-notes.html`). Open questions for review: the **"Keep on API <"** label wording; whether to refresh the standalone `prototype.html` to the three-band split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
