### PR TITLE
feat(038): MCP v2 — OAuth connectivity + expanded tool set

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,14 +1,50 @@
 # MCP Server
 
 The AI Developer Hub exposes a read-only [Model Context Protocol](https://modelcontextprotocol.io)
-server so MCP clients (Claude Desktop / Code, Cursor, etc.) can query live
-AI-spend data in natural language.
+server so MCP clients (Claude Desktop / claude.ai / Claude Code, Cursor, etc.)
+can query live AI-spend data in natural language.
 
 - **Endpoint:** `POST /api/mcp/mcp` (Streamable HTTP transport)
-- **Auth:** `Authorization: Bearer <MCP_SERVER_SECRET>`
+- **Auth:** OAuth 2.1 (per-user grants, used by Claude connectors) **or**
+  `Authorization: Bearer <MCP_SERVER_SECRET>` (shared secret for headless clients)
 - **Access:** read-only. No mutations, no decrypted API keys, no password hashes.
 
-## Setup
+## Connecting from Claude (OAuth)
+
+The Hub embeds a minimal OAuth 2.1 authorization server (spec 038), so Claude
+clients connect with zero pre-provisioning — they self-register via Dynamic
+Client Registration and each user signs in with their normal Hub account.
+
+- **Claude Desktop / claude.ai / mobile:** Settings → Connectors → *Add custom
+  connector* → URL `https://<your-hub-host>/api/mcp/mcp`. Claude opens the
+  Hub's consent screen in a browser; sign in and click **Allow**.
+- **Claude Code:**
+
+  ```bash
+  claude mcp add --transport http ai-developer-hub https://<your-hub-host>/api/mcp/mcp
+  # then inside Claude Code: /mcp → authenticate
+  ```
+
+Every grant is bound to the Hub user who consented: access tokens expire after
+1 hour (clients refresh automatically; refresh tokens rotate and last 60 days),
+deactivating the user kills their tokens, and users can revoke a connection
+anytime under **Settings → Connections**.
+
+OAuth plumbing (all served by the app itself):
+
+| Endpoint | Purpose |
+| --- | --- |
+| `/.well-known/oauth-protected-resource[/api/mcp/mcp]` | RFC 9728 resource metadata (points at the Hub as authorization server) |
+| `/.well-known/oauth-authorization-server` | RFC 8414 AS metadata (S256-only PKCE, public clients) |
+| `POST /api/oauth/register` | RFC 7591 dynamic client registration (rate-limited) |
+| `GET /oauth/authorize` | Consent screen behind the normal Hub login |
+| `POST /api/oauth/token` | Code + PKCE exchange, rotating refresh tokens |
+
+> Vercel preview deployments with protection enabled block the unauthenticated
+> metadata probes, so OAuth connects are for production (or unprotected
+> previews) — the same constraint as the profile API.
+
+## Shared secret (headless clients)
 
 1. Generate a secret (min 16 chars) and set it in the environment:
 
@@ -16,65 +52,82 @@ AI-spend data in natural language.
    MCP_SERVER_SECRET="$(openssl rand -base64 32)"
    ```
 
-2. Deploy. The server is **dormant by default**: when `MCP_SERVER_SECRET` is
-   unset, every request is rejected with `401` and a one-time warning is logged,
-   so the feature stays off until a secret is provisioned.
+2. Configure the client with a static header:
 
-## Client configuration
+   ```jsonc
+   {
+     "mcpServers": {
+       "ai-developer-hub": {
+         "type": "http",
+         "url": "https://<your-hub-host>/api/mcp/mcp",
+         "headers": { "Authorization": "Bearer <MCP_SERVER_SECRET>" }
+       }
+     }
+   }
+   ```
 
-```jsonc
-{
-  "mcpServers": {
-    "ai-developer-hub": {
-      "type": "http",
-      "url": "https://<your-hub-host>/api/mcp/mcp",
-      "headers": { "Authorization": "Bearer <MCP_SERVER_SECRET>" }
-    }
-  }
-}
-```
+When `MCP_SERVER_SECRET` is unset the shared-secret path is dormant (one-time
+warning in the logs); OAuth tokens keep working independently.
 
 Test locally with the MCP Inspector:
 
 ```bash
 npx @modelcontextprotocol/inspector
-# then point it at http://localhost:3000/api/mcp/mcp with the bearer header
+# point it at http://localhost:3000/api/mcp/mcp — it will walk the OAuth flow,
+# or set the bearer header to use the shared secret.
 ```
 
 ## Tools
 
 All monetary fields are returned as both integer cents (`*Cents`) and a derived
-USD number (`*Usd`).
+USD number (`*Usd`). Every tool carries `annotations.readOnlyHint = true`.
 
 | Tool | Input | Description |
 | --- | --- | --- |
-| `list_ai_tools` | – | Active AI tools and their access tiers with monthly cost. |
-| `get_user_cost_profile` | `email`, `month?` (YYYY-MM) | A user's active licenses and Claude API cost breakdown for a month. Looked up by exact email. |
-| `get_claude_spend_summary` | `month?` (YYYY-MM) | Org-wide Claude spend KPIs: MTD total, MoM delta, month-end projection, workspaces over 80% of cap, today's estimate. Defaults to current month. |
+| `list_ai_tools` | – | Active AI tools with access tiers, monthly cost, active license counts, and license utilization. |
+| `find_users` | `query`, `limit?` | Search users by partial name/email — resolve a person before user-keyed calls. |
+| `get_user_cost_profile` | `email`, `month?` (YYYY-MM) | A user's active licenses and Claude API cost breakdown for a month (exact email; suggests near-matches on miss). |
+| `get_claude_spend_summary` | `month?` (YYYY-MM) | Org-wide Claude spend KPIs: MTD total, MoM delta, month-end projection, workspaces over 80% of cap, today's estimate. |
+| `list_claude_users` | `month?`, `limit?` | Per-user Claude spend for a month, ordered by cost: totals, tokens, models, last active. |
+| `get_claude_cost_dashboard` | `month?` | Daily spend series, per-workspace totals with MoM deltas, 12-month history. |
 | `list_claude_workspaces` | – | Anthropic workspaces with current-month spend, cap, utilization %, and today's estimate. |
-| `get_budget_status` | `fiscalYear?` | Annual budget: per-period planned/billed/expected/actual and an OLS forecast with on-track / at-risk verdict. Defaults to the active budget. |
-| `get_copilot_usage_summary` | `since?`, `until?` (YYYY-MM-DD) | GitHub Copilot seat/billing snapshot and aggregated usage over a range. Defaults to the last 28 days. |
+| `get_budget_status` | `fiscalYear?` | Annual budget: per-period planned/billed/expected/actual and an OLS forecast with on-track / at-risk verdict. |
+| `get_budget_report` | – | Detailed budget report: per-period actuals incl. running API costs, per-tool YTD + EoY projection, last period's variance drivers. |
+| `list_license_assignments` | `email?`, `toolName?`, `status?`, `limit?` | The license register: who holds which license at what monthly cost. |
+| `list_invoices` | `month?`, `vendor?`, `linked?`, `limit?` | Uploaded invoices with amounts and budget-period link status. |
+| `get_copilot_usage_summary` | `since?`, `until?` (YYYY-MM-DD) | GitHub Copilot seat/billing snapshot and aggregated usage over a range. |
+| `get_copilot_analytics` | `since?`, `until?` (YYYY-MM-DD) | Daily Copilot usage series plus top languages and editors. |
 | `list_recent_sync_events` | `sourceType?`, `limit?` | Recent data-pipeline sync events plus Claude-spend data freshness. |
 
 ## Architecture
 
 - `src/app/api/mcp/[transport]/route.ts` — mounts the server via `mcp-handler`
   (`createMcpHandler` + `withMcpAuth`). Thin by design.
-- `src/lib/mcp/auth.ts` — shared-secret `verifyMcpToken` (constant-time compare).
+- `src/lib/mcp/auth.ts` — `verifyMcpToken`: shared secret (constant-time
+  compare) or OAuth access token lookup.
 - `src/lib/mcp/tools.ts` — registers the tools (Zod input schemas).
 - `src/lib/mcp/data.ts` — data assembly; delegates to the existing tested read
-  layer (`profile-data`, `anthropic/queries`, `actions/budget`, ...).
+  layer (`profile-data`, `anthropic/queries`, `actions/budget`, ...) or runs
+  focused read-only queries.
 - `src/lib/mcp/format.ts` — pure helpers (`centsToUsd`, `usd`, result wrappers).
+- `src/lib/oauth/` — embedded authorization server: `validate.ts` (redirect
+  URI policy, PKCE, DCR schema), `metadata.ts` (discovery docs), `store.ts`
+  (clients/codes/tokens, SHA-256-hashed at rest, rotating refresh tokens with
+  family-revocation reuse detection), `authorize.ts` (authorize-request
+  validation shared by page + consent actions).
 
-The route is excluded from the NextAuth middleware matcher (so unauthenticated
-clients get a clean `401` instead of a redirect to `/login`) and added to the
-nighthawk agent deny-list as defense-in-depth, mirroring `/api/sync`.
+The MCP route, `/api/oauth/*`, and `/.well-known/*` are excluded from the
+NextAuth middleware matcher; `/oauth/authorize` deliberately stays behind it so
+anonymous visitors are sent to `/login` and back.
 
 ## Security notes
 
 - Read-only: there are no write/mutation tools.
 - `get_user_cost_profile` returns only the same surface as the existing
   `/api/profile` route — never decrypted API keys.
-- The shared-secret model matches the Hub's other machine-to-machine endpoints
-  (`PROFILE_API_SECRET`, `CRON_SECRET`). OAuth 2.1 is the documented upgrade
-  path; `withMcpAuth` keeps that door open without reworking the tools.
+- OAuth tokens are stored as SHA-256 hashes only; access tokens live 1 h,
+  refresh tokens rotate (replaying a rotated token revokes its whole family).
+- Token verification joins `users.status = 'active'`, so deactivating a user
+  revokes their MCP access immediately.
+- Redirect URIs: exact match, https-only except loopback `http` (port ignored
+  per RFC 8252 §7.3). Registration and token endpoints are rate-limited.

--- a/specs/038-mcp-v2/brainstorm.html
+++ b/specs/038-mcp-v2/brainstorm.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>038 · MCP v2 — Brainstorm: OAuth + Tool Expansion</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --panel-2: #1d212b; --border: #2a2f3a;
+    --text: #e6e9ef; --muted: #9aa3b2; --accent: #e8503a; --good: #4cc38a;
+    --warn: #e5b454; --bad: #e0556a; --mono: "Cascadia Code", "JetBrains Mono", Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text); font: 15px/1.6 "Segoe UI", system-ui, sans-serif; }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 48px 32px 96px; }
+  header { border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 40px; }
+  .kicker { font-family: var(--mono); font-size: 12px; letter-spacing: .18em; text-transform: uppercase; color: var(--accent); }
+  h1 { font-size: 30px; margin: 8px 0 6px; letter-spacing: -.01em; }
+  .meta { color: var(--muted); font-size: 13px; font-family: var(--mono); }
+  h2 { font-size: 21px; margin: 48px 0 12px; padding-top: 8px; }
+  h2 .no { color: var(--accent); font-family: var(--mono); font-size: 15px; margin-right: 10px; }
+  h3 { font-size: 16px; margin: 28px 0 8px; }
+  p { margin: 10px 0; }
+  .muted { color: var(--muted); }
+  code { font-family: var(--mono); font-size: 13px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; }
+  pre { background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.55; }
+  pre code { background: none; border: none; padding: 0; }
+  table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 13.5px; }
+  th { text-align: left; font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); border-bottom: 1px solid var(--border); padding: 8px 10px; }
+  td { border-bottom: 1px solid var(--border); padding: 9px 10px; vertical-align: top; }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 18px 20px; margin: 16px 0; }
+  .card h3 { margin-top: 0; }
+  .pill { display: inline-block; font-family: var(--mono); font-size: 11px; padding: 2px 9px; border-radius: 999px; border: 1px solid var(--border); margin-right: 6px; }
+  .pill.rec { color: var(--good); border-color: var(--good); }
+  .pill.rej { color: var(--bad); border-color: var(--bad); }
+  .pill.p1 { color: var(--good); border-color: var(--good); }
+  .pill.p2 { color: var(--warn); border-color: var(--warn); }
+  .pill.p3 { color: var(--muted); }
+  .flow { font-family: var(--mono); font-size: 12.5px; }
+  ul { margin: 8px 0; padding-left: 22px; }
+  li { margin: 4px 0; }
+  .verdict { border-left: 3px solid var(--accent); padding: 10px 16px; background: var(--panel); border-radius: 0 8px 8px 0; margin: 16px 0; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <div class="kicker">Spec 038 · Brainstorm</div>
+  <h1>MCP v2 — OAuth Connectivity &amp; Tool Expansion</h1>
+  <div class="meta">ai-developer-hub · 2026-06-11 · builds on spec 034 (read-only MCP server, PR #112)</div>
+</header>
+
+<p>The Hub already ships a read-only MCP server at <code>/api/mcp/mcp</code> (Streamable HTTP via
+<code>mcp-handler</code> 1.1.0) guarded by a single shared bearer secret (<code>MCP_SERVER_SECRET</code>).
+Two asks for v2:</p>
+<ul>
+  <li><strong>Connectivity</strong> — make the Hub addable as a custom connector in Claude Desktop / claude.ai and
+      via <code>claude mcp add</code> in Claude Code, which means a real OAuth flow instead of a copy-pasted secret.</li>
+  <li><strong>Capability</strong> — extend the seven existing tools with the highest-value data the app already computes.</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2><span class="no">1</span>What Claude clients actually require</h2>
+
+<p>Verified against the Claude connector docs (June 2026) and <code>mcp-handler</code>'s authorization guide:</p>
+<table>
+  <tr><th>Requirement</th><th>Detail</th></tr>
+  <tr><td>Transport</td><td>Streamable HTTP — already in place (<code>/api/mcp/mcp</code>).</td></tr>
+  <tr><td>Resource metadata (RFC 9728)</td><td>Claude probes <code>/.well-known/oauth-protected-resource/api/mcp/mcp</code> first, then the root path; alternatively a <code>WWW-Authenticate: Bearer resource_metadata="…"</code> on the 401. <code>mcp-handler</code> ships <code>protectedResourceHandler</code> for this.</td></tr>
+  <tr><td>AS metadata (RFC 8414)</td><td><code>/.well-known/oauth-authorization-server</code> advertising authorize/token/register endpoints, <code>code_challenge_methods_supported: ["S256"]</code>.</td></tr>
+  <tr><td>Dynamic Client Registration (RFC 7591)</td><td>Claude registers itself as a <strong>public client</strong> (no secret) by POSTing JSON to the registration endpoint. No manual client setup possible for claude.ai/Desktop free-form connectors (advanced settings allow a pre-provisioned client id, but DCR is the zero-friction path).</td></tr>
+  <tr><td>PKCE</td><td>S256 on every authorization request; OAuth 2.1 — no implicit grant, exact redirect URI matching.</td></tr>
+  <tr><td>Redirect URIs</td><td>Hosted Claude (web/Desktop/mobile): <code>https://claude.ai/api/mcp/auth_callback</code>. Claude Code: loopback <code>http://localhost:&lt;ephemeral-port&gt;/callback</code> — the AS must ignore the port component per RFC 8252.</td></tr>
+  <tr><td>Token endpoint</td><td>Accepts <code>application/x-www-form-urlencoded</code>; RFC 6749 error codes (<code>invalid_grant</code> for a dead refresh token, not <code>invalid_request</code>). Refresh-token rotation expected for public clients. 10 s timeout budget.</td></tr>
+</table>
+
+<div class="verdict"><strong>Implication.</strong> <code>mcp-handler</code> covers only the <em>resource-server</em> half
+(token verification hook + resource metadata route). The <em>authorization-server</em> half — authorize page, consent,
+code &amp; token issuance, DCR — does not exist anywhere in the stack and is the core of this feature. NextAuth v5
+(credentials provider) is a session library, not an OAuth provider; it gives us the logged-in admin/viewer identity
+we anchor the consent screen to, nothing more.</p></div>
+
+<!-- ============================================================ -->
+<h2><span class="no">2</span>Auth approaches considered</h2>
+
+<div class="card">
+  <h3><span class="pill rej">rejected</span> A. Keep shared secret only</h3>
+  <p>Claude Desktop custom connectors have no header field for arbitrary bearer tokens; only Claude Code supports
+  <code>--header</code>. One org-wide secret means no per-user identity, no revocation granularity, and manual
+  secret distribution. Fails ask #1 outright.</p>
+</div>
+
+<div class="card">
+  <h3><span class="pill rej">rejected</span> B. External identity provider (Auth0 / Clerk / Entra ID)</h3>
+  <p>Offloads the hard OAuth parts, but: the Hub's users live in its own Postgres <code>users</code> table with
+  bcrypt credentials — wiring an external IdP means federating identity for exactly one consumer, a new SaaS
+  dependency, new secrets, and tenant setup the team doesn't otherwise need. Entra ID DCR support is poor.
+  Disproportionate for a single internal app.</p>
+</div>
+
+<div class="card">
+  <h3><span class="pill rej">rejected</span> C. Per-user long-lived API keys (PAT style)</h3>
+  <p>A "create MCP token" button under settings, pasted into Claude Code via <code>--header</code>. Simple, but
+  Claude Desktop/claude.ai custom connectors can't send custom headers, so it fails ask #1 for the desktop app;
+  it would only serve Claude Code. Could exist as a fallback, but it's not the headline.</p>
+</div>
+
+<div class="card">
+  <h3><span class="pill rec">recommended</span> D. Minimal embedded OAuth 2.1 authorization server</h3>
+  <p>Implement the four endpoints inside the app, anchored on the existing NextAuth session for the authorize step:</p>
+  <pre class="flow">Claude                        Hub (Next.js)
+  |                              |
+  |  GET /api/mcp/mcp  ───────► | 401 + WWW-Authenticate: resource_metadata=…
+  |  GET /.well-known/oauth-protected-resource/api/mcp/mcp ─► points at Hub-as-AS
+  |  GET /.well-known/oauth-authorization-server ──────────► endpoints + S256
+  |  POST /api/oauth/register (DCR, public client) ────────► client_id
+  |  browser: GET /oauth/authorize?…&code_challenge=…
+  |     └─ no session → /login?callbackUrl=…  (existing flow)
+  |     └─ session    → consent screen → issue code (10 min, single-use)
+  |  POST /api/oauth/token (code + PKCE verifier) ─────────► access + refresh
+  |  POST /api/mcp/mcp  Bearer &lt;access&gt; ───────────────────► tools, scoped to user</pre>
+  <p>Three new tables (<code>mcp_oauth_clients</code>, <code>mcp_oauth_codes</code>, <code>mcp_oauth_tokens</code>),
+  tokens stored as SHA-256 hashes (the <code>invite_tokens</code> pattern), rotating refresh tokens, exact-match
+  redirect URIs with the RFC 8252 loopback-port exception. The shared secret stays as a parallel path for
+  headless/CI clients. <strong>Every grant is tied to a real Hub user</strong>, so MCP access inherits account
+  lifecycle: deactivate the user → tokens die.</p>
+  <p class="muted">Scope model: single <code>mcp:read</code> scope for now (server is read-only by design — spec 034).
+  Writing tools would be a separate feature with per-scope consent.</p>
+</div>
+
+<!-- ============================================================ -->
+<h2><span class="no">3</span>Tool expansion — candidates</h2>
+
+<p>From a full sweep of the data layer (37 tables, ~30 reusable query helpers). Existing seven tools:
+<code>list_ai_tools</code>, <code>get_user_cost_profile</code>, <code>get_claude_spend_summary</code>,
+<code>list_claude_workspaces</code>, <code>get_budget_status</code>, <code>get_copilot_usage_summary</code>,
+<code>list_recent_sync_events</code>.</p>
+
+<table>
+  <tr><th></th><th>Proposed tool</th><th>Backed by</th><th>Why / why not</th></tr>
+  <tr><td><span class="pill p1">P1</span></td><td><code>list_claude_users</code></td><td><code>getUserList</code> (anthropic-users)</td><td>"Who are the top Claude spenders this month?" — single most common spend question; per-user cents, tokens, models, last-active. Today it takes one exact-email call per user.</td></tr>
+  <tr><td><span class="pill p1">P1</span></td><td><code>find_users</code></td><td><code>users</code> table, ILIKE</td><td>Fuzzy name/email lookup. <code>get_user_cost_profile</code> requires an exact email — an assistant rarely has it. Tiny tool, big UX unlock for every user-keyed tool.</td></tr>
+  <tr><td><span class="pill p1">P1</span></td><td><code>get_claude_cost_dashboard</code></td><td><code>getGlobalCostDashboard</code></td><td>Daily per-workspace series, 12-month history, pacing vs last month, top movers. The page exists; the data is one call away.</td></tr>
+  <tr><td><span class="pill p1">P1</span></td><td><code>get_budget_report</code></td><td><code>getBudgetReportData</code> (028)</td><td>Per-tool spend breakdown + running (un-invoiced) Claude costs per period — the piece <code>get_budget_status</code> lacks; answers "what is each tool costing us".</td></tr>
+  <tr><td><span class="pill p1">P1</span></td><td><code>list_license_assignments</code></td><td><code>licenseAssignments</code> + joins</td><td>The register: who has what license at what cost, filter by tool/status/email. Core inventory question, currently invisible to MCP.</td></tr>
+  <tr><td><span class="pill p2">P2</span></td><td><code>list_invoices</code></td><td><code>invoices</code> + period link</td><td>Vendor/month/link-status filters; "which invoices arrived for February and are any unlinked?"</td></tr>
+  <tr><td><span class="pill p2">P2</span></td><td><code>get_copilot_analytics</code></td><td><code>getCopilotAnalyticsData</code></td><td>Daily series + language/editor breakdowns; existing summary only aggregates.</td></tr>
+  <tr><td><span class="pill p3">P3</span></td><td><code>list_license_requests</code></td><td>spec 032 workflow</td><td>Approval queue visibility. Niche audience (admins in Teams already see it). Defer.</td></tr>
+  <tr><td><span class="pill p3">P3</span></td><td><code>get_ingestion_history</code></td><td>spec 023 log</td><td>Mostly covered by <code>list_recent_sync_events</code> + <code>list_invoices</code>. Defer.</td></tr>
+  <tr><td><span class="pill p3">P3</span></td><td><code>simulate_budget_forecast</code> / <code>compare_api_vs_subscription</code></td><td>specs 035/036 engines</td><td>Tempting "calculator" tools, but inputs are wide (price overrides, seat counts) and the engines are client-side modules — porting them server-side is its own feature. Defer.</td></tr>
+  <tr><td><span class="pill p3">P3</span></td><td>MCP resources / prompts</td><td>—</td><td>Claude clients' resource support is still thin compared to tools; skip for v2.</td></tr>
+</table>
+
+<h3>Improvements to existing tools</h3>
+<ul>
+  <li><code>list_ai_tools</code> — add active license counts and <code>maxLicenses</code> utilization per tool (cheap join; turns a static catalog into an inventory answer).</li>
+  <li><code>get_user_cost_profile</code> — on email miss, return near-match candidates (powered by the same lookup as <code>find_users</code>) instead of a bare error.</li>
+  <li>All tools — add MCP <code>annotations: { readOnlyHint: true }</code> so clients can skip confirmation prompts.</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2><span class="no">4</span>Security considerations</h2>
+<ul>
+  <li><strong>Token storage</strong> — only SHA-256 hashes in Postgres; raw tokens exist client-side only. Access tokens short-lived (≈1 h), refresh tokens rotating with reuse detection (rotated-token replay revokes the family).</li>
+  <li><strong>Consent is user-anchored</strong> — the authorize page sits behind the normal NextAuth login; agent accounts (<code>isAgent</code>) are refused consent. Viewer-role users get the same read-only tools as admins — acceptable because spec 034 already deemed every exposed field viewer-safe (no API keys, no hashes); revisit if a write tool ever lands.</li>
+  <li><strong>Redirect URI policy</strong> — exact string match against registered URIs; the only relaxation is ignoring the port for <code>http://localhost</code> / <code>http://127.0.0.1</code> loopbacks (RFC 8252 §7.3). No wildcards, no open redirects; <code>state</code> echoed verbatim.</li>
+  <li><strong>DCR abuse</strong> — registration is unauthenticated by spec. Mitigations: store only validated metadata, cap stored clients, prune clients with no tokens, and rate-limit via the existing <code>rate-limit.ts</code> helper. A registered client grants nothing without a logged-in user consenting.</li>
+  <li><strong>No new write surface</strong> — the MCP server stays read-only; OAuth only changes <em>who can read</em>, from "anyone with the org secret" to "named users who consented".</li>
+  <li><strong>Revocation</strong> — settings page lists a user's active grants (client name, last used) with revoke; deactivating a user revokes everything via the token check joining <code>users.status</code>.</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2><span class="no">5</span>Recommended scope for v2</h2>
+<div class="verdict">
+  <p><strong>Ship:</strong> embedded OAuth 2.1 AS (option D) with DCR + PKCE + rotating refresh tokens, shared-secret path retained · five P1 tools + two P2 tools · the three existing-tool improvements · grants management in settings · migration with three new tables.</p>
+  <p><strong>Defer:</strong> license-request/ingestion tools, scenario calculators, MCP resources, scoped write access, pre-provisioned client management UI.</p>
+</div>
+
+<h3>Open questions for the implementation plan</h3>
+<ul>
+  <li>Access-token TTL: 1 h (strict OAuth 2.1 posture) vs 24 h (fewer refresh round-trips). Leaning 1 h since Claude refreshes automatically.</li>
+  <li>Should the consent screen be per-client-forever (silent re-approve on the same client) or re-prompt each authorize? Leaning silent re-approve when an unexpired grant for the same client exists.</li>
+  <li>Where the well-known routes live: Next.js route handlers under <code>src/app/.well-known/…/route.ts</code> — need to confirm middleware matcher exclusion.</li>
+</ul>
+
+</div>
+</body>
+</html>

--- a/specs/038-mcp-v2/implementation-notes.html
+++ b/specs/038-mcp-v2/implementation-notes.html
@@ -97,7 +97,11 @@
   already used for Copilot). <code>getBudgetReportData</code> is the exception — it performs no session check
   and is imported directly, exactly like the existing <code>actions/budget</code> imports.
   <strong>Consequence:</strong> MCP results are deliberately leaner than the admin pages (e.g. the cost dashboard
-  omits the page's pacing curve and calibrated today-estimate).</p>
+  omits the page's pacing curve and calibrated today-estimate). The <code>/simplify</code> pass flagged the
+  duplication risk and two real drift points were fixed (the sync-lock sentinel user is now excluded from
+  <code>list_claude_users</code> like the admin query does, and the default-workspace label matches the
+  dashboard's capitalization); the structural duplication is accepted and documented rather than refactoring
+  <code>anthropic-users.ts</code>/<code>anthropic-global.ts</code> inside this PR.</p>
 </div>
 
 <div class="entry">

--- a/specs/038-mcp-v2/implementation-notes.html
+++ b/specs/038-mcp-v2/implementation-notes.html
@@ -161,6 +161,16 @@
   <code>revalidatePath</code> already refreshes the route when invoked from a client component.</p>
 </div>
 
+<div class="entry">
+  <h3><span class="tag decision">decision</span>Copilot passes 2–3 (5 more comments, all addressed; loop stopped here)</h3>
+  <p>Pass 2 (8141d26): concurrent refresh-token rotation race — the revoke UPDATE is now conditional on
+  <code>revokedAt IS NULL</code> with a row-count check; the race loser is treated as a replay (family revoked).
+  Pass 3 (8082f19): 429 on token-endpoint throttling, empty-hostname redirect URIs rejected, empty forwarded
+  headers normalized in <code>clientIp</code>, and <code>consumeAuthCode</code> binds the client id into the
+  atomic consume predicate so a wrong-client presentation doesn't burn the code. Per reviewer-fatigue feedback,
+  no further automated passes were requested — findings had converged to minor hardening.</p>
+</div>
+
 <h2>Open questions</h2>
 
 <div class="entry">

--- a/specs/038-mcp-v2/implementation-notes.html
+++ b/specs/038-mcp-v2/implementation-notes.html
@@ -151,6 +151,16 @@
   build logs via <code>vercel inspect --logs</code>.</p>
 </div>
 
+<div class="entry">
+  <h3><span class="tag decision">decision</span>PR #118 review round (Copilot, 3 comments — all addressed in 8361720)</h3>
+  <p>Copilot's first pass errored; re-triggered via
+  <code>gh api …/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"</code> (pushes and
+  close/reopen do not re-trigger it). Findings: (1) <code>requestOrigin</code> must split comma-separated
+  forwarded headers — fixed + unit test; (2)+(3) revoke button should <code>router.refresh()</code> after
+  success — adopted to match the settings-page convention, noting the server action's
+  <code>revalidatePath</code> already refreshes the route when invoked from a client component.</p>
+</div>
+
 <h2>Open questions</h2>
 
 <div class="entry">

--- a/specs/038-mcp-v2/implementation-notes.html
+++ b/specs/038-mcp-v2/implementation-notes.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>038 · MCP v2 — Implementation Notes</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --panel-2: #1d212b; --border: #2a2f3a;
+    --text: #e6e9ef; --muted: #9aa3b2; --accent: #e8503a; --good: #4cc38a;
+    --warn: #e5b454; --bad: #e0556a; --mono: "Cascadia Code", "JetBrains Mono", Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text); font: 15px/1.6 "Segoe UI", system-ui, sans-serif; }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 48px 32px 96px; }
+  header { border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 40px; }
+  .kicker { font-family: var(--mono); font-size: 12px; letter-spacing: .18em; text-transform: uppercase; color: var(--accent); }
+  h1 { font-size: 30px; margin: 8px 0 6px; letter-spacing: -.01em; }
+  .meta { color: var(--muted); font-size: 13px; font-family: var(--mono); }
+  h2 { font-size: 21px; margin: 44px 0 12px; }
+  p { margin: 10px 0; }
+  .muted { color: var(--muted); }
+  code { font-family: var(--mono); font-size: 13px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; }
+  .entry { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 16px 20px; margin: 14px 0; }
+  .entry h3 { margin: 0 0 6px; font-size: 15.5px; }
+  .tag { display: inline-block; font-family: var(--mono); font-size: 11px; padding: 2px 9px; border-radius: 999px; border: 1px solid var(--border); margin-right: 8px; vertical-align: 2px; }
+  .tag.decision { color: var(--good); border-color: var(--good); }
+  .tag.deviation { color: var(--bad); border-color: var(--bad); }
+  .tag.tradeoff { color: var(--warn); border-color: var(--warn); }
+  .tag.question { color: #7aa7e8; border-color: #7aa7e8; }
+  ul { margin: 8px 0; padding-left: 22px; }
+  li { margin: 4px 0; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <div class="kicker">Spec 038 · Implementation Notes</div>
+  <h1>MCP v2 — Running Notes</h1>
+  <div class="meta">Maintained during implementation · entries are append-ordered, newest last ·
+  tags: <span class="tag decision">decision</span><span class="tag deviation">deviation</span><span class="tag tradeoff">tradeoff</span><span class="tag question">open question</span></div>
+</header>
+
+<h2>Entries</h2>
+
+<div class="entry">
+  <h3><span class="tag decision">decision</span>Spec folder numbered 038</h3>
+  <p>Specs run through 037 (<code>037-tier-cost-propagation</code>); this feature is <code>specs/038-mcp-v2/</code>.
+  The original MCP server spec is 034; this builds on it rather than amending it.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag decision">decision</span>Embedded OAuth AS over external IdP / PAT-style keys</h3>
+  <p>Claude Desktop &amp; claude.ai custom connectors cannot send custom headers, so any header-token scheme fails
+  the primary requirement. An external IdP would federate identity for a single consumer of an app whose users
+  live in its own Postgres. Full rationale in <code>brainstorm.html</code> §2; risk discussion in
+  <code>implementation-plan.html</code> §4.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag tradeoff">tradeoff</span>Opaque hashed tokens (DB lookup per call) over JWTs</h3>
+  <p>Chose instant revocation + user-deactivation guarantees over saving one indexed SELECT per tool call.
+  For an internal admin tool the read is negligible; "revoke" in the settings UI must actually mean revoke.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag deviation">deviation</span>No silent re-approve on the consent screen</h3>
+  <p>The plan leaned toward auto-issuing a code when the user already holds a live grant for the same client.
+  Implemented <strong>always-show-consent</strong> instead: silent re-approve means issuing a code (a DB write)
+  during a server-component render, which Next.js semantics discourage (renders may be replayed/prefetched).
+  Cost is one extra click per re-connect, and with 60-day rotating refresh tokens that screen appears rarely.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag decision">decision</span>Redirect URI policy: https + loopback http only — no custom schemes</h3>
+  <p>Claude's documented callbacks are <code>https://claude.ai/api/mcp/auth_callback</code> and port-agnostic
+  <code>http://localhost/…</code> (RFC 8252 §7.3 — port ignored at match time, implemented and unit-tested).
+  Private-use schemes like <code>cursor://</code> are rejected at registration. If a custom-scheme client ever
+  matters, it's a one-line relaxation in <code>isAllowedRedirectUri</code> plus a deny-list for
+  <code>javascript:</code>/<code>data:</code> — deliberately not pre-built.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag decision">decision</span>Scope handling: <code>offline_access</code> tolerated, always grant <code>mcp:read</code></h3>
+  <p>Claude appends <code>offline_access</code> when a server lists it; we don't list it but tolerate it being
+  requested (refresh tokens are always issued anyway). Any other unknown scope is rejected with
+  <code>invalid_scope</code> so the consent screen never under-describes what's granted.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag deviation">deviation</span>New tools query the DB directly instead of "lifting" page queries into src/lib</h3>
+  <p>The plan said to lift session-checking action queries (e.g. <code>_getUserList</code>) into shared lib
+  modules. Dropped that: exporting anything from a <code>"use server"</code> file mints a callable server-action
+  endpoint, and refactoring 700-line action files to share internals would churn admin-page code in an MCP PR.
+  Instead each tool runs a focused read-only query in <code>src/lib/mcp/data.ts</code> (the pattern spec 034
+  already used for Copilot). <code>getBudgetReportData</code> is the exception — it performs no session check
+  and is imported directly, exactly like the existing <code>actions/budget</code> imports.
+  <strong>Consequence:</strong> MCP results are deliberately leaner than the admin pages (e.g. the cost dashboard
+  omits the page's pacing curve and calibrated today-estimate).</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag decision">decision</span>Authorization model unchanged: any authenticated MCP credential sees all read-only data</h3>
+  <p>OAuth adds <em>who</em> (user-bound tokens, per-user revocation) but not per-role filtering: a viewer-role
+  user's token reads the same org-wide spend data as an admin's, matching the shared-secret behavior spec 034
+  shipped and the data-is-viewer-safe judgment made there. Per-user spend (<code>list_claude_users</code>) is
+  visible org-wide in the admin UI only — flagging this explicitly as something to confirm (see open questions).</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag decision">decision</span>Token-endpoint rate limit keyed on IP + client_id</h3>
+  <p>Hosted Claude egresses every tenant through <code>160.79.104.0/21</code>, so a pure-IP limiter could lock out
+  unrelated users. Registration stays per-IP (10/10 min); token grants are 60/10 min per IP+client.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag decision">decision</span><code>safeEqual</code> moved to <code>src/lib/oauth/validate.ts</code></h3>
+  <p><code>mcp/auth.ts</code> now imports from the OAuth layer, which itself needs <code>safeEqual</code> — keeping
+  it in <code>mcp/auth.ts</code> would create an import cycle. Re-exported from the old location so existing
+  imports/tests are untouched.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag tradeoff">tradeoff</span>Opportunistic cleanup instead of a cron job</h3>
+  <p>Expired codes/tokens are deleted piggy-backed on issuance writes. Registered <em>clients</em> are never
+  auto-pruned (a client row is ~200 bytes and registration is rate-limited); accepting slow accumulation over
+  another scheduled job. Revisit if DCR abuse ever shows up in practice.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag decision">decision</span>Migration 0025 generated; not applied from this machine</h3>
+  <p><code>0025_colorful_vector.sql</code> creates the three OAuth tables. The worktree's <code>.env.local</code>
+  (copied from the main checkout for the build) points at the <em>production</em> Neon branch, so no
+  <code>db:push</code>/<code>db:migrate</code> was run locally — the migration applies through the normal deploy
+  pipeline. Journal ordering verified (new <code>when</code> &gt; 1781164840619).</p>
+</div>
+
+<h2>Open questions</h2>
+
+<div class="entry">
+  <h3><span class="tag question">open question</span>Should viewer-role tokens see org-wide per-user spend?</h3>
+  <p>Today: yes (matches spec 034's shared-secret model — anyone with the org secret saw everything). If that's
+  not acceptable now that tokens are user-bound, the hook exists: <code>verifyMcpToken</code> already puts
+  <code>userId</code>/<code>email</code> into <code>AuthInfo.extra</code>, so role-scoping individual tools is a
+  follow-up, not a redesign.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag question">open question</span>Access-token TTL: 1 hour</h3>
+  <p>Chose the strict OAuth 2.1 posture (1 h access / 60 d rotating refresh). If hourly refresh traffic ever
+  bothers you in logs, bumping <code>ACCESS_TOKEN_TTL_MS</code> is a one-line change.</p>
+</div>
+
+<div class="entry">
+  <h3><span class="tag question">open question</span>P2 tools shipped — confirm they earn their keep</h3>
+  <p><code>list_invoices</code> and <code>get_copilot_analytics</code> were the designated drop-candidates if
+  review finds the tool count excessive (14 total). Both are thin; flagging rather than pre-cutting.</p>
+</div>
+
+</div>
+</body>
+</html>

--- a/specs/038-mcp-v2/implementation-notes.html
+++ b/specs/038-mcp-v2/implementation-notes.html
@@ -140,6 +140,17 @@
   pipeline. Journal ordering verified (new <code>when</code> &gt; 1781164840619).</p>
 </div>
 
+<div class="entry">
+  <h3><span class="tag decision">decision</span>Red Vercel check on PR #118 is environmental, not this branch</h3>
+  <p>The preview deployment fails during <code>next build</code>: static generation of
+  <code>/reports</code>, <code>/reports/budget</code>, and <code>/settings/license-templates</code> times out
+  (3 × 60 s) hitting the database. Verified by control experiment: deploying <strong>main</strong>
+  (<code>6bd1dac</code>, whose last deployment succeeded) from the same machine fails with byte-identical
+  timeouts, while this branch builds clean locally. The Vercel-build→preview-DB path is unhealthy at the time
+  of writing; the check should be retried once it recovers. Also explains why the PR's git deployments show no
+  build logs via <code>vercel inspect --logs</code>.</p>
+</div>
+
 <h2>Open questions</h2>
 
 <div class="entry">

--- a/specs/038-mcp-v2/implementation-plan.html
+++ b/specs/038-mcp-v2/implementation-plan.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>038 · MCP v2 — Implementation Plan</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --panel-2: #1d212b; --border: #2a2f3a;
+    --text: #e6e9ef; --muted: #9aa3b2; --accent: #e8503a; --good: #4cc38a;
+    --warn: #e5b454; --bad: #e0556a; --mono: "Cascadia Code", "JetBrains Mono", Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text); font: 15px/1.6 "Segoe UI", system-ui, sans-serif; }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 48px 32px 96px; }
+  header { border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 40px; }
+  .kicker { font-family: var(--mono); font-size: 12px; letter-spacing: .18em; text-transform: uppercase; color: var(--accent); }
+  h1 { font-size: 30px; margin: 8px 0 6px; letter-spacing: -.01em; }
+  .meta { color: var(--muted); font-size: 13px; font-family: var(--mono); }
+  h2 { font-size: 21px; margin: 48px 0 12px; }
+  h2 .no { color: var(--accent); font-family: var(--mono); font-size: 15px; margin-right: 10px; }
+  h3 { font-size: 16px; margin: 26px 0 8px; }
+  p { margin: 10px 0; }
+  .muted { color: var(--muted); }
+  code { font-family: var(--mono); font-size: 13px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; }
+  pre { background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.55; }
+  pre code { background: none; border: none; padding: 0; }
+  table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 13.5px; }
+  th { text-align: left; font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); border-bottom: 1px solid var(--border); padding: 8px 10px; }
+  td { border-bottom: 1px solid var(--border); padding: 9px 10px; vertical-align: top; }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 18px 20px; margin: 16px 0; }
+  .card h3 { margin-top: 0; }
+  ul { margin: 8px 0; padding-left: 22px; }
+  li { margin: 4px 0; }
+  .verdict { border-left: 3px solid var(--accent); padding: 10px 16px; background: var(--panel); border-radius: 0 8px 8px 0; margin: 16px 0; }
+  .challenge { border-left: 3px solid var(--warn); padding: 10px 16px; background: var(--panel); border-radius: 0 8px 8px 0; margin: 12px 0; }
+  .challenge .q { color: var(--warn); font-weight: 600; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <div class="kicker">Spec 038 · Implementation Plan</div>
+  <h1>MCP v2 — OAuth Connectivity &amp; Tool Expansion</h1>
+  <div class="meta">ai-developer-hub · 2026-06-11 · source: brainstorm.html · branch <code>038-mcp-oauth-and-tools</code></div>
+</header>
+
+<div class="verdict">
+<strong>Scope.</strong> (1) Embedded OAuth 2.1 authorization server so the Hub can be added as a Claude
+Desktop / claude.ai custom connector and via <code>claude mcp add --transport http</code> — DCR, PKCE&nbsp;S256,
+rotating refresh tokens, consent anchored on the existing NextAuth login; shared-secret auth retained for
+headless clients. (2) Seven new read-only MCP tools + three improvements to existing tools. No new write surface.
+</div>
+
+<!-- ============================================================ -->
+<h2><span class="no">1</span>Data model — 3 new tables</h2>
+
+<pre><code>mcp_oauth_clients
+  id                serial PK
+  client_id         varchar(64)  unique, not null   -- "mcp_client_" + 24B base64url
+  client_name       varchar(255) not null
+  redirect_uris     jsonb        not null            -- string[]
+  created_at        timestamp    default now()
+  last_used_at      timestamp                        -- bumped on token issuance
+
+mcp_oauth_codes                                      -- authorization codes, 10 min TTL
+  id                serial PK
+  code_hash         varchar(64)  unique, not null    -- sha256 hex
+  client_id         integer      FK → mcp_oauth_clients, cascade
+  user_id           integer      FK → users, cascade
+  redirect_uri      text         not null
+  code_challenge    varchar(128) not null            -- PKCE S256 challenge
+  scope             varchar(255) not null
+  expires_at        timestamp    not null
+  consumed_at       timestamp                        -- single use
+  created_at        timestamp    default now()
+
+mcp_oauth_tokens                                     -- one row per access+refresh pair
+  id                 serial PK
+  family_id          varchar(36)  not null            -- uuid; refresh-rotation lineage
+  access_token_hash  varchar(64)  unique, not null
+  refresh_token_hash varchar(64)  unique, not null
+  client_id          integer      FK → mcp_oauth_clients, cascade
+  user_id            integer      FK → users, cascade
+  scope              varchar(255) not null
+  access_expires_at  timestamp    not null            -- now + 1 h
+  refresh_expires_at timestamp    not null            -- now + 60 d
+  revoked_at         timestamp                        -- set on rotation/revoke
+  last_used_at       timestamp
+  created_at         timestamp    default now()</code></pre>
+
+<ul>
+  <li>Raw tokens never stored — SHA-256 hex only (the <code>invite_tokens</code> pattern). Token formats:
+      <code>mcp_at_…</code> / <code>mcp_rt_…</code> / auth code <code>mcp_ac_…</code>, each 32 random bytes base64url.</li>
+  <li><strong>Rotation + reuse detection:</strong> a refresh grant marks the old row revoked and inserts a new row with the same
+      <code>family_id</code>. Presenting a refresh token that maps to a <em>revoked</em> row revokes the whole family
+      (stolen-token replay defense, RFC 9700 §4.14).</li>
+  <li>Expired rows are pruned opportunistically during issuance — no cron.</li>
+  <li>Migration via <code>pnpm db:generate</code>; journal <code>when</code> ordering verified (last entry 1781164840619, ascending).</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2><span class="no">2</span>OAuth endpoints</h2>
+
+<table>
+  <tr><th>Route</th><th>File</th><th>Behavior</th></tr>
+  <tr><td><code>GET /.well-known/oauth-protected-resource[/api/mcp/mcp]</code></td><td><code>src/app/.well-known/oauth-protected-resource/[[...rest]]/route.ts</code></td><td>RFC 9728 doc: <code>resource</code> = origin + <code>/api/mcp/mcp</code>, <code>authorization_servers</code> = [origin]. Catch-all because Claude probes the path-suffixed variant first. CORS: <code>*</code> (metadata is public).</td></tr>
+  <tr><td><code>GET /.well-known/oauth-authorization-server</code></td><td><code>src/app/.well-known/oauth-authorization-server/route.ts</code></td><td>RFC 8414 doc: issuer = origin, endpoints below, <code>code_challenge_methods_supported: ["S256"]</code>, <code>grant_types: ["authorization_code","refresh_token"]</code>, <code>token_endpoint_auth_methods_supported: ["none"]</code>, <code>scopes_supported: ["mcp:read"]</code>.</td></tr>
+  <tr><td><code>POST /api/oauth/register</code></td><td><code>src/app/api/oauth/register/route.ts</code></td><td>RFC 7591 DCR. Accepts JSON; validates <code>redirect_uris</code> (https, or http loopback), public client only. Rate-limited via existing <code>rate-limit.ts</code> (per-IP). Returns <code>client_id</code> + echoed metadata.</td></tr>
+  <tr><td><code>GET /oauth/authorize</code></td><td><code>src/app/oauth/authorize/page.tsx</code></td><td>Server component behind normal NextAuth login (middleware redirects to <code>/login?callbackUrl=…</code>). Validates client, redirect URI (exact match; loopback ignores port per RFC 8252 §7.3), <code>response_type=code</code>, PKCE S256 presence. Invalid client/redirect → error page, <em>never</em> redirect. Valid → consent card (client name, user, scope). Approve (server action) → single-use code, 302 to <code>redirect_uri?code=…&amp;state=…</code>. Deny → <code>error=access_denied</code>. Silent re-approve when the user already holds a live grant for the same client. Agent accounts (<code>isAgent</code>) are refused.</td></tr>
+  <tr><td><code>POST /api/oauth/token</code></td><td><code>src/app/api/oauth/token/route.ts</code></td><td>Form-urlencoded. <code>authorization_code</code>: hash lookup, single-use, expiry, client + redirect_uri match, PKCE verifier check (constant-time) → access (1 h) + refresh (60 d). <code>refresh_token</code>: rotate within family, reuse ⇒ family revocation. RFC 6749 JSON errors (<code>invalid_grant</code> etc.). Rate-limited.</td></tr>
+</table>
+
+<h3>Supporting changes</h3>
+<ul>
+  <li><code>src/lib/oauth/</code> — <code>tokens.ts</code> (generate/hash/issue/rotate/verify), <code>clients.ts</code> (register/load),
+      <code>codes.ts</code> (issue/consume), <code>validate.ts</code> (redirect-URI + PKCE helpers), <code>metadata.ts</code> (RFC 8414/9728 docs from request origin — origin derived per-request so Vercel previews work).</li>
+  <li><code>verifyMcpToken</code> (<code>src/lib/mcp/auth.ts</code>) becomes async: shared-secret check first (unchanged semantics), else SHA-256 lookup in <code>mcp_oauth_tokens</code> joined to <code>users.status = 'active'</code> → <code>AuthInfo</code> with <code>scopes: ["mcp:read"]</code>, <code>extra: { userId, email }</code>. Bumps <code>last_used_at</code> (throttled).</li>
+  <li><code>middleware.ts</code> matcher: exclude <code>\.well-known</code> and <code>api/oauth</code>. <code>/oauth/authorize</code> stays matched (login redirect is the desired behavior).</li>
+  <li><code>src/lib/routes.ts</code>: <code>isBareLayoutPath()</code> = public paths ∪ <code>/oauth/authorize</code> so the consent screen renders without the sidebar shell (root layout currently keys off <code>isPublicPath</code> alone).</li>
+  <li><code>src/app/settings/connections/page.tsx</code> + <code>src/actions/oauth.ts</code> — list the signed-in user's active grants (client, created, last used, expiry) with revoke; nav entry in <code>settings-nav.tsx</code>.</li>
+  <li>Docs: extend <code>docs/mcp-server.md</code> with connect instructions for Claude Desktop / claude.ai / Claude Code.</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2><span class="no">3</span>Tool expansion</h2>
+
+<p>All additions follow the established three-layer pattern: data assembly in <code>src/lib/mcp/data.ts</code>
+(reusing existing query helpers; <em>never</em> server actions that enforce a session), registration in
+<code>src/lib/mcp/tools.ts</code>, formatting via <code>usd()</code> in <code>format.ts</code>.</p>
+
+<table>
+  <tr><th>Tool</th><th>Inputs</th><th>Backed by</th></tr>
+  <tr><td><code>find_users</code></td><td><code>query</code> (min 2 chars), <code>limit?</code></td><td>ILIKE over <code>users.name/email</code>; returns id, name, email, role, circle, discipline, status.</td></tr>
+  <tr><td><code>list_claude_users</code></td><td><code>month?</code>, <code>limit?</code></td><td>per-user month aggregation over <code>anthropic_usage_metrics</code> (the <code>getUserList</code> query, lifted into a session-free helper if needed), sorted by spend.</td></tr>
+  <tr><td><code>get_claude_cost_dashboard</code></td><td><code>month?</code></td><td><code>getGlobalCostDashboard</code> internals: daily per-workspace stacks, 12-month history, pacing, top movers.</td></tr>
+  <tr><td><code>get_budget_report</code></td><td>—</td><td><code>getBudgetReportData</code> (spec 028): periods with billed+running actuals, per-tool breakdown, forecast.</td></tr>
+  <tr><td><code>list_license_assignments</code></td><td><code>email?</code>, <code>toolName?</code>, <code>status?</code>, <code>limit?</code></td><td>join assignments × users × tools × tiers; cost snapshot cents+USD.</td></tr>
+  <tr><td><code>list_invoices</code></td><td><code>month?</code>, <code>vendor?</code>, <code>linked?</code>, <code>limit?</code></td><td><code>invoices</code> + linked billed-cost period label. Excludes blob URLs.</td></tr>
+  <tr><td><code>get_copilot_analytics</code></td><td><code>since?</code>, <code>until?</code></td><td><code>getCopilotAnalyticsData</code> internals: daily series + language/editor breakdowns.</td></tr>
+</table>
+
+<p><strong>Improvements:</strong> <code>list_ai_tools</code> gains per-tool active-assignment counts and
+<code>maxLicenses</code> utilization; <code>get_user_cost_profile</code> returns up to 5 near-match candidates on
+email miss; every tool gets <code>annotations: { readOnlyHint: true }</code>.</p>
+
+<!-- ============================================================ -->
+<h2><span class="no">4</span>Self-challenge</h2>
+
+<div class="challenge"><span class="q">“Hand-rolling OAuth is how people get burned. Why not a library?”</span><br/>
+Surveyed the field: <code>node-oidc-provider</code> is Koa/Express-centric and fights Next.js route handlers +
+serverless cold starts; Auth.js v5 has no AS mode; <code>@modelcontextprotocol/sdk</code> ships only client-side
+auth helpers and an Express-based demo AS. The spec we must satisfy is narrow and fixed (one grant type + refresh,
+one scope, public clients, S256-only) and every security-sensitive primitive is delegated to platform crypto
+(<code>crypto.randomBytes</code>, <code>createHash</code>, <code>timingSafeEqual</code> — already used in this codebase).
+The dangerous corners are <em>policy</em> (redirect matching, single-use codes, rotation) and each is unit-tested.
+Accepting the risk consciously; the alternative dependencies are heavier than the feature.</div>
+
+<div class="challenge"><span class="q">“Is the consent screen + grants page scope creep for an internal tool?”</span><br/>
+The consent screen is the mechanism that binds a token to a user — without it DCR would mint tokens for whoever
+hits an endpoint, so it cannot be cut. The grants page <em>could</em> be cut, but shipping token issuance with no
+user-visible revocation is the kind of gap security review flags; it is one read + one update action over a table
+we already have. Kept, deliberately minimal (no admin view of others' grants in v2).</div>
+
+<div class="challenge"><span class="q">“Seven new tools — why not three?”</span><br/>
+Each tool is a thin mapping over a query that already exists and is already tested upstream; marginal cost is
+~30 lines + a unit test. The brainstorm already cut license-requests, ingestion, and the scenario calculators.
+If review pushes back, <code>list_invoices</code> and <code>get_copilot_analytics</code> (the two P2s) are the
+natural drop — flagged in implementation-notes as the contingency.</div>
+
+<div class="challenge"><span class="q">“Reusing server actions from the MCP layer crosses an auth boundary.”</span><br/>
+Correct, and the existing code already imports <code>getActiveBudget</code>/<code>getBudgetWithCosts</code> from
+<code>@/actions/budget</code> — those happen to be session-free helpers exported from an actions file. Rule for v2:
+only call functions that do not read the session; where a needed query lives inside a session-checking action
+(e.g. <code>getUserList</code>), lift the query into <code>src/lib/</code> and have both callers share it. Checked
+per-tool during implementation and recorded in implementation-notes.</div>
+
+<div class="challenge"><span class="q">“JWT access tokens would avoid a DB read per MCP call.”</span><br/>
+True and rejected: opaque+hashed gives instant revocation (the grants page and user-deactivation guarantees),
+and one indexed point lookup per tool call is noise for an internal admin tool. Stateless tokens would make
+“revoke” a lie until expiry.</div>
+
+<div class="challenge"><span class="q">“What breaks on Vercel previews?”</span><br/>
+Metadata derives issuer/origin from the incoming request (like <code>auth.ts</code> does for previews), so
+discovery URLs always match the host being hit. Preview deployments with Vercel protection enabled will block
+Claude's unauthenticated metadata probes — documented limitation; OAuth connect is for production (or unprotected
+previews), same constraint the profile API already has.</div>
+
+<!-- ============================================================ -->
+<h2><span class="no">5</span>Testing &amp; verification</h2>
+<ul>
+  <li><strong>Unit (Vitest, mocked DB)</strong> — redirect-URI matching incl. loopback ports; PKCE S256 verify; DCR validation;
+      metadata document shape; code consume single-use + expiry; token rotation + family-revocation on reuse;
+      <code>verifyMcpToken</code> shared-secret / OAuth / inactive-user paths; each new data function; tool registration inventory.</li>
+  <li><strong>Manual E2E</strong> — MCP Inspector (<code>npx @modelcontextprotocol/inspector</code>) against the dev server:
+      full DCR → authorize → token → tool-call loop; plus <code>claude mcp add</code> once deployed.</li>
+  <li><strong>Gates</strong> — <code>pnpm lint</code>, <code>pnpm typecheck</code>, <code>pnpm test</code>, <code>pnpm build</code>.</li>
+</ul>
+
+<h2><span class="no">6</span>Sequencing</h2>
+<table>
+  <tr><th>#</th><th>Step</th><th>Touches</th></tr>
+  <tr><td>1</td><td>Branch, schema + migration</td><td><code>schema.ts</code>, migrations</td></tr>
+  <tr><td>2</td><td><code>src/lib/oauth/*</code> core + unit tests</td><td>new module</td></tr>
+  <tr><td>3</td><td>Well-known + register + token routes</td><td><code>src/app/.well-known/*</code>, <code>src/app/api/oauth/*</code></td></tr>
+  <tr><td>4</td><td>Authorize page + consent action + bare layout + middleware matcher</td><td><code>src/app/oauth/*</code>, <code>routes.ts</code>, <code>layout.tsx</code>, <code>middleware.ts</code></td></tr>
+  <tr><td>5</td><td><code>verifyMcpToken</code> OAuth path</td><td><code>src/lib/mcp/auth.ts</code></td></tr>
+  <tr><td>6</td><td>New tools + improvements + tests</td><td><code>src/lib/mcp/data.ts</code>, <code>tools.ts</code></td></tr>
+  <tr><td>7</td><td>Settings connections page</td><td><code>src/app/settings/connections/*</code>, <code>src/actions/oauth.ts</code></td></tr>
+  <tr><td>8</td><td>Docs, /simplify, gates, PR</td><td><code>docs/mcp-server.md</code></td></tr>
+</table>
+
+<p class="muted">Running divergences/decisions are tracked in <code>implementation-notes.html</code> next to this file.</p>
+
+</div>
+</body>
+</html>

--- a/src/actions/oauth.ts
+++ b/src/actions/oauth.ts
@@ -1,0 +1,104 @@
+"use server";
+
+/**
+ * Server actions for the embedded MCP OAuth server (038-mcp-v2): consent
+ * approval/denial on /oauth/authorize and grant revocation from
+ * /settings/connections.
+ */
+
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+
+import { auth } from "@/lib/auth";
+import {
+  buildRedirect,
+  validateAuthorizeRequest,
+  type AuthorizeParams,
+} from "@/lib/oauth/authorize";
+import { issueAuthCode, revokeGrantForUser } from "@/lib/oauth/store";
+
+function authorizeParamsFromForm(formData: FormData): AuthorizeParams {
+  const read = (key: string): string | undefined => {
+    const value = formData.get(key);
+    return typeof value === "string" && value !== "" ? value : undefined;
+  };
+  return {
+    client_id: read("client_id"),
+    redirect_uri: read("redirect_uri"),
+    response_type: read("response_type"),
+    code_challenge: read("code_challenge"),
+    code_challenge_method: read("code_challenge_method"),
+    scope: read("scope"),
+    state: read("state"),
+  };
+}
+
+/**
+ * Consent "Allow" — re-validates the full authorization request (form fields
+ * are client-controlled), issues a single-use code bound to the signed-in
+ * user, and redirects back to the client.
+ */
+export async function approveAuthorization(formData: FormData): Promise<void> {
+  const session = await auth();
+  if (!session?.user?.id || session.user.isAgent) {
+    throw new Error("Unauthorized");
+  }
+
+  const validation = await validateAuthorizeRequest(
+    authorizeParamsFromForm(formData),
+  );
+  if (!validation.ok) {
+    if (validation.fatal) throw new Error(validation.message);
+    redirect(validation.redirectTo);
+  }
+
+  const code = await issueAuthCode({
+    clientRowId: validation.client.id,
+    userId: Number(session.user.id),
+    redirectUri: validation.redirectUri,
+    codeChallenge: validation.codeChallenge,
+    scope: validation.grantedScope,
+  });
+
+  redirect(buildRedirect(validation.redirectUri, { code, state: validation.state }));
+}
+
+/** Consent "Deny" — informs the client via the standard error redirect. */
+export async function denyAuthorization(formData: FormData): Promise<void> {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error("Unauthorized");
+
+  const validation = await validateAuthorizeRequest(
+    authorizeParamsFromForm(formData),
+  );
+  if (!validation.ok) {
+    if (validation.fatal) throw new Error(validation.message);
+    redirect(validation.redirectTo);
+  }
+
+  redirect(
+    buildRedirect(validation.redirectUri, {
+      error: "access_denied",
+      error_description: "The user denied the request",
+      state: validation.state,
+    }),
+  );
+}
+
+/** Revoke one of the signed-in user's own MCP connections (token family). */
+export async function revokeConnection(
+  familyId: string,
+): Promise<{ success: true } | { success: false; error: string }> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const revoked = await revokeGrantForUser(Number(session.user.id), familyId);
+  if (!revoked) {
+    return { success: false, error: "Connection not found" };
+  }
+
+  revalidatePath("/settings/connections");
+  return { success: true };
+}

