### PR TITLE
fix: propagate tier price changes to active assignment cost snapshots

### DIFF
--- a/specs/037-tier-cost-propagation/implementation-notes.html
+++ b/specs/037-tier-cost-propagation/implementation-notes.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Implementation Notes — stale tier-cost snapshots in reports</title>
+<style>
+  body { font-family: ui-sans-serif, system-ui, sans-serif; max-width: 880px; margin: 2rem auto; padding: 0 1rem; line-height: 1.55; color: #1a1a1a; }
+  h1 { font-size: 1.5rem; } h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #ddd; padding-bottom: .25rem; }
+  code, pre { font-family: ui-monospace, Consolas, monospace; background: #f5f5f5; border-radius: 4px; }
+  code { padding: .1em .35em; } pre { padding: .75rem 1rem; overflow-x: auto; }
+  table { border-collapse: collapse; width: 100%; } th, td { border: 1px solid #ddd; padding: .4rem .6rem; text-align: left; vertical-align: top; }
+  th { background: #fafafa; }
+  .status-todo { color: #b45309; } .status-done { color: #15803d; }
+</style>
+</head>
+<body>
+<h1>Stale tier-cost snapshots — reports show 0 after tier price change</h1>
+<p><em>Branch: <code>fix/tier-cost-propagation</code> · Started 2026-06-11</em></p>
+
+<h2>Symptom</h2>
+<p>A cost was added to the Microsoft Copilot access tier, but the Reports page (and dashboard) still show the tool's monthly spend as 0.</p>
+
+<h2>Root cause</h2>
+<p><code>license_assignments.cost_at_assignment_cents</code> (schema.ts:249) is a price snapshot taken when a license is assigned. Every spend aggregation in the app sums this snapshot, not the live tier price:</p>
+<table>
+  <tr><th>Read site</th><th>What it computes</th></tr>
+  <tr><td><code>src/app/reports/page.tsx:52,69,96</code></td><td>Reports overview: per-tool monthly cost, total monthly spend, prior-month comparison</td></tr>
+  <tr><td><code>src/actions/reports.ts:128–157</code></td><td>Budget tab: per-tool per-period expected spend</td></tr>
+  <tr><td><code>src/actions/dashboard.ts:158,173,199,554</code></td><td>Admin + viewer dashboards</td></tr>
+  <tr><td><code>src/actions/budget.ts:318,571</code></td><td>Expected spend per budget period</td></tr>
+  <tr><td><code>src/lib/reports/circle-report.ts:25</code></td><td>Per-user circle report</td></tr>
+</table>
+<p>But <code>updateTier</code> (<code>src/actions/tools.ts:296</code>) only updates <code>access_tiers.monthly_cost_cents</code>. Existing active assignments keep their old snapshot (0 in this case), so every report keeps summing 0. The tier was created while free → all Copilot assignments snapshotted 0 → price edit changed only the tier row.</p>
+
+<h2>Other places with the same bug</h2>
+<ul>
+  <li><strong><code>src/lib/copilot-sync.ts:103–108</code></strong> — GitHub Copilot billing sync auto-updates a tier's <code>monthlyCostCents</code> when the plan price differs, and likewise never touches existing assignments. A GitHub price change would silently leave every synced seat at the old cost.</li>
+  <li><strong>Existing data</strong> — assignments created while the tier price was wrong remain stale forever; code fixes alone don't repair them. Needs a one-time backfill.</li>
+</ul>
+
+<h2>Places checked and found OK</h2>
+<ul>
+  <li><code>src/actions/assignments.ts:224–229</code> — changing an assignment's tier already re-snapshots the cost.</li>
+  <li>New assignments (manual, bulk import, license requests, copilot-sync seat creation) all snapshot the current tier price at creation.</li>
+  <li>Scenarios (<code>src/lib/scenarios/*queries.ts</code>) and MCP <code>list_ai_tools</code> read live <code>access_tiers.monthly_cost_cents</code> — always current.</li>
+</ul>
+
+<h2>Fix design</h2>
+<p>Chosen approach: <strong>propagate price changes to <em>active</em> assignments</strong> wherever a tier's price is mutated, plus a one-time backfill migration. Revoked/inactive assignments keep their historical snapshot (correct for past-period reporting).</p>
+<p>Rationale: this matches the codebase idiom (cf. <code>annual_budgets.totalAmountCents</code> — "mutated … so existing read sites stay accurate without churn", schema.ts:278) and the existing behavior of <code>updateAssignment</code>, and it fixes all ~15 read sites at once instead of rewriting every aggregation to join <code>access_tiers</code>.</p>
+
+<h2>Changes</h2>
+<table>
+  <tr><th>#</th><th>Change</th><th>Status</th></tr>
+  <tr><td>1</td><td><code>updateTier</code> (src/actions/tools.ts): on <code>monthlyCostCents</code> change, update <code>cost_at_assignment_cents</code> of active assignments on that tier in the same transaction; revalidate /, /assignments, /budget, /reports, /reports/budget</td><td class="status-done">done</td></tr>
+  <tr><td>2</td><td><code>copilot-sync.ts</code> <code>syncBillingData</code>: when billing sync changes a tier price, resync active assignments' snapshots in the same transaction</td><td class="status-done">done</td></tr>
+  <tr><td>3</td><td>Backfill migration <code>0024_resync_assignment_cost_snapshots.sql</code>: <code>UPDATE license_assignments SET cost_at_assignment_cents = tier price WHERE status = 'active' AND snapshot &lt;&gt; tier price</code>. Journal <code>when</code> = 1781164840619 &gt; 1781080218076 (prod journal-ordering guard satisfied)</td><td class="status-done">done</td></tr>
+  <tr><td>4</td><td>Unit tests: <code>tests/unit/actions/tier-cost-propagation.test.ts</code> — price change updates active assignments; name-only change doesn't; unchanged price is a no-op; copilot-sync price drift propagates</td><td class="status-done">done</td></tr>
+</table>
+
+<h2>Migration review (drizzle-migration-reviewer agent)</h2>
+<p>Verdict: <strong>safe to apply</strong>. SQL verified against schema (enum value <code>'active'</code> valid; both columns NOT NULL integers, no NULL pitfalls); snapshot 0024 semantically identical to 0023 with correct <code>prevId</code> chain; single-statement UPDATE, no locking concerns on Neon. Caveats before running against production:</p>
+<ul>
+  <li>The backfill is an irreversible overwrite that bypasses the change-log. Capture the affected rows first:
+  <pre>SELECT la.id, la.cost_at_assignment_cents, t.monthly_cost_cents
+FROM license_assignments la JOIN access_tiers t ON t.id = la.tier_id
+WHERE la.status = 'active' AND la.cost_at_assignment_cents &lt;&gt; t.monthly_cost_cents;</pre></li>
+  <li>Resolve which Neon branch <code>DATABASE_URL</code> points at before <code>pnpm db:migrate</code> (current .env.local → <code>ep-little-frost</code>, not the known prod endpoint).</li>
+  <li>Semantic shift: for <em>active</em> assignments, <code>cost_at_assignment_cents</code> now means "current tier price"; only revoked rows keep a true historical snapshot.</li>
+</ul>
+
+<h2>Verification log</h2>
+<ul>
+  <li class="status-done">pnpm typecheck — clean (after <code>pnpm install</code>; node_modules was stale, missing <code>@modelcontextprotocol/sdk</code> — pre-existing, unrelated)</li>
+  <li class="status-done">eslint on changed files — clean. (Full <code>pnpm lint</code> fails on leftover build artifacts in <code>.claude/worktrees/nothing-design/.next</code> — pre-existing, unrelated to this branch)</li>
+  <li class="status-done">pnpm test — 488/488 passed (46 files), including 4 new tests</li>
+</ul>
+</body>
+</html>

--- a/src/actions/tools.ts
+++ b/src/actions/tools.ts
@@ -21,7 +21,7 @@ import {
 // ---- Tool Actions ----
 
 export async function createTool(
-  input: unknown
+  input: unknown,
 ): Promise<ActionResult<{ id: number }>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
@@ -56,9 +56,7 @@ export async function createTool(
   return { success: true, data: { id: tool.id } };
 }
 
-export async function updateTool(
-  input: unknown
-): Promise<ActionResult<void>> {
+export async function updateTool(input: unknown): Promise<ActionResult<void>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
 
@@ -134,8 +132,8 @@ export async function archiveTool(input: {
     .where(
       and(
         eq(licenseAssignments.toolId, input.id),
-        eq(licenseAssignments.status, "active")
-      )
+        eq(licenseAssignments.status, "active"),
+      ),
     );
 
   if (activeCount.count > 0) {
@@ -155,7 +153,7 @@ export async function archiveTool(input: {
     input.id,
     Number(admin.id),
     existing.status,
-    "archived"
+    "archived",
   );
 
   revalidatePath("/tools");
@@ -165,7 +163,7 @@ export async function archiveTool(input: {
 // ---- Tier Actions ----
 
 export async function createTier(
-  input: unknown
+  input: unknown,
 ): Promise<ActionResult<{ id: number }>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
@@ -211,9 +209,7 @@ export async function createTier(
   return { success: true, data: { id: tier.id } };
 }
 
-export async function updateTier(
-  input: unknown
-): Promise<ActionResult<void>> {
+export async function updateTier(input: unknown): Promise<ActionResult<void>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
 
@@ -237,7 +233,7 @@ export async function updateTier(
     const duplicate = await db.query.accessTiers.findFirst({
       where: and(
         eq(accessTiers.toolId, existing.toolId),
-        eq(accessTiers.name, updates.name)
+        eq(accessTiers.name, updates.name),
       ),
     });
     if (duplicate) {
@@ -269,7 +265,10 @@ export async function updateTier(
     };
     values.monthlyCostCents = updates.monthlyCostCents;
   }
-  if (updates.isActive !== undefined && updates.isActive !== existing.isActive) {
+  if (
+    updates.isActive !== undefined &&
+    updates.isActive !== existing.isActive
+  ) {
     // If deactivating, check for active assignments
     if (!updates.isActive) {
       const [activeCount] = await db
@@ -278,8 +277,8 @@ export async function updateTier(
         .where(
           and(
             eq(licenseAssignments.tierId, id),
-            eq(licenseAssignments.status, "active")
-          )
+            eq(licenseAssignments.status, "active"),
+          ),
         );
       if (activeCount.count > 0) {
         return {
@@ -293,8 +292,38 @@ export async function updateTier(
   }
 
   if (Object.keys(changes).length > 0) {
-    await db.update(accessTiers).set(values).where(eq(accessTiers.id, id));
+    const newCostCents = changes.monthlyCostCents
+      ? updates.monthlyCostCents
+      : undefined;
+
+    await db.transaction(async (tx) => {
+      await tx.update(accessTiers).set(values).where(eq(accessTiers.id, id));
+
+      // Every spend aggregation (reports, dashboard, budget expected spend)
+      // sums license_assignments.cost_at_assignment_cents, so active
+      // assignments must follow the tier's new price or reports keep showing
+      // the old one. Revoked assignments keep their historical snapshot.
+      if (newCostCents !== undefined) {
+        await tx
+          .update(licenseAssignments)
+          .set({ costAtAssignmentCents: newCostCents, updatedAt: new Date() })
+          .where(
+            and(
+              eq(licenseAssignments.tierId, id),
+              eq(licenseAssignments.status, "active"),
+            ),
+          );
+      }
+    });
     await recordUpdate("access_tier", id, Number(admin.id), changes);
+
+    if (newCostCents !== undefined) {
+      revalidatePath("/");
+      revalidatePath("/assignments");
+      revalidatePath("/budget");
+      revalidatePath("/reports");
+      revalidatePath("/reports/budget");
+    }
   }
 
   revalidatePath(`/tools/${existing.toolId}`);
@@ -321,7 +350,7 @@ export async function getToolWithTiers(id: number) {
 }
 
 export async function getActiveAssignmentCountForTool(
-  toolId: number
+  toolId: number,
 ): Promise<number> {
   const [result] = await db
     .select({ count: count() })
@@ -329,14 +358,14 @@ export async function getActiveAssignmentCountForTool(
     .where(
       and(
         eq(licenseAssignments.toolId, toolId),
-        eq(licenseAssignments.status, "active")
-      )
+        eq(licenseAssignments.status, "active"),
+      ),
     );
   return result.count;
 }
 
 export async function getActiveAssignmentCountForTier(
-  tierId: number
+  tierId: number,
 ): Promise<number> {
   const [result] = await db
     .select({ count: count() })
@@ -344,8 +373,8 @@ export async function getActiveAssignmentCountForTier(
     .where(
       and(
         eq(licenseAssignments.tierId, tierId),
-        eq(licenseAssignments.status, "active")
-      )
+        eq(licenseAssignments.status, "active"),
+      ),
     );
   return result.count;
 }

--- a/src/lib/copilot-sync.ts
+++ b/src/lib/copilot-sync.ts
@@ -101,10 +101,23 @@ export async function syncBillingData(
         monthlyCostCents: costCents,
       });
     } else if (tier.monthlyCostCents !== costCents) {
-      await db
-        .update(accessTiers)
-        .set({ monthlyCostCents: costCents, updatedAt: new Date() })
-        .where(eq(accessTiers.id, tier.id));
+      await db.transaction(async (tx) => {
+        await tx
+          .update(accessTiers)
+          .set({ monthlyCostCents: costCents, updatedAt: new Date() })
+          .where(eq(accessTiers.id, tier.id));
+        // Spend reports sum cost_at_assignment_cents, so active assignments
+        // must follow the new tier price. Revoked ones keep their snapshot.
+        await tx
+          .update(licenseAssignments)
+          .set({ costAtAssignmentCents: costCents, updatedAt: new Date() })
+          .where(
+            and(
+              eq(licenseAssignments.tierId, tier.id),
+              eq(licenseAssignments.status, "active"),
+            ),
+          );
+      });
     }
   }
 
@@ -458,4 +471,3 @@ export async function syncUsageMetrics(
 
   return { metricsProcessed: processed };
 }
-

--- a/src/lib/db/migrations/0024_resync_assignment_cost_snapshots.sql
+++ b/src/lib/db/migrations/0024_resync_assignment_cost_snapshots.sql
@@ -1,0 +1,13 @@
+-- Custom SQL migration file, put your code below! --
+
+-- One-time backfill: active assignments whose cost snapshot drifted from
+-- their tier's current price (tier prices were edited without propagation
+-- before fix/tier-cost-propagation). Revoked/inactive assignments keep
+-- their historical snapshot on purpose.
+UPDATE "license_assignments" la
+SET "cost_at_assignment_cents" = t."monthly_cost_cents",
+    "updated_at" = now()
+FROM "access_tiers" t
+WHERE la."tier_id" = t."id"
+  AND la."status" = 'active'
+  AND la."cost_at_assignment_cents" <> t."monthly_cost_cents";

--- a/src/lib/db/migrations/meta/0024_snapshot.json
+++ b/src/lib/db/migrations/meta/0024_snapshot.json
@@ -1,0 +1,4602 @@
+{
+  "id": "5e8916e7-d50d-40fc-ba87-69603ea97813",
+  "prevId": "95802b74-b79e-4813-a187-f6aaeb9cf43c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_tiers": {
+      "name": "access_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_cost_cents": {
+          "name": "monthly_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_tiers_tool_id_idx": {
+          "name": "access_tiers_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "access_tiers_tool_name_idx": {
+          "name": "access_tiers_tool_name_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "access_tiers_tool_id_ai_tools_id_fk": {
+          "name": "access_tiers_tool_id_ai_tools_id_fk",
+          "tableFrom": "access_tiers",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "tableTo": "ai_tools",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tools": {
+      "name": "ai_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_licenses": {
+          "name": "max_licenses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tool_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_tools_name_idx": {
+          "name": "ai_tools_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ai_tools_vendor_idx": {
+          "name": "ai_tools_vendor_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.annual_budgets": {
+      "name": "annual_budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fiscal_year": {
+          "name": "fiscal_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_cents": {
+          "name": "total_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount_cents": {
+          "name": "original_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "budget_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annual_budgets_fiscal_year_idx": {
+          "name": "annual_budgets_fiscal_year_idx",
+          "columns": [
+            {
+              "expression": "fiscal_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "annual_budgets_status_idx": {
+          "name": "annual_budgets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_alert_state": {
+      "name": "anthropic_alert_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_month": {
+          "name": "billing_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_80_fired_at": {
+          "name": "threshold_80_fired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_100_fired_at": {
+          "name": "threshold_100_fired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_120_fired_at": {
+          "name": "threshold_120_fired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forecast_at_risk": {
+          "name": "forecast_at_risk",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forecast_changed_at": {
+          "name": "forecast_changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_alert_state_workspace_month_idx": {
+          "name": "anthropic_alert_state_workspace_month_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"anthropic_alert_state\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "anthropic_alert_state_default_month_idx": {
+          "name": "anthropic_alert_state_default_month_idx",
+          "columns": [
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"anthropic_alert_state\".\"workspace_id\" IS NULL",
+          "concurrently": false
+        },
+        "anthropic_alert_state_month_idx": {
+          "name": "anthropic_alert_state_month_idx",
+          "columns": [
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_alert_state_billing_month_format": {
+          "name": "anthropic_alert_state_billing_month_format",
+          "value": "\"anthropic_alert_state\".\"billing_month\" ~ '^[0-9]{4}-(0[1-9]|1[0-2])$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_org_config": {
+      "name": "anthropic_org_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "billing_budget_limit_cents": {
+          "name": "billing_budget_limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anthropic_org_config_updated_by_users_id_fk": {
+          "name": "anthropic_org_config_updated_by_users_id_fk",
+          "tableFrom": "anthropic_org_config",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_org_config_id_check": {
+          "name": "anthropic_org_config_id_check",
+          "value": "\"anthropic_org_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_sync_status": {
+      "name": "anthropic_sync_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_days": {
+          "name": "synced_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_api_key_id": {
+          "name": "resolved_api_key_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_workspace_id": {
+          "name": "resolved_workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sync_completed_at": {
+          "name": "workspace_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "anthropic_sync_status_user_id_idx": {
+          "name": "anthropic_sync_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_usage_metrics": {
+      "name": "anthropic_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncached_input_tokens": {
+          "name": "uncached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_cost_cents": {
+          "name": "computed_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pricing_resolved": {
+          "name": "pricing_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_usage_metrics_user_date_model_idx": {
+          "name": "anthropic_usage_metrics_user_date_model_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "anthropic_usage_metrics_user_date_idx": {
+          "name": "anthropic_usage_metrics_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "anthropic_usage_metrics_date_idx": {
+          "name": "anthropic_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "anthropic_usage_metrics_pricing_resolved_idx": {
+          "name": "anthropic_usage_metrics_pricing_resolved_idx",
+          "columns": [
+            {
+              "expression": "pricing_resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "anthropic_usage_metrics_user_id_users_id_fk": {
+          "name": "anthropic_usage_metrics_user_id_users_id_fk",
+          "tableFrom": "anthropic_usage_metrics",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_costs": {
+      "name": "anthropic_workspace_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_costs_workspace_date_idx": {
+          "name": "anthropic_workspace_costs_workspace_date_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "anthropic_workspace_costs_default_date_idx": {
+          "name": "anthropic_workspace_costs_default_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NULL",
+          "concurrently": false
+        },
+        "anthropic_workspace_costs_date_idx": {
+          "name": "anthropic_workspace_costs_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "anthropic_workspace_costs_workspace_id_idx": {
+          "name": "anthropic_workspace_costs_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_workspace_costs_cost_cents_check": {
+          "name": "anthropic_workspace_costs_cost_cents_check",
+          "value": "\"anthropic_workspace_costs\".\"cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_limits": {
+      "name": "anthropic_workspace_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_cents": {
+          "name": "limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_limits_workspace_id_idx": {
+          "name": "anthropic_workspace_limits_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "anthropic_workspace_limits_default_idx": {
+          "name": "anthropic_workspace_limits_default_idx",
+          "columns": [
+            {
+              "expression": "(1)",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspaces": {
+      "name": "anthropic_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_color": {
+          "name": "display_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_created_at": {
+          "name": "anthropic_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspaces_workspace_id_idx": {
+          "name": "anthropic_workspaces_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"anthropic_workspaces\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "anthropic_workspaces_is_default_idx": {
+          "name": "anthropic_workspaces_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"anthropic_workspaces\".\"is_default\" = true",
+          "concurrently": false
+        },
+        "anthropic_workspaces_archived_idx": {
+          "name": "anthropic_workspaces_archived_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assignment_comments": {
+      "name": "assignment_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assignment_comments_assignment_id_idx": {
+          "name": "assignment_comments_assignment_id_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "assignment_comments_author_id_idx": {
+          "name": "assignment_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "assignment_comments_created_at_idx": {
+          "name": "assignment_comments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "assignment_comments_assignment_id_license_assignments_id_fk": {
+          "name": "assignment_comments_assignment_id_license_assignments_id_fk",
+          "tableFrom": "assignment_comments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "tableTo": "license_assignments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "assignment_comments_author_id_users_id_fk": {
+          "name": "assignment_comments_author_id_users_id_fk",
+          "tableFrom": "assignment_comments",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billed_costs": {
+      "name": "billed_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor_reference": {
+          "name": "vendor_reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billed_costs_period_id_idx": {
+          "name": "billed_costs_period_id_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "billed_costs_invoice_date_idx": {
+          "name": "billed_costs_invoice_date_idx",
+          "columns": [
+            {
+              "expression": "invoice_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "billed_costs_period_id_budget_periods_id_fk": {
+          "name": "billed_costs_period_id_budget_periods_id_fk",
+          "tableFrom": "billed_costs",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "tableTo": "budget_periods",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_extension_period_allocations": {
+      "name": "budget_extension_period_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extension_id": {
+          "name": "extension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bepa_unique_ext_period": {
+          "name": "bepa_unique_ext_period",
+          "columns": [
+            {
+              "expression": "extension_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "bepa_period_idx": {
+          "name": "bepa_period_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "budget_extension_period_allocations_extension_id_budget_extensions_id_fk": {
+          "name": "budget_extension_period_allocations_extension_id_budget_extensions_id_fk",
+          "tableFrom": "budget_extension_period_allocations",
+          "columnsFrom": [
+            "extension_id"
+          ],
+          "tableTo": "budget_extensions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "budget_extension_period_allocations_period_id_budget_periods_id_fk": {
+          "name": "budget_extension_period_allocations_period_id_budget_periods_id_fk",
+          "tableFrom": "budget_extension_period_allocations",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "tableTo": "budget_periods",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_extensions": {
+      "name": "budget_extensions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "budget_extension_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_tool_id": {
+          "name": "linked_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_extensions_budget_idx": {
+          "name": "budget_extensions_budget_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "budget_extensions_effective_idx": {
+          "name": "budget_extensions_effective_idx",
+          "columns": [
+            {
+              "expression": "effective_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "budget_extensions_linked_tool_idx": {
+          "name": "budget_extensions_linked_tool_idx",
+          "columns": [
+            {
+              "expression": "linked_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "budget_extensions_created_by_idx": {
+          "name": "budget_extensions_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "budget_extensions_budget_id_annual_budgets_id_fk": {
+          "name": "budget_extensions_budget_id_annual_budgets_id_fk",
+          "tableFrom": "budget_extensions",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "tableTo": "annual_budgets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "budget_extensions_linked_tool_id_ai_tools_id_fk": {
+          "name": "budget_extensions_linked_tool_id_ai_tools_id_fk",
+          "tableFrom": "budget_extensions",
+          "columnsFrom": [
+            "linked_tool_id"
+          ],
+          "tableTo": "ai_tools",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "budget_extensions_created_by_users_id_fk": {
+          "name": "budget_extensions_created_by_users_id_fk",
+          "tableFrom": "budget_extensions",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "budget_extensions_amount_non_zero": {
+          "name": "budget_extensions_amount_non_zero",
+          "value": "\"budget_extensions\".\"amount_cents\" <> 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.budget_periods": {
+      "name": "budget_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_amount_cents": {
+          "name": "planned_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_periods_budget_id_idx": {
+          "name": "budget_periods_budget_id_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "budget_periods_budget_period_idx": {
+          "name": "budget_periods_budget_period_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "budget_periods_budget_id_annual_budgets_id_fk": {
+          "name": "budget_periods_budget_id_annual_budgets_id_fk",
+          "tableFrom": "budget_periods",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "tableTo": "annual_budgets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_history": {
+      "name": "change_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "change_history_entity_idx": {
+          "name": "change_history_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "change_history_changed_by_idx": {
+          "name": "change_history_changed_by_idx",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "change_history_created_at_idx": {
+          "name": "change_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "change_history_changed_by_users_id_fk": {
+          "name": "change_history_changed_by_users_id_fk",
+          "tableFrom": "change_history",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_billing_snapshots": {
+      "name": "copilot_billing_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_month": {
+          "name": "billing_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seats": {
+          "name": "total_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_seats": {
+          "name": "active_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_cost_cents": {
+          "name": "seat_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost_cents": {
+          "name": "total_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_billing_snapshots_connection_month_idx": {
+          "name": "copilot_billing_snapshots_connection_month_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "copilot_billing_snapshots_connection_id_github_connections_id_fk": {
+          "name": "copilot_billing_snapshots_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_billing_snapshots",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "tableTo": "github_connections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_usage_metrics": {
+      "name": "copilot_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_engaged_users": {
+          "name": "total_engaged_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_suggestions": {
+          "name": "total_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_acceptances": {
+          "name": "total_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_suggested": {
+          "name": "total_lines_suggested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_accepted": {
+          "name": "total_lines_accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_chat_turns": {
+          "name": "total_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_chat_acceptances": {
+          "name": "total_chat_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_dotcom_chat_turns": {
+          "name": "total_dotcom_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pr_summaries": {
+          "name": "total_pr_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_breakdown": {
+          "name": "language_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_breakdown": {
+          "name": "editor_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_cli": {
+          "name": "used_cli",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_agent": {
+          "name": "used_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_edit_count": {
+          "name": "agent_edit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_breakdown": {
+          "name": "cli_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_usage_metrics_connection_date_idx": {
+          "name": "copilot_usage_metrics_connection_date_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "copilot_usage_metrics_date_idx": {
+          "name": "copilot_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "copilot_usage_metrics_connection_id_github_connections_id_fk": {
+          "name": "copilot_usage_metrics_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_usage_metrics",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "tableTo": "github_connections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_login": {
+          "name": "org_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_avatar_url": {
+          "name": "org_avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_scopes_csv": {
+          "name": "token_scopes_csv",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_sync_enabled": {
+          "name": "copilot_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "copilot_sync_schedule": {
+          "name": "copilot_sync_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        }
+      },
+      "indexes": {
+        "github_connections_status_idx": {
+          "name": "github_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "github_connections_connected_by_users_id_fk": {
+          "name": "github_connections_connected_by_users_id_fk",
+          "tableFrom": "github_connections",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_profiles": {
+      "name": "github_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_profiles_user_id_idx": {
+          "name": "github_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "github_profiles_github_id_idx": {
+          "name": "github_profiles_github_id_idx",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "github_profiles_github_login_idx": {
+          "name": "github_profiles_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "github_profiles_user_id_users_id_fk": {
+          "name": "github_profiles_user_id_users_id_fk",
+          "tableFrom": "github_profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sync_events": {
+      "name": "github_sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_members": {
+          "name": "total_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manually_matched_count": {
+          "name": "manually_matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "copilot_sync_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "seats_processed": {
+          "name": "seats_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_processed": {
+          "name": "metrics_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_processed": {
+          "name": "billing_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_linked": {
+          "name": "billing_linked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_skipped": {
+          "name": "billing_skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_sync_events_connection_id_idx": {
+          "name": "github_sync_events_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "github_sync_events_triggered_by_idx": {
+          "name": "github_sync_events_triggered_by_idx",
+          "columns": [
+            {
+              "expression": "triggered_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "github_sync_events_connection_id_github_connections_id_fk": {
+          "name": "github_sync_events_connection_id_github_connections_id_fk",
+          "tableFrom": "github_sync_events",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "tableTo": "github_connections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "github_sync_events_triggered_by_users_id_fk": {
+          "name": "github_sync_events_triggered_by_users_id_fk",
+          "tableFrom": "github_sync_events",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_filters": {
+      "name": "ingestion_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "filter_field",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "filter_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_filters_enabled_idx": {
+          "name": "ingestion_filters_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ingestion_filters_created_by_users_id_fk": {
+          "name": "ingestion_filters_created_by_users_id_fk",
+          "tableFrom": "ingestion_filters",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_log": {
+      "name": "ingestion_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "ingestion_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "ingestion_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_invoice_id": {
+          "name": "linked_invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_log_outcome_idx": {
+          "name": "ingestion_log_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ingestion_log_created_at_idx": {
+          "name": "ingestion_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ingestion_log_vendor_idx": {
+          "name": "ingestion_log_vendor_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ingestion_log_channel_idx": {
+          "name": "ingestion_log_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ingestion_log_linked_invoice_id_invoices_id_fk": {
+          "name": "ingestion_log_linked_invoice_id_invoices_id_fk",
+          "tableFrom": "ingestion_log",
+          "columnsFrom": [
+            "linked_invoice_id"
+          ],
+          "tableTo": "invoices",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "ingestion_log_uploaded_by_users_id_fk": {
+          "name": "ingestion_log_uploaded_by_users_id_fk",
+          "tableFrom": "ingestion_log",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_tokens": {
+      "name": "invite_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_token_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_tokens_token_hash_idx": {
+          "name": "invite_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "invite_tokens_user_id_idx": {
+          "name": "invite_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "invite_tokens_active_user_idx": {
+          "name": "invite_tokens_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"invite_tokens\".\"status\" = 'active'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invite_tokens_user_id_users_id_fk": {
+          "name": "invite_tokens_user_id_users_id_fk",
+          "tableFrom": "invite_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_billed_cost_id": {
+          "name": "linked_billed_cost_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filtered_out": {
+          "name": "filtered_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "invoices_created_at_idx": {
+          "name": "invoices_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "invoices_linked_billed_cost_id_idx": {
+          "name": "invoices_linked_billed_cost_id_idx",
+          "columns": [
+            {
+              "expression": "linked_billed_cost_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_billed_cost_id_billed_costs_id_fk": {
+          "name": "invoices_linked_billed_cost_id_billed_costs_id_fk",
+          "tableFrom": "invoices",
+          "columnsFrom": [
+            "linked_billed_cost_id"
+          ],
+          "tableTo": "billed_costs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "invoices_uploaded_by_users_id_fk": {
+          "name": "invoices_uploaded_by_users_id_fk",
+          "tableFrom": "invoices",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_assignments": {
+      "name": "license_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_at_assignment_cents": {
+          "name": "cost_at_assignment_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace": {
+          "name": "workspace",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "license_assignments_user_id_idx": {
+          "name": "license_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "license_assignments_tool_id_idx": {
+          "name": "license_assignments_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "license_assignments_tier_id_idx": {
+          "name": "license_assignments_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "license_assignments_status_idx": {
+          "name": "license_assignments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "license_assignments_active_lookup_idx": {
+          "name": "license_assignments_active_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "license_assignments_user_id_users_id_fk": {
+          "name": "license_assignments_user_id_users_id_fk",
+          "tableFrom": "license_assignments",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "license_assignments_tool_id_ai_tools_id_fk": {
+          "name": "license_assignments_tool_id_ai_tools_id_fk",
+          "tableFrom": "license_assignments",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "tableTo": "ai_tools",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "license_assignments_tier_id_access_tiers_id_fk": {
+          "name": "license_assignments_tier_id_access_tiers_id_fk",
+          "tableFrom": "license_assignments",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "tableTo": "access_tiers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_requests": {
+      "name": "license_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "form_response_id": {
+          "name": "form_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_email": {
+          "name": "requester_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_name": {
+          "name": "requester_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_user_id": {
+          "name": "requester_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_tool_id": {
+          "name": "requested_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_tier_id": {
+          "name": "requested_tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_payload": {
+          "name": "form_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_team_id": {
+          "name": "teams_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_channel_id": {
+          "name": "teams_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_parent_message_id": {
+          "name": "teams_parent_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_chat_id": {
+          "name": "teams_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "license_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_message_md": {
+          "name": "approval_message_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_message_md": {
+          "name": "completion_message_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "license_requests_requester_user_id_idx": {
+          "name": "license_requests_requester_user_id_idx",
+          "columns": [
+            {
+              "expression": "requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "license_requests_requested_tool_id_idx": {
+          "name": "license_requests_requested_tool_id_idx",
+          "columns": [
+            {
+              "expression": "requested_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "license_requests_status_idx": {
+          "name": "license_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "license_requests_decided_by_idx": {
+          "name": "license_requests_decided_by_idx",
+          "columns": [
+            {
+              "expression": "decided_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "license_requests_assignment_id_idx": {
+          "name": "license_requests_assignment_id_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "license_requests_created_at_idx": {
+          "name": "license_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "license_requests_requester_user_id_users_id_fk": {
+          "name": "license_requests_requester_user_id_users_id_fk",
+          "tableFrom": "license_requests",
+          "columnsFrom": [
+            "requester_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "license_requests_requested_tool_id_ai_tools_id_fk": {
+          "name": "license_requests_requested_tool_id_ai_tools_id_fk",
+          "tableFrom": "license_requests",
+          "columnsFrom": [
+            "requested_tool_id"
+          ],
+          "tableTo": "ai_tools",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "license_requests_requested_tier_id_access_tiers_id_fk": {
+          "name": "license_requests_requested_tier_id_access_tiers_id_fk",
+          "tableFrom": "license_requests",
+          "columnsFrom": [
+            "requested_tier_id"
+          ],
+          "tableTo": "access_tiers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "license_requests_decided_by_users_id_fk": {
+          "name": "license_requests_decided_by_users_id_fk",
+          "tableFrom": "license_requests",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "license_requests_completed_by_users_id_fk": {
+          "name": "license_requests_completed_by_users_id_fk",
+          "tableFrom": "license_requests",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "license_requests_assignment_id_license_assignments_id_fk": {
+          "name": "license_requests_assignment_id_license_assignments_id_fk",
+          "tableFrom": "license_requests",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "tableTo": "license_assignments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "license_requests_form_response_id_unique": {
+          "name": "license_requests_form_response_id_unique",
+          "columns": [
+            "form_response_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_templates": {
+      "name": "message_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "message_template_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_md": {
+          "name": "body_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_templates_tool_id_idx": {
+          "name": "message_templates_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "message_templates_tier_id_idx": {
+          "name": "message_templates_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "message_templates_tool_default_kind_idx": {
+          "name": "message_templates_tool_default_kind_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_templates\".\"tier_id\" IS NULL",
+          "concurrently": false
+        },
+        "message_templates_tool_tier_kind_idx": {
+          "name": "message_templates_tool_tier_kind_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_templates\".\"tier_id\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "message_templates_tool_id_ai_tools_id_fk": {
+          "name": "message_templates_tool_id_ai_tools_id_fk",
+          "tableFrom": "message_templates",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "tableTo": "ai_tools",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "message_templates_tier_id_access_tiers_id_fk": {
+          "name": "message_templates_tier_id_access_tiers_id_fk",
+          "tableFrom": "message_templates",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "tableTo": "access_tiers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_events": {
+      "name": "sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "sync_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "backfill_start_date": {
+          "name": "backfill_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sync_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_events_source_type_idx": {
+          "name": "sync_events_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "sync_events_outcome_idx": {
+          "name": "sync_events_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "sync_events_started_at_idx": {
+          "name": "sync_events_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "sync_events_source_started_idx": {
+          "name": "sync_events_source_started_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sync_events_triggered_by_users_id_fk": {
+          "name": "sync_events_triggered_by_users_id_fk",
+          "tableFrom": "sync_events",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_sources": {
+      "name": "sync_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cron_schedule": {
+          "name": "cron_schedule",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_sources_source_type_idx": {
+          "name": "sync_sources_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circle": {
+          "name": "circle",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"theme\":\"system\"}'::jsonb"
+        },
+        "profile": {
+          "name": "profile",
+          "type": "user_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline": {
+          "name": "discipline",
+          "type": "user_discipline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'developer'"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_agent": {
+          "name": "is_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_circle_idx": {
+          "name": "users_circle_idx",
+          "columns": [
+            {
+              "expression": "circle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_status_idx": {
+          "name": "users_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.budget_extension_category": {
+      "name": "budget_extension_category",
+      "schema": "public",
+      "values": [
+        "new_tool",
+        "scope_increase",
+        "seat_increase",
+        "vendor_price_increase",
+        "reallocation",
+        "other"
+      ]
+    },
+    "public.budget_status": {
+      "name": "budget_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.change_type": {
+      "name": "change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "deleted",
+        "status_change"
+      ]
+    },
+    "public.copilot_sync_type": {
+      "name": "copilot_sync_type",
+      "schema": "public",
+      "values": [
+        "members",
+        "copilot"
+      ]
+    },
+    "public.filter_field": {
+      "name": "filter_field",
+      "schema": "public",
+      "values": [
+        "vendor",
+        "invoice_number"
+      ]
+    },
+    "public.filter_mode": {
+      "name": "filter_mode",
+      "schema": "public",
+      "values": [
+        "whitelist",
+        "blacklist"
+      ]
+    },
+    "public.github_connection_status": {
+      "name": "github_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disconnected"
+      ]
+    },
+    "public.github_sync_status": {
+      "name": "github_sync_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.ingestion_channel": {
+      "name": "ingestion_channel",
+      "schema": "public",
+      "values": [
+        "manual",
+        "api",
+        "bulk"
+      ]
+    },
+    "public.ingestion_outcome": {
+      "name": "ingestion_outcome",
+      "schema": "public",
+      "values": [
+        "success",
+        "failed",
+        "filtered"
+      ]
+    },
+    "public.invite_token_status": {
+      "name": "invite_token_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "consumed",
+        "invalidated"
+      ]
+    },
+    "public.license_request_status": {
+      "name": "license_request_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.message_template_kind": {
+      "name": "message_template_kind",
+      "schema": "public",
+      "values": [
+        "approval",
+        "completion"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "quarterly"
+      ]
+    },
+    "public.sync_operation_type": {
+      "name": "sync_operation_type",
+      "schema": "public",
+      "values": [
+        "regular",
+        "backfill"
+      ]
+    },
+    "public.sync_outcome": {
+      "name": "sync_outcome",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "success",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.sync_source_type": {
+      "name": "sync_source_type",
+      "schema": "public",
+      "values": [
+        "github_copilot_billing",
+        "anthropic_api_usage",
+        "anthropic_team_invoices",
+        "github_members",
+        "invoice_period_matching",
+        "anthropic_api_costs"
+      ]
+    },
+    "public.tool_status": {
+      "name": "tool_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.user_discipline": {
+      "name": "user_discipline",
+      "schema": "public",
+      "values": [
+        "developer",
+        "conception",
+        "business"
+      ]
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "public",
+      "values": [
+        "boost",
+        "maxed",
+        "indie"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "viewer"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1781080218076,
       "tag": "0023_white_gauntlet",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1781164840619,
+      "tag": "0024_resync_assignment_cost_snapshots",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/actions/tier-cost-propagation.test.ts
+++ b/tests/unit/actions/tier-cost-propagation.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock transitive dependencies that require server-only modules
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/auth-helpers", () => ({ requireAdmin: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/actions/history", () => ({
+  recordCreation: vi.fn(),
+  recordUpdate: vi.fn(),
+  recordStatusChange: vi.fn(),
+}));
+vi.mock("@/lib/copilot-api", () => ({
+  fetchCopilotBilling: vi.fn(),
+  fetchCopilotSeats: vi.fn(),
+  fetchCopilotOrgDayReport: vi.fn(),
+  fetchCopilotUsersDayReport: vi.fn(),
+  downloadReportNdjson: vi.fn(),
+}));
+
+const mockTx = {
+  update: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      accessTiers: { findFirst: vi.fn() },
+      aiTools: { findFirst: vi.fn() },
+    },
+    transaction: vi.fn(async (cb: (tx: unknown) => Promise<void>) =>
+      cb(mockTx),
+    ),
+    update: vi.fn(),
+    insert: vi.fn(),
+    select: vi.fn(),
+  },
+}));
+
+import { updateTier } from "@/actions/tools";
+import { syncBillingData } from "@/lib/copilot-sync";
+import { requireAdmin } from "@/lib/auth-helpers";
+import { fetchCopilotBilling } from "@/lib/copilot-api";
+import { db } from "@/lib/db";
+import { accessTiers, licenseAssignments } from "@/lib/db/schema";
+
+function chainedUpdate() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where });
+  return { update: { set }, set, where };
+}
+
+const existingTier = {
+  id: 5,
+  toolId: 2,
+  name: "Business",
+  description: null,
+  monthlyCostCents: 0,
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("updateTier cost propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdmin).mockResolvedValue({
+      id: "1",
+      role: "admin",
+    } as never);
+    vi.mocked(db.query.accessTiers.findFirst).mockResolvedValue(
+      existingTier as never,
+    );
+  });
+
+  it("updates active assignments' cost snapshot when the price changes", async () => {
+    const tierUpdate = chainedUpdate();
+    const assignmentUpdate = chainedUpdate();
+    mockTx.update
+      .mockReturnValueOnce(tierUpdate.update)
+      .mockReturnValueOnce(assignmentUpdate.update);
+
+    const result = await updateTier({ id: 5, monthlyCostCents: 1900 });
+
+    expect(result.success).toBe(true);
+    expect(mockTx.update).toHaveBeenCalledTimes(2);
+    expect(mockTx.update).toHaveBeenNthCalledWith(1, accessTiers);
+    expect(mockTx.update).toHaveBeenNthCalledWith(2, licenseAssignments);
+    expect(assignmentUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({ costAtAssignmentCents: 1900 }),
+    );
+  });
+
+  it("does not touch assignments when only the name changes", async () => {
+    const tierUpdate = chainedUpdate();
+    mockTx.update.mockReturnValueOnce(tierUpdate.update);
+    // Name-uniqueness check: second findFirst call returns no duplicate
+    vi.mocked(db.query.accessTiers.findFirst)
+      .mockResolvedValueOnce(existingTier as never)
+      .mockResolvedValueOnce(undefined as never);
+
+    const result = await updateTier({ id: 5, name: "Business Plus" });
+
+    expect(result.success).toBe(true);
+    expect(mockTx.update).toHaveBeenCalledTimes(1);
+    expect(mockTx.update).toHaveBeenCalledWith(accessTiers);
+  });
+
+  it("is a no-op when the price is unchanged", async () => {
+    const result = await updateTier({ id: 5, monthlyCostCents: 0 });
+
+    expect(result.success).toBe(true);
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(mockTx.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("syncBillingData tier price drift propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchCopilotBilling).mockResolvedValue({
+      data: {
+        seat_breakdown: { total: 3, active_this_cycle: 2 },
+        plan_type: "business",
+      },
+    } as never);
+    vi.mocked(db.query.aiTools.findFirst).mockResolvedValue({
+      id: 2,
+      name: "GitHub Copilot",
+    } as never);
+    // db.update for maxLicenses
+    vi.mocked(db.update).mockReturnValue(chainedUpdate().update as never);
+    // billing snapshot upsert chain
+    const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({ onConflictDoUpdate }),
+    } as never);
+  });
+
+  it("resyncs active assignments when a tier's synced price differs", async () => {
+    // Business tier exists with stale price; Enterprise tier already correct
+    vi.mocked(db.query.accessTiers.findFirst)
+      .mockResolvedValueOnce({
+        id: 5,
+        toolId: 2,
+        name: "Business",
+        monthlyCostCents: 0,
+      } as never)
+      .mockResolvedValueOnce({
+        id: 6,
+        toolId: 2,
+        name: "Enterprise",
+        monthlyCostCents: 3900,
+      } as never);
+
+    const tierUpdate = chainedUpdate();
+    const assignmentUpdate = chainedUpdate();
+    mockTx.update
+      .mockReturnValueOnce(tierUpdate.update)
+      .mockReturnValueOnce(assignmentUpdate.update);
+
+    await syncBillingData({ id: 1, orgLogin: "acme" }, "token");
+
+    // One transaction for the drifted Business tier, none for Enterprise
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(mockTx.update).toHaveBeenNthCalledWith(1, accessTiers);
+    expect(mockTx.update).toHaveBeenNthCalledWith(2, licenseAssignments);
+    expect(tierUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({ monthlyCostCents: 1900 }),
+    );
+    expect(assignmentUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({ costAtAssignmentCents: 1900 }),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Adding a cost to the Microsoft Copilot access tier did not show up in reports — they kept showing 0.

Every spend aggregation (Reports overview, Budget tab, admin/viewer dashboards, expected spend per budget period, circle report) sums `license_assignments.cost_at_assignment_cents`, a price snapshot taken at assignment time. `updateTier` only updated `access_tiers.monthly_cost_cents`, so existing active assignments kept their stale snapshot (0) forever.

The GitHub Copilot billing sync (`syncBillingData`) had the same gap: it auto-corrects a tier's price when GitHub reports a different plan price, without touching existing seats.

## Fix

- **`updateTier`** (`src/actions/tools.ts`): on a price change, resync `cost_at_assignment_cents` of *active* assignments on that tier in the same transaction, and revalidate the affected report/budget/dashboard paths. Revoked assignments keep their historical snapshot (past-period reports rely on it).
- **`syncBillingData`** (`src/lib/copilot-sync.ts`): same propagation when GitHub billing drifts a tier price.
- **Migration `0024_resync_assignment_cost_snapshots.sql`**: one-time backfill of already-stale active-assignment snapshots from current tier prices. Journal `when` (1781164840619) exceeds the prod journal-ordering guard (1781080218076).
- **Tests**: `tests/unit/actions/tier-cost-propagation.test.ts` — price change propagates to active assignments; name-only change doesn't; unchanged price is a no-op; copilot-sync drift propagates.

Full analysis in `specs/037-tier-cost-propagation/implementation-notes.html`.

## Verification

- `pnpm typecheck` clean
- eslint clean on changed files (full `pnpm lint` fails on pre-existing stray build artifacts under `.claude/worktrees/`, unrelated)
- `pnpm test`: 488/488 passing
- Migration reviewed by drizzle-migration-reviewer agent: safe to apply; recommendation to snapshot affected rows before prod migrate (query in the notes file)

## Deploy note

The reports only become correct once the 0024 backfill runs — the code change alone can't repair already-stale rows (re-saving the same price is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)