### PR TITLE
docs(api-subscription): note monthly vs yearly seat pricing in top box

### DIFF
--- a/src/app/scenarios/api-subscription/api-subscription-client.tsx
+++ b/src/app/scenarios/api-subscription/api-subscription-client.tsx
@@ -361,6 +361,16 @@ export function ApiSubscriptionClient({
             </button>
           </div>
 
+          {/* Pricing reference — the seat fields default to monthly list
+              pricing; billed yearly each seat is cheaper. */}
+          <p className="mb-4 max-w-2xl text-xs leading-relaxed text-muted-foreground">
+            Seat prices are per seat, per month. The fields default to monthly
+            list pricing — <span className="text-ink">$25</span> Standard ·{" "}
+            <span className="text-ink">$125</span> Premium. Billed yearly, seats
+            are cheaper: <span className="text-ink">$20</span> Standard ·{" "}
+            <span className="text-ink">$100</span> Premium.
+          </p>
+
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             <PriceField
               id="std-price"


### PR DESCRIPTION
## What

Adds a short pricing reference to the **Assumptions** panel (the top box) of the **API → Subscription Migration** scenario (`/scenarios/api-subscription`).

The two seat price fields default to **monthly** list pricing pulled from `access_tiers` ($25 Standard / $125 Premium), but nothing on the page tells you that, or that billing yearly is cheaper. The note makes the defaults self-explanatory:

> Seat prices are per seat, per month. The fields default to monthly list pricing — **$25** Standard · **$125** Premium. Billed yearly, seats are cheaper: **$20** Standard · **$100** Premium.

## Scope

- UI copy only — one `<p>` added between the panel header and the controls grid.
- No engine, query, schema, or default-value changes; the price inputs still initialise from `dataset.defaultStandardCents` / `defaultPremiumCents` as before.

## Verification

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (623 passed)
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)