--- a/src/actions/oauth.ts
+++ b/src/actions/oauth.ts
@@ -12,49 +12,47 @@ import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import {
   buildRedirect,
+  readAuthorizeParams,
   validateAuthorizeRequest,
-  type AuthorizeParams,
 } from "@/lib/oauth/authorize";
 import { issueAuthCode, revokeGrantForUser } from "@/lib/oauth/store";
 
-function authorizeParamsFromForm(formData: FormData): AuthorizeParams {
-  const read = (key: string): string | undefined => {
-    const value = formData.get(key);
-    return typeof value === "string" && value !== "" ? value : undefined;
-  };
-  return {
-    client_id: read("client_id"),
-    redirect_uri: read("redirect_uri"),
-    response_type: read("response_type"),
-    code_challenge: read("code_challenge"),
-    code_challenge_method: read("code_challenge_method"),
-    scope: read("scope"),
-    state: read("state"),
-  };
-}
-
 /**
- * Consent "Allow" — re-validates the full authorization request (form fields
- * are client-controlled), issues a single-use code bound to the signed-in
- * user, and redirects back to the client.
+ * Shared head of both consent actions: require a session and re-validate the
+ * full authorization request (hidden form fields are client-controlled).
+ * Redirects with an OAuth error for client-deliverable failures, throws for
+ * fatal ones, and returns the validated request plus the acting user id.
  */
-export async function approveAuthorization(formData: FormData): Promise<void> {
+async function validateConsentSubmission(formData: FormData) {
   const session = await auth();
   if (!session?.user?.id || session.user.isAgent) {
     throw new Error("Unauthorized");
   }
 
-  const validation = await validateAuthorizeRequest(
-    authorizeParamsFromForm(formData),
-  );
+  const params = readAuthorizeParams((key) => {
+    const value = formData.get(key);
+    return typeof value === "string" && value !== "" ? value : undefined;
+  });
+
+  const validation = await validateAuthorizeRequest(params);
   if (!validation.ok) {
     if (validation.fatal) throw new Error(validation.message);
     redirect(validation.redirectTo);
   }
 
+  return { validation, userId: Number(session.user.id) };
+}
+
+/**
+ * Consent "Allow" — issues a single-use code bound to the signed-in user and
+ * redirects back to the client.
+ */
+export async function approveAuthorization(formData: FormData): Promise<void> {
+  const { validation, userId } = await validateConsentSubmission(formData);
+
   const code = await issueAuthCode({
     clientRowId: validation.client.id,
-    userId: Number(session.user.id),
+    userId,
     redirectUri: validation.redirectUri,
     codeChallenge: validation.codeChallenge,
     scope: validation.grantedScope,
@@ -65,16 +63,7 @@ export async function approveAuthorization(formData: FormData): Promise<void> {
 
 /** Consent "Deny" — informs the client via the standard error redirect. */
 export async function denyAuthorization(formData: FormData): Promise<void> {
-  const session = await auth();
-  if (!session?.user?.id) throw new Error("Unauthorized");
-
-  const validation = await validateAuthorizeRequest(
-    authorizeParamsFromForm(formData),
-  );
-  if (!validation.ok) {
-    if (validation.fatal) throw new Error(validation.message);
-    redirect(validation.redirectTo);
-  }
+  const { validation } = await validateConsentSubmission(formData);
 
   redirect(
     buildRedirect(validation.redirectUri, {

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,21 @@
+/**
+ * RFC 8414 authorization-server metadata for the embedded MCP OAuth server
+ * (038-mcp-v2). Public, CORS-open; excluded from the auth middleware matcher.
+ */
+
+import {
+  authorizationServerMetadata,
+  oauthJson,
+  oauthPreflight,
+  requestOrigin,
+} from "@/lib/oauth/metadata";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  return oauthJson(authorizationServerMetadata(requestOrigin(req)));
+}
+
+export function OPTIONS(): Response {
+  return oauthPreflight();
+}

--- a/src/app/.well-known/oauth-protected-resource/[[...rest]]/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/[[...rest]]/route.ts
@@ -1,0 +1,24 @@
+/**
+ * RFC 9728 protected-resource metadata for the MCP endpoint (038-mcp-v2).
+ *
+ * Catch-all because Claude probes the path-suffixed variant
+ * (/.well-known/oauth-protected-resource/api/mcp/mcp) before falling back to
+ * the root document — both serve the same metadata. Public, CORS-open.
+ */
+
+import {
+  oauthJson,
+  oauthPreflight,
+  protectedResourceMetadata,
+  requestOrigin,
+} from "@/lib/oauth/metadata";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  return oauthJson(protectedResourceMetadata(requestOrigin(req)));
+}
+
+export function OPTIONS(): Response {
+  return oauthPreflight();
+}

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -1,9 +1,13 @@
 /**
  * MCP server endpoint (Model Context Protocol over Streamable HTTP).
  *
- * Mounts the Hub's read-only tools at `/api/mcp/mcp`. Auth is the shared
- * `MCP_SERVER_SECRET` bearer token enforced by `withMcpAuth`; when the secret
- * is unset the server rejects every request (see src/lib/mcp/auth.ts).
+ * Mounts the Hub's read-only tools at `/api/mcp/mcp`. Auth accepts either the
+ * shared `MCP_SERVER_SECRET` bearer token (headless clients) or an OAuth
+ * access token issued by the embedded authorization server (Claude Desktop /
+ * claude.ai / Claude Code connectors) — see src/lib/mcp/auth.ts and
+ * src/lib/oauth/*. Unauthenticated requests get a 401 whose WWW-Authenticate
+ * header points clients at /.well-known/oauth-protected-resource to start the
+ * OAuth flow.
  *
  * This route is excluded from the NextAuth middleware matcher so unauthenticated
  * clients receive a clean 401 instead of a redirect to /login.

--- a/src/app/api/oauth/register/route.ts
+++ b/src/app/api/oauth/register/route.ts
@@ -1,0 +1,84 @@
+/**
+ * RFC 7591 dynamic client registration for the embedded MCP OAuth server
+ * (038-mcp-v2). Registration is unauthenticated by spec — a registered client
+ * grants nothing by itself; every token still requires a logged-in Hub user
+ * consenting on /oauth/authorize. Rate-limited per IP to blunt abuse.
+ */
+
+import { isRateLimited } from "@/lib/rate-limit";
+import { oauthJson, oauthPreflight } from "@/lib/oauth/metadata";
+import {
+  clientRegistrationSchema,
+  isAllowedRedirectUri,
+} from "@/lib/oauth/validate";
+import { registerClient } from "@/lib/oauth/store";
+
+export const dynamic = "force-dynamic";
+
+function registrationError(description: string): Response {
+  return oauthJson(
+    { error: "invalid_client_metadata", error_description: description },
+    { status: 400 },
+  );
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  if (
+    isRateLimited(`oauth-register:${ip}`, {
+      maxAttempts: 10,
+      windowMs: 10 * 60 * 1000,
+    })
+  ) {
+    return oauthJson(
+      { error: "invalid_client_metadata", error_description: "Rate limited" },
+      { status: 429 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return registrationError("Request body must be JSON");
+  }
+
+  const parsed = clientRegistrationSchema.safeParse(body);
+  if (!parsed.success) {
+    return registrationError(
+      parsed.error.issues[0]?.message ?? "Invalid client metadata",
+    );
+  }
+
+  const invalidUri = parsed.data.redirect_uris.find(
+    (uri) => !isAllowedRedirectUri(uri),
+  );
+  if (invalidUri !== undefined) {
+    return registrationError(
+      `redirect_uri not allowed (must be https, or http on a loopback host): ${invalidUri}`,
+    );
+  }
+
+  const client = await registerClient({
+    clientName: parsed.data.client_name ?? "MCP client",
+    redirectUris: parsed.data.redirect_uris,
+  });
+
+  // Public client — no secret is ever issued.
+  return oauthJson(
+    {
+      client_id: client.clientId,
+      client_name: client.clientName,
+      redirect_uris: client.redirectUris,
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+    },
+    { status: 201 },
+  );
+}
+
+export function OPTIONS(): Response {
+  return oauthPreflight();
+}

--- a/src/app/api/oauth/register/route.ts
+++ b/src/app/api/oauth/register/route.ts
@@ -5,7 +5,7 @@
  * consenting on /oauth/authorize. Rate-limited per IP to blunt abuse.
  */
 
-import { isRateLimited } from "@/lib/rate-limit";
+import { clientIp, isRateLimited } from "@/lib/rate-limit";
 import { oauthJson, oauthPreflight } from "@/lib/oauth/metadata";
 import {
   clientRegistrationSchema,
@@ -23,10 +23,8 @@ function registrationError(description: string): Response {
 }
 
 export async function POST(req: Request): Promise<Response> {
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
   if (
-    isRateLimited(`oauth-register:${ip}`, {
+    isRateLimited(`oauth-register:${clientIp(req.headers)}`, {
       maxAttempts: 10,
       windowMs: 10 * 60 * 1000,
     })

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -1,0 +1,134 @@
+/**
+ * OAuth 2.1 token endpoint for the embedded MCP authorization server
+ * (038-mcp-v2). Public clients only (token_endpoint_auth_method "none") —
+ * possession is proven by PKCE on the authorization-code grant and by the
+ * rotating refresh token afterwards.
+ *
+ * Accepts application/x-www-form-urlencoded per RFC 6749 §4.1.3 and returns
+ * RFC 6749 §5.2 error codes (Claude specifically distinguishes invalid_grant
+ * to know when to restart the flow).
+ */
+
+import { isRateLimited } from "@/lib/rate-limit";
+import { oauthJson, oauthPreflight } from "@/lib/oauth/metadata";
+import { verifyPkce } from "@/lib/oauth/validate";
+import {
+  consumeAuthCode,
+  getClientByPublicId,
+  issueTokens,
+  rotateRefreshToken,
+  type IssuedTokens,
+} from "@/lib/oauth/store";
+
+export const dynamic = "force-dynamic";
+
+function tokenError(
+  error: "invalid_request" | "invalid_client" | "invalid_grant" | "unsupported_grant_type",
+  description: string,
+): Response {
+  return oauthJson(
+    { error, error_description: description },
+    { status: error === "invalid_client" ? 401 : 400 },
+  );
+}
+
+function tokenSuccess(tokens: IssuedTokens): Response {
+  return oauthJson({
+    access_token: tokens.accessToken,
+    token_type: "Bearer",
+    expires_in: tokens.expiresIn,
+    refresh_token: tokens.refreshToken,
+    scope: tokens.scope,
+  });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  let form: URLSearchParams;
+  try {
+    form = new URLSearchParams(await req.text());
+  } catch {
+    return tokenError("invalid_request", "Malformed request body");
+  }
+
+  const grantType = form.get("grant_type");
+  const clientId = form.get("client_id");
+
+  // Hosted Claude egresses many tenants through one IP range, so the limiter
+  // is keyed on IP + client to avoid cross-tenant lockout.
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  if (
+    isRateLimited(`oauth-token:${ip}:${clientId ?? "none"}`, {
+      maxAttempts: 60,
+      windowMs: 10 * 60 * 1000,
+    })
+  ) {
+    return tokenError("invalid_request", "Rate limited");
+  }
+
+  if (!clientId) {
+    return tokenError("invalid_request", "client_id is required");
+  }
+  const client = await getClientByPublicId(clientId);
+  if (!client) {
+    return tokenError("invalid_client", "Unknown client");
+  }
+
+  if (grantType === "authorization_code") {
+    const code = form.get("code");
+    const codeVerifier = form.get("code_verifier");
+    const redirectUri = form.get("redirect_uri");
+
+    if (!code || !codeVerifier || !redirectUri) {
+      return tokenError(
+        "invalid_request",
+        "code, code_verifier and redirect_uri are required",
+      );
+    }
+
+    const consumed = await consumeAuthCode(code);
+    if (!consumed || consumed.clientId !== client.id) {
+      return tokenError("invalid_grant", "Authorization code is invalid, expired, or already used");
+    }
+
+    // Must be byte-identical to the URI used on the authorize request
+    // (RFC 6749 §4.1.3) — the loopback-port relaxation applies only between
+    // registration and authorization, not here.
+    if (consumed.redirectUri !== redirectUri) {
+      return tokenError("invalid_grant", "redirect_uri does not match the authorization request");
+    }
+
+    if (!verifyPkce(codeVerifier, consumed.codeChallenge)) {
+      return tokenError("invalid_grant", "PKCE verification failed");
+    }
+
+    const tokens = await issueTokens({
+      clientRowId: client.id,
+      userId: consumed.userId,
+      scope: consumed.scope,
+    });
+    return tokenSuccess(tokens);
+  }
+
+  if (grantType === "refresh_token") {
+    const refreshToken = form.get("refresh_token");
+    if (!refreshToken) {
+      return tokenError("invalid_request", "refresh_token is required");
+    }
+
+    const result = await rotateRefreshToken(refreshToken, client.id);
+    if (!result.ok) {
+      return tokenError("invalid_grant", "Refresh token is invalid, expired, or revoked");
+    }
+    return tokenSuccess(result.tokens);
+  }
+
+  return tokenError(
+    "unsupported_grant_type",
+    "grant_type must be authorization_code or refresh_token",
+  );
+}
+
+export function OPTIONS(): Response {
+  return oauthPreflight();
+}

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -61,7 +61,12 @@ export async function POST(req: Request): Promise<Response> {
       windowMs: 10 * 60 * 1000,
     })
   ) {
-    return tokenError("invalid_request", "Rate limited");
+    // 429 (not an OAuth error code) so clients back off instead of treating
+    // throttling as a permanent request error.
+    return oauthJson(
+      { error: "invalid_request", error_description: "Rate limited" },
+      { status: 429 },
+    );
   }
 
   if (!clientId) {
@@ -84,8 +89,10 @@ export async function POST(req: Request): Promise<Response> {
       );
     }
 
-    const consumed = await consumeAuthCode(code);
-    if (!consumed || consumed.clientId !== client.id) {
+    // Client binding is part of the consume predicate, so a code presented
+    // by the wrong client is refused without being burned.
+    const consumed = await consumeAuthCode(code, client.id);
+    if (!consumed) {
       return tokenError("invalid_grant", "Authorization code is invalid, expired, or already used");
     }
 

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -9,7 +9,7 @@
  * to know when to restart the flow).
  */
 
-import { isRateLimited } from "@/lib/rate-limit";
+import { clientIp, isRateLimited } from "@/lib/rate-limit";
 import { oauthJson, oauthPreflight } from "@/lib/oauth/metadata";
 import { verifyPkce } from "@/lib/oauth/validate";
 import {
@@ -55,10 +55,8 @@ export async function POST(req: Request): Promise<Response> {
 
   // Hosted Claude egresses many tenants through one IP range, so the limiter
   // is keyed on IP + client to avoid cross-tenant lockout.
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
   if (
-    isRateLimited(`oauth-token:${ip}:${clientId ?? "none"}`, {
+    isRateLimited(`oauth-token:${clientIp(req.headers)}:${clientId ?? "none"}`, {
       maxAttempts: 60,
       windowMs: 10 * 60 * 1000,
     })

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Space_Grotesk, Space_Mono, Doto } from "next/font/google";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
-import { isPublicPath } from "@/lib/routes";
+import { isBareLayoutPath } from "@/lib/routes";
 import { AppSidebar } from "@/components/app-sidebar";
 import { ThemeProvider } from "@/components/theme-provider";
 import { SessionProvider } from "@/components/session-provider";
@@ -46,7 +46,7 @@ export default async function RootLayout({
 }>) {
   const headerStore = await headers();
   const pathname = (headerStore.get("x-pathname") ?? "/").split("?")[0];
-  const showSidebar = !isPublicPath(pathname);
+  const showSidebar = !isBareLayoutPath(pathname);
   const session = showSidebar ? await auth() : null;
   const alerts = showSidebar && session?.user?.role === "admin"
     ? await getActiveAlerts().catch(() => null)

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -1,0 +1,145 @@
+/**
+ * OAuth 2.1 authorization (consent) page for the embedded MCP authorization
+ * server (038-mcp-v2).
+ *
+ * Sits behind the normal NextAuth login (the middleware redirects anonymous
+ * visitors to /login with a callbackUrl pointing back here), renders without
+ * the app sidebar (see isBareLayoutPath), and re-validates everything in the
+ * server actions on submit.
+ */
+
+import { redirect } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+import { approveAuthorization, denyAuthorization } from "@/actions/oauth";
+import {
+  validateAuthorizeRequest,
+  type AuthorizeParams,
+} from "@/lib/oauth/authorize";
+import { MCP_SCOPE } from "@/lib/oauth/validate";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+
+function first(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function ErrorCard({ message }: { message: string }) {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-6">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Authorization error</CardTitle>
+          <CardDescription>
+            This authorization request cannot be completed.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">{message}</p>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}
+
+export default async function AuthorizePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const raw = await searchParams;
+  const params: AuthorizeParams = {
+    client_id: first(raw.client_id),
+    redirect_uri: first(raw.redirect_uri),
+    response_type: first(raw.response_type),
+    code_challenge: first(raw.code_challenge),
+    code_challenge_method: first(raw.code_challenge_method),
+    scope: first(raw.scope),
+    state: first(raw.state),
+  };
+
+  const session = await auth();
+  if (!session?.user) {
+    // Middleware normally handles this; kept as defense in depth.
+    const query = new URLSearchParams(
+      Object.entries(params).filter(([, v]) => v !== undefined) as [
+        string,
+        string,
+      ][],
+    );
+    redirect(`/login?callbackUrl=${encodeURIComponent(`/oauth/authorize?${query}`)}`);
+  }
+  if (session.user.isAgent) {
+    return <ErrorCard message="Agent accounts cannot authorize MCP clients." />;
+  }
+
+  const validation = await validateAuthorizeRequest(params);
+  if (!validation.ok) {
+    if (validation.fatal) return <ErrorCard message={validation.message} />;
+    redirect(validation.redirectTo);
+  }
+
+  const hiddenFields: AuthorizeParams = { ...params };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-6">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Authorize {validation.client.clientName}</CardTitle>
+          <CardDescription>
+            <span className="font-medium text-foreground">
+              {validation.client.clientName}
+            </span>{" "}
+            wants to connect to the AI Developer Hub MCP server as{" "}
+            <span className="font-medium text-foreground">
+              {session.user.email}
+            </span>
+            .
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="font-medium">This grants:</p>
+          <ul className="list-disc pl-5 text-muted-foreground">
+            <li>
+              Read-only access to AI spend data — tools, budgets, Claude and
+              Copilot usage (<code className="font-mono text-xs">{MCP_SCOPE}</code>)
+            </li>
+          </ul>
+          <p className="text-muted-foreground">
+            No write access. You can revoke this anytime under Settings →
+            Connections.
+          </p>
+        </CardContent>
+        <CardFooter>
+          <form action={approveAuthorization} className="flex w-full gap-3">
+            {Object.entries(hiddenFields).map(([key, value]) =>
+              value !== undefined ? (
+                <input key={key} type="hidden" name={key} value={value} />
+              ) : null,
+            )}
+            <Button
+              type="submit"
+              formAction={denyAuthorization}
+              variant="outline"
+              className="flex-1"
+            >
+              Deny
+            </Button>
+            <Button type="submit" className="flex-1">
+              Allow
+            </Button>
+          </form>
+        </CardFooter>
+      </Card>
+    </main>
+  );
+}

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -13,8 +13,8 @@ import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { approveAuthorization, denyAuthorization } from "@/actions/oauth";
 import {
+  readAuthorizeParams,
   validateAuthorizeRequest,
-  type AuthorizeParams,
 } from "@/lib/oauth/authorize";
 import { MCP_SCOPE } from "@/lib/oauth/validate";
 import { Button } from "@/components/ui/button";
@@ -57,15 +57,7 @@ export default async function AuthorizePage({
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const raw = await searchParams;
-  const params: AuthorizeParams = {
-    client_id: first(raw.client_id),
-    redirect_uri: first(raw.redirect_uri),
-    response_type: first(raw.response_type),
-    code_challenge: first(raw.code_challenge),
-    code_challenge_method: first(raw.code_challenge_method),
-    scope: first(raw.scope),
-    state: first(raw.state),
-  };
+  const params = readAuthorizeParams((key) => first(raw[key]));
 
   const session = await auth();
   if (!session?.user) {
@@ -87,8 +79,6 @@ export default async function AuthorizePage({
     if (validation.fatal) return <ErrorCard message={validation.message} />;
     redirect(validation.redirectTo);
   }
-
-  const hiddenFields: AuthorizeParams = { ...params };
 
   return (
     <main className="flex min-h-screen items-center justify-center p-6">
@@ -121,7 +111,7 @@ export default async function AuthorizePage({
         </CardContent>
         <CardFooter>
           <form action={approveAuthorization} className="flex w-full gap-3">
-            {Object.entries(hiddenFields).map(([key, value]) =>
+            {Object.entries(params).map(([key, value]) =>
               value !== undefined ? (
                 <input key={key} type="hidden" name={key} value={value} />
               ) : null,

--- a/src/app/settings/connections/page.tsx
+++ b/src/app/settings/connections/page.tsx
@@ -6,6 +6,7 @@
 import { redirect } from "next/navigation";
 
 import { auth } from "@/lib/auth";
+import { formatDate } from "@/lib/utils";
 import { listGrantsForUser } from "@/lib/oauth/store";
 import {
   Card,
@@ -25,15 +26,6 @@ import {
 import { RevokeConnectionButton } from "./revoke-button";
 
 export const dynamic = "force-dynamic";
-
-function formatDate(date: Date | null): string {
-  if (!date) return "—";
-  return date.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
 
 export default async function ConnectionsPage() {
   const session = await auth();
@@ -75,7 +67,7 @@ export default async function ConnectionsPage() {
             </TableHeader>
             <TableBody>
               {grants.map((grant) => (
-                <TableRow key={grant.tokenId}>
+                <TableRow key={grant.familyId}>
                   <TableCell className="font-medium">
                     {grant.clientName}
                   </TableCell>

--- a/src/app/settings/connections/page.tsx
+++ b/src/app/settings/connections/page.tsx
@@ -1,0 +1,102 @@
+/**
+ * Settings → Connections (038-mcp-v2): the signed-in user's active MCP OAuth
+ * grants, with revocation. Available to every role — grants are personal.
+ */
+
+import { redirect } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+import { listGrantsForUser } from "@/lib/oauth/store";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { RevokeConnectionButton } from "./revoke-button";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(date: Date | null): string {
+  if (!date) return "—";
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default async function ConnectionsPage() {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/login");
+
+  const grants = await listGrantsForUser(Number(session.user.id));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>MCP Connections</CardTitle>
+        <CardDescription>
+          Apps you have authorized to read AI-spend data through the Hub&apos;s
+          MCP server (e.g. Claude Desktop, Claude Code). Revoking a connection
+          immediately invalidates its tokens.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {grants.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No active connections. Add the Hub as a custom connector in Claude
+            (Settings → Connectors) or run{" "}
+            <code className="font-mono text-xs">
+              claude mcp add --transport http ai-developer-hub &lt;hub-url&gt;/api/mcp/mcp
+            </code>{" "}
+            to create one.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Client</TableHead>
+                <TableHead>Access</TableHead>
+                <TableHead>Authorized</TableHead>
+                <TableHead>Last used</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead className="w-[100px]" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {grants.map((grant) => (
+                <TableRow key={grant.tokenId}>
+                  <TableCell className="font-medium">
+                    {grant.clientName}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {grant.scope}
+                  </TableCell>
+                  <TableCell>{formatDate(grant.createdAt)}</TableCell>
+                  <TableCell>{formatDate(grant.lastUsedAt)}</TableCell>
+                  <TableCell>{formatDate(grant.refreshExpiresAt)}</TableCell>
+                  <TableCell className="text-right">
+                    <RevokeConnectionButton
+                      familyId={grant.familyId}
+                      clientName={grant.clientName}
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/settings/connections/revoke-button.tsx
+++ b/src/app/settings/connections/revoke-button.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+import { revokeConnection } from "@/actions/oauth";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+export function RevokeConnectionButton({
+  familyId,
+  clientName,
+}: {
+  familyId: string;
+  clientName: string;
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleRevoke = () => {
+    startTransition(async () => {
+      const result = await revokeConnection(familyId);
+      if (result.success) {
+        toast.success(`Revoked access for ${clientName}`);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline" size="sm" disabled={isPending}>
+          Revoke
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Revoke {clientName}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            The client&apos;s tokens stop working immediately. You can
+            re-authorize later by reconnecting from the client.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleRevoke}>Revoke</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/settings/connections/revoke-button.tsx
+++ b/src/app/settings/connections/revoke-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
 import { revokeConnection } from "@/actions/oauth";
@@ -25,12 +26,14 @@ export function RevokeConnectionButton({
   clientName: string;
 }) {
   const [isPending, startTransition] = useTransition();
+  const router = useRouter();
 
   const handleRevoke = () => {
     startTransition(async () => {
       const result = await revokeConnection(familyId);
       if (result.success) {
         toast.success(`Revoked access for ${clientName}`);
+        router.refresh();
       } else {
         toast.error(result.error);
       }

--- a/src/app/settings/settings-nav.tsx
+++ b/src/app/settings/settings-nav.tsx
@@ -4,7 +4,10 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 
-const baseTabs = [{ label: "Appearance", href: "/settings/appearance" }];
+const baseTabs = [
+  { label: "Appearance", href: "/settings/appearance" },
+  { label: "Connections", href: "/settings/connections" },
+];
 
 const adminTabs = [
   { label: "Integrations", href: "/settings/integrations" },

--- a/src/lib/db/migrations/0025_colorful_vector.sql
+++ b/src/lib/db/migrations/0025_colorful_vector.sql
@@ -1,0 +1,48 @@
+CREATE TABLE "mcp_oauth_clients" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"client_id" varchar(64) NOT NULL,
+	"client_name" varchar(255) NOT NULL,
+	"redirect_uris" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"last_used_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "mcp_oauth_codes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"code_hash" varchar(64) NOT NULL,
+	"client_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"redirect_uri" text NOT NULL,
+	"code_challenge" varchar(128) NOT NULL,
+	"scope" varchar(255) NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"consumed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "mcp_oauth_tokens" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"family_id" varchar(36) NOT NULL,
+	"access_token_hash" varchar(64) NOT NULL,
+	"refresh_token_hash" varchar(64) NOT NULL,
+	"client_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"scope" varchar(255) NOT NULL,
+	"access_expires_at" timestamp NOT NULL,
+	"refresh_expires_at" timestamp NOT NULL,
+	"revoked_at" timestamp,
+	"last_used_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "mcp_oauth_codes" ADD CONSTRAINT "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."mcp_oauth_clients"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mcp_oauth_codes" ADD CONSTRAINT "mcp_oauth_codes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mcp_oauth_tokens" ADD CONSTRAINT "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."mcp_oauth_clients"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mcp_oauth_tokens" ADD CONSTRAINT "mcp_oauth_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "mcp_oauth_clients_client_id_idx" ON "mcp_oauth_clients" USING btree ("client_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "mcp_oauth_codes_code_hash_idx" ON "mcp_oauth_codes" USING btree ("code_hash");--> statement-breakpoint
+CREATE INDEX "mcp_oauth_codes_user_id_idx" ON "mcp_oauth_codes" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "mcp_oauth_tokens_access_token_hash_idx" ON "mcp_oauth_tokens" USING btree ("access_token_hash");--> statement-breakpoint
+CREATE UNIQUE INDEX "mcp_oauth_tokens_refresh_token_hash_idx" ON "mcp_oauth_tokens" USING btree ("refresh_token_hash");--> statement-breakpoint
+CREATE INDEX "mcp_oauth_tokens_user_id_idx" ON "mcp_oauth_tokens" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "mcp_oauth_tokens_family_id_idx" ON "mcp_oauth_tokens" USING btree ("family_id");

--- a/src/lib/db/migrations/meta/0025_snapshot.json
+++ b/src/lib/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,4974 @@
+{
+  "id": "aa0d3cdb-3366-4dba-b396-94b67e267dd8",
+  "prevId": "5e8916e7-d50d-40fc-ba87-69603ea97813",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_tiers": {
+      "name": "access_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_cost_cents": {
+          "name": "monthly_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_tiers_tool_id_idx": {
+          "name": "access_tiers_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_tiers_tool_name_idx": {
+          "name": "access_tiers_tool_name_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_tiers_tool_id_ai_tools_id_fk": {
+          "name": "access_tiers_tool_id_ai_tools_id_fk",
+          "tableFrom": "access_tiers",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tools": {
+      "name": "ai_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_licenses": {
+          "name": "max_licenses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tool_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_tools_name_idx": {
+          "name": "ai_tools_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_vendor_idx": {
+          "name": "ai_tools_vendor_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.annual_budgets": {
+      "name": "annual_budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fiscal_year": {
+          "name": "fiscal_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_cents": {
+          "name": "total_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount_cents": {
+          "name": "original_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "budget_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annual_budgets_fiscal_year_idx": {
+          "name": "annual_budgets_fiscal_year_idx",
+          "columns": [
+            {
+              "expression": "fiscal_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annual_budgets_status_idx": {
+          "name": "annual_budgets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_alert_state": {
+      "name": "anthropic_alert_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_month": {
+          "name": "billing_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_80_fired_at": {
+          "name": "threshold_80_fired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_100_fired_at": {
+          "name": "threshold_100_fired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_120_fired_at": {
+          "name": "threshold_120_fired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forecast_at_risk": {
+          "name": "forecast_at_risk",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forecast_changed_at": {
+          "name": "forecast_changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_alert_state_workspace_month_idx": {
+          "name": "anthropic_alert_state_workspace_month_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_alert_state\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_alert_state_default_month_idx": {
+          "name": "anthropic_alert_state_default_month_idx",
+          "columns": [
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_alert_state\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_alert_state_month_idx": {
+          "name": "anthropic_alert_state_month_idx",
+          "columns": [
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_alert_state_billing_month_format": {
+          "name": "anthropic_alert_state_billing_month_format",
+          "value": "\"anthropic_alert_state\".\"billing_month\" ~ '^[0-9]{4}-(0[1-9]|1[0-2])$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_org_config": {
+      "name": "anthropic_org_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "billing_budget_limit_cents": {
+          "name": "billing_budget_limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anthropic_org_config_updated_by_users_id_fk": {
+          "name": "anthropic_org_config_updated_by_users_id_fk",
+          "tableFrom": "anthropic_org_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_org_config_id_check": {
+          "name": "anthropic_org_config_id_check",
+          "value": "\"anthropic_org_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_sync_status": {
+      "name": "anthropic_sync_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_days": {
+          "name": "synced_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_api_key_id": {
+          "name": "resolved_api_key_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_workspace_id": {
+          "name": "resolved_workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sync_completed_at": {
+          "name": "workspace_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "anthropic_sync_status_user_id_idx": {
+          "name": "anthropic_sync_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_usage_metrics": {
+      "name": "anthropic_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncached_input_tokens": {
+          "name": "uncached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_cost_cents": {
+          "name": "computed_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pricing_resolved": {
+          "name": "pricing_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_usage_metrics_user_date_model_idx": {
+          "name": "anthropic_usage_metrics_user_date_model_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_user_date_idx": {
+          "name": "anthropic_usage_metrics_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_date_idx": {
+          "name": "anthropic_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_pricing_resolved_idx": {
+          "name": "anthropic_usage_metrics_pricing_resolved_idx",
+          "columns": [
+            {
+              "expression": "pricing_resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anthropic_usage_metrics_user_id_users_id_fk": {
+          "name": "anthropic_usage_metrics_user_id_users_id_fk",
+          "tableFrom": "anthropic_usage_metrics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_costs": {
+      "name": "anthropic_workspace_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_costs_workspace_date_idx": {
+          "name": "anthropic_workspace_costs_workspace_date_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_default_date_idx": {
+          "name": "anthropic_workspace_costs_default_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_date_idx": {
+          "name": "anthropic_workspace_costs_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_workspace_id_idx": {
+          "name": "anthropic_workspace_costs_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_workspace_costs_cost_cents_check": {
+          "name": "anthropic_workspace_costs_cost_cents_check",
+          "value": "\"anthropic_workspace_costs\".\"cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_limits": {
+      "name": "anthropic_workspace_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_cents": {
+          "name": "limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_limits_workspace_id_idx": {
+          "name": "anthropic_workspace_limits_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_limits_default_idx": {
+          "name": "anthropic_workspace_limits_default_idx",
+          "columns": [
+            {
+              "expression": "(1)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspaces": {
+      "name": "anthropic_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_color": {
+          "name": "display_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_created_at": {
+          "name": "anthropic_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspaces_workspace_id_idx": {
+          "name": "anthropic_workspaces_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspaces\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspaces_is_default_idx": {
+          "name": "anthropic_workspaces_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspaces\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspaces_archived_idx": {
+          "name": "anthropic_workspaces_archived_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assignment_comments": {
+      "name": "assignment_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assignment_comments_assignment_id_idx": {
+          "name": "assignment_comments_assignment_id_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_comments_author_id_idx": {
+          "name": "assignment_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_comments_created_at_idx": {
+          "name": "assignment_comments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assignment_comments_assignment_id_license_assignments_id_fk": {
+          "name": "assignment_comments_assignment_id_license_assignments_id_fk",
+          "tableFrom": "assignment_comments",
+          "tableTo": "license_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_comments_author_id_users_id_fk": {
+          "name": "assignment_comments_author_id_users_id_fk",
+          "tableFrom": "assignment_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billed_costs": {
+      "name": "billed_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor_reference": {
+          "name": "vendor_reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billed_costs_period_id_idx": {
+          "name": "billed_costs_period_id_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billed_costs_invoice_date_idx": {
+          "name": "billed_costs_invoice_date_idx",
+          "columns": [
+            {
+              "expression": "invoice_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billed_costs_period_id_budget_periods_id_fk": {
+          "name": "billed_costs_period_id_budget_periods_id_fk",
+          "tableFrom": "billed_costs",
+          "tableTo": "budget_periods",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_extension_period_allocations": {
+      "name": "budget_extension_period_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extension_id": {
+          "name": "extension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bepa_unique_ext_period": {
+          "name": "bepa_unique_ext_period",
+          "columns": [
+            {
+              "expression": "extension_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bepa_period_idx": {
+          "name": "bepa_period_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_extension_period_allocations_extension_id_budget_extensions_id_fk": {
+          "name": "budget_extension_period_allocations_extension_id_budget_extensions_id_fk",
+          "tableFrom": "budget_extension_period_allocations",
+          "tableTo": "budget_extensions",
+          "columnsFrom": [
+            "extension_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budget_extension_period_allocations_period_id_budget_periods_id_fk": {
+          "name": "budget_extension_period_allocations_period_id_budget_periods_id_fk",
+          "tableFrom": "budget_extension_period_allocations",
+          "tableTo": "budget_periods",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_extensions": {
+      "name": "budget_extensions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "budget_extension_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_tool_id": {
+          "name": "linked_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_extensions_budget_idx": {
+          "name": "budget_extensions_budget_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_extensions_effective_idx": {
+          "name": "budget_extensions_effective_idx",
+          "columns": [
+            {
+              "expression": "effective_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_extensions_linked_tool_idx": {
+          "name": "budget_extensions_linked_tool_idx",
+          "columns": [
+            {
+              "expression": "linked_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_extensions_created_by_idx": {
+          "name": "budget_extensions_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_extensions_budget_id_annual_budgets_id_fk": {
+          "name": "budget_extensions_budget_id_annual_budgets_id_fk",
+          "tableFrom": "budget_extensions",
+          "tableTo": "annual_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budget_extensions_linked_tool_id_ai_tools_id_fk": {
+          "name": "budget_extensions_linked_tool_id_ai_tools_id_fk",
+          "tableFrom": "budget_extensions",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "linked_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "budget_extensions_created_by_users_id_fk": {
+          "name": "budget_extensions_created_by_users_id_fk",
+          "tableFrom": "budget_extensions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "budget_extensions_amount_non_zero": {
+          "name": "budget_extensions_amount_non_zero",
+          "value": "\"budget_extensions\".\"amount_cents\" <> 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.budget_periods": {
+      "name": "budget_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_amount_cents": {
+          "name": "planned_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_periods_budget_id_idx": {
+          "name": "budget_periods_budget_id_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_periods_budget_period_idx": {
+          "name": "budget_periods_budget_period_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_periods_budget_id_annual_budgets_id_fk": {
+          "name": "budget_periods_budget_id_annual_budgets_id_fk",
+          "tableFrom": "budget_periods",
+          "tableTo": "annual_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_history": {
+      "name": "change_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "change_history_entity_idx": {
+          "name": "change_history_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_history_changed_by_idx": {
+          "name": "change_history_changed_by_idx",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_history_created_at_idx": {
+          "name": "change_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_history_changed_by_users_id_fk": {
+          "name": "change_history_changed_by_users_id_fk",
+          "tableFrom": "change_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_billing_snapshots": {
+      "name": "copilot_billing_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_month": {
+          "name": "billing_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seats": {
+          "name": "total_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_seats": {
+          "name": "active_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_cost_cents": {
+          "name": "seat_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost_cents": {
+          "name": "total_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_billing_snapshots_connection_month_idx": {
+          "name": "copilot_billing_snapshots_connection_month_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_billing_snapshots_connection_id_github_connections_id_fk": {
+          "name": "copilot_billing_snapshots_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_billing_snapshots",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_usage_metrics": {
+      "name": "copilot_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_engaged_users": {
+          "name": "total_engaged_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_suggestions": {
+          "name": "total_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_acceptances": {
+          "name": "total_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_suggested": {
+          "name": "total_lines_suggested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_accepted": {
+          "name": "total_lines_accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_chat_turns": {
+          "name": "total_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_chat_acceptances": {
+          "name": "total_chat_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_dotcom_chat_turns": {
+          "name": "total_dotcom_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pr_summaries": {
+          "name": "total_pr_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_breakdown": {
+          "name": "language_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_breakdown": {
+          "name": "editor_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_cli": {
+          "name": "used_cli",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_agent": {
+          "name": "used_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_edit_count": {
+          "name": "agent_edit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_breakdown": {
+          "name": "cli_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_usage_metrics_connection_date_idx": {
+          "name": "copilot_usage_metrics_connection_date_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_usage_metrics_date_idx": {
+          "name": "copilot_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_usage_metrics_connection_id_github_connections_id_fk": {
+          "name": "copilot_usage_metrics_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_usage_metrics",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_login": {
+          "name": "org_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_avatar_url": {
+          "name": "org_avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_scopes_csv": {
+          "name": "token_scopes_csv",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_sync_enabled": {
+          "name": "copilot_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "copilot_sync_schedule": {
+          "name": "copilot_sync_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        }
+      },
+      "indexes": {
+        "github_connections_status_idx": {
+          "name": "github_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_connections_connected_by_users_id_fk": {
+          "name": "github_connections_connected_by_users_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_profiles": {
+      "name": "github_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_profiles_user_id_idx": {
+          "name": "github_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_profiles_github_id_idx": {
+          "name": "github_profiles_github_id_idx",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_profiles_github_login_idx": {
+          "name": "github_profiles_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_profiles_user_id_users_id_fk": {
+          "name": "github_profiles_user_id_users_id_fk",
+          "tableFrom": "github_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sync_events": {
+      "name": "github_sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_members": {
+          "name": "total_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manually_matched_count": {
+          "name": "manually_matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "copilot_sync_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "seats_processed": {
+          "name": "seats_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_processed": {
+          "name": "metrics_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_processed": {
+          "name": "billing_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_linked": {
+          "name": "billing_linked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_skipped": {
+          "name": "billing_skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_sync_events_connection_id_idx": {
+          "name": "github_sync_events_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_sync_events_triggered_by_idx": {
+          "name": "github_sync_events_triggered_by_idx",
+          "columns": [
+            {
+              "expression": "triggered_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sync_events_connection_id_github_connections_id_fk": {
+          "name": "github_sync_events_connection_id_github_connections_id_fk",
+          "tableFrom": "github_sync_events",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_sync_events_triggered_by_users_id_fk": {
+          "name": "github_sync_events_triggered_by_users_id_fk",
+          "tableFrom": "github_sync_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_filters": {
+      "name": "ingestion_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "filter_field",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "filter_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_filters_enabled_idx": {
+          "name": "ingestion_filters_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_filters_created_by_users_id_fk": {
+          "name": "ingestion_filters_created_by_users_id_fk",
+          "tableFrom": "ingestion_filters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_log": {
+      "name": "ingestion_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "ingestion_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "ingestion_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_invoice_id": {
+          "name": "linked_invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_log_outcome_idx": {
+          "name": "ingestion_log_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_log_created_at_idx": {
+          "name": "ingestion_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_log_vendor_idx": {
+          "name": "ingestion_log_vendor_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_log_channel_idx": {
+          "name": "ingestion_log_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_log_linked_invoice_id_invoices_id_fk": {
+          "name": "ingestion_log_linked_invoice_id_invoices_id_fk",
+          "tableFrom": "ingestion_log",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "linked_invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ingestion_log_uploaded_by_users_id_fk": {
+          "name": "ingestion_log_uploaded_by_users_id_fk",
+          "tableFrom": "ingestion_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_tokens": {
+      "name": "invite_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_token_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_tokens_token_hash_idx": {
+          "name": "invite_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_tokens_user_id_idx": {
+          "name": "invite_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_tokens_active_user_idx": {
+          "name": "invite_tokens_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_tokens\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_tokens_user_id_users_id_fk": {
+          "name": "invite_tokens_user_id_users_id_fk",
+          "tableFrom": "invite_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_billed_cost_id": {
+          "name": "linked_billed_cost_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filtered_out": {
+          "name": "filtered_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_created_at_idx": {
+          "name": "invoices_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_linked_billed_cost_id_idx": {
+          "name": "invoices_linked_billed_cost_id_idx",
+          "columns": [
+            {
+              "expression": "linked_billed_cost_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_billed_cost_id_billed_costs_id_fk": {
+          "name": "invoices_linked_billed_cost_id_billed_costs_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "billed_costs",
+          "columnsFrom": [
+            "linked_billed_cost_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invoices_uploaded_by_users_id_fk": {
+          "name": "invoices_uploaded_by_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_assignments": {
+      "name": "license_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_at_assignment_cents": {
+          "name": "cost_at_assignment_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace": {
+          "name": "workspace",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "license_assignments_user_id_idx": {
+          "name": "license_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_tool_id_idx": {
+          "name": "license_assignments_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_tier_id_idx": {
+          "name": "license_assignments_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_status_idx": {
+          "name": "license_assignments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_active_lookup_idx": {
+          "name": "license_assignments_active_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_assignments_user_id_users_id_fk": {
+          "name": "license_assignments_user_id_users_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_assignments_tool_id_ai_tools_id_fk": {
+          "name": "license_assignments_tool_id_ai_tools_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_assignments_tier_id_access_tiers_id_fk": {
+          "name": "license_assignments_tier_id_access_tiers_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "access_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_requests": {
+      "name": "license_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "form_response_id": {
+          "name": "form_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_email": {
+          "name": "requester_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_name": {
+          "name": "requester_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_user_id": {
+          "name": "requester_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_tool_id": {
+          "name": "requested_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_tier_id": {
+          "name": "requested_tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_payload": {
+          "name": "form_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_team_id": {
+          "name": "teams_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_channel_id": {
+          "name": "teams_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_parent_message_id": {
+          "name": "teams_parent_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_chat_id": {
+          "name": "teams_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "license_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_message_md": {
+          "name": "approval_message_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_message_md": {
+          "name": "completion_message_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "license_requests_requester_user_id_idx": {
+          "name": "license_requests_requester_user_id_idx",
+          "columns": [
+            {
+              "expression": "requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_requested_tool_id_idx": {
+          "name": "license_requests_requested_tool_id_idx",
+          "columns": [
+            {
+              "expression": "requested_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_status_idx": {
+          "name": "license_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_decided_by_idx": {
+          "name": "license_requests_decided_by_idx",
+          "columns": [
+            {
+              "expression": "decided_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_assignment_id_idx": {
+          "name": "license_requests_assignment_id_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_created_at_idx": {
+          "name": "license_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_requests_requester_user_id_users_id_fk": {
+          "name": "license_requests_requester_user_id_users_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "license_requests_requested_tool_id_ai_tools_id_fk": {
+          "name": "license_requests_requested_tool_id_ai_tools_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "requested_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_requests_requested_tier_id_access_tiers_id_fk": {
+          "name": "license_requests_requested_tier_id_access_tiers_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "access_tiers",
+          "columnsFrom": [
+            "requested_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "license_requests_decided_by_users_id_fk": {
+          "name": "license_requests_decided_by_users_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "license_requests_completed_by_users_id_fk": {
+          "name": "license_requests_completed_by_users_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "license_requests_assignment_id_license_assignments_id_fk": {
+          "name": "license_requests_assignment_id_license_assignments_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "license_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "license_requests_form_response_id_unique": {
+          "name": "license_requests_form_response_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_response_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_oauth_clients_client_id_idx": {
+          "name": "mcp_oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_code_hash_idx": {
+          "name": "mcp_oauth_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_codes_user_id_idx": {
+          "name": "mcp_oauth_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_access_token_hash_idx": {
+          "name": "mcp_oauth_tokens_access_token_hash_idx",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_refresh_token_hash_idx": {
+          "name": "mcp_oauth_tokens_refresh_token_hash_idx",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_id_idx": {
+          "name": "mcp_oauth_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_family_id_idx": {
+          "name": "mcp_oauth_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_templates": {
+      "name": "message_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "message_template_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_md": {
+          "name": "body_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_templates_tool_id_idx": {
+          "name": "message_templates_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_templates_tier_id_idx": {
+          "name": "message_templates_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_templates_tool_default_kind_idx": {
+          "name": "message_templates_tool_default_kind_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"message_templates\".\"tier_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_templates_tool_tier_kind_idx": {
+          "name": "message_templates_tool_tier_kind_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"message_templates\".\"tier_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_templates_tool_id_ai_tools_id_fk": {
+          "name": "message_templates_tool_id_ai_tools_id_fk",
+          "tableFrom": "message_templates",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_templates_tier_id_access_tiers_id_fk": {
+          "name": "message_templates_tier_id_access_tiers_id_fk",
+          "tableFrom": "message_templates",
+          "tableTo": "access_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_events": {
+      "name": "sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "sync_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "backfill_start_date": {
+          "name": "backfill_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sync_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_events_source_type_idx": {
+          "name": "sync_events_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_outcome_idx": {
+          "name": "sync_events_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_started_at_idx": {
+          "name": "sync_events_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_source_started_idx": {
+          "name": "sync_events_source_started_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_events_triggered_by_users_id_fk": {
+          "name": "sync_events_triggered_by_users_id_fk",
+          "tableFrom": "sync_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_sources": {
+      "name": "sync_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cron_schedule": {
+          "name": "cron_schedule",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_sources_source_type_idx": {
+          "name": "sync_sources_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circle": {
+          "name": "circle",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"theme\":\"system\"}'::jsonb"
+        },
+        "profile": {
+          "name": "profile",
+          "type": "user_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline": {
+          "name": "discipline",
+          "type": "user_discipline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'developer'"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_agent": {
+          "name": "is_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_circle_idx": {
+          "name": "users_circle_idx",
+          "columns": [
+            {
+              "expression": "circle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_status_idx": {
+          "name": "users_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.budget_extension_category": {
+      "name": "budget_extension_category",
+      "schema": "public",
+      "values": [
+        "new_tool",
+        "scope_increase",
+        "seat_increase",
+        "vendor_price_increase",
+        "reallocation",
+        "other"
+      ]
+    },
+    "public.budget_status": {
+      "name": "budget_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.change_type": {
+      "name": "change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "deleted",
+        "status_change"
+      ]
+    },
+    "public.copilot_sync_type": {
+      "name": "copilot_sync_type",
+      "schema": "public",
+      "values": [
+        "members",
+        "copilot"
+      ]
+    },
+    "public.filter_field": {
+      "name": "filter_field",
+      "schema": "public",
+      "values": [
+        "vendor",
+        "invoice_number"
+      ]
+    },
+    "public.filter_mode": {
+      "name": "filter_mode",
+      "schema": "public",
+      "values": [
+        "whitelist",
+        "blacklist"
+      ]
+    },
+    "public.github_connection_status": {
+      "name": "github_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disconnected"
+      ]
+    },
+    "public.github_sync_status": {
+      "name": "github_sync_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.ingestion_channel": {
+      "name": "ingestion_channel",
+      "schema": "public",
+      "values": [
+        "manual",
+        "api",
+        "bulk"
+      ]
+    },
+    "public.ingestion_outcome": {
+      "name": "ingestion_outcome",
+      "schema": "public",
+      "values": [
+        "success",
+        "failed",
+        "filtered"
+      ]
+    },
+    "public.invite_token_status": {
+      "name": "invite_token_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "consumed",
+        "invalidated"
+      ]
+    },
+    "public.license_request_status": {
+      "name": "license_request_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.message_template_kind": {
+      "name": "message_template_kind",
+      "schema": "public",
+      "values": [
+        "approval",
+        "completion"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "quarterly"
+      ]
+    },
+    "public.sync_operation_type": {
+      "name": "sync_operation_type",
+      "schema": "public",
+      "values": [
+        "regular",
+        "backfill"
+      ]
+    },
+    "public.sync_outcome": {
+      "name": "sync_outcome",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "success",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.sync_source_type": {
+      "name": "sync_source_type",
+      "schema": "public",
+      "values": [
+        "github_copilot_billing",
+        "anthropic_api_usage",
+        "anthropic_team_invoices",
+        "github_members",
+        "invoice_period_matching",
+        "anthropic_api_costs"
+      ]
+    },
+    "public.tool_status": {
+      "name": "tool_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.user_discipline": {
+      "name": "user_discipline",
+      "schema": "public",
+      "values": [
+        "developer",
+        "conception",
+        "business"
+      ]
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "public",
+      "values": [
+        "boost",
+        "maxed",
+        "indie"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "viewer"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1781164840619,
       "tag": "0024_resync_assignment_cost_snapshots",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1781171027885,
+      "tag": "0025_colorful_vector",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -970,6 +970,84 @@ export const messageTemplates = pgTable(
   ]
 );
 
+// MCP OAuth (038-mcp-v2) — minimal embedded OAuth 2.1 authorization server so
+// Claude clients can connect to the MCP endpoint with per-user grants. Tokens
+// and authorization codes are stored as SHA-256 hashes only (invite_tokens
+// pattern); raw values exist client-side only.
+export const mcpOauthClients = pgTable(
+  "mcp_oauth_clients",
+  {
+    id: serial("id").primaryKey(),
+    clientId: varchar("client_id", { length: 64 }).notNull(),
+    clientName: varchar("client_name", { length: 255 }).notNull(),
+    redirectUris: jsonb("redirect_uris").$type<string[]>().notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    lastUsedAt: timestamp("last_used_at"),
+  },
+  (table) => [uniqueIndex("mcp_oauth_clients_client_id_idx").on(table.clientId)]
+);
+
+export const mcpOauthCodes = pgTable(
+  "mcp_oauth_codes",
+  {
+    id: serial("id").primaryKey(),
+    codeHash: varchar("code_hash", { length: 64 }).notNull(),
+    clientId: integer("client_id")
+      .notNull()
+      .references(() => mcpOauthClients.id, { onDelete: "cascade" }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    redirectUri: text("redirect_uri").notNull(),
+    // PKCE S256 challenge — base64url(sha256(verifier)), always 43 chars but
+    // sized generously.
+    codeChallenge: varchar("code_challenge", { length: 128 }).notNull(),
+    scope: varchar("scope", { length: 255 }).notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    consumedAt: timestamp("consumed_at"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("mcp_oauth_codes_code_hash_idx").on(table.codeHash),
+    index("mcp_oauth_codes_user_id_idx").on(table.userId),
+  ]
+);
+
+export const mcpOauthTokens = pgTable(
+  "mcp_oauth_tokens",
+  {
+    id: serial("id").primaryKey(),
+    // Refresh-rotation lineage: rotation revokes the old row and inserts a new
+    // one with the same familyId. Replaying a revoked refresh token revokes
+    // the whole family (RFC 9700 §4.14 reuse detection).
+    familyId: varchar("family_id", { length: 36 }).notNull(),
+    accessTokenHash: varchar("access_token_hash", { length: 64 }).notNull(),
+    refreshTokenHash: varchar("refresh_token_hash", { length: 64 }).notNull(),
+    clientId: integer("client_id")
+      .notNull()
+      .references(() => mcpOauthClients.id, { onDelete: "cascade" }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    scope: varchar("scope", { length: 255 }).notNull(),
+    accessExpiresAt: timestamp("access_expires_at").notNull(),
+    refreshExpiresAt: timestamp("refresh_expires_at").notNull(),
+    revokedAt: timestamp("revoked_at"),
+    lastUsedAt: timestamp("last_used_at"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("mcp_oauth_tokens_access_token_hash_idx").on(
+      table.accessTokenHash
+    ),
+    uniqueIndex("mcp_oauth_tokens_refresh_token_hash_idx").on(
+      table.refreshTokenHash
+    ),
+    index("mcp_oauth_tokens_user_id_idx").on(table.userId),
+    index("mcp_oauth_tokens_family_id_idx").on(table.familyId),
+  ]
+);
+
 // Relations
 export const usersRelations = relations(users, ({ many, one }) => ({
   licenseAssignments: many(licenseAssignments),

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -16,7 +16,7 @@
 
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 
-import { verifyAccessToken } from "@/lib/oauth/store";
+import { ACCESS_TOKEN_PREFIX, verifyAccessToken } from "@/lib/oauth/store";
 import { MCP_SCOPE, safeEqual } from "@/lib/oauth/validate";
 
 // Re-exported for existing consumers/tests; implementation moved to
@@ -24,9 +24,6 @@ import { MCP_SCOPE, safeEqual } from "@/lib/oauth/validate";
 export { safeEqual };
 
 let warnedMissingSecret = false;
-
-/** Prefix of access tokens issued by the embedded OAuth server. */
-const OAUTH_ACCESS_TOKEN_PREFIX = "mcp_at_";
 
 /**
  * Validate the bearer token presented by an MCP client. Checks the shared
@@ -56,7 +53,7 @@ export async function verifyMcpToken(
     };
   }
 
-  if (bearerToken.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
+  if (bearerToken.startsWith(ACCESS_TOKEN_PREFIX)) {
     const verified = await verifyAccessToken(bearerToken);
     if (verified) {
       return {

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -1,62 +1,76 @@
 /**
  * Authentication for the MCP server.
  *
- * The Hub uses shared bearer secrets for its machine-to-machine endpoints
- * (PROFILE_API_SECRET, CRON_SECRET, ...). The MCP server follows the same
- * convention via `MCP_SERVER_SECRET`, plugged into mcp-handler's
- * `withMcpAuth(handler, verifyMcpToken, { required: true })`.
+ * Two parallel credential types (038-mcp-v2):
  *
- * Dormant-by-default: when MCP_SERVER_SECRET is unset, every request is
- * rejected (verifyMcpToken returns undefined → 401) and a one-time warning is
- * logged, so the feature stays off until an operator provisions a secret.
+ * 1. Shared secret — `MCP_SERVER_SECRET`, the original machine-to-machine
+ *    convention (PROFILE_API_SECRET, CRON_SECRET, ...) for headless clients.
+ * 2. OAuth access tokens (`mcp_at_…`) issued by the embedded authorization
+ *    server, each bound to a Hub user; used by Claude Desktop / claude.ai /
+ *    Claude Code connectors.
+ *
+ * When MCP_SERVER_SECRET is unset the shared-secret path is dormant (one-time
+ * warning) but OAuth tokens still work — the server is enabled by either
+ * mechanism independently.
  */
 
-import { timingSafeEqual } from "node:crypto";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 
-/** Constant-time string comparison that is safe for unequal lengths. */
-export function safeEqual(a: string, b: string): boolean {
-  const bufA = Buffer.from(a, "utf8");
-  const bufB = Buffer.from(b, "utf8");
-  if (bufA.length !== bufB.length) {
-    // Still run a comparison to avoid leaking length via early return timing.
-    timingSafeEqual(bufA, bufA);
-    return false;
-  }
-  return timingSafeEqual(bufA, bufB);
-}
+import { verifyAccessToken } from "@/lib/oauth/store";
+import { MCP_SCOPE, safeEqual } from "@/lib/oauth/validate";
+
+// Re-exported for existing consumers/tests; implementation moved to
+// src/lib/oauth/validate.ts so the OAuth layer can use it without a cycle.
+export { safeEqual };
 
 let warnedMissingSecret = false;
 
+/** Prefix of access tokens issued by the embedded OAuth server. */
+const OAUTH_ACCESS_TOKEN_PREFIX = "mcp_at_";
+
 /**
- * Validate the bearer token presented by an MCP client against
- * MCP_SERVER_SECRET. Returns an AuthInfo on success or undefined on any
- * failure (missing secret, missing/invalid token), which mcp-handler maps to a
- * 401 response.
+ * Validate the bearer token presented by an MCP client. Checks the shared
+ * MCP_SERVER_SECRET first, then OAuth access tokens issued by the embedded
+ * authorization server. Returns an AuthInfo on success or undefined on any
+ * failure, which mcp-handler maps to a 401 response.
  */
-export function verifyMcpToken(
+export async function verifyMcpToken(
   _req: Request,
   bearerToken?: string,
-): AuthInfo | undefined {
+): Promise<AuthInfo | undefined> {
+  if (!bearerToken) return undefined;
+
   const secret = process.env.MCP_SERVER_SECRET;
+  if (!secret && !warnedMissingSecret) {
+    warnedMissingSecret = true;
+    console.warn(
+      "[mcp] MCP_SERVER_SECRET is not set — shared-secret MCP auth is disabled (OAuth tokens still work).",
+    );
+  }
 
-  if (!secret) {
-    if (!warnedMissingSecret) {
-      warnedMissingSecret = true;
-      console.warn(
-        "[mcp] MCP_SERVER_SECRET is not set — the MCP server is disabled and will reject all requests.",
-      );
+  if (secret && safeEqual(bearerToken, secret)) {
+    return {
+      token: bearerToken,
+      clientId: "mcp-shared-secret",
+      scopes: [MCP_SCOPE],
+    };
+  }
+
+  if (bearerToken.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
+    const verified = await verifyAccessToken(bearerToken);
+    if (verified) {
+      return {
+        token: bearerToken,
+        clientId: verified.clientPublicId,
+        scopes: verified.scope.split(" "),
+        extra: {
+          userId: verified.userId,
+          email: verified.email,
+          name: verified.name,
+        },
+      };
     }
-    return undefined;
   }
 
-  if (!bearerToken || !safeEqual(bearerToken, secret)) {
-    return undefined;
-  }
-
-  return {
-    token: bearerToken,
-    clientId: "mcp-shared-secret",
-    scopes: [],
-  };
+  return undefined;
 }

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -8,7 +8,8 @@
  * hashes, or invite tokens.
  */
 
-import { and, asc, desc, eq, gte, ilike, isNull, lte, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, ilike, isNull, lte, ne, or, sql } from "drizzle-orm";
+import { endOfMonth, format, parseISO, subMonths } from "date-fns";
 
 import { db } from "@/lib/db";
 import {
@@ -34,24 +35,18 @@ import {
   loadSyncStatus,
   loadWorkspaceList,
 } from "@/lib/anthropic/queries";
-import {
-  getActiveBudget,
-  getBudgetWithCosts,
-  fetchActualByPeriod,
-} from "@/actions/budget";
+import { getBudgetWithCosts, fetchActualByPeriod } from "@/actions/budget";
 import { getBudgetReportData } from "@/actions/reports";
 import { buildBudgetForecast } from "@/lib/forecast";
+import { LOCK_USER_ID } from "@/lib/anthropic-sync";
 import { getCurrentMonth, formatUtcDateOnly } from "@/lib/utils";
 import type { SyncSourceType } from "@/lib/sync/framework";
 import { usd } from "@/lib/mcp/format";
 
-/** Inclusive YYYY-MM-DD start/end of a YYYY-MM month (UTC). */
+/** Inclusive YYYY-MM-DD start/end of a YYYY-MM month. */
 function monthRange(month: string): { start: string; end: string } {
-  const [y, m] = month.split("-").map(Number);
-  return {
-    start: `${month}-01`,
-    end: formatUtcDateOnly(new Date(Date.UTC(y, m, 0))),
-  };
+  const start = `${month}-01`;
+  return { start, end: format(endOfMonth(parseISO(start)), "yyyy-MM-dd") };
 }
 
 /** Escape ILIKE wildcards in user-supplied search terms. */
@@ -283,7 +278,10 @@ export async function getBudgetStatusData(fiscalYear?: number) {
     if (!row) throw new Error(`No budget found for fiscal year ${fiscalYear}`);
     budgetId = row.id;
   } else {
-    const active = await getActiveBudget();
+    const active = await db.query.annualBudgets.findFirst({
+      where: (b, { eq: eqOp }) => eqOp(b.status, "active"),
+      columns: { id: true },
+    });
     if (!active) throw new Error("No active budget configured");
     budgetId = active.id;
   }
@@ -323,20 +321,40 @@ export async function getBudgetStatusData(fiscalYear?: number) {
 // get_copilot_usage_summary
 // ---------------------------------------------------------------------------
 
-export async function getCopilotUsageSummaryData(
-  since?: string,
-  until?: string,
-) {
-  // Match getActiveConnection() in copilot-data.ts: a connection only counts as
-  // active for Copilot when syncing is enabled — otherwise its metrics are
-  // absent or stale and "connected: true" would be misleading.
-  const connection = await db.query.githubConnections.findFirst({
+/**
+ * Match getActiveConnection() in copilot-data.ts: a connection only counts as
+ * active for Copilot when syncing is enabled — otherwise its metrics are
+ * absent or stale and "connected: true" would be misleading.
+ */
+function findActiveCopilotConnection() {
+  return db.query.githubConnections.findFirst({
     where: and(
       eq(githubConnections.status, "active"),
       eq(githubConnections.copilotSyncEnabled, true),
     ),
     columns: { id: true, orgLogin: true },
   });
+}
+
+/**
+ * Default a Copilot date range to the last 28 days in UTC so the YYYY-MM-DD
+ * day boundary is timezone-stable (matches the rest of the codebase, which
+ * keys daily metrics on UTC dates).
+ */
+function defaultCopilotRange(since?: string, until?: string) {
+  const today = new Date();
+  return {
+    sinceDate:
+      since ?? formatUtcDateOnly(new Date(today.getTime() - 27 * 86_400_000)),
+    untilDate: until ?? formatUtcDateOnly(today),
+  };
+}
+
+export async function getCopilotUsageSummaryData(
+  since?: string,
+  until?: string,
+) {
+  const connection = await findActiveCopilotConnection();
   if (!connection) {
     return {
       connected: false as const,
@@ -344,12 +362,7 @@ export async function getCopilotUsageSummaryData(
     };
   }
 
-  // Default the range in UTC so the YYYY-MM-DD day boundary is timezone-stable
-  // (matches the rest of the codebase, which keys daily metrics on UTC dates).
-  const today = new Date();
-  const untilDate = until ?? formatUtcDateOnly(today);
-  const sinceDate =
-    since ?? formatUtcDateOnly(new Date(today.getTime() - 27 * 86_400_000));
+  const { sinceDate, untilDate } = defaultCopilotRange(since, until);
 
   const [rows, billing] = await Promise.all([
     db
@@ -423,7 +436,7 @@ export async function listRecentSyncEventsData(
   sourceType?: SyncSourceType,
   limit?: number,
 ) {
-  const cappedLimit = Math.min(Math.max(limit ?? 10, 1), 50);
+  const cappedLimit = clampLimit(limit, 10, 50);
 
   const [rows, freshness] = await Promise.all([
     db
@@ -524,6 +537,9 @@ export async function listClaudeUsersData(month?: string, limit?: number) {
       and(
         gte(anthropicUsageMetrics.date, start),
         lte(anthropicUsageMetrics.date, end),
+        // Exclude the sync-lock sentinel row, matching _getUserList in
+        // src/actions/anthropic-users.ts.
+        ne(users.id, LOCK_USER_ID),
       ),
     )
     .groupBy(users.id, users.name, users.email, users.circle, users.status)
@@ -560,14 +576,13 @@ export async function getClaudeCostDashboardData(month?: string) {
   const targetMonth = month ?? getCurrentMonth();
   const { start, end } = monthRange(targetMonth);
 
-  const [y, m] = targetMonth.split("-").map(Number);
-  const priorMonthDate = new Date(Date.UTC(y, m - 2, 1));
-  const priorMonth = `${priorMonthDate.getUTCFullYear()}-${String(priorMonthDate.getUTCMonth() + 1).padStart(2, "0")}`;
+  const priorMonth = format(subMonths(parseISO(start), 1), "yyyy-MM");
   const { start: priorStart, end: priorEnd } = monthRange(priorMonth);
-  const twelveMonthsAgo = new Date(Date.UTC(y - 1, m - 1, 1));
+  const twelveMonthsAgoStart = format(subMonths(parseISO(start), 12), "yyyy-MM-dd");
 
   const workspaceName = sql<string | null>`${anthropicWorkspaces.name}`;
   const workspaceJoin = sql`${anthropicWorkspaces.workspaceId} IS NOT DISTINCT FROM ${anthropicWorkspaceCosts.workspaceId}`;
+  const monthExpr = sql<string>`to_char(${anthropicWorkspaceCosts.date}, 'YYYY-MM')`;
 
   const [dailyTotals, workspaceTotals, monthlySeries] = await Promise.all([
     db
@@ -602,13 +617,13 @@ export async function getClaudeCostDashboardData(month?: string) {
       .groupBy(anthropicWorkspaceCosts.workspaceId, anthropicWorkspaces.name),
     db
       .select({
-        month: sql<string>`to_char(${anthropicWorkspaceCosts.date}, 'YYYY-MM')`,
+        month: monthExpr,
         costCents: sql<string>`sum(${anthropicWorkspaceCosts.costCents})`,
       })
       .from(anthropicWorkspaceCosts)
-      .where(gte(anthropicWorkspaceCosts.date, formatUtcDateOnly(twelveMonthsAgo)))
-      .groupBy(sql`to_char(${anthropicWorkspaceCosts.date}, 'YYYY-MM')`)
-      .orderBy(sql`to_char(${anthropicWorkspaceCosts.date}, 'YYYY-MM')`),
+      .where(gte(anthropicWorkspaceCosts.date, twelveMonthsAgoStart))
+      .groupBy(monthExpr)
+      .orderBy(monthExpr),
   ]);
 
   const workspaces = workspaceTotals
@@ -617,7 +632,8 @@ export async function getClaudeCostDashboardData(month?: string) {
       const prior = Number(w.priorCents);
       return {
         workspaceId: w.workspaceId,
-        name: w.workspaceName ?? "Default workspace",
+        // Capitalization matches the admin dashboard (anthropic-global.ts).
+        name: w.workspaceName ?? "Default Workspace",
         ...usd("currentMonth", current),
         ...usd("priorMonth", prior),
         ...usd("delta", current - prior),
@@ -708,12 +724,13 @@ export async function listLicenseAssignmentsData(filters: {
   status?: "active" | "inactive";
   limit?: number;
 }) {
+  const status = filters.status ?? "active";
   const conditions = [
     filters.email ? ilike(users.email, escapeLike(filters.email)) : undefined,
     filters.toolName
       ? ilike(aiTools.name, `%${escapeLike(filters.toolName)}%`)
       : undefined,
-    eq(licenseAssignments.status, filters.status ?? "active"),
+    eq(licenseAssignments.status, status),
   ].filter((c) => c !== undefined);
 
   const rows = await db
@@ -742,7 +759,7 @@ export async function listLicenseAssignmentsData(filters: {
     filters: {
       email: filters.email ?? null,
       toolName: filters.toolName ?? null,
-      status: filters.status ?? "active",
+      status,
     },
     count: rows.length,
     ...usd("monthlyTotal", rows.reduce((s, r) => s + r.costAtAssignmentCents, 0)),
@@ -867,13 +884,7 @@ function topBreakdown(map: Map<string, BreakdownAccumulator>, label: string) {
 }
 
 export async function getCopilotAnalyticsData(since?: string, until?: string) {
-  const connection = await db.query.githubConnections.findFirst({
-    where: and(
-      eq(githubConnections.status, "active"),
-      eq(githubConnections.copilotSyncEnabled, true),
-    ),
-    columns: { id: true, orgLogin: true },
-  });
+  const connection = await findActiveCopilotConnection();
   if (!connection) {
     return {
       connected: false as const,
@@ -881,13 +892,19 @@ export async function getCopilotAnalyticsData(since?: string, until?: string) {
     };
   }
 
-  const today = new Date();
-  const untilDate = until ?? formatUtcDateOnly(today);
-  const sinceDate =
-    since ?? formatUtcDateOnly(new Date(today.getTime() - 27 * 86_400_000));
+  const { sinceDate, untilDate } = defaultCopilotRange(since, until);
 
   const rows = await db
-    .select()
+    .select({
+      date: copilotUsageMetrics.date,
+      totalActiveUsers: copilotUsageMetrics.totalActiveUsers,
+      totalEngagedUsers: copilotUsageMetrics.totalEngagedUsers,
+      totalSuggestions: copilotUsageMetrics.totalSuggestions,
+      totalAcceptances: copilotUsageMetrics.totalAcceptances,
+      totalChatTurns: copilotUsageMetrics.totalChatTurns,
+      languageBreakdown: copilotUsageMetrics.languageBreakdown,
+      editorBreakdown: copilotUsageMetrics.editorBreakdown,
+    })
     .from(copilotUsageMetrics)
     .where(
       and(

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -8,16 +8,23 @@
  * hashes, or invite tokens.
  */
 
-import { and, desc, eq, gte, lte } from "drizzle-orm";
+import { and, asc, desc, eq, gte, ilike, isNull, lte, or, sql } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import {
   accessTiers,
   aiTools,
   anthropicSyncStatus,
+  anthropicUsageMetrics,
+  anthropicWorkspaceCosts,
+  anthropicWorkspaces,
+  billedCosts,
+  budgetPeriods,
   copilotBillingSnapshots,
   copilotUsageMetrics,
   githubConnections,
+  invoices,
+  licenseAssignments,
   syncEvents,
   users,
 } from "@/lib/db/schema";
@@ -32,10 +39,29 @@ import {
   getBudgetWithCosts,
   fetchActualByPeriod,
 } from "@/actions/budget";
+import { getBudgetReportData } from "@/actions/reports";
 import { buildBudgetForecast } from "@/lib/forecast";
 import { getCurrentMonth, formatUtcDateOnly } from "@/lib/utils";
 import type { SyncSourceType } from "@/lib/sync/framework";
 import { usd } from "@/lib/mcp/format";
+
+/** Inclusive YYYY-MM-DD start/end of a YYYY-MM month (UTC). */
+function monthRange(month: string): { start: string; end: string } {
+  const [y, m] = month.split("-").map(Number);
+  return {
+    start: `${month}-01`,
+    end: formatUtcDateOnly(new Date(Date.UTC(y, m, 0))),
+  };
+}
+
+/** Escape ILIKE wildcards in user-supplied search terms. */
+function escapeLike(term: string): string {
+  return term.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+function clampLimit(limit: number | undefined, fallback: number, max: number): number {
+  return Math.min(Math.max(limit ?? fallback, 1), max);
+}
 
 /** Shape a calibrated "today" spend estimate (or null) for an MCP response. */
 function formatTodayEstimate(
@@ -54,13 +80,14 @@ function formatTodayEstimate(
 // ---------------------------------------------------------------------------
 
 export async function listAiToolsData() {
-  const [tools, tiers] = await Promise.all([
+  const [tools, tiers, assignmentCounts] = await Promise.all([
     db
       .select({
         id: aiTools.id,
         name: aiTools.name,
         vendor: aiTools.vendor,
         status: aiTools.status,
+        maxLicenses: aiTools.maxLicenses,
       })
       .from(aiTools)
       .where(eq(aiTools.status, "active")),
@@ -74,6 +101,14 @@ export async function listAiToolsData() {
       })
       .from(accessTiers)
       .where(eq(accessTiers.isActive, true)),
+    db
+      .select({
+        toolId: licenseAssignments.toolId,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(licenseAssignments)
+      .where(eq(licenseAssignments.status, "active"))
+      .groupBy(licenseAssignments.toolId),
   ]);
 
   const tiersByTool = new Map<number, typeof tiers>();
@@ -82,16 +117,31 @@ export async function listAiToolsData() {
     list.push(tier);
     tiersByTool.set(tier.toolId, list);
   }
+  const countByTool = new Map(
+    assignmentCounts.map((c) => [c.toolId, Number(c.count)]),
+  );
 
   return {
-    tools: tools.map((tool) => ({
-      ...tool,
-      tiers: (tiersByTool.get(tool.id) ?? []).map((tier) => ({
-        id: tier.id,
-        name: tier.name,
-        ...usd("monthlyCost", tier.monthlyCostCents),
-      })),
-    })),
+    tools: tools.map((tool) => {
+      const activeAssignments = countByTool.get(tool.id) ?? 0;
+      return {
+        id: tool.id,
+        name: tool.name,
+        vendor: tool.vendor,
+        status: tool.status,
+        activeAssignments,
+        maxLicenses: tool.maxLicenses,
+        licenseUtilizationPct:
+          tool.maxLicenses && tool.maxLicenses > 0
+            ? Math.round((activeAssignments / tool.maxLicenses) * 100)
+            : null,
+        tiers: (tiersByTool.get(tool.id) ?? []).map((tier) => ({
+          id: tier.id,
+          name: tier.name,
+          ...usd("monthlyCost", tier.monthlyCostCents),
+        })),
+      };
+    }),
   };
 }
 
@@ -105,7 +155,27 @@ export async function getUserCostProfileData(email: string, month?: string) {
     columns: { id: true },
   });
   if (!user) {
-    throw new Error(`No user found with email: ${email}`);
+    // Help the caller recover from a near-miss (assistants rarely have the
+    // exact address) by suggesting candidates that share the local part.
+    const localPart = email.split("@")[0] ?? email;
+    const candidates = await db
+      .select({ name: users.name, email: users.email })
+      .from(users)
+      .where(
+        and(
+          eq(users.isAgent, false),
+          or(
+            ilike(users.email, `%${escapeLike(localPart)}%`),
+            ilike(users.name, `%${escapeLike(localPart.replace(/[._-]/g, " "))}%`),
+          ),
+        ),
+      )
+      .limit(5);
+    const hint =
+      candidates.length > 0
+        ? ` Did you mean: ${candidates.map((c) => `${c.email} (${c.name})`).join(", ")}? Use find_users to search.`
+        : ` Use find_users to search by name or partial email.`;
+    throw new Error(`No user found with email: ${email}.${hint}`);
   }
 
   const [profile, syncRows] = await Promise.all([
@@ -394,5 +464,460 @@ export async function listRecentSyncEventsData(
       errorCount: e.errorCount,
       errorMessage: e.errorMessage,
     })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// find_users
+// ---------------------------------------------------------------------------
+
+export async function findUsersData(query: string, limit?: number) {
+  const pattern = `%${escapeLike(query.trim())}%`;
+  const rows = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      role: users.role,
+      status: users.status,
+      circle: users.circle,
+      profile: users.profile,
+      discipline: users.discipline,
+    })
+    .from(users)
+    .where(
+      and(
+        eq(users.isAgent, false),
+        or(ilike(users.name, pattern), ilike(users.email, pattern)),
+      ),
+    )
+    .orderBy(asc(users.name))
+    .limit(clampLimit(limit, 10, 25));
+
+  return { query, matches: rows };
+}
+
+// ---------------------------------------------------------------------------
+// list_claude_users
+// ---------------------------------------------------------------------------
+
+export async function listClaudeUsersData(month?: string, limit?: number) {
+  const targetMonth = month ?? getCurrentMonth();
+  const { start, end } = monthRange(targetMonth);
+
+  const rows = await db
+    .select({
+      userId: users.id,
+      name: users.name,
+      email: users.email,
+      circle: users.circle,
+      status: users.status,
+      costCents: sql<string>`coalesce(sum(${anthropicUsageMetrics.computedCostCents}), 0)`,
+      totalTokens: sql<string>`coalesce(sum(${anthropicUsageMetrics.uncachedInputTokens} + ${anthropicUsageMetrics.cacheReadInputTokens} + ${anthropicUsageMetrics.cacheCreationInputTokens} + ${anthropicUsageMetrics.outputTokens}), 0)`,
+      modelsUsed: sql<string>`count(distinct ${anthropicUsageMetrics.model})`,
+      lastActive: sql<string | null>`max(${anthropicUsageMetrics.date})`,
+      hasUnresolvedPricing: sql<boolean>`bool_or(not ${anthropicUsageMetrics.pricingResolved})`,
+    })
+    .from(anthropicUsageMetrics)
+    .innerJoin(users, eq(users.id, anthropicUsageMetrics.userId))
+    .where(
+      and(
+        gte(anthropicUsageMetrics.date, start),
+        lte(anthropicUsageMetrics.date, end),
+      ),
+    )
+    .groupBy(users.id, users.name, users.email, users.circle, users.status)
+    .orderBy(desc(sql`sum(${anthropicUsageMetrics.computedCostCents})`))
+    .limit(clampLimit(limit, 25, 100));
+
+  const userRows = rows.map((r) => ({
+    userId: r.userId,
+    name: r.name,
+    email: r.email,
+    circle: r.circle,
+    status: r.status,
+    ...usd("cost", Number(r.costCents)),
+    totalTokens: Number(r.totalTokens),
+    modelsUsed: Number(r.modelsUsed),
+    lastActive: r.lastActive,
+    hasUnresolvedPricing: Boolean(r.hasUnresolvedPricing),
+  }));
+
+  return {
+    month: targetMonth,
+    note: "Users with Claude API usage in the month, ordered by spend (descending).",
+    userCount: userRows.length,
+    ...usd("listedTotal", userRows.reduce((s, u) => s + (u.costCents ?? 0), 0)),
+    users: userRows,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// get_claude_cost_dashboard
+// ---------------------------------------------------------------------------
+
+export async function getClaudeCostDashboardData(month?: string) {
+  const targetMonth = month ?? getCurrentMonth();
+  const { start, end } = monthRange(targetMonth);
+
+  const [y, m] = targetMonth.split("-").map(Number);
+  const priorMonthDate = new Date(Date.UTC(y, m - 2, 1));
+  const priorMonth = `${priorMonthDate.getUTCFullYear()}-${String(priorMonthDate.getUTCMonth() + 1).padStart(2, "0")}`;
+  const { start: priorStart, end: priorEnd } = monthRange(priorMonth);
+  const twelveMonthsAgo = new Date(Date.UTC(y - 1, m - 1, 1));
+
+  const workspaceName = sql<string | null>`${anthropicWorkspaces.name}`;
+  const workspaceJoin = sql`${anthropicWorkspaces.workspaceId} IS NOT DISTINCT FROM ${anthropicWorkspaceCosts.workspaceId}`;
+
+  const [dailyTotals, workspaceTotals, monthlySeries] = await Promise.all([
+    db
+      .select({
+        date: anthropicWorkspaceCosts.date,
+        costCents: sql<string>`sum(${anthropicWorkspaceCosts.costCents})`,
+      })
+      .from(anthropicWorkspaceCosts)
+      .where(
+        and(
+          gte(anthropicWorkspaceCosts.date, start),
+          lte(anthropicWorkspaceCosts.date, end),
+        ),
+      )
+      .groupBy(anthropicWorkspaceCosts.date)
+      .orderBy(asc(anthropicWorkspaceCosts.date)),
+    db
+      .select({
+        workspaceId: anthropicWorkspaceCosts.workspaceId,
+        workspaceName,
+        currentCents: sql<string>`coalesce(sum(${anthropicWorkspaceCosts.costCents}) filter (where ${anthropicWorkspaceCosts.date} between ${start} and ${end}), 0)`,
+        priorCents: sql<string>`coalesce(sum(${anthropicWorkspaceCosts.costCents}) filter (where ${anthropicWorkspaceCosts.date} between ${priorStart} and ${priorEnd}), 0)`,
+      })
+      .from(anthropicWorkspaceCosts)
+      .leftJoin(anthropicWorkspaces, workspaceJoin)
+      .where(
+        and(
+          gte(anthropicWorkspaceCosts.date, priorStart),
+          lte(anthropicWorkspaceCosts.date, end),
+        ),
+      )
+      .groupBy(anthropicWorkspaceCosts.workspaceId, anthropicWorkspaces.name),
+    db
+      .select({
+        month: sql<string>`to_char(${anthropicWorkspaceCosts.date}, 'YYYY-MM')`,
+        costCents: sql<string>`sum(${anthropicWorkspaceCosts.costCents})`,
+      })
+      .from(anthropicWorkspaceCosts)
+      .where(gte(anthropicWorkspaceCosts.date, formatUtcDateOnly(twelveMonthsAgo)))
+      .groupBy(sql`to_char(${anthropicWorkspaceCosts.date}, 'YYYY-MM')`)
+      .orderBy(sql`to_char(${anthropicWorkspaceCosts.date}, 'YYYY-MM')`),
+  ]);
+
+  const workspaces = workspaceTotals
+    .map((w) => {
+      const current = Number(w.currentCents);
+      const prior = Number(w.priorCents);
+      return {
+        workspaceId: w.workspaceId,
+        name: w.workspaceName ?? "Default workspace",
+        ...usd("currentMonth", current),
+        ...usd("priorMonth", prior),
+        ...usd("delta", current - prior),
+        deltaPct: prior > 0 ? Math.round(((current - prior) / prior) * 100) : null,
+      };
+    })
+    .sort((a, b) => (b.currentMonthCents ?? 0) - (a.currentMonthCents ?? 0));
+
+  const monthTotal = dailyTotals.reduce((s, d) => s + Number(d.costCents), 0);
+
+  return {
+    month: targetMonth,
+    priorMonth,
+    ...usd("monthTotal", monthTotal),
+    dailyTotals: dailyTotals.map((d) => ({
+      date: d.date,
+      ...usd("cost", Number(d.costCents)),
+    })),
+    workspaces,
+    last12Months: monthlySeries.map((row) => ({
+      month: row.month,
+      ...usd("cost", Number(row.costCents)),
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// get_budget_report
+// ---------------------------------------------------------------------------
+
+export async function getBudgetReportToolData() {
+  const report = await getBudgetReportData();
+  if (report.kind === "empty") {
+    throw new Error("No active budget configured");
+  }
+
+  return {
+    fiscalYear: report.budget.fiscalYear,
+    ...usd("budgetTotal", report.budget.totalAmountCents),
+    periods: report.periodsWithActual.map((p) => ({
+      label: p.periodLabel,
+      startDate: p.startDate,
+      endDate: p.endDate,
+      ...usd("planned", p.plannedAmountCents),
+      ...usd("billed", p.billedTotalCents),
+      ...usd("running", p.runningCostCents),
+      ...usd("actual", p.actualCents),
+    })),
+    forecast: {
+      status: report.forecast.status,
+      ...usd("actualSpendToDate", report.forecast.actualSpendToDateCents),
+      ...usd("projectedAnnualTotal", report.forecast.projectedAnnualTotalCents),
+      ...usd("budgetCeiling", report.forecast.budgetCeilingCents),
+    },
+    perTool: report.perTool.map((t) => ({
+      toolName: t.toolName,
+      isAnthropicApi: t.isAnthropicApi,
+      ...usd("ytdSpent", t.ytdSpentCents),
+      ...usd("currentMonthly", t.currentMonthlyCents),
+      ...usd("projectedEoy", t.projectedEoyCents),
+    })),
+    pastMonth: report.pastMonth
+      ? {
+          periodLabel: report.pastMonth.periodLabel,
+          ...usd("planned", report.pastMonth.plannedCents),
+          ...usd("actual", report.pastMonth.actualCents),
+          ...usd("variance", report.pastMonth.varianceCents),
+          variancePct: report.pastMonth.variancePct,
+          drivers: report.pastMonth.drivers.map((d) => ({
+            toolName: d.toolName,
+            ...usd("prior", d.priorCents),
+            ...usd("past", d.pastCents),
+            ...usd("delta", d.deltaCents),
+            deltaPct: d.deltaPct,
+          })),
+        }
+      : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// list_license_assignments
+// ---------------------------------------------------------------------------
+
+export async function listLicenseAssignmentsData(filters: {
+  email?: string;
+  toolName?: string;
+  status?: "active" | "inactive";
+  limit?: number;
+}) {
+  const conditions = [
+    filters.email ? ilike(users.email, escapeLike(filters.email)) : undefined,
+    filters.toolName
+      ? ilike(aiTools.name, `%${escapeLike(filters.toolName)}%`)
+      : undefined,
+    eq(licenseAssignments.status, filters.status ?? "active"),
+  ].filter((c) => c !== undefined);
+
+  const rows = await db
+    .select({
+      id: licenseAssignments.id,
+      userName: users.name,
+      userEmail: users.email,
+      toolName: aiTools.name,
+      tierName: accessTiers.name,
+      status: licenseAssignments.status,
+      costAtAssignmentCents: licenseAssignments.costAtAssignmentCents,
+      assignedAt: licenseAssignments.assignedAt,
+      revokedAt: licenseAssignments.revokedAt,
+      workspace: licenseAssignments.workspace,
+      source: licenseAssignments.source,
+    })
+    .from(licenseAssignments)
+    .innerJoin(users, eq(users.id, licenseAssignments.userId))
+    .innerJoin(aiTools, eq(aiTools.id, licenseAssignments.toolId))
+    .leftJoin(accessTiers, eq(accessTiers.id, licenseAssignments.tierId))
+    .where(and(...conditions))
+    .orderBy(desc(licenseAssignments.assignedAt))
+    .limit(clampLimit(filters.limit, 100, 500));
+
+  return {
+    filters: {
+      email: filters.email ?? null,
+      toolName: filters.toolName ?? null,
+      status: filters.status ?? "active",
+    },
+    count: rows.length,
+    ...usd("monthlyTotal", rows.reduce((s, r) => s + r.costAtAssignmentCents, 0)),
+    assignments: rows.map((r) => ({
+      id: r.id,
+      user: { name: r.userName, email: r.userEmail },
+      toolName: r.toolName,
+      tierName: r.tierName,
+      status: r.status,
+      ...usd("monthlyCost", r.costAtAssignmentCents),
+      assignedAt: r.assignedAt?.toISOString() ?? null,
+      revokedAt: r.revokedAt?.toISOString() ?? null,
+      workspace: r.workspace,
+      source: r.source,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// list_invoices
+// ---------------------------------------------------------------------------
+
+export async function listInvoicesData(filters: {
+  month?: string;
+  vendor?: string;
+  linked?: boolean;
+  limit?: number;
+}) {
+  const range = filters.month ? monthRange(filters.month) : null;
+  const conditions = [
+    range ? gte(invoices.invoiceDate, range.start) : undefined,
+    range ? lte(invoices.invoiceDate, range.end) : undefined,
+    filters.vendor
+      ? ilike(invoices.vendor, `%${escapeLike(filters.vendor)}%`)
+      : undefined,
+    filters.linked === true
+      ? sql`${invoices.linkedBilledCostId} IS NOT NULL`
+      : undefined,
+    filters.linked === false ? isNull(invoices.linkedBilledCostId) : undefined,
+  ].filter((c) => c !== undefined);
+
+  const rows = await db
+    .select({
+      id: invoices.id,
+      invoiceNumber: invoices.invoiceNumber,
+      invoiceDate: invoices.invoiceDate,
+      amountCents: invoices.amountCents,
+      vendor: invoices.vendor,
+      filteredOut: invoices.filteredOut,
+      linkedBilledCostId: invoices.linkedBilledCostId,
+      periodLabel: budgetPeriods.periodLabel,
+      createdAt: invoices.createdAt,
+    })
+    .from(invoices)
+    .leftJoin(billedCosts, eq(billedCosts.id, invoices.linkedBilledCostId))
+    .leftJoin(budgetPeriods, eq(budgetPeriods.id, billedCosts.periodId))
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(desc(invoices.invoiceDate))
+    .limit(clampLimit(filters.limit, 50, 200));
+
+  return {
+    filters: {
+      month: filters.month ?? null,
+      vendor: filters.vendor ?? null,
+      linked: filters.linked ?? null,
+    },
+    count: rows.length,
+    ...usd("listedTotal", rows.reduce((s, r) => s + r.amountCents, 0)),
+    invoices: rows.map((r) => ({
+      id: r.id,
+      invoiceNumber: r.invoiceNumber,
+      invoiceDate: r.invoiceDate,
+      ...usd("amount", r.amountCents),
+      vendor: r.vendor,
+      linkedToPeriod: r.periodLabel,
+      isLinked: r.linkedBilledCostId !== null,
+      filteredOut: r.filteredOut,
+      uploadedAt: r.createdAt?.toISOString() ?? null,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// get_copilot_analytics
+// ---------------------------------------------------------------------------
+
+interface BreakdownAccumulator {
+  suggestions: number;
+  acceptances: number;
+}
+
+function accumulateBreakdown(
+  map: Map<string, BreakdownAccumulator>,
+  breakdown: unknown,
+  nameKeys: string[],
+): void {
+  if (!Array.isArray(breakdown)) return;
+  for (const entry of breakdown) {
+    const item = entry as Record<string, unknown>;
+    const nameKey = nameKeys.find((k) => item[k] != null);
+    const name = String(nameKey ? item[nameKey] : "unknown");
+    const acc = map.get(name) ?? { suggestions: 0, acceptances: 0 };
+    acc.suggestions += Number(item.suggestions ?? item.totalSuggestions ?? 0);
+    acc.acceptances += Number(item.acceptances ?? item.totalAcceptances ?? 0);
+    map.set(name, acc);
+  }
+}
+
+function topBreakdown(map: Map<string, BreakdownAccumulator>, label: string) {
+  return Array.from(map.entries())
+    .map(([name, data]) => ({
+      [label]: name,
+      suggestions: data.suggestions,
+      acceptances: data.acceptances,
+      acceptanceRatePct:
+        data.suggestions > 0
+          ? Math.round((data.acceptances / data.suggestions) * 100)
+          : null,
+    }))
+    .sort((a, b) => b.suggestions - a.suggestions)
+    .slice(0, 10);
+}
+
+export async function getCopilotAnalyticsData(since?: string, until?: string) {
+  const connection = await db.query.githubConnections.findFirst({
+    where: and(
+      eq(githubConnections.status, "active"),
+      eq(githubConnections.copilotSyncEnabled, true),
+    ),
+    columns: { id: true, orgLogin: true },
+  });
+  if (!connection) {
+    return {
+      connected: false as const,
+      message: "No active GitHub connection with Copilot sync enabled",
+    };
+  }
+
+  const today = new Date();
+  const untilDate = until ?? formatUtcDateOnly(today);
+  const sinceDate =
+    since ?? formatUtcDateOnly(new Date(today.getTime() - 27 * 86_400_000));
+
+  const rows = await db
+    .select()
+    .from(copilotUsageMetrics)
+    .where(
+      and(
+        eq(copilotUsageMetrics.connectionId, connection.id),
+        gte(copilotUsageMetrics.date, sinceDate),
+        lte(copilotUsageMetrics.date, untilDate),
+      ),
+    )
+    .orderBy(asc(copilotUsageMetrics.date));
+
+  const byLanguage = new Map<string, BreakdownAccumulator>();
+  const byEditor = new Map<string, BreakdownAccumulator>();
+  for (const row of rows) {
+    accumulateBreakdown(byLanguage, row.languageBreakdown, ["language", "name"]);
+    accumulateBreakdown(byEditor, row.editorBreakdown, ["editor", "name"]);
+  }
+
+  return {
+    connected: true as const,
+    org: connection.orgLogin,
+    dateRange: { since: sinceDate, until: untilDate },
+    daily: rows.map((r) => ({
+      date: r.date,
+      activeUsers: r.totalActiveUsers,
+      engagedUsers: r.totalEngagedUsers,
+      suggestions: r.totalSuggestions,
+      acceptances: r.totalAcceptances,
+      chatTurns: r.totalChatTurns,
+    })),
+    topLanguages: topBreakdown(byLanguage, "language"),
+    topEditors: topBreakdown(byEditor, "editor"),
   };
 }

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -14,12 +14,19 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { syncSourceTypeEnum } from "@/lib/db/schema";
 import { safeJsonResult } from "@/lib/mcp/format";
 import {
+  findUsersData,
+  getBudgetReportToolData,
   getBudgetStatusData,
+  getClaudeCostDashboardData,
   getClaudeSpendSummaryData,
+  getCopilotAnalyticsData,
   getCopilotUsageSummaryData,
   getUserCostProfileData,
   listAiToolsData,
+  listClaudeUsersData,
   listClaudeWorkspacesData,
+  listInvoicesData,
+  listLicenseAssignmentsData,
   listRecentSyncEventsData,
 } from "@/lib/mcp/data";
 
@@ -33,6 +40,12 @@ const dateSchema = z
     "Expected YYYY-MM-DD",
   );
 
+/**
+ * Every Hub tool is read-only by design (spec 034); the annotation lets MCP
+ * clients skip mutation-confirmation prompts.
+ */
+const READ_ONLY = { readOnlyHint: true } as const;
+
 /** Minimal surface of McpServer.registerTool used here — eases fake-server tests. */
 export type ToolRegistrar = Pick<McpServer, "registerTool">;
 
@@ -42,8 +55,9 @@ export function registerHubTools(server: ToolRegistrar): void {
     {
       title: "List AI tools",
       description:
-        "List the active AI tools tracked by the Hub with their access tiers and monthly cost (cents and USD).",
+        "List the active AI tools tracked by the Hub with their access tiers, monthly cost (cents and USD), active license counts, and license utilization.",
       inputSchema: {},
+      annotations: READ_ONLY,
     },
     () => safeJsonResult(() => listAiToolsData()),
   );
@@ -58,6 +72,7 @@ export function registerHubTools(server: ToolRegistrar): void {
         email: z.string().email("Expected a valid email address"),
         month: monthSchema.optional(),
       },
+      annotations: READ_ONLY,
     },
     ({ email, month }) =>
       safeJsonResult(() => getUserCostProfileData(email, month)),
@@ -72,6 +87,7 @@ export function registerHubTools(server: ToolRegistrar): void {
       inputSchema: {
         month: monthSchema.optional(),
       },
+      annotations: READ_ONLY,
     },
     ({ month }) => safeJsonResult(() => getClaudeSpendSummaryData(month)),
   );
@@ -83,6 +99,7 @@ export function registerHubTools(server: ToolRegistrar): void {
       description:
         "List Anthropic workspaces with current-month spend, monthly cap, utilization %, and today's estimate, ordered by cap-utilization severity.",
       inputSchema: {},
+      annotations: READ_ONLY,
     },
     () => safeJsonResult(() => listClaudeWorkspacesData()),
   );
@@ -96,6 +113,7 @@ export function registerHubTools(server: ToolRegistrar): void {
       inputSchema: {
         fiscalYear: z.number().int().min(2000).max(2100).optional(),
       },
+      annotations: READ_ONLY,
     },
     ({ fiscalYear }) => safeJsonResult(() => getBudgetStatusData(fiscalYear)),
   );
@@ -110,6 +128,7 @@ export function registerHubTools(server: ToolRegistrar): void {
         since: dateSchema.optional(),
         until: dateSchema.optional(),
       },
+      annotations: READ_ONLY,
     },
     ({ since, until }) =>
       safeJsonResult(() => getCopilotUsageSummaryData(since, until)),
@@ -125,8 +144,115 @@ export function registerHubTools(server: ToolRegistrar): void {
         sourceType: z.enum(syncSourceTypeEnum.enumValues).optional(),
         limit: z.number().int().min(1).max(50).optional(),
       },
+      annotations: READ_ONLY,
     },
     ({ sourceType, limit }) =>
       safeJsonResult(() => listRecentSyncEventsData(sourceType, limit)),
+  );
+
+  server.registerTool(
+    "find_users",
+    {
+      title: "Find users",
+      description:
+        "Search Hub users by partial name or email (case-insensitive). Use this to resolve a person to their exact email before calling get_user_cost_profile.",
+      inputSchema: {
+        query: z.string().min(2, "Query must be at least 2 characters"),
+        limit: z.number().int().min(1).max(25).optional(),
+      },
+      annotations: READ_ONLY,
+    },
+    ({ query, limit }) => safeJsonResult(() => findUsersData(query, limit)),
+  );
+
+  server.registerTool(
+    "list_claude_users",
+    {
+      title: "List Claude users by spend",
+      description:
+        "Per-user Claude (Anthropic) API spend for a month, ordered by cost: total cost, tokens, distinct models, and last-active date per user. Defaults to the current month. Answers questions like 'who are the top Claude spenders'.",
+      inputSchema: {
+        month: monthSchema.optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      annotations: READ_ONLY,
+    },
+    ({ month, limit }) => safeJsonResult(() => listClaudeUsersData(month, limit)),
+  );
+
+  server.registerTool(
+    "get_claude_cost_dashboard",
+    {
+      title: "Get Claude cost dashboard",
+      description:
+        "Org-wide Claude cost dashboard for a month: daily spend series, per-workspace totals with month-over-month deltas, and a 12-month history. Defaults to the current month.",
+      inputSchema: {
+        month: monthSchema.optional(),
+      },
+      annotations: READ_ONLY,
+    },
+    ({ month }) => safeJsonResult(() => getClaudeCostDashboardData(month)),
+  );
+
+  server.registerTool(
+    "get_budget_report",
+    {
+      title: "Get budget report",
+      description:
+        "Detailed report on the active annual budget: per-period planned/billed/running/actual spend, forecast, per-tool YTD + projected end-of-year breakdown (including un-invoiced Anthropic API costs), and last completed period's variance drivers.",
+      inputSchema: {},
+      annotations: READ_ONLY,
+    },
+    () => safeJsonResult(() => getBudgetReportToolData()),
+  );
+
+  server.registerTool(
+    "list_license_assignments",
+    {
+      title: "List license assignments",
+      description:
+        "The license register: who holds which AI-tool license at what monthly cost. Filter by user email (exact), tool name (partial), and status (default: active).",
+      inputSchema: {
+        email: z.string().email().optional(),
+        toolName: z.string().min(1).optional(),
+        status: z.enum(["active", "inactive"]).optional(),
+        limit: z.number().int().min(1).max(500).optional(),
+      },
+      annotations: READ_ONLY,
+    },
+    (filters) => safeJsonResult(() => listLicenseAssignmentsData(filters)),
+  );
+
+  server.registerTool(
+    "list_invoices",
+    {
+      title: "List invoices",
+      description:
+        "Uploaded invoices with amount, vendor, and budget-period link status. Filter by invoice month (YYYY-MM), vendor (partial), and linked (true = linked to a budget period, false = unlinked).",
+      inputSchema: {
+        month: monthSchema.optional(),
+        vendor: z.string().min(1).optional(),
+        linked: z.boolean().optional(),
+        limit: z.number().int().min(1).max(200).optional(),
+      },
+      annotations: READ_ONLY,
+    },
+    (filters) => safeJsonResult(() => listInvoicesData(filters)),
+  );
+
+  server.registerTool(
+    "get_copilot_analytics",
+    {
+      title: "Get GitHub Copilot analytics",
+      description:
+        "Daily GitHub Copilot usage series (active/engaged users, suggestions, acceptances, chat turns) plus top languages and editors over a date range. Defaults to the last 28 days.",
+      inputSchema: {
+        since: dateSchema.optional(),
+        until: dateSchema.optional(),
+      },
+      annotations: READ_ONLY,
+    },
+    ({ since, until }) =>
+      safeJsonResult(() => getCopilotAnalyticsData(since, until)),
   );
 }

--- a/src/lib/oauth/authorize.ts
+++ b/src/lib/oauth/authorize.ts
@@ -1,0 +1,117 @@
+/**
+ * Validation for /oauth/authorize requests (038-mcp-v2).
+ *
+ * Outcome semantics follow RFC 6749 §4.1.2.1: when the client identity or the
+ * redirect URI cannot be trusted the user agent must NOT be redirected
+ * (`fatal`), otherwise errors are delivered to the client via redirect with
+ * `error=` query params. Shared by the page (GET render) and the consent
+ * server actions, which re-validate everything because form fields are
+ * client-controlled.
+ */
+
+import type { mcpOauthClients } from "@/lib/db/schema";
+
+import { getClientByPublicId } from "@/lib/oauth/store";
+import {
+  redirectUriMatches,
+  validateRequestedScope,
+} from "@/lib/oauth/validate";
+
+export interface AuthorizeParams {
+  client_id?: string;
+  redirect_uri?: string;
+  response_type?: string;
+  code_challenge?: string;
+  code_challenge_method?: string;
+  scope?: string;
+  state?: string;
+}
+
+export type AuthorizeValidation =
+  | {
+      ok: true;
+      client: typeof mcpOauthClients.$inferSelect;
+      redirectUri: string;
+      codeChallenge: string;
+      grantedScope: string;
+      state: string | null;
+    }
+  | { ok: false; fatal: true; message: string }
+  | { ok: false; fatal: false; redirectTo: string };
+
+/** Append OAuth response params to a redirect URI, preserving its own query. */
+export function buildRedirect(
+  redirectUri: string,
+  params: Record<string, string | null>,
+): string {
+  const url = new URL(redirectUri);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== null) url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+export async function validateAuthorizeRequest(
+  params: AuthorizeParams,
+): Promise<AuthorizeValidation> {
+  const state = params.state ?? null;
+
+  if (!params.client_id) {
+    return { ok: false, fatal: true, message: "Missing client_id" };
+  }
+  const client = await getClientByPublicId(params.client_id);
+  if (!client) {
+    return { ok: false, fatal: true, message: "Unknown client" };
+  }
+
+  if (!params.redirect_uri) {
+    return { ok: false, fatal: true, message: "Missing redirect_uri" };
+  }
+  const redirectUri = params.redirect_uri;
+  const registered = client.redirectUris.some((uri) =>
+    redirectUriMatches(uri, redirectUri),
+  );
+  if (!registered) {
+    return {
+      ok: false,
+      fatal: true,
+      message: "redirect_uri is not registered for this client",
+    };
+  }
+
+  // From here on the redirect URI is trusted — deliver errors to the client.
+  const fail = (error: string, description: string): AuthorizeValidation => ({
+    ok: false,
+    fatal: false,
+    redirectTo: buildRedirect(redirectUri, {
+      error,
+      error_description: description,
+      state,
+    }),
+  });
+
+  if (params.response_type !== "code") {
+    return fail("unsupported_response_type", "Only response_type=code is supported");
+  }
+
+  if (!params.code_challenge) {
+    return fail("invalid_request", "PKCE code_challenge is required");
+  }
+  if ((params.code_challenge_method ?? "plain") !== "S256") {
+    return fail("invalid_request", "Only code_challenge_method=S256 is supported");
+  }
+
+  const scope = validateRequestedScope(params.scope);
+  if (!scope.ok) {
+    return fail("invalid_scope", "Unknown scope requested");
+  }
+
+  return {
+    ok: true,
+    client,
+    redirectUri,
+    codeChallenge: params.code_challenge,
+    grantedScope: scope.granted,
+    state,
+  };
+}

--- a/src/lib/oauth/authorize.ts
+++ b/src/lib/oauth/authorize.ts
@@ -13,18 +13,40 @@ import type { mcpOauthClients } from "@/lib/db/schema";
 
 import { getClientByPublicId } from "@/lib/oauth/store";
 import {
+  isValidScopeRequest,
   redirectUriMatches,
-  validateRequestedScope,
+  MCP_SCOPE,
 } from "@/lib/oauth/validate";
 
-export interface AuthorizeParams {
-  client_id?: string;
-  redirect_uri?: string;
-  response_type?: string;
-  code_challenge?: string;
-  code_challenge_method?: string;
-  scope?: string;
-  state?: string;
+/**
+ * The OAuth authorize request parameters the Hub understands. The page reads
+ * them from searchParams and round-trips them through hidden form fields to
+ * the consent server actions — both sides iterate this list.
+ */
+export const AUTHORIZE_PARAM_KEYS = [
+  "client_id",
+  "redirect_uri",
+  "response_type",
+  "code_challenge",
+  "code_challenge_method",
+  "scope",
+  "state",
+] as const;
+
+export type AuthorizeParams = Partial<
+  Record<(typeof AUTHORIZE_PARAM_KEYS)[number], string>
+>;
+
+/** Build AuthorizeParams by reading each known key through `read`. */
+export function readAuthorizeParams(
+  read: (key: (typeof AUTHORIZE_PARAM_KEYS)[number]) => string | undefined,
+): AuthorizeParams {
+  const params: AuthorizeParams = {};
+  for (const key of AUTHORIZE_PARAM_KEYS) {
+    const value = read(key);
+    if (value !== undefined) params[key] = value;
+  }
+  return params;
 }
 
 export type AuthorizeValidation =
@@ -101,8 +123,7 @@ export async function validateAuthorizeRequest(
     return fail("invalid_request", "Only code_challenge_method=S256 is supported");
   }
 
-  const scope = validateRequestedScope(params.scope);
-  if (!scope.ok) {
+  if (!isValidScopeRequest(params.scope)) {
     return fail("invalid_scope", "Unknown scope requested");
   }
 
@@ -111,7 +132,7 @@ export async function validateAuthorizeRequest(
     client,
     redirectUri,
     codeChallenge: params.code_challenge,
-    grantedScope: scope.granted,
+    grantedScope: MCP_SCOPE,
     state,
   };
 }

--- a/src/lib/oauth/metadata.ts
+++ b/src/lib/oauth/metadata.ts
@@ -13,15 +13,27 @@ import { MCP_SCOPE } from "@/lib/oauth/validate";
 const MCP_RESOURCE_PATH = "/api/mcp/mcp";
 
 /**
+ * In multi-hop proxy chains forwarded headers can be comma-separated lists
+ * ("client-facing, hop2"); the first entry is the client-facing value.
+ */
+function firstForwardedValue(value: string | null): string | undefined {
+  const first = value?.split(",")[0]?.trim();
+  return first ? first : undefined;
+}
+
+/**
  * Derive the external origin (scheme://host) for an incoming request,
  * honouring reverse-proxy headers (Vercel sets x-forwarded-host/proto).
  */
 export function requestOrigin(req: Request): string {
   const url = new URL(req.url);
   const host =
-    req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? url.host;
+    firstForwardedValue(req.headers.get("x-forwarded-host")) ??
+    req.headers.get("host") ??
+    url.host;
   const proto =
-    req.headers.get("x-forwarded-proto") ?? url.protocol.replace(":", "");
+    firstForwardedValue(req.headers.get("x-forwarded-proto")) ??
+    url.protocol.replace(":", "");
   return `${proto}://${host}`;
 }
 

--- a/src/lib/oauth/metadata.ts
+++ b/src/lib/oauth/metadata.ts
@@ -1,0 +1,81 @@
+/**
+ * OAuth discovery documents for the embedded authorization server (038-mcp-v2).
+ *
+ * The issuer/origin is derived from the incoming request rather than an env
+ * var so the documents are correct on production, Vercel previews, and local
+ * dev without configuration (mirrors the NEXTAUTH_URL preview handling in
+ * src/lib/auth.ts).
+ */
+
+import { MCP_SCOPE } from "@/lib/oauth/validate";
+
+/** Path of the MCP Streamable HTTP endpoint this AS protects. */
+export const MCP_RESOURCE_PATH = "/api/mcp/mcp";
+
+/**
+ * Derive the external origin (scheme://host) for an incoming request,
+ * honouring reverse-proxy headers (Vercel sets x-forwarded-host/proto).
+ */
+export function requestOrigin(req: Request): string {
+  const url = new URL(req.url);
+  const host =
+    req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? url.host;
+  const proto =
+    req.headers.get("x-forwarded-proto") ?? url.protocol.replace(":", "");
+  return `${proto}://${host}`;
+}
+
+/** RFC 8414 authorization-server metadata. */
+export function authorizationServerMetadata(origin: string) {
+  return {
+    issuer: origin,
+    authorization_endpoint: `${origin}/oauth/authorize`,
+    token_endpoint: `${origin}/api/oauth/token`,
+    registration_endpoint: `${origin}/api/oauth/register`,
+    scopes_supported: [MCP_SCOPE],
+    response_types_supported: ["code"],
+    response_modes_supported: ["query"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    token_endpoint_auth_methods_supported: ["none"],
+    code_challenge_methods_supported: ["S256"],
+  };
+}
+
+/** RFC 9728 protected-resource metadata for the MCP endpoint. */
+export function protectedResourceMetadata(origin: string) {
+  return {
+    resource: `${origin}${MCP_RESOURCE_PATH}`,
+    authorization_servers: [origin],
+    scopes_supported: [MCP_SCOPE],
+    bearer_methods_supported: ["header"],
+  };
+}
+
+/** Shared CORS headers for the public discovery/registration/token endpoints. */
+export const OAUTH_CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, mcp-protocol-version",
+  "Access-Control-Max-Age": "86400",
+} as const;
+
+/** JSON response helper with CORS + no-store cache semantics. */
+export function oauthJson(
+  body: unknown,
+  init?: { status?: number },
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      Pragma: "no-cache",
+      ...OAUTH_CORS_HEADERS,
+    },
+  });
+}
+
+/** Standard OPTIONS preflight response for the OAuth endpoints. */
+export function oauthPreflight(): Response {
+  return new Response(null, { status: 204, headers: OAUTH_CORS_HEADERS });
+}

--- a/src/lib/oauth/metadata.ts
+++ b/src/lib/oauth/metadata.ts
@@ -10,7 +10,7 @@
 import { MCP_SCOPE } from "@/lib/oauth/validate";
 
 /** Path of the MCP Streamable HTTP endpoint this AS protects. */
-export const MCP_RESOURCE_PATH = "/api/mcp/mcp";
+const MCP_RESOURCE_PATH = "/api/mcp/mcp";
 
 /**
  * Derive the external origin (scheme://host) for an incoming request,
@@ -52,7 +52,7 @@ export function protectedResourceMetadata(origin: string) {
 }
 
 /** Shared CORS headers for the public discovery/registration/token endpoints. */
-export const OAUTH_CORS_HEADERS = {
+const OAUTH_CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type, Authorization, mcp-protocol-version",

--- a/src/lib/oauth/store.ts
+++ b/src/lib/oauth/store.ts
@@ -14,7 +14,7 @@
  */
 
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { and, eq, gt, isNull, lt } from "drizzle-orm";
+import { and, eq, gt, isNull, lt, sql } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import {
@@ -24,15 +24,23 @@ import {
   users,
 } from "@/lib/db/schema";
 
-export const AUTH_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes
-export const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
-export const REFRESH_TOKEN_TTL_MS = 60 * 24 * 60 * 60 * 1000; // 60 days
+const AUTH_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+const REFRESH_TOKEN_TTL_MS = 60 * 24 * 60 * 60 * 1000; // 60 days
+
+/**
+ * Token prefixes. ACCESS_TOKEN_PREFIX is also used by verifyMcpToken to decide
+ * whether a presented bearer token should be looked up in this store.
+ */
+export const ACCESS_TOKEN_PREFIX = "mcp_at_";
+const REFRESH_TOKEN_PREFIX = "mcp_rt_";
+const AUTH_CODE_PREFIX = "mcp_ac_";
 
 export function sha256Hex(value: string): string {
   return createHash("sha256").update(value, "utf8").digest("hex");
 }
 
-function newSecret(prefix: "mcp_ac_" | "mcp_at_" | "mcp_rt_"): string {
+function newSecret(prefix: string): string {
   return `${prefix}${randomBytes(32).toString("base64url")}`;
 }
 
@@ -73,21 +81,25 @@ export async function issueAuthCode(input: {
   codeChallenge: string;
   scope: string;
 }): Promise<string> {
-  const code = newSecret("mcp_ac_");
-  await db.insert(mcpOauthCodes).values({
-    codeHash: sha256Hex(code),
-    clientId: input.clientRowId,
-    userId: input.userId,
-    redirectUri: input.redirectUri,
-    codeChallenge: input.codeChallenge,
-    scope: input.scope,
-    expiresAt: new Date(Date.now() + AUTH_CODE_TTL_MS),
-  });
-  // Opportunistic cleanup — keeps the table from accumulating dead rows
-  // without needing a cron job.
-  await db
-    .delete(mcpOauthCodes)
-    .where(lt(mcpOauthCodes.expiresAt, new Date(Date.now() - AUTH_CODE_TTL_MS)));
+  const code = newSecret(AUTH_CODE_PREFIX);
+  await Promise.all([
+    db.insert(mcpOauthCodes).values({
+      codeHash: sha256Hex(code),
+      clientId: input.clientRowId,
+      userId: input.userId,
+      redirectUri: input.redirectUri,
+      codeChallenge: input.codeChallenge,
+      scope: input.scope,
+      expiresAt: new Date(Date.now() + AUTH_CODE_TTL_MS),
+    }),
+    // Opportunistic cleanup — keeps the table from accumulating dead rows
+    // without needing a cron job.
+    db
+      .delete(mcpOauthCodes)
+      .where(
+        lt(mcpOauthCodes.expiresAt, new Date(Date.now() - AUTH_CODE_TTL_MS)),
+      ),
+  ]);
   return code;
 }
 
@@ -129,8 +141,8 @@ export async function issueTokens(input: {
   scope: string;
   familyId?: string;
 }): Promise<IssuedTokens> {
-  const accessToken = newSecret("mcp_at_");
-  const refreshToken = newSecret("mcp_rt_");
+  const accessToken = newSecret(ACCESS_TOKEN_PREFIX);
+  const refreshToken = newSecret(REFRESH_TOKEN_PREFIX);
   const now = Date.now();
 
   await db.insert(mcpOauthTokens).values({
@@ -176,9 +188,23 @@ export async function rotateRefreshToken(
   rawRefreshToken: string,
   clientRowId: number,
 ): Promise<RefreshResult> {
-  const row = await db.query.mcpOauthTokens.findFirst({
-    where: eq(mcpOauthTokens.refreshTokenHash, sha256Hex(rawRefreshToken)),
-  });
+  // Single round-trip: the token row plus whether its user is still active
+  // (the join mirrors verifyAccessToken below).
+  const [row] = await db
+    .select({
+      id: mcpOauthTokens.id,
+      familyId: mcpOauthTokens.familyId,
+      clientId: mcpOauthTokens.clientId,
+      userId: mcpOauthTokens.userId,
+      scope: mcpOauthTokens.scope,
+      refreshExpiresAt: mcpOauthTokens.refreshExpiresAt,
+      revokedAt: mcpOauthTokens.revokedAt,
+      userIsActive: sql<boolean>`${users.status} = 'active'`,
+    })
+    .from(mcpOauthTokens)
+    .innerJoin(users, eq(users.id, mcpOauthTokens.userId))
+    .where(eq(mcpOauthTokens.refreshTokenHash, sha256Hex(rawRefreshToken)))
+    .limit(1);
 
   if (!row || row.clientId !== clientRowId) return { ok: false, error: "invalid_grant" };
 
@@ -186,16 +212,9 @@ export async function rotateRefreshToken(
     await revokeTokenFamily(row.familyId);
     return { ok: false, error: "invalid_grant" };
   }
-  if (row.refreshExpiresAt <= new Date()) {
+  if (row.refreshExpiresAt <= new Date() || !row.userIsActive) {
     return { ok: false, error: "invalid_grant" };
   }
-
-  // The user behind the grant must still be active.
-  const user = await db.query.users.findFirst({
-    where: and(eq(users.id, row.userId), eq(users.status, "active")),
-    columns: { id: true },
-  });
-  if (!user) return { ok: false, error: "invalid_grant" };
 
   await db
     .update(mcpOauthTokens)
@@ -211,7 +230,7 @@ export async function rotateRefreshToken(
   return { ok: true, tokens };
 }
 
-export async function revokeTokenFamily(familyId: string): Promise<void> {
+async function revokeTokenFamily(familyId: string): Promise<void> {
   await db
     .update(mcpOauthTokens)
     .set({ revokedAt: new Date() })
@@ -296,7 +315,6 @@ export async function verifyAccessToken(
 export async function listGrantsForUser(userId: number) {
   return db
     .select({
-      tokenId: mcpOauthTokens.id,
       familyId: mcpOauthTokens.familyId,
       clientName: mcpOauthClients.clientName,
       scope: mcpOauthTokens.scope,

--- a/src/lib/oauth/store.ts
+++ b/src/lib/oauth/store.ts
@@ -105,16 +105,19 @@ export async function issueAuthCode(input: {
 
 /**
  * Atomically consume an authorization code: the UPDATE only matches an
- * unconsumed, unexpired row, so a replayed code (or a race between two token
- * requests) yields undefined for the loser.
+ * unconsumed, unexpired row bound to the presenting client, so a replayed
+ * code, a race between two token requests, or a code presented by the wrong
+ * client yields undefined — without burning a code that belongs to another
+ * client.
  */
-export async function consumeAuthCode(rawCode: string) {
+export async function consumeAuthCode(rawCode: string, clientRowId: number) {
   const [row] = await db
     .update(mcpOauthCodes)
     .set({ consumedAt: new Date() })
     .where(
       and(
         eq(mcpOauthCodes.codeHash, sha256Hex(rawCode)),
+        eq(mcpOauthCodes.clientId, clientRowId),
         isNull(mcpOauthCodes.consumedAt),
         gt(mcpOauthCodes.expiresAt, new Date()),
       ),

--- a/src/lib/oauth/store.ts
+++ b/src/lib/oauth/store.ts
@@ -1,0 +1,339 @@
+/**
+ * Persistence layer for the embedded OAuth 2.1 authorization server
+ * (038-mcp-v2): client registrations, single-use authorization codes, and
+ * access/refresh token pairs.
+ *
+ * Secrets are generated with high entropy (32 random bytes, base64url) and
+ * only their SHA-256 hex digests are stored — the invite_tokens pattern. A
+ * lookup by hash is therefore also constant-time with respect to the secret.
+ *
+ * Refresh tokens rotate: each refresh grant revokes the presented row and
+ * inserts a successor sharing the same familyId. Presenting an already-revoked
+ * refresh token is treated as theft and revokes the entire family
+ * (RFC 9700 §4.14).
+ */
+
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { and, eq, gt, isNull, lt } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import {
+  mcpOauthClients,
+  mcpOauthCodes,
+  mcpOauthTokens,
+  users,
+} from "@/lib/db/schema";
+
+export const AUTH_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+export const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+export const REFRESH_TOKEN_TTL_MS = 60 * 24 * 60 * 60 * 1000; // 60 days
+
+export function sha256Hex(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function newSecret(prefix: "mcp_ac_" | "mcp_at_" | "mcp_rt_"): string {
+  return `${prefix}${randomBytes(32).toString("base64url")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Clients (RFC 7591 dynamic registration)
+// ---------------------------------------------------------------------------
+
+export async function registerClient(input: {
+  clientName: string;
+  redirectUris: string[];
+}) {
+  const clientId = `mcp_client_${randomBytes(18).toString("base64url")}`;
+  const [row] = await db
+    .insert(mcpOauthClients)
+    .values({
+      clientId,
+      clientName: input.clientName,
+      redirectUris: input.redirectUris,
+    })
+    .returning();
+  return row;
+}
+
+export async function getClientByPublicId(clientId: string) {
+  return db.query.mcpOauthClients.findFirst({
+    where: eq(mcpOauthClients.clientId, clientId),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Authorization codes
+// ---------------------------------------------------------------------------
+
+export async function issueAuthCode(input: {
+  clientRowId: number;
+  userId: number;
+  redirectUri: string;
+  codeChallenge: string;
+  scope: string;
+}): Promise<string> {
+  const code = newSecret("mcp_ac_");
+  await db.insert(mcpOauthCodes).values({
+    codeHash: sha256Hex(code),
+    clientId: input.clientRowId,
+    userId: input.userId,
+    redirectUri: input.redirectUri,
+    codeChallenge: input.codeChallenge,
+    scope: input.scope,
+    expiresAt: new Date(Date.now() + AUTH_CODE_TTL_MS),
+  });
+  // Opportunistic cleanup — keeps the table from accumulating dead rows
+  // without needing a cron job.
+  await db
+    .delete(mcpOauthCodes)
+    .where(lt(mcpOauthCodes.expiresAt, new Date(Date.now() - AUTH_CODE_TTL_MS)));
+  return code;
+}
+
+/**
+ * Atomically consume an authorization code: the UPDATE only matches an
+ * unconsumed, unexpired row, so a replayed code (or a race between two token
+ * requests) yields undefined for the loser.
+ */
+export async function consumeAuthCode(rawCode: string) {
+  const [row] = await db
+    .update(mcpOauthCodes)
+    .set({ consumedAt: new Date() })
+    .where(
+      and(
+        eq(mcpOauthCodes.codeHash, sha256Hex(rawCode)),
+        isNull(mcpOauthCodes.consumedAt),
+        gt(mcpOauthCodes.expiresAt, new Date()),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// Tokens
+// ---------------------------------------------------------------------------
+
+export interface IssuedTokens {
+  accessToken: string;
+  refreshToken: string;
+  /** Access-token lifetime in seconds (OAuth `expires_in`). */
+  expiresIn: number;
+  scope: string;
+}
+
+export async function issueTokens(input: {
+  clientRowId: number;
+  userId: number;
+  scope: string;
+  familyId?: string;
+}): Promise<IssuedTokens> {
+  const accessToken = newSecret("mcp_at_");
+  const refreshToken = newSecret("mcp_rt_");
+  const now = Date.now();
+
+  await db.insert(mcpOauthTokens).values({
+    familyId: input.familyId ?? randomUUID(),
+    accessTokenHash: sha256Hex(accessToken),
+    refreshTokenHash: sha256Hex(refreshToken),
+    clientId: input.clientRowId,
+    userId: input.userId,
+    scope: input.scope,
+    accessExpiresAt: new Date(now + ACCESS_TOKEN_TTL_MS),
+    refreshExpiresAt: new Date(now + REFRESH_TOKEN_TTL_MS),
+  });
+
+  await Promise.all([
+    db
+      .update(mcpOauthClients)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(mcpOauthClients.id, input.clientRowId)),
+    // Opportunistic cleanup of rows whose refresh window has fully lapsed.
+    db
+      .delete(mcpOauthTokens)
+      .where(lt(mcpOauthTokens.refreshExpiresAt, new Date(now - 24 * 60 * 60 * 1000))),
+  ]);
+
+  return {
+    accessToken,
+    refreshToken,
+    expiresIn: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
+    scope: input.scope,
+  };
+}
+
+export type RefreshResult =
+  | { ok: true; tokens: IssuedTokens }
+  | { ok: false; error: "invalid_grant" };
+
+/**
+ * Rotate a refresh token. The presented row is revoked and a successor is
+ * issued within the same family. A revoked row being presented again means
+ * the token leaked (or a very stale client) — the whole family is revoked.
+ */
+export async function rotateRefreshToken(
+  rawRefreshToken: string,
+  clientRowId: number,
+): Promise<RefreshResult> {
+  const row = await db.query.mcpOauthTokens.findFirst({
+    where: eq(mcpOauthTokens.refreshTokenHash, sha256Hex(rawRefreshToken)),
+  });
+
+  if (!row || row.clientId !== clientRowId) return { ok: false, error: "invalid_grant" };
+
+  if (row.revokedAt) {
+    await revokeTokenFamily(row.familyId);
+    return { ok: false, error: "invalid_grant" };
+  }
+  if (row.refreshExpiresAt <= new Date()) {
+    return { ok: false, error: "invalid_grant" };
+  }
+
+  // The user behind the grant must still be active.
+  const user = await db.query.users.findFirst({
+    where: and(eq(users.id, row.userId), eq(users.status, "active")),
+    columns: { id: true },
+  });
+  if (!user) return { ok: false, error: "invalid_grant" };
+
+  await db
+    .update(mcpOauthTokens)
+    .set({ revokedAt: new Date() })
+    .where(eq(mcpOauthTokens.id, row.id));
+
+  const tokens = await issueTokens({
+    clientRowId: row.clientId,
+    userId: row.userId,
+    scope: row.scope,
+    familyId: row.familyId,
+  });
+  return { ok: true, tokens };
+}
+
+export async function revokeTokenFamily(familyId: string): Promise<void> {
+  await db
+    .update(mcpOauthTokens)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(eq(mcpOauthTokens.familyId, familyId), isNull(mcpOauthTokens.revokedAt)),
+    );
+}
+
+export interface VerifiedAccessToken {
+  userId: number;
+  email: string;
+  name: string;
+  clientPublicId: string;
+  scope: string;
+}
+
+/** Throttle for last_used_at writes — at most one update per row per 5 min. */
+const LAST_USED_WRITE_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Resolve a presented access token to its user, enforcing expiry, revocation,
+ * and that the user account is still active.
+ */
+export async function verifyAccessToken(
+  rawAccessToken: string,
+): Promise<VerifiedAccessToken | null> {
+  const [row] = await db
+    .select({
+      tokenId: mcpOauthTokens.id,
+      userId: mcpOauthTokens.userId,
+      scope: mcpOauthTokens.scope,
+      lastUsedAt: mcpOauthTokens.lastUsedAt,
+      email: users.email,
+      name: users.name,
+      clientPublicId: mcpOauthClients.clientId,
+    })
+    .from(mcpOauthTokens)
+    .innerJoin(users, eq(users.id, mcpOauthTokens.userId))
+    .innerJoin(
+      mcpOauthClients,
+      eq(mcpOauthClients.id, mcpOauthTokens.clientId),
+    )
+    .where(
+      and(
+        eq(mcpOauthTokens.accessTokenHash, sha256Hex(rawAccessToken)),
+        isNull(mcpOauthTokens.revokedAt),
+        gt(mcpOauthTokens.accessExpiresAt, new Date()),
+        eq(users.status, "active"),
+      ),
+    )
+    .limit(1);
+
+  if (!row) return null;
+
+  const lastUsed = row.lastUsedAt?.getTime() ?? 0;
+  if (Date.now() - lastUsed > LAST_USED_WRITE_INTERVAL_MS) {
+    // Fire-and-forget freshness marker for the settings UI.
+    db.update(mcpOauthTokens)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(mcpOauthTokens.id, row.tokenId))
+      .catch(() => {});
+  }
+
+  return {
+    userId: row.userId,
+    email: row.email,
+    name: row.name,
+    clientPublicId: row.clientPublicId,
+    scope: row.scope,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Grants (settings UI)
+// ---------------------------------------------------------------------------
+
+/**
+ * A user's live grants — one row per token family that is neither revoked nor
+ * past its refresh window. (Rotation revokes predecessors, so at most one
+ * live row exists per family.)
+ */
+export async function listGrantsForUser(userId: number) {
+  return db
+    .select({
+      tokenId: mcpOauthTokens.id,
+      familyId: mcpOauthTokens.familyId,
+      clientName: mcpOauthClients.clientName,
+      scope: mcpOauthTokens.scope,
+      createdAt: mcpOauthTokens.createdAt,
+      lastUsedAt: mcpOauthTokens.lastUsedAt,
+      refreshExpiresAt: mcpOauthTokens.refreshExpiresAt,
+    })
+    .from(mcpOauthTokens)
+    .innerJoin(
+      mcpOauthClients,
+      eq(mcpOauthClients.id, mcpOauthTokens.clientId),
+    )
+    .where(
+      and(
+        eq(mcpOauthTokens.userId, userId),
+        isNull(mcpOauthTokens.revokedAt),
+        gt(mcpOauthTokens.refreshExpiresAt, new Date()),
+      ),
+    )
+    .orderBy(mcpOauthTokens.createdAt);
+}
+
+/** Revoke one of the caller's own grants (whole family). */
+export async function revokeGrantForUser(
+  userId: number,
+  familyId: string,
+): Promise<boolean> {
+  const result = await db
+    .update(mcpOauthTokens)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(
+        eq(mcpOauthTokens.familyId, familyId),
+        eq(mcpOauthTokens.userId, userId),
+        isNull(mcpOauthTokens.revokedAt),
+      ),
+    )
+    .returning({ id: mcpOauthTokens.id });
+  return result.length > 0;
+}

--- a/src/lib/oauth/store.ts
+++ b/src/lib/oauth/store.ts
@@ -216,10 +216,20 @@ export async function rotateRefreshToken(
     return { ok: false, error: "invalid_grant" };
   }
 
-  await db
+  // Atomic revoke: only matches the row while it is still unrevoked, so two
+  // concurrent refreshes of the same token cannot both rotate. The loser is
+  // indistinguishable from a replay and gets the same family revocation.
+  const [revoked] = await db
     .update(mcpOauthTokens)
     .set({ revokedAt: new Date() })
-    .where(eq(mcpOauthTokens.id, row.id));
+    .where(
+      and(eq(mcpOauthTokens.id, row.id), isNull(mcpOauthTokens.revokedAt)),
+    )
+    .returning({ id: mcpOauthTokens.id });
+  if (!revoked) {
+    await revokeTokenFamily(row.familyId);
+    return { ok: false, error: "invalid_grant" };
+  }
 
   const tokens = await issueTokens({
     clientRowId: row.clientId,

--- a/src/lib/oauth/validate.ts
+++ b/src/lib/oauth/validate.ts
@@ -58,6 +58,7 @@ export function isAllowedRedirectUri(uri: string): boolean {
   } catch {
     return false;
   }
+  if (parsed.hostname === "") return false;
   if (parsed.hash !== "") return false;
   if (parsed.username !== "" || parsed.password !== "") return false;
   if (parsed.protocol === "https:") return true;

--- a/src/lib/oauth/validate.ts
+++ b/src/lib/oauth/validate.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure validation helpers for the embedded OAuth 2.1 authorization server
+ * (038-mcp-v2). No I/O — fully unit testable.
+ *
+ * Policy summary:
+ * - Public clients only (PKCE S256 mandatory, no client secrets).
+ * - Redirect URIs must be https, or http on a loopback host (RFC 8252 §7.3).
+ *   Loopback matching ignores the port because Claude Code redirects to an
+ *   ephemeral localhost port chosen at authorize time.
+ * - Single scope: `mcp:read` (the MCP server is read-only by design, spec 034).
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+
+export const MCP_SCOPE = "mcp:read";
+
+/** Constant-time string comparison that is safe for unequal lengths. */
+export function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  if (bufA.length !== bufB.length) {
+    // Still run a comparison to avoid leaking length via early return timing.
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/** RFC 7591 client metadata — only the fields the Hub stores or echoes. */
+export const clientRegistrationSchema = z.object({
+  client_name: z.string().trim().min(1).max(255).optional(),
+  redirect_uris: z
+    .array(z.string().min(1).max(2000))
+    .min(1, "redirect_uris must contain at least one URI")
+    .max(10, "too many redirect_uris"),
+});
+
+export type ClientRegistration = z.infer<typeof clientRegistrationSchema>;
+
+function isLoopbackHost(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname === "::1"
+  );
+}
+
+/**
+ * A redirect URI is registrable when it is https, or http pointing at a
+ * loopback host (native-app pattern). Fragments are forbidden (RFC 6749 §3.1.2)
+ * and custom URI schemes are not accepted — Claude's clients use the hosted
+ * https callback or a loopback http URL.
+ */
+export function isAllowedRedirectUri(uri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (parsed.hash !== "") return false;
+  if (parsed.username !== "" || parsed.password !== "") return false;
+  if (parsed.protocol === "https:") return true;
+  if (parsed.protocol === "http:") return isLoopbackHost(parsed.hostname);
+  return false;
+}
+
+/**
+ * Exact-match a presented redirect URI against a registered one, with the
+ * single RFC 8252 §7.3 relaxation: for http loopback URIs the port component
+ * is ignored (Claude Code binds a random ephemeral port per authorization).
+ */
+export function redirectUriMatches(
+  registered: string,
+  presented: string,
+): boolean {
+  if (registered === presented) return true;
+
+  let a: URL;
+  let b: URL;
+  try {
+    a = new URL(registered);
+    b = new URL(presented);
+  } catch {
+    return false;
+  }
+
+  return (
+    a.protocol === "http:" &&
+    b.protocol === "http:" &&
+    isLoopbackHost(a.hostname) &&
+    a.hostname === b.hostname &&
+    a.pathname === b.pathname &&
+    a.search === b.search &&
+    b.hash === "" &&
+    b.username === "" &&
+    b.password === ""
+  );
+}
+
+/** base64url(sha256(verifier)) — the S256 transform from RFC 7636 §4.2. */
+export function pkceChallengeFromVerifier(verifier: string): string {
+  return createHash("sha256").update(verifier, "ascii").digest("base64url");
+}
+
+/**
+ * Verify a PKCE code_verifier against the stored S256 challenge.
+ * Enforces the RFC 7636 §4.1 verifier alphabet/length before hashing.
+ */
+export function verifyPkce(verifier: string, storedChallenge: string): boolean {
+  if (!/^[A-Za-z0-9\-._~]{43,128}$/.test(verifier)) return false;
+  return safeEqual(pkceChallengeFromVerifier(verifier), storedChallenge);
+}
+
+/**
+ * Validate a requested scope string (space-delimited). Empty/absent is fine —
+ * the grant defaults to MCP_SCOPE. Unknown scopes are rejected so the consent
+ * screen never overstates what it grants. `offline_access` is tolerated and
+ * ignored (some clients request it reflexively; refresh tokens are always
+ * issued).
+ */
+export function validateRequestedScope(scope: string | undefined | null): {
+  ok: boolean;
+  granted: string;
+} {
+  if (!scope || scope.trim() === "") return { ok: true, granted: MCP_SCOPE };
+  const requested = scope.trim().split(/\s+/);
+  const known = new Set([MCP_SCOPE, "offline_access"]);
+  if (requested.some((s) => !known.has(s))) {
+    return { ok: false, granted: MCP_SCOPE };
+  }
+  return { ok: true, granted: MCP_SCOPE };
+}

--- a/src/lib/oauth/validate.ts
+++ b/src/lib/oauth/validate.ts
@@ -36,8 +36,6 @@ export const clientRegistrationSchema = z.object({
     .max(10, "too many redirect_uris"),
 });
 
-export type ClientRegistration = z.infer<typeof clientRegistrationSchema>;
-
 function isLoopbackHost(hostname: string): boolean {
   return (
     hostname === "localhost" ||
@@ -115,21 +113,17 @@ export function verifyPkce(verifier: string, storedChallenge: string): boolean {
 }
 
 /**
- * Validate a requested scope string (space-delimited). Empty/absent is fine —
- * the grant defaults to MCP_SCOPE. Unknown scopes are rejected so the consent
- * screen never overstates what it grants. `offline_access` is tolerated and
- * ignored (some clients request it reflexively; refresh tokens are always
- * issued).
+ * Is the requested scope string (space-delimited) acceptable? Empty/absent is
+ * fine — the grant is always MCP_SCOPE regardless. Unknown scopes are rejected
+ * so the consent screen never overstates what it grants. `offline_access` is
+ * tolerated and ignored (some clients request it reflexively; refresh tokens
+ * are always issued).
  */
-export function validateRequestedScope(scope: string | undefined | null): {
-  ok: boolean;
-  granted: string;
-} {
-  if (!scope || scope.trim() === "") return { ok: true, granted: MCP_SCOPE };
-  const requested = scope.trim().split(/\s+/);
+export function isValidScopeRequest(scope: string | undefined | null): boolean {
+  if (!scope || scope.trim() === "") return true;
   const known = new Set([MCP_SCOPE, "offline_access"]);
-  if (requested.some((s) => !known.has(s))) {
-    return { ok: false, granted: MCP_SCOPE };
-  }
-  return { ok: true, granted: MCP_SCOPE };
+  return scope
+    .trim()
+    .split(/\s+/)
+    .every((s) => known.has(s));
 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -43,9 +43,7 @@ export function resetLimit(key: string): void {
  * (Vercel sets x-forwarded-for; x-real-ip is a common fallback).
  */
 export function clientIp(headers: Headers): string {
-  return (
-    headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    headers.get("x-real-ip") ??
-    "unknown"
-  );
+  const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const realIp = headers.get("x-real-ip")?.trim();
+  return forwarded || realIp || "unknown";
 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -37,3 +37,15 @@ export function isRateLimited(key: string, config: RateLimitConfig): boolean {
 export function resetLimit(key: string): void {
   store.delete(key);
 }
+
+/**
+ * Best-effort client IP for rate-limit keys, honouring reverse-proxy headers
+ * (Vercel sets x-forwarded-for; x-real-ip is a common fallback).
+ */
+export function clientIp(headers: Headers): string {
+  return (
+    headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    headers.get("x-real-ip") ??
+    "unknown"
+  );
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -2,10 +2,12 @@ export const PUBLIC_PATHS = ["/login", "/setup-password"];
 
 export const MUST_CHANGE_PASSWORD_ERROR = "MUST_CHANGE_PASSWORD";
 
+function matchesAny(pathname: string, paths: string[]): boolean {
+  return paths.some((p) => pathname === p || pathname.startsWith(p + "/"));
+}
+
 export function isPublicPath(pathname: string): boolean {
-  return PUBLIC_PATHS.some(
-    (p) => pathname === p || pathname.startsWith(p + "/")
-  );
+  return matchesAny(pathname, PUBLIC_PATHS);
 }
 
 /**
@@ -16,10 +18,5 @@ export function isPublicPath(pathname: string): boolean {
 const BARE_LAYOUT_PATHS = ["/oauth/authorize"];
 
 export function isBareLayoutPath(pathname: string): boolean {
-  return (
-    isPublicPath(pathname) ||
-    BARE_LAYOUT_PATHS.some(
-      (p) => pathname === p || pathname.startsWith(p + "/")
-    )
-  );
+  return isPublicPath(pathname) || matchesAny(pathname, BARE_LAYOUT_PATHS);
 }

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -7,3 +7,19 @@ export function isPublicPath(pathname: string): boolean {
     (p) => pathname === p || pathname.startsWith(p + "/")
   );
 }
+
+/**
+ * Paths rendered without the app sidebar shell. Superset of the public paths:
+ * the OAuth consent screen requires a session but is shown to users arriving
+ * from an external client, so the app chrome would be noise (038-mcp-v2).
+ */
+const BARE_LAYOUT_PATHS = ["/oauth/authorize"];
+
+export function isBareLayoutPath(pathname: string): boolean {
+  return (
+    isPublicPath(pathname) ||
+    BARE_LAYOUT_PATHS.some(
+      (p) => pathname === p || pathname.startsWith(p + "/")
+    )
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,6 +41,6 @@ export default auth((req) => {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon\\.ico|api/auth|api/sync|api/invoices/ingest|api/license-requests/ingest|api/profile|api/agent/session|api/mcp).*)",
+    "/((?!_next/static|_next/image|favicon\\.ico|api/auth|api/sync|api/invoices/ingest|api/license-requests/ingest|api/profile|api/agent/session|api/mcp|api/oauth|\\.well-known).*)",
   ],
 };

--- a/tests/unit/mcp/auth.test.ts
+++ b/tests/unit/mcp/auth.test.ts
@@ -1,11 +1,21 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+vi.mock("@/lib/oauth/store", () => ({
+  verifyAccessToken: vi.fn(),
+}));
+
 import { safeEqual, verifyMcpToken } from "@/lib/mcp/auth";
+import { verifyAccessToken } from "@/lib/oauth/store";
 
 const SECRET = "super-secret-mcp-token-123456";
 
 function req(): Request {
   return new Request("http://localhost:3000/api/mcp/mcp", { method: "POST" });
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -26,29 +36,67 @@ describe("safeEqual", () => {
   });
 });
 
-describe("verifyMcpToken", () => {
-  it("rejects when MCP_SERVER_SECRET is not set", () => {
+describe("verifyMcpToken — shared secret", () => {
+  it("rejects a non-OAuth token when MCP_SERVER_SECRET is not set", async () => {
     vi.stubEnv("MCP_SERVER_SECRET", "");
-    expect(verifyMcpToken(req(), "anything")).toBeUndefined();
+    await expect(verifyMcpToken(req(), "anything")).resolves.toBeUndefined();
+    expect(verifyAccessToken).not.toHaveBeenCalled();
   });
 
-  it("rejects when no bearer token is provided", () => {
+  it("rejects when no bearer token is provided", async () => {
     vi.stubEnv("MCP_SERVER_SECRET", SECRET);
-    expect(verifyMcpToken(req(), undefined)).toBeUndefined();
+    await expect(verifyMcpToken(req(), undefined)).resolves.toBeUndefined();
   });
 
-  it("rejects an incorrect token", () => {
+  it("rejects an incorrect token", async () => {
     vi.stubEnv("MCP_SERVER_SECRET", SECRET);
-    expect(verifyMcpToken(req(), "wrong-token")).toBeUndefined();
+    await expect(verifyMcpToken(req(), "wrong-token")).resolves.toBeUndefined();
   });
 
-  it("returns AuthInfo for the correct token", () => {
+  it("returns AuthInfo with the read scope for the correct token", async () => {
     vi.stubEnv("MCP_SERVER_SECRET", SECRET);
-    const info = verifyMcpToken(req(), SECRET);
+    const info = await verifyMcpToken(req(), SECRET);
     expect(info).toEqual({
       token: SECRET,
       clientId: "mcp-shared-secret",
-      scopes: [],
+      scopes: ["mcp:read"],
     });
+    expect(verifyAccessToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("verifyMcpToken — OAuth access tokens", () => {
+  it("resolves an mcp_at_ token via the OAuth store even without a shared secret", async () => {
+    vi.stubEnv("MCP_SERVER_SECRET", "");
+    vi.mocked(verifyAccessToken).mockResolvedValue({
+      userId: 42,
+      email: "jane@example.com",
+      name: "Jane",
+      clientPublicId: "mcp_client_abc",
+      scope: "mcp:read",
+    });
+
+    const info = await verifyMcpToken(req(), "mcp_at_sometoken");
+    expect(info).toEqual({
+      token: "mcp_at_sometoken",
+      clientId: "mcp_client_abc",
+      scopes: ["mcp:read"],
+      extra: { userId: 42, email: "jane@example.com", name: "Jane" },
+    });
+    expect(verifyAccessToken).toHaveBeenCalledWith("mcp_at_sometoken");
+  });
+
+  it("rejects an unknown/revoked/expired OAuth token", async () => {
+    vi.stubEnv("MCP_SERVER_SECRET", SECRET);
+    vi.mocked(verifyAccessToken).mockResolvedValue(null);
+    await expect(
+      verifyMcpToken(req(), "mcp_at_revoked"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not hit the OAuth store for tokens without the mcp_at_ prefix", async () => {
+    vi.stubEnv("MCP_SERVER_SECRET", SECRET);
+    await expect(verifyMcpToken(req(), "random-token")).resolves.toBeUndefined();
+    expect(verifyAccessToken).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/mcp/auth.test.ts
+++ b/tests/unit/mcp/auth.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
 vi.mock("@/lib/oauth/store", () => ({
   verifyAccessToken: vi.fn(),
+  ACCESS_TOKEN_PREFIX: "mcp_at_",
 }));
 
 import { safeEqual, verifyMcpToken } from "@/lib/mcp/auth";

--- a/tests/unit/mcp/data.test.ts
+++ b/tests/unit/mcp/data.test.ts
@@ -9,6 +9,8 @@ interface SelectChain {
   from: () => SelectChain;
   where: () => SelectChain;
   innerJoin: () => SelectChain;
+  leftJoin: () => SelectChain;
+  groupBy: () => SelectChain;
   orderBy: () => SelectChain;
   limit: () => SelectChain;
   then: (
@@ -37,6 +39,8 @@ vi.mock("@/lib/db", () => {
       from: () => chain,
       where: () => chain,
       innerJoin: () => chain,
+      leftJoin: () => chain,
+      groupBy: () => chain,
       orderBy: () => chain,
       limit: () => chain,
       then: (resolve, reject) => Promise.resolve(rows).then(resolve, reject),
@@ -69,6 +73,9 @@ vi.mock("@/actions/budget", () => ({
   getBudgetWithCosts: vi.fn(),
   fetchActualByPeriod: vi.fn(),
 }));
+vi.mock("@/actions/reports", () => ({
+  getBudgetReportData: vi.fn(),
+}));
 
 // ── Import after mocks ───────────────────────────────────────────────────────
 
@@ -80,6 +87,13 @@ import {
   getBudgetStatusData,
   getCopilotUsageSummaryData,
   listRecentSyncEventsData,
+  findUsersData,
+  listClaudeUsersData,
+  getClaudeCostDashboardData,
+  getBudgetReportToolData,
+  listLicenseAssignmentsData,
+  listInvoicesData,
+  getCopilotAnalyticsData,
 } from "@/lib/mcp/data";
 import { fetchProfileDataInternal } from "@/lib/profile-data";
 import {
@@ -92,6 +106,7 @@ import {
   getBudgetWithCosts,
   fetchActualByPeriod,
 } from "@/actions/budget";
+import { getBudgetReportData } from "@/actions/reports";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -103,7 +118,15 @@ beforeEach(() => {
 describe("listAiToolsData", () => {
   it("groups active tiers under their tool and converts cost to USD", async () => {
     selectQueue.push(
-      [{ id: 1, name: "Claude API", vendor: "Anthropic", status: "active" }],
+      [
+        {
+          id: 1,
+          name: "Claude API",
+          vendor: "Anthropic",
+          status: "active",
+          maxLicenses: 20,
+        },
+      ],
       [
         {
           id: 10,
@@ -113,6 +136,7 @@ describe("listAiToolsData", () => {
           isActive: true,
         },
       ],
+      [{ toolId: 1, count: 15 }],
     );
 
     const result = await listAiToolsData();
@@ -121,6 +145,9 @@ describe("listAiToolsData", () => {
       id: 1,
       name: "Claude API",
       vendor: "Anthropic",
+      activeAssignments: 15,
+      maxLicenses: 20,
+      licenseUtilizationPct: 75,
     });
     expect(result.tools[0].tiers[0]).toEqual({
       id: 10,
@@ -130,13 +157,24 @@ describe("listAiToolsData", () => {
     });
   });
 
-  it("returns a tool with no tiers when none are active", async () => {
+  it("returns a tool with no tiers and null utilization without maxLicenses", async () => {
     selectQueue.push(
-      [{ id: 2, name: "Cursor", vendor: "Anysphere", status: "active" }],
+      [
+        {
+          id: 2,
+          name: "Cursor",
+          vendor: "Anysphere",
+          status: "active",
+          maxLicenses: null,
+        },
+      ],
+      [],
       [],
     );
     const result = await listAiToolsData();
     expect(result.tools[0].tiers).toEqual([]);
+    expect(result.tools[0].activeAssignments).toBe(0);
+    expect(result.tools[0].licenseUtilizationPct).toBeNull();
   });
 });
 
@@ -184,8 +222,17 @@ describe("getUserCostProfileData", () => {
 
   it("throws when the user is not found", async () => {
     mockUsersFindFirst.mockResolvedValue(undefined);
+    selectQueue.push([]); // no near-match candidates
     await expect(getUserCostProfileData("missing@example.com")).rejects.toThrow(
       /No user found/,
+    );
+  });
+
+  it("suggests near-match candidates when the email misses", async () => {
+    mockUsersFindFirst.mockResolvedValue(undefined);
+    selectQueue.push([{ name: "Jane Doe", email: "jane.doe@example.com" }]);
+    await expect(getUserCostProfileData("jane@example.com")).rejects.toThrow(
+      /Did you mean: jane\.doe@example\.com \(Jane Doe\)/,
     );
   });
 
@@ -457,6 +504,345 @@ describe("listRecentSyncEventsData", () => {
       outcome: "success",
       startedAt: "2026-05-21T08:00:00.000Z",
       completedAt: "2026-05-21T08:01:00.000Z",
+    });
+  });
+});
+
+describe("findUsersData", () => {
+  it("returns matching users with the original query echoed", async () => {
+    selectQueue.push([
+      {
+        id: 1,
+        name: "Jane Doe",
+        email: "jane@example.com",
+        role: "viewer",
+        status: "active",
+        circle: "Platform",
+        profile: "boost",
+        discipline: "developer",
+      },
+    ]);
+    const result = await findUsersData("jane");
+    expect(result.query).toBe("jane");
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].email).toBe("jane@example.com");
+  });
+});
+
+describe("listClaudeUsersData", () => {
+  it("converts bigint-ish aggregates to numbers and sums the listed total", async () => {
+    selectQueue.push([
+      {
+        userId: 1,
+        name: "Jane",
+        email: "jane@example.com",
+        circle: "Platform",
+        status: "active",
+        costCents: "120000",
+        totalTokens: "5000000",
+        modelsUsed: "2",
+        lastActive: "2026-05-20",
+        hasUnresolvedPricing: false,
+      },
+      {
+        userId: 2,
+        name: "Bob",
+        email: "bob@example.com",
+        circle: null,
+        status: "active",
+        costCents: "30000",
+        totalTokens: "900000",
+        modelsUsed: "1",
+        lastActive: "2026-05-18",
+        hasUnresolvedPricing: true,
+      },
+    ]);
+
+    const result = await listClaudeUsersData("2026-05");
+    expect(result.month).toBe("2026-05");
+    expect(result.userCount).toBe(2);
+    expect(result.listedTotalCents).toBe(150000);
+    expect(result.listedTotalUsd).toBe(1500);
+    expect(result.users[0]).toMatchObject({
+      email: "jane@example.com",
+      costCents: 120000,
+      costUsd: 1200,
+      totalTokens: 5000000,
+      modelsUsed: 2,
+    });
+    expect(result.users[1].hasUnresolvedPricing).toBe(true);
+  });
+});
+
+describe("getClaudeCostDashboardData", () => {
+  it("assembles daily totals, workspace deltas, and the 12-month series", async () => {
+    selectQueue.push(
+      // dailyTotals
+      [
+        { date: "2026-05-01", costCents: "10000" },
+        { date: "2026-05-02", costCents: "20000" },
+      ],
+      // workspaceTotals (current + prior month)
+      [
+        {
+          workspaceId: "ws_1",
+          workspaceName: "Engineering",
+          currentCents: "25000",
+          priorCents: "20000",
+        },
+        {
+          workspaceId: null,
+          workspaceName: null,
+          currentCents: "5000",
+          priorCents: "0",
+        },
+      ],
+      // monthlySeries
+      [
+        { month: "2026-04", costCents: "100000" },
+        { month: "2026-05", costCents: "30000" },
+      ],
+    );
+
+    const result = await getClaudeCostDashboardData("2026-05");
+    expect(result.month).toBe("2026-05");
+    expect(result.priorMonth).toBe("2026-04");
+    expect(result.monthTotalCents).toBe(30000);
+    expect(result.dailyTotals).toHaveLength(2);
+    expect(result.workspaces[0]).toMatchObject({
+      name: "Engineering",
+      currentMonthCents: 25000,
+      priorMonthCents: 20000,
+      deltaCents: 5000,
+      deltaPct: 25,
+    });
+    expect(result.workspaces[1]).toMatchObject({
+      name: "Default workspace",
+      deltaPct: null,
+    });
+    expect(result.last12Months).toHaveLength(2);
+  });
+});
+
+describe("getBudgetReportToolData", () => {
+  it("throws when there is no active budget", async () => {
+    vi.mocked(getBudgetReportData).mockResolvedValue({
+      kind: "empty",
+      reason: "no_active_budget",
+    } as Awaited<ReturnType<typeof getBudgetReportData>>);
+    await expect(getBudgetReportToolData()).rejects.toThrow(/No active budget/);
+  });
+
+  it("maps periods, forecast, per-tool rows, and past-month variance to USD", async () => {
+    vi.mocked(getBudgetReportData).mockResolvedValue({
+      kind: "ready",
+      budget: { fiscalYear: 2026, totalAmountCents: 1200000 },
+      periodsWithActual: [
+        {
+          periodLabel: "May 2026",
+          startDate: "2026-05-01",
+          endDate: "2026-05-31",
+          plannedAmountCents: 100000,
+          billedTotalCents: 60000,
+          runningCostCents: 30000,
+          actualCents: 90000,
+        },
+      ],
+      forecast: {
+        status: "on_track",
+        actualSpendToDateCents: 90000,
+        projectedAnnualTotalCents: 1100000,
+        budgetCeilingCents: 1200000,
+      },
+      perTool: [
+        {
+          toolId: null,
+          toolName: "Anthropic API",
+          isAnthropicApi: true,
+          ytdSpentCents: 50000,
+          currentMonthlyCents: 30000,
+          projectedEoyCents: 260000,
+        },
+      ],
+      pastMonth: {
+        periodLabel: "Apr 2026",
+        plannedCents: 100000,
+        actualCents: 110000,
+        varianceCents: 10000,
+        variancePct: 10,
+        drivers: [
+          {
+            toolName: "Cursor",
+            priorCents: 0,
+            pastCents: 10000,
+            deltaCents: 10000,
+            deltaPct: null,
+          },
+        ],
+      },
+    } as unknown as Awaited<ReturnType<typeof getBudgetReportData>>);
+
+    const result = await getBudgetReportToolData();
+    expect(result.fiscalYear).toBe(2026);
+    expect(result.budgetTotalUsd).toBe(12000);
+    expect(result.periods[0]).toMatchObject({
+      label: "May 2026",
+      runningUsd: 300,
+      actualUsd: 900,
+    });
+    expect(result.perTool[0]).toMatchObject({
+      toolName: "Anthropic API",
+      isAnthropicApi: true,
+      ytdSpentUsd: 500,
+    });
+    expect(result.pastMonth).toMatchObject({
+      periodLabel: "Apr 2026",
+      varianceUsd: 100,
+      variancePct: 10,
+    });
+    expect(result.pastMonth?.drivers[0]).toMatchObject({
+      toolName: "Cursor",
+      deltaUsd: 100,
+    });
+  });
+});
+
+describe("listLicenseAssignmentsData", () => {
+  it("maps assignment rows with USD cost and echoes the filters", async () => {
+    selectQueue.push([
+      {
+        id: 7,
+        userName: "Jane",
+        userEmail: "jane@example.com",
+        toolName: "Cursor",
+        tierName: "Pro",
+        status: "active",
+        costAtAssignmentCents: 2000,
+        assignedAt: new Date("2026-01-15T00:00:00Z"),
+        revokedAt: null,
+        workspace: null,
+        source: "manual",
+      },
+    ]);
+
+    const result = await listLicenseAssignmentsData({ toolName: "Cursor" });
+    expect(result.filters).toEqual({
+      email: null,
+      toolName: "Cursor",
+      status: "active",
+    });
+    expect(result.count).toBe(1);
+    expect(result.monthlyTotalUsd).toBe(20);
+    expect(result.assignments[0]).toMatchObject({
+      user: { name: "Jane", email: "jane@example.com" },
+      toolName: "Cursor",
+      tierName: "Pro",
+      monthlyCostUsd: 20,
+      assignedAt: "2026-01-15T00:00:00.000Z",
+      revokedAt: null,
+    });
+  });
+});
+
+describe("listInvoicesData", () => {
+  it("maps invoices with link status and excludes blob fields", async () => {
+    selectQueue.push([
+      {
+        id: 3,
+        invoiceNumber: "INV-100",
+        invoiceDate: "2026-05-10",
+        amountCents: 50000,
+        vendor: "Anthropic",
+        filteredOut: false,
+        linkedBilledCostId: 9,
+        periodLabel: "May 2026",
+        createdAt: new Date("2026-05-11T08:00:00Z"),
+      },
+      {
+        id: 4,
+        invoiceNumber: "INV-101",
+        invoiceDate: "2026-05-12",
+        amountCents: 10000,
+        vendor: "GitHub",
+        filteredOut: false,
+        linkedBilledCostId: null,
+        periodLabel: null,
+        createdAt: null,
+      },
+    ]);
+
+    const result = await listInvoicesData({ month: "2026-05" });
+    expect(result.count).toBe(2);
+    expect(result.listedTotalUsd).toBe(600);
+    expect(result.invoices[0]).toMatchObject({
+      invoiceNumber: "INV-100",
+      amountUsd: 500,
+      isLinked: true,
+      linkedToPeriod: "May 2026",
+    });
+    expect(result.invoices[1]).toMatchObject({
+      isLinked: false,
+      linkedToPeriod: null,
+      uploadedAt: null,
+    });
+    expect(result.invoices[0]).not.toHaveProperty("blobUrl");
+  });
+});
+
+describe("getCopilotAnalyticsData", () => {
+  it("returns connected:false when no active connection", async () => {
+    mockGithubFindFirst.mockResolvedValue(undefined);
+    const result = await getCopilotAnalyticsData();
+    expect(result).toMatchObject({ connected: false });
+  });
+
+  it("builds the daily series and aggregates language/editor breakdowns", async () => {
+    mockGithubFindFirst.mockResolvedValue({ id: 3, orgLogin: "acme" });
+    selectQueue.push([
+      {
+        date: "2026-05-01",
+        totalActiveUsers: 10,
+        totalEngagedUsers: 8,
+        totalSuggestions: 100,
+        totalAcceptances: 40,
+        totalChatTurns: 12,
+        languageBreakdown: [
+          { language: "typescript", suggestions: 60, acceptances: 30 },
+          { language: "python", suggestions: 40, acceptances: 10 },
+        ],
+        editorBreakdown: [{ editor: "vscode", suggestions: 100, acceptances: 40 }],
+      },
+      {
+        date: "2026-05-02",
+        totalActiveUsers: 12,
+        totalEngagedUsers: 9,
+        totalSuggestions: 50,
+        totalAcceptances: 25,
+        totalChatTurns: 5,
+        languageBreakdown: [
+          { language: "typescript", suggestions: 50, acceptances: 25 },
+        ],
+        editorBreakdown: null,
+      },
+    ]);
+
+    const result = await getCopilotAnalyticsData("2026-05-01", "2026-05-02");
+    if (!result.connected) throw new Error("expected connected");
+    expect(result.daily).toHaveLength(2);
+    expect(result.daily[1]).toMatchObject({
+      date: "2026-05-02",
+      activeUsers: 12,
+      suggestions: 50,
+    });
+    expect(result.topLanguages[0]).toEqual({
+      language: "typescript",
+      suggestions: 110,
+      acceptances: 55,
+      acceptanceRatePct: 50,
+    });
+    expect(result.topEditors[0]).toMatchObject({
+      editor: "vscode",
+      suggestions: 100,
     });
   });
 });

--- a/tests/unit/mcp/data.test.ts
+++ b/tests/unit/mcp/data.test.ts
@@ -69,7 +69,6 @@ vi.mock("@/lib/anthropic/queries", () => ({
   loadSyncStatus: vi.fn(),
 }));
 vi.mock("@/actions/budget", () => ({
-  getActiveBudget: vi.fn(),
   getBudgetWithCosts: vi.fn(),
   fetchActualByPeriod: vi.fn(),
 }));
@@ -101,11 +100,7 @@ import {
   loadWorkspaceList,
   loadSyncStatus,
 } from "@/lib/anthropic/queries";
-import {
-  getActiveBudget,
-  getBudgetWithCosts,
-  fetchActualByPeriod,
-} from "@/actions/budget";
+import { getBudgetWithCosts, fetchActualByPeriod } from "@/actions/budget";
 import { getBudgetReportData } from "@/actions/reports";
 
 beforeEach(() => {
@@ -368,14 +363,12 @@ describe("getBudgetStatusData", () => {
   };
 
   it("throws when there is no active budget", async () => {
-    vi.mocked(getActiveBudget).mockResolvedValue(undefined);
+    mockAnnualFindFirst.mockResolvedValue(undefined);
     await expect(getBudgetStatusData()).rejects.toThrow(/No active budget/);
   });
 
   it("assembles per-period actuals and a forecast verdict", async () => {
-    vi.mocked(getActiveBudget).mockResolvedValue(
-      budget as unknown as Awaited<ReturnType<typeof getActiveBudget>>,
-    );
+    mockAnnualFindFirst.mockResolvedValue({ id: 5 });
     vi.mocked(getBudgetWithCosts).mockResolvedValue(
       budget as unknown as Awaited<ReturnType<typeof getBudgetWithCosts>>,
     );
@@ -402,7 +395,7 @@ describe("getBudgetStatusData", () => {
     vi.mocked(fetchActualByPeriod).mockResolvedValue(new Map([[50, 96000]]));
     const result = await getBudgetStatusData(2026);
     expect(result.fiscalYear).toBe(2026);
-    expect(getActiveBudget).not.toHaveBeenCalled();
+    expect(mockAnnualFindFirst).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -617,7 +610,7 @@ describe("getClaudeCostDashboardData", () => {
       deltaPct: 25,
     });
     expect(result.workspaces[1]).toMatchObject({
-      name: "Default workspace",
+      name: "Default Workspace",
       deltaPct: null,
     });
     expect(result.last12Months).toHaveLength(2);

--- a/tests/unit/mcp/tools.test.ts
+++ b/tests/unit/mcp/tools.test.ts
@@ -9,6 +9,13 @@ vi.mock("@/lib/mcp/data", () => ({
   getBudgetStatusData: vi.fn(),
   getCopilotUsageSummaryData: vi.fn(),
   listRecentSyncEventsData: vi.fn(),
+  findUsersData: vi.fn(),
+  listClaudeUsersData: vi.fn(),
+  getClaudeCostDashboardData: vi.fn(),
+  getBudgetReportToolData: vi.fn(),
+  listLicenseAssignmentsData: vi.fn(),
+  listInvoicesData: vi.fn(),
+  getCopilotAnalyticsData: vi.fn(),
 }));
 
 import { registerHubTools, type ToolRegistrar } from "@/lib/mcp/tools";
@@ -40,6 +47,13 @@ const EXPECTED_TOOLS = [
   "get_budget_status",
   "get_copilot_usage_summary",
   "list_recent_sync_events",
+  "find_users",
+  "list_claude_users",
+  "get_claude_cost_dashboard",
+  "get_budget_report",
+  "list_license_assignments",
+  "list_invoices",
+  "get_copilot_analytics",
 ];
 
 beforeEach(() => {

--- a/tests/unit/mcp/tools.test.ts
+++ b/tests/unit/mcp/tools.test.ts
@@ -26,17 +26,24 @@ import {
 } from "@/lib/mcp/data";
 
 type Handler = (args: Record<string, unknown>) => Promise<McpToolResult>;
+type ToolMeta = { annotations?: { readOnlyHint?: boolean } };
 
-function collectHandlers(): Map<string, Handler> {
-  const handlers = new Map<string, Handler>();
+function collectTools(): Map<string, { meta: ToolMeta; handler: Handler }> {
+  const tools = new Map<string, { meta: ToolMeta; handler: Handler }>();
   const fakeServer = {
-    registerTool: (name: string, _meta: unknown, handler: Handler) => {
-      handlers.set(name, handler);
+    registerTool: (name: string, meta: ToolMeta, handler: Handler) => {
+      tools.set(name, { meta, handler });
       return undefined;
     },
   };
   registerHubTools(fakeServer as unknown as ToolRegistrar);
-  return handlers;
+  return tools;
+}
+
+function collectHandlers(): Map<string, Handler> {
+  return new Map(
+    [...collectTools()].map(([name, { handler }]) => [name, handler]),
+  );
 }
 
 const EXPECTED_TOOLS = [
@@ -64,6 +71,14 @@ describe("registerHubTools", () => {
   it("registers exactly the expected read-only tools", () => {
     const handlers = collectHandlers();
     expect([...handlers.keys()].sort()).toEqual([...EXPECTED_TOOLS].sort());
+  });
+
+  it("marks every tool with the readOnlyHint annotation", () => {
+    for (const [name, { meta }] of collectTools()) {
+      expect(meta.annotations?.readOnlyHint, `${name} missing readOnlyHint`).toBe(
+        true,
+      );
+    }
   });
 
   it("routes a successful call through jsonResult", async () => {

--- a/tests/unit/oauth/authorize.test.ts
+++ b/tests/unit/oauth/authorize.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/oauth/store", () => ({
+  getClientByPublicId: vi.fn(),
+}));
+
+import {
+  buildRedirect,
+  validateAuthorizeRequest,
+} from "@/lib/oauth/authorize";
+import { getClientByPublicId } from "@/lib/oauth/store";
+import { pkceChallengeFromVerifier } from "@/lib/oauth/validate";
+
+const CLIENT = {
+  id: 1,
+  clientId: "mcp_client_abc",
+  clientName: "Claude",
+  redirectUris: [
+    "https://claude.ai/api/mcp/auth_callback",
+    "http://localhost/callback",
+  ],
+  createdAt: new Date(),
+  lastUsedAt: null,
+};
+
+const CHALLENGE = pkceChallengeFromVerifier(
+  "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+);
+
+function validParams() {
+  return {
+    client_id: "mcp_client_abc",
+    redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+    response_type: "code",
+    code_challenge: CHALLENGE,
+    code_challenge_method: "S256",
+    state: "xyz",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getClientByPublicId).mockResolvedValue(CLIENT);
+});
+
+describe("validateAuthorizeRequest", () => {
+  it("accepts a valid request and grants mcp:read", async () => {
+    const result = await validateAuthorizeRequest(validParams());
+    expect(result).toMatchObject({
+      ok: true,
+      redirectUri: "https://claude.ai/api/mcp/auth_callback",
+      grantedScope: "mcp:read",
+      state: "xyz",
+    });
+  });
+
+  it("accepts a loopback redirect on any port", async () => {
+    const result = await validateAuthorizeRequest({
+      ...validParams(),
+      redirect_uri: "http://localhost:53682/callback",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("is fatal (no redirect) for unknown client or unregistered redirect_uri", async () => {
+    vi.mocked(getClientByPublicId).mockResolvedValue(undefined);
+    const unknownClient = await validateAuthorizeRequest(validParams());
+    expect(unknownClient).toMatchObject({ ok: false, fatal: true });
+
+    vi.mocked(getClientByPublicId).mockResolvedValue(CLIENT);
+    const badRedirect = await validateAuthorizeRequest({
+      ...validParams(),
+      redirect_uri: "https://evil.example.com/cb",
+    });
+    expect(badRedirect).toMatchObject({ ok: false, fatal: true });
+  });
+
+  it("is fatal when client_id or redirect_uri is missing", async () => {
+    expect(
+      await validateAuthorizeRequest({ ...validParams(), client_id: undefined }),
+    ).toMatchObject({ ok: false, fatal: true });
+    expect(
+      await validateAuthorizeRequest({ ...validParams(), redirect_uri: undefined }),
+    ).toMatchObject({ ok: false, fatal: true });
+  });
+
+  it.each([
+    [
+      "unsupported response_type",
+      { response_type: "token" },
+      "unsupported_response_type",
+    ],
+    ["missing code_challenge", { code_challenge: undefined }, "invalid_request"],
+    [
+      "non-S256 challenge method",
+      { code_challenge_method: "plain" },
+      "invalid_request",
+    ],
+    ["unknown scope", { scope: "admin:write" }, "invalid_scope"],
+  ])("redirects with an error for %s", async (_label, overrides, expectedError) => {
+    const result = await validateAuthorizeRequest({
+      ...validParams(),
+      ...overrides,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok || result.fatal) throw new Error("expected redirect error");
+    const url = new URL(result.redirectTo);
+    expect(url.origin + url.pathname).toBe("https://claude.ai/api/mcp/auth_callback");
+    expect(url.searchParams.get("error")).toBe(expectedError);
+    expect(url.searchParams.get("state")).toBe("xyz");
+  });
+});
+
+describe("buildRedirect", () => {
+  it("appends params while preserving the URI's own query", () => {
+    const result = buildRedirect("http://localhost/cb?keep=1", {
+      code: "abc",
+      state: "xyz",
+      skipped: null,
+    });
+    const url = new URL(result);
+    expect(url.searchParams.get("keep")).toBe("1");
+    expect(url.searchParams.get("code")).toBe("abc");
+    expect(url.searchParams.get("state")).toBe("xyz");
+    expect(url.searchParams.has("skipped")).toBe(false);
+  });
+});

--- a/tests/unit/oauth/metadata.test.ts
+++ b/tests/unit/oauth/metadata.test.ts
@@ -21,6 +21,16 @@ describe("requestOrigin", () => {
     });
     expect(requestOrigin(req)).toBe("https://hub.example.com");
   });
+
+  it("takes the first entry of comma-separated forwarded headers", () => {
+    const req = new Request("http://10.0.0.1/.well-known/oauth-authorization-server", {
+      headers: {
+        "x-forwarded-host": "hub.example.com, internal-proxy.local",
+        "x-forwarded-proto": "https, http",
+      },
+    });
+    expect(requestOrigin(req)).toBe("https://hub.example.com");
+  });
 });
 
 describe("authorizationServerMetadata", () => {

--- a/tests/unit/oauth/metadata.test.ts
+++ b/tests/unit/oauth/metadata.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  authorizationServerMetadata,
+  protectedResourceMetadata,
+  requestOrigin,
+} from "@/lib/oauth/metadata";
+
+describe("requestOrigin", () => {
+  it("uses the request URL for plain local requests", () => {
+    const req = new Request("http://localhost:3000/.well-known/oauth-authorization-server");
+    expect(requestOrigin(req)).toBe("http://localhost:3000");
+  });
+
+  it("honours x-forwarded-host and x-forwarded-proto behind a proxy", () => {
+    const req = new Request("http://10.0.0.1/.well-known/oauth-authorization-server", {
+      headers: {
+        "x-forwarded-host": "hub.example.com",
+        "x-forwarded-proto": "https",
+      },
+    });
+    expect(requestOrigin(req)).toBe("https://hub.example.com");
+  });
+});
+
+describe("authorizationServerMetadata", () => {
+  it("advertises the endpoints and S256-only PKCE", () => {
+    const doc = authorizationServerMetadata("https://hub.example.com");
+    expect(doc).toMatchObject({
+      issuer: "https://hub.example.com",
+      authorization_endpoint: "https://hub.example.com/oauth/authorize",
+      token_endpoint: "https://hub.example.com/api/oauth/token",
+      registration_endpoint: "https://hub.example.com/api/oauth/register",
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      token_endpoint_auth_methods_supported: ["none"],
+      code_challenge_methods_supported: ["S256"],
+    });
+  });
+});
+
+describe("protectedResourceMetadata", () => {
+  it("points at the MCP endpoint with the origin as authorization server", () => {
+    const doc = protectedResourceMetadata("https://hub.example.com");
+    expect(doc).toMatchObject({
+      resource: "https://hub.example.com/api/mcp/mcp",
+      authorization_servers: ["https://hub.example.com"],
+      scopes_supported: ["mcp:read"],
+    });
+  });
+});

--- a/tests/unit/oauth/store.test.ts
+++ b/tests/unit/oauth/store.test.ts
@@ -82,19 +82,17 @@ import {
 const FUTURE = new Date(Date.now() + 86_400_000);
 const PAST = new Date(Date.now() - 86_400_000);
 
+/** Row shape returned by rotateRefreshToken's token+user joined select. */
 function tokenRow(overrides: Record<string, unknown> = {}) {
   return {
     id: 11,
     familyId: "fam-1",
-    refreshTokenHash: "h",
     clientId: 1,
     userId: 42,
     scope: "mcp:read",
-    accessExpiresAt: FUTURE,
     refreshExpiresAt: FUTURE,
     revokedAt: null,
-    lastUsedAt: null,
-    createdAt: PAST,
+    userIsActive: true,
     ...overrides,
   };
 }
@@ -125,7 +123,7 @@ describe("issueTokens", () => {
 
 describe("rotateRefreshToken", () => {
   it("rejects an unknown refresh token", async () => {
-    mockTokensFindFirst.mockResolvedValue(undefined);
+    selectQueue.push([]);
     expect(await rotateRefreshToken("mcp_rt_x", 1)).toEqual({
       ok: false,
       error: "invalid_grant",
@@ -133,12 +131,12 @@ describe("rotateRefreshToken", () => {
   });
 
   it("rejects a token presented by a different client", async () => {
-    mockTokensFindFirst.mockResolvedValue(tokenRow({ clientId: 99 }));
+    selectQueue.push([tokenRow({ clientId: 99 })]);
     expect((await rotateRefreshToken("mcp_rt_x", 1)).ok).toBe(false);
   });
 
   it("revokes the whole family when a revoked token is replayed", async () => {
-    mockTokensFindFirst.mockResolvedValue(tokenRow({ revokedAt: PAST }));
+    selectQueue.push([tokenRow({ revokedAt: PAST })]);
     const result = await rotateRefreshToken("mcp_rt_x", 1);
     expect(result.ok).toBe(false);
     // One revocation update fired (the family), no new tokens inserted.
@@ -147,19 +145,17 @@ describe("rotateRefreshToken", () => {
   });
 
   it("rejects an expired refresh token", async () => {
-    mockTokensFindFirst.mockResolvedValue(tokenRow({ refreshExpiresAt: PAST }));
+    selectQueue.push([tokenRow({ refreshExpiresAt: PAST })]);
     expect((await rotateRefreshToken("mcp_rt_x", 1)).ok).toBe(false);
   });
 
   it("rejects when the user behind the grant is no longer active", async () => {
-    mockTokensFindFirst.mockResolvedValue(tokenRow());
-    mockUsersFindFirst.mockResolvedValue(undefined);
+    selectQueue.push([tokenRow({ userIsActive: false })]);
     expect((await rotateRefreshToken("mcp_rt_x", 1)).ok).toBe(false);
   });
 
   it("rotates within the same family on success", async () => {
-    mockTokensFindFirst.mockResolvedValue(tokenRow());
-    mockUsersFindFirst.mockResolvedValue({ id: 42 });
+    selectQueue.push([tokenRow()]);
 
     const result = await rotateRefreshToken("mcp_rt_x", 1);
     if (!result.ok) throw new Error("expected rotation to succeed");

--- a/tests/unit/oauth/store.test.ts
+++ b/tests/unit/oauth/store.test.ts
@@ -156,6 +156,7 @@ describe("rotateRefreshToken", () => {
 
   it("rotates within the same family on success", async () => {
     selectQueue.push([tokenRow()]);
+    updateReturningQueue.push([{ id: 11 }]); // conditional revoke matched
 
     const result = await rotateRefreshToken("mcp_rt_x", 1);
     if (!result.ok) throw new Error("expected rotation to succeed");
@@ -165,6 +166,18 @@ describe("rotateRefreshToken", () => {
     expect(stored.familyId).toBe("fam-1");
     expect(stored.userId).toBe(42);
     expect(stored.scope).toBe("mcp:read");
+  });
+
+  it("revokes the family when losing a concurrent-rotation race", async () => {
+    selectQueue.push([tokenRow()]);
+    updateReturningQueue.push([]); // conditional revoke matched no rows
+
+    const result = await rotateRefreshToken("mcp_rt_x", 1);
+    expect(result).toEqual({ ok: false, error: "invalid_grant" });
+    // Two updates fired (failed conditional revoke + family revocation),
+    // no successor tokens inserted.
+    expect(updateCalls.length).toBe(2);
+    expect(insertedRows.length).toBe(0);
   });
 });
 

--- a/tests/unit/oauth/store.test.ts
+++ b/tests/unit/oauth/store.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Chainable db mock ────────────────────────────────────────────────────────
+// insert/update/delete/select chains are awaitable at any point; .returning()
+// and terminal awaits consume per-operation queues. db.query.*.findFirst are
+// plain mocks.
+
+const {
+  updateReturningQueue,
+  selectQueue,
+  mockTokensFindFirst,
+  mockClientsFindFirst,
+  mockUsersFindFirst,
+  insertedRows,
+  updateCalls,
+} = vi.hoisted(() => ({
+  updateReturningQueue: [] as unknown[],
+  selectQueue: [] as unknown[],
+  mockTokensFindFirst: vi.fn(),
+  mockClientsFindFirst: vi.fn(),
+  mockUsersFindFirst: vi.fn(),
+  insertedRows: [] as Array<{ table: unknown; values: unknown }>,
+  updateCalls: [] as Array<{ set: unknown }>,
+}));
+
+vi.mock("@/lib/db", () => {
+  const awaitable = (rows: unknown) => ({
+    then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(rows).then(resolve, reject),
+  });
+  return {
+    db: {
+      insert: (table: unknown) => ({
+        values: (values: unknown) => {
+          insertedRows.push({ table, values });
+          return {
+            ...awaitable(undefined),
+            returning: () => Promise.resolve([values]),
+          };
+        },
+      }),
+      update: () => ({
+        set: (set: unknown) => {
+          updateCalls.push({ set });
+          return {
+            where: () => ({
+              ...awaitable(undefined),
+              returning: () =>
+                Promise.resolve(updateReturningQueue.shift() ?? []),
+            }),
+          };
+        },
+      }),
+      delete: () => ({ where: () => awaitable(undefined) }),
+      select: () => {
+        const chain: Record<string, unknown> = {};
+        for (const method of ["from", "innerJoin", "where", "limit", "orderBy"]) {
+          chain[method] = () => chain;
+        }
+        chain.then = (
+          resolve: (v: unknown) => unknown,
+          reject?: (e: unknown) => unknown,
+        ) => Promise.resolve(selectQueue.shift() ?? []).then(resolve, reject);
+        return chain;
+      },
+      query: {
+        mcpOauthTokens: { findFirst: mockTokensFindFirst },
+        mcpOauthClients: { findFirst: mockClientsFindFirst },
+        users: { findFirst: mockUsersFindFirst },
+      },
+    },
+  };
+});
+
+import {
+  issueTokens,
+  rotateRefreshToken,
+  sha256Hex,
+  verifyAccessToken,
+} from "@/lib/oauth/store";
+
+const FUTURE = new Date(Date.now() + 86_400_000);
+const PAST = new Date(Date.now() - 86_400_000);
+
+function tokenRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 11,
+    familyId: "fam-1",
+    refreshTokenHash: "h",
+    clientId: 1,
+    userId: 42,
+    scope: "mcp:read",
+    accessExpiresAt: FUTURE,
+    refreshExpiresAt: FUTURE,
+    revokedAt: null,
+    lastUsedAt: null,
+    createdAt: PAST,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateReturningQueue.length = 0;
+  selectQueue.length = 0;
+  insertedRows.length = 0;
+  updateCalls.length = 0;
+});
+
+describe("issueTokens", () => {
+  it("returns prefixed high-entropy tokens and stores only hashes", async () => {
+    const tokens = await issueTokens({ clientRowId: 1, userId: 42, scope: "mcp:read" });
+
+    expect(tokens.accessToken).toMatch(/^mcp_at_[A-Za-z0-9_-]{43}$/);
+    expect(tokens.refreshToken).toMatch(/^mcp_rt_[A-Za-z0-9_-]{43}$/);
+    expect(tokens.expiresIn).toBe(3600);
+
+    const stored = insertedRows[0].values as Record<string, unknown>;
+    expect(stored.accessTokenHash).toBe(sha256Hex(tokens.accessToken));
+    expect(stored.refreshTokenHash).toBe(sha256Hex(tokens.refreshToken));
+    expect(JSON.stringify(stored)).not.toContain(tokens.accessToken);
+    expect(typeof stored.familyId).toBe("string");
+  });
+});
+
+describe("rotateRefreshToken", () => {
+  it("rejects an unknown refresh token", async () => {
+    mockTokensFindFirst.mockResolvedValue(undefined);
+    expect(await rotateRefreshToken("mcp_rt_x", 1)).toEqual({
+      ok: false,
+      error: "invalid_grant",
+    });
+  });
+
+  it("rejects a token presented by a different client", async () => {
+    mockTokensFindFirst.mockResolvedValue(tokenRow({ clientId: 99 }));
+    expect((await rotateRefreshToken("mcp_rt_x", 1)).ok).toBe(false);
+  });
+
+  it("revokes the whole family when a revoked token is replayed", async () => {
+    mockTokensFindFirst.mockResolvedValue(tokenRow({ revokedAt: PAST }));
+    const result = await rotateRefreshToken("mcp_rt_x", 1);
+    expect(result.ok).toBe(false);
+    // One revocation update fired (the family), no new tokens inserted.
+    expect(updateCalls.length).toBe(1);
+    expect(insertedRows.length).toBe(0);
+  });
+
+  it("rejects an expired refresh token", async () => {
+    mockTokensFindFirst.mockResolvedValue(tokenRow({ refreshExpiresAt: PAST }));
+    expect((await rotateRefreshToken("mcp_rt_x", 1)).ok).toBe(false);
+  });
+
+  it("rejects when the user behind the grant is no longer active", async () => {
+    mockTokensFindFirst.mockResolvedValue(tokenRow());
+    mockUsersFindFirst.mockResolvedValue(undefined);
+    expect((await rotateRefreshToken("mcp_rt_x", 1)).ok).toBe(false);
+  });
+
+  it("rotates within the same family on success", async () => {
+    mockTokensFindFirst.mockResolvedValue(tokenRow());
+    mockUsersFindFirst.mockResolvedValue({ id: 42 });
+
+    const result = await rotateRefreshToken("mcp_rt_x", 1);
+    if (!result.ok) throw new Error("expected rotation to succeed");
+    expect(result.tokens.refreshToken).toMatch(/^mcp_rt_/);
+
+    const stored = insertedRows[0].values as Record<string, unknown>;
+    expect(stored.familyId).toBe("fam-1");
+    expect(stored.userId).toBe(42);
+    expect(stored.scope).toBe("mcp:read");
+  });
+});
+
+describe("verifyAccessToken", () => {
+  it("returns null for an unknown token", async () => {
+    selectQueue.push([]);
+    expect(await verifyAccessToken("mcp_at_x")).toBeNull();
+  });
+
+  it("maps a live token row to the verified identity", async () => {
+    selectQueue.push([
+      {
+        tokenId: 11,
+        userId: 42,
+        scope: "mcp:read",
+        lastUsedAt: new Date(),
+        email: "jane@example.com",
+        name: "Jane",
+        clientPublicId: "mcp_client_abc",
+      },
+    ]);
+    expect(await verifyAccessToken("mcp_at_x")).toEqual({
+      userId: 42,
+      email: "jane@example.com",
+      name: "Jane",
+      clientPublicId: "mcp_client_abc",
+      scope: "mcp:read",
+    });
+  });
+});

--- a/tests/unit/oauth/validate.test.ts
+++ b/tests/unit/oauth/validate.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+
+import {
+  clientRegistrationSchema,
+  isAllowedRedirectUri,
+  pkceChallengeFromVerifier,
+  redirectUriMatches,
+  validateRequestedScope,
+  verifyPkce,
+  MCP_SCOPE,
+} from "@/lib/oauth/validate";
+
+describe("isAllowedRedirectUri", () => {
+  it("allows https URIs", () => {
+    expect(isAllowedRedirectUri("https://claude.ai/api/mcp/auth_callback")).toBe(true);
+  });
+
+  it("allows http only on loopback hosts", () => {
+    expect(isAllowedRedirectUri("http://localhost:53682/callback")).toBe(true);
+    expect(isAllowedRedirectUri("http://127.0.0.1:8080/callback")).toBe(true);
+    expect(isAllowedRedirectUri("http://[::1]:8080/callback")).toBe(true);
+    expect(isAllowedRedirectUri("http://example.com/callback")).toBe(false);
+    expect(isAllowedRedirectUri("http://192.168.1.10/callback")).toBe(false);
+  });
+
+  it("rejects fragments, credentials, custom schemes, and garbage", () => {
+    expect(isAllowedRedirectUri("https://a.com/cb#frag")).toBe(false);
+    expect(isAllowedRedirectUri("https://user:pw@a.com/cb")).toBe(false);
+    expect(isAllowedRedirectUri("myapp://callback")).toBe(false);
+    expect(isAllowedRedirectUri("javascript:alert(1)")).toBe(false);
+    expect(isAllowedRedirectUri("not a uri")).toBe(false);
+  });
+});
+
+describe("redirectUriMatches", () => {
+  it("matches exact strings", () => {
+    expect(
+      redirectUriMatches(
+        "https://claude.ai/api/mcp/auth_callback",
+        "https://claude.ai/api/mcp/auth_callback",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects any https mismatch (no port relaxation)", () => {
+    expect(
+      redirectUriMatches("https://a.com/cb", "https://a.com:8443/cb"),
+    ).toBe(false);
+    expect(redirectUriMatches("https://a.com/cb", "https://a.com/cb2")).toBe(false);
+  });
+
+  it("ignores the port for http loopback URIs (RFC 8252 §7.3)", () => {
+    expect(
+      redirectUriMatches("http://localhost/callback", "http://localhost:53682/callback"),
+    ).toBe(true);
+    expect(
+      redirectUriMatches("http://127.0.0.1:1234/callback", "http://127.0.0.1:9999/callback"),
+    ).toBe(true);
+  });
+
+  it("does not relax host, path, or query for loopback URIs", () => {
+    expect(
+      redirectUriMatches("http://localhost/callback", "http://127.0.0.1/callback"),
+    ).toBe(false);
+    expect(
+      redirectUriMatches("http://localhost/callback", "http://localhost/other"),
+    ).toBe(false);
+    expect(
+      redirectUriMatches("http://localhost/cb?a=1", "http://localhost/cb?a=2"),
+    ).toBe(false);
+  });
+});
+
+describe("PKCE", () => {
+  const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+
+  it("computes the S256 challenge as base64url(sha256(verifier))", () => {
+    const expected = createHash("sha256").update(verifier, "ascii").digest("base64url");
+    expect(pkceChallengeFromVerifier(verifier)).toBe(expected);
+  });
+
+  it("verifies a correct verifier and rejects a wrong one", () => {
+    const challenge = pkceChallengeFromVerifier(verifier);
+    expect(verifyPkce(verifier, challenge)).toBe(true);
+    expect(verifyPkce(`${verifier.slice(0, -1)}x`, challenge)).toBe(false);
+  });
+
+  it("rejects verifiers outside the RFC 7636 alphabet/length", () => {
+    expect(verifyPkce("too-short", pkceChallengeFromVerifier("too-short"))).toBe(false);
+    const invalid = "!".repeat(50);
+    expect(verifyPkce(invalid, pkceChallengeFromVerifier(invalid))).toBe(false);
+  });
+});
+
+describe("validateRequestedScope", () => {
+  it("defaults to mcp:read when absent", () => {
+    expect(validateRequestedScope(undefined)).toEqual({ ok: true, granted: MCP_SCOPE });
+    expect(validateRequestedScope("")).toEqual({ ok: true, granted: MCP_SCOPE });
+  });
+
+  it("accepts mcp:read and tolerates offline_access", () => {
+    expect(validateRequestedScope("mcp:read")).toEqual({ ok: true, granted: MCP_SCOPE });
+    expect(validateRequestedScope("mcp:read offline_access").ok).toBe(true);
+  });
+
+  it("rejects unknown scopes", () => {
+    expect(validateRequestedScope("admin:write").ok).toBe(false);
+  });
+});
+
+describe("clientRegistrationSchema", () => {
+  it("accepts minimal valid metadata", () => {
+    const result = clientRegistrationSchema.safeParse({
+      client_name: "Claude",
+      redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("requires at least one redirect URI", () => {
+    expect(
+      clientRegistrationSchema.safeParse({ redirect_uris: [] }).success,
+    ).toBe(false);
+    expect(clientRegistrationSchema.safeParse({}).success).toBe(false);
+  });
+});

--- a/tests/unit/oauth/validate.test.ts
+++ b/tests/unit/oauth/validate.test.ts
@@ -4,11 +4,10 @@ import { createHash } from "node:crypto";
 import {
   clientRegistrationSchema,
   isAllowedRedirectUri,
+  isValidScopeRequest,
   pkceChallengeFromVerifier,
   redirectUriMatches,
-  validateRequestedScope,
   verifyPkce,
-  MCP_SCOPE,
 } from "@/lib/oauth/validate";
 
 describe("isAllowedRedirectUri", () => {
@@ -93,19 +92,19 @@ describe("PKCE", () => {
   });
 });
 
-describe("validateRequestedScope", () => {
-  it("defaults to mcp:read when absent", () => {
-    expect(validateRequestedScope(undefined)).toEqual({ ok: true, granted: MCP_SCOPE });
-    expect(validateRequestedScope("")).toEqual({ ok: true, granted: MCP_SCOPE });
+describe("isValidScopeRequest", () => {
+  it("accepts an absent or empty scope", () => {
+    expect(isValidScopeRequest(undefined)).toBe(true);
+    expect(isValidScopeRequest("")).toBe(true);
   });
 
   it("accepts mcp:read and tolerates offline_access", () => {
-    expect(validateRequestedScope("mcp:read")).toEqual({ ok: true, granted: MCP_SCOPE });
-    expect(validateRequestedScope("mcp:read offline_access").ok).toBe(true);
+    expect(isValidScopeRequest("mcp:read")).toBe(true);
+    expect(isValidScopeRequest("mcp:read offline_access")).toBe(true);
   });
 
   it("rejects unknown scopes", () => {
-    expect(validateRequestedScope("admin:write").ok).toBe(false);
+    expect(isValidScopeRequest("admin:write")).toBe(false);
   });
 });
 

--- a/tests/unit/oauth/validate.test.ts
+++ b/tests/unit/oauth/validate.test.ts
@@ -23,11 +23,12 @@ describe("isAllowedRedirectUri", () => {
     expect(isAllowedRedirectUri("http://192.168.1.10/callback")).toBe(false);
   });
 
-  it("rejects fragments, credentials, custom schemes, and garbage", () => {
+  it("rejects fragments, credentials, custom schemes, empty hosts, and garbage", () => {
     expect(isAllowedRedirectUri("https://a.com/cb#frag")).toBe(false);
     expect(isAllowedRedirectUri("https://user:pw@a.com/cb")).toBe(false);
     expect(isAllowedRedirectUri("myapp://callback")).toBe(false);
     expect(isAllowedRedirectUri("javascript:alert(1)")).toBe(false);
+    expect(isAllowedRedirectUri("file:///etc/passwd")).toBe(false);
     expect(isAllowedRedirectUri("not a uri")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Two upgrades to the MCP server shipped in spec 034 (#112):

**1. OAuth 2.1 connectivity — add the Hub to Claude Desktop / claude.ai / Claude Code**

The app now embeds a minimal OAuth 2.1 authorization server, so it can be added as a custom connector with zero pre-provisioning:

- RFC 7591 dynamic client registration (`POST /api/oauth/register`, rate-limited, public clients only)
- RFC 8414 / RFC 9728 discovery documents under `/.well-known/` (origin derived per-request, so previews work)
- `GET /oauth/authorize` consent screen behind the normal NextAuth login (bare layout, agent accounts refused)
- `POST /api/oauth/token` with mandatory PKCE S256 and rotating refresh tokens (replaying a rotated token revokes the whole family, RFC 9700 §4.14)
- Loopback redirect URIs are port-agnostic per RFC 8252 §7.3 (Claude Code uses ephemeral ports)
- Tokens stored as SHA-256 hashes only; access 1 h / refresh 60 d; verification joins `users.status = 'active'` so deactivating a user kills their access instantly
- New **Settings → Connections** page lists a user''s grants with revoke
- The shared `MCP_SERVER_SECRET` path is unchanged for headless clients

**2. Seven new read-only tools + improvements**

`find_users`, `list_claude_users`, `get_claude_cost_dashboard`, `get_budget_report`, `list_license_assignments`, `list_invoices`, `get_copilot_analytics`. `list_ai_tools` gains license counts/utilization, `get_user_cost_profile` suggests near-matches on email miss, and every tool now carries `annotations.readOnlyHint`.

## Data model

Migration `0025_colorful_vector.sql` adds `mcp_oauth_clients`, `mcp_oauth_codes`, `mcp_oauth_tokens`. **Not applied to any DB from my machine** — apply via the normal deploy pipeline.

## Spec artifacts

`specs/038-mcp-v2/` contains the brainstorm report, the (self-challenged) implementation plan, and `implementation-notes.html` documenting design decisions, deviations, tradeoffs, and open questions — notably: consent is always shown (no silent re-approve), tool queries are deliberately MCP-shaped rather than lifted from admin actions, and viewer-role tokens currently see the same org-wide read-only data as admins (matching spec 034''s shared-secret model; flagged for confirmation).

## Testing

- 539 unit tests pass (≈60 new: OAuth validation/PKCE/redirect-URI policy, token rotation + reuse detection, authorize-request validation, metadata docs, all new data functions, readOnlyHint inventory)
- `pnpm lint`, `pnpm typecheck`, `pnpm build` clean
- `/simplify` review pass applied (4 parallel reviewers; findings folded into the second commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)