### PR TITLE
feat(041): saved forecast scenarios — persist, load, rename, delete named parameter sets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ pnpm lighthouse        # Lighthouse CI
 - Server Components by default — `"use client"` only when client interactivity needed
 
 ## Recent Changes
+- 041-forecast-scenario-persistence: Saved Forecast Scenarios — persist named `ForecastInputs` parameter sets for the Budget / Cost Forecast Simulation (new `forecast_scenarios` table, migration 0026; CRUD server actions with audit snapshots; save/load/rename/delete UI with StatusText feedback); scenarios are shared per active budget and re-projected against live data on load
 - 040-h2-forecast-presets: Replaced the Budget / Cost Forecast presets with three H2 2026 migration scenarios (Console API fade-out, Claude seat ramp at 35–40% Premium) and added a Monthly/Yearly Claude billing toggle (yearly = 20% off the live tier prices); engine + client + unit tests only, no schema/loader changes
 - 039-mcp-role-scoping: Added TypeScript 5.9.3 (strict mode), Node.js LTS + Next.js 15.5.12 (App Router), `mcp-handler` 1.1.0, `@modelcontextprotocol/sdk` (via mcp-handler), Drizzle ORM 0.45.1, Zod 4.3.6
 - 036-budget-forecast-simulation: Added the Budget / Cost Forecast Simulation scenario (`/scenarios/budget-forecast`) — a pure projection engine + Recharts burn-up UI (Nothing design), read-only over existing budget/cost tables

--- a/specs/041-forecast-scenario-persistence/implementation-notes.html
+++ b/specs/041-forecast-scenario-persistence/implementation-notes.html
@@ -552,6 +552,46 @@
       </div>
 
       <!-- ========================================================= -->
+      <h2>Review pass <span class="ts">(PR #122 — single cycle)</span></h2>
+
+      <div class="entry to">
+        <h3>GitHub Copilot Code Review — 4 inline comments, 3 fixed, 1 refuted with docs <span class="tag to">copilot</span></h3>
+        <ul>
+          <li>
+            <b>Tie-break inconsistency in <code>budget-utils.ts</code> (2
+            comments — both legitimate):</b> <code>findActivePeriodForDate</code>
+            and <code>findPeriodForDate</code> still broke ties between
+            multiple active budgets by <code>createdAt</code>, while this PR's
+            new contract is "highest fiscal year wins". <b>Fixed</b>: both now
+            order by <code>fiscal_year DESC</code>, matching
+            <code>getActiveBudgetId()</code>.
+          </li>
+          <li>
+            <b>Integration FY collision window:</b> the 999-value random range
+            on a unique column could flake on parallel/retried runs.
+            <b>Fixed</b>: widened to 900k values (999,000–1,898,999), still
+            strictly above every other suite's range.
+          </li>
+          <li>
+            <b><code>startTransition(async …)</code> / <code>isPending</code>
+            concern — refuted for React 19, half-adopted anyway:</b> per the
+            current React docs, <code>isPending</code> "switches to true at the
+            first call to startTransition, and stays true until all Actions
+            complete", so the disabled buttons cover the whole server round
+            trip and double-submission cannot occur (and the identical pattern
+            is the house precedent in <code>ingestion-filters-section.tsx</code>).
+            The documented React 19 caveat about post-<code>await</code> state
+            updates is real, so those are now wrapped in an inner
+            <code>startTransition</code> per the docs' recommended shape.
+          </li>
+        </ul>
+        <p>
+          All suites re-run green after the fixes (648 unit · 36 integration ·
+          typecheck · lint). Replies posted in-thread on each comment.
+        </p>
+      </div>
+
+      <!-- ========================================================= -->
       <h2>Open questions <span class="ts">(for review)</span></h2>
 
       <div class="entry oq">

--- a/specs/041-forecast-scenario-persistence/implementation-notes.html
+++ b/specs/041-forecast-scenario-persistence/implementation-notes.html
@@ -478,6 +478,80 @@
       </div>
 
       <!-- ========================================================= -->
+      <h2>Simplify pass <span class="ts">(4 parallel cleanup reviews → fixes applied)</span></h2>
+
+      <div class="entry to">
+        <h3>7 fixes applied — one exposed a real latent bug — 4 findings deliberately skipped <span class="tag to">post-implementation</span></h3>
+        <ul>
+          <li>
+            <b>Applied — and it caught a bug:</b> the case-insensitive
+            <code>nameTaken</code> pre-check was redundant with the
+            unique-index catch (both produced the identical friendly error), so
+            it was deleted (~30 lines + one Neon round trip per save/rename;
+            the index permits same-row case-variant renames naturally).
+            Removing it made the integration suite exercise the catch path for
+            the first time — which <b>failed</b>: drizzle 0.45 wraps driver
+            errors (<code>DrizzleQueryError</code> with the Postgres error on
+            <code>.cause</code>), so the top-level <code>code === "23505"</code>
+            check never matched. The detector now walks the cause chain, and
+            both the integration test and a live-browser probe confirm the
+            duplicate error renders. The pre-check had been silently masking
+            this the whole time.
+          </li>
+          <li>
+            <b>Applied:</b> the bespoke <code>resolveActiveBudgetId</code> was
+            one of two competing definitions of "the active budget" on the same
+            page (<code>getActiveBudget()</code> in <code>budget.ts</code> is
+            an unordered <code>findFirst</code> that could disagree under the
+            multi-active state). The deterministic rule (highest fiscal year
+            wins) now lives once in <code>lib/budget-utils.ts</code> as
+            <code>getActiveBudgetId()</code>, and <code>getActiveBudget()</code>
+            gained the same ordering — the chart and the scenario list can no
+            longer resolve different budgets.
+          </li>
+          <li>
+            <b>Applied:</b> the hand-rolled delete-snapshot audit insert was
+            the third copy of the <code>deleteBilledCost</code> pattern —
+            extracted as <code>recordDeletion()</code> in
+            <code>actions/history.ts</code> beside
+            <code>recordCreation</code>/<code>recordUpdate</code> (this feature
+            migrates; the two legacy sites are a follow-up). The delete also
+            folds its fetch into <code>delete().returning()</code> — one fewer
+            round trip and no fetch/delete TOCTOU window.
+          </li>
+          <li>
+            <b>Applied:</b> three per-dialog <code>useInlineStatus</code>
+            instances collapsed to one shared <code>dialogStatus</code> (the
+            dialogs are mutually exclusive; each opener already clears);
+            <code>renameTarget</code>/<code>deleteTarget</code> hold the whole
+            <code>SavedForecastScenario</code> instead of re-picked field
+            subsets; dead validator exports removed; a <b>key-set equality</b>
+            type assertion added beside the assignability round trip —
+            assignability alone cannot catch a forgotten <i>optional</i> lever
+            (exactly how <code>billing</code> arrived in 040), key-set equality
+            fails <code>pnpm typecheck</code> if <code>ToolParams</code> gains
+            a field the schema doesn't know.
+          </li>
+          <li>
+            <b>Skipped:</b> folding the active-budget subquery into the list
+            select (saves one ~30 ms round trip on an admin page at the cost of
+            raw-SQL readability); removing the
+            <code>revalidatePath</code>+<code>router.refresh()</code> double
+            refresh (matches the established house pattern, e.g.
+            budget-detail); a shared <code>validationFailure()</code> helper
+            for the <code>fieldErrors</code> boilerplate (16 copies codebase-
+            wide — a repo-wide cleanup, not a 041 obligation); migrating the
+            two legacy delete-audit sites to <code>recordDeletion</code> (out
+            of this PR's scope, noted as follow-up).
+          </li>
+          <li>
+            All suites re-run green after the pass: 648 unit · 36 integration ·
+            typecheck · lint clean · browser probe of the now-live catch path.
+          </li>
+        </ul>
+      </div>
+
+      <!-- ========================================================= -->
       <h2>Open questions <span class="ts">(for review)</span></h2>
 
       <div class="entry oq">
@@ -524,14 +598,82 @@
       </div>
 
       <!-- ========================================================= -->
+      <h2>Migration review <span class="ts">(drizzle-migration-reviewer agent)</span></h2>
+
+      <div class="entry to">
+        <h3>One change requested, applied before the migration was committed <span class="tag to">schema</span></h3>
+        <p>
+          The reviewer verified the migration is purely additive, the FK
+          semantics match siblings, the expression unique index emits correct
+          SQL with <code>"isExpression": true</code> in the snapshot (so future
+          generates round-trip it), the journal/snapshot chain is intact, and
+          the type-only import creates no runtime cycle. <b>One blocking item:</b>
+          <code>created_by</code> had no index on the referencing column (the
+          repo's FK-index rule; sibling precedent was split). Fixed by
+          regenerating migration 0026 with
+          <code>forecast_scenarios_created_by_idx</code> while it was still
+          uncommitted. The reviewer also flagged the <code>db:push</code>
+          blind spot for expression indexes — this table must go through
+          <code>generate</code>/<code>migrate</code>, noted in the plan.
+        </p>
+      </div>
+
+      <!-- ========================================================= -->
       <h2>Verification <span class="ts">(what was checked)</span></h2>
 
       <div class="entry to">
-        <h3>Status <span class="tag to">pending</span></h3>
-        <p>
-          To be filled as implementation proceeds: unit suite, integration round
-          trip, lint/typecheck, Playwright browser pass, migration review.
-        </p>
+        <h3>Status <span class="tag to">green</span></h3>
+        <ul>
+          <li>
+            <b>Unit tests</b>: 648/648 pass (<code>pnpm test</code>; 623 before
+            this feature, 25 new) — <code>inputsFromSaved</code> merge matrix
+            incl. the yearly-billing round-trip and the stranded-billing
+            cost-neutrality proof; the validator accept/reject/strip matrix +
+            the type-level round trip (enforced via <code>pnpm typecheck</code>);
+            auth gating (list → <code>[]</code>, mutations →
+            <code>Unauthorized</code>, DB untouched).
+          </li>
+          <li>
+            <b>Integration</b> (real Neon dev DB): 11/11 — create lands on the
+            seeded budget under the deterministic resolution contract;
+            audit rows asserted for created/updated (incl. full params
+            snapshots) and the delete previousValue round trip; rename-only
+            leaves params untouched; case-insensitive duplicate rejected via
+            the action <i>and</i> via a direct insert (the expression index
+            itself fires); a deliberately-malformed jsonb row is skipped by the
+            read path; the 50-cap error (bulk-seeded, one action call). First
+            full-suite run exposed a real isolation bug: <code>invoice-sync</code>
+            seeds active budgets at FY ≈ 20k–30k, above the plan's FY 3000 —
+            the suite now seeds FY ≥ 999,000 and documents that it must own the
+            highest fiscal year in the run.
+          </li>
+          <li><b>Lint</b>: source clean, zero warnings. <b>Typecheck</b>: clean.</li>
+          <li>
+            <b>Browser (Playwright, dev server + minted agent session, live
+            data)</b>: 27/27 checks — persistent card with mono empty state;
+            save dialog echoes <code>CEILING $50,000 · CLAUDE BILLING YEARLY ·
+            5 OF 5 TOOLS INCLUDED</code>; saved row shows recomputed year-end,
+            &ldquo;+$44,538 vs saved $50,000&rdquo;, and the
+            <code>Nighthawk Agent · 2026-06-12</code> caption; reset → load
+            restores the $50,000 ceiling, the yearly cadence, and presses the
+            row; the &ldquo;Your plan&rdquo; comparison row takes the active
+            ink-bar; control edits flip to Custom but keep the
+            <code>Update &ldquo;name&rdquo;</code> offer; a preset tile click
+            clears it; rename-only leaves the stored ceiling intact on reload;
+            case-variant duplicate shows the inline dialog error; delete
+            confirm names scenario + creator; deleting the last row restores
+            the empty state. Full-page screenshots reviewed. (Two initial
+            script failures were probe races — a non-waiting visibility check
+            caught the dialog mid-<code>SAVING…</code> — re-probed green.)
+          </li>
+          <li>
+            <b>Process note</b>: <code>pnpm format</code> repo-wide fails on
+            pre-existing malformed HTML in old spec folders (030, 038) and
+            reformats ~800 files of pre-existing drift — deliberately not
+            applied beyond this feature's files (which the format-on-edit hook
+            already keeps canonical).
+          </li>
+        </ul>
       </div>
 
       <footer>

--- a/specs/041-forecast-scenario-persistence/implementation-notes.html
+++ b/specs/041-forecast-scenario-persistence/implementation-notes.html
@@ -1,242 +1,543 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Implementation Notes — Saved Forecast Scenarios (041)</title>
-  <style>
-    :root {
-      --bg:#0b0d12; --bg-elev:#11141b; --bg-card:#161a24; --border:#232938; --border-strong:#2f3850;
-      --fg:#e7ebf3; --fg-muted:#9aa3b5; --fg-dim:#6b7488;
-      --accent:#f0a072; --accent-2:#7dd3fc; --good:#86efac; --warn:#fcd34d; --bad:#fca5a5;
-      --mono: ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
-      --sans: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
-    }
-    * { box-sizing:border-box; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--fg); font-family:var(--sans); line-height:1.55; }
-    body { padding:48px 24px 96px; }
-    main { max-width:1000px; margin:0 auto; }
-    h1 { font-size:30px; margin:0 0 6px; letter-spacing:-0.01em; }
-    h2 { font-size:20px; margin:44px 0 4px; padding-bottom:8px; border-bottom:1px solid var(--border); }
-    h3 { font-size:15px; margin:22px 0 4px; }
-    p { margin:0 0 10px; }
-    a { color:var(--accent); }
-    code { font-family:var(--mono); font-size:0.88em; background:var(--bg-elev); padding:1px 5px; border-radius:4px; border:1px solid var(--border); }
-    .lede { color:var(--fg-muted); font-size:15.5px; max-width:80ch; }
-    .meta { color:var(--fg-dim); font-size:13px; margin-top:8px; font-family:var(--mono); }
-    .badge { display:inline-block; font-size:11px; font-family:var(--mono); padding:2px 8px; border-radius:999px; border:1px solid var(--border-strong); color:var(--fg-muted); background:var(--bg-elev); }
-    .entry { background:var(--bg-card); border:1px solid var(--border); border-radius:10px; padding:18px 20px; margin:14px 0; }
-    .entry.dd { border-left:3px solid var(--accent-2); }
-    .entry.dev { border-left:3px solid var(--warn); }
-    .entry.to { border-left:3px solid var(--accent); }
-    .entry.oq { border-left:3px solid var(--bad); }
-    .entry h3 { margin-top:0; }
-    .tag { font-family:var(--mono); font-size:10px; text-transform:uppercase; letter-spacing:0.1em; padding:2px 7px; border-radius:3px; vertical-align:middle; margin-left:8px; }
-    .tag.dd { color:var(--accent-2); border:1px solid rgba(125,211,252,0.3); }
-    .tag.dev { color:var(--warn); border:1px solid rgba(252,211,77,0.3); }
-    .tag.to { color:var(--accent); border:1px solid rgba(240,160,114,0.3); }
-    .tag.oq { color:var(--bad); border:1px solid rgba(252,165,165,0.3); }
-    .entry p { font-size:13.5px; color:var(--fg-muted); }
-    .entry b { color:var(--fg); }
-    ul { padding-left:20px; margin:6px 0 10px; } li { margin:3px 0; font-size:13.5px; color:var(--fg-muted); }
-    .ts { font-family:var(--mono); font-size:11px; color:var(--fg-dim); }
-    footer { color:var(--fg-dim); font-size:12.5px; margin-top:56px; padding-top:20px; border-top:1px solid var(--border); font-family:var(--mono); }
-  </style>
-</head>
-<body>
-<main>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Implementation Notes — Saved Forecast Scenarios (041)</title>
+    <style>
+      :root {
+        --bg: #0b0d12;
+        --bg-elev: #11141b;
+        --bg-card: #161a24;
+        --border: #232938;
+        --border-strong: #2f3850;
+        --fg: #e7ebf3;
+        --fg-muted: #9aa3b5;
+        --fg-dim: #6b7488;
+        --accent: #f0a072;
+        --accent-2: #7dd3fc;
+        --good: #86efac;
+        --warn: #fcd34d;
+        --bad: #fca5a5;
+        --mono:
+          ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+        --sans:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--sans);
+        line-height: 1.55;
+      }
+      body {
+        padding: 48px 24px 96px;
+      }
+      main {
+        max-width: 1000px;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 30px;
+        margin: 0 0 6px;
+        letter-spacing: -0.01em;
+      }
+      h2 {
+        font-size: 20px;
+        margin: 44px 0 4px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border);
+      }
+      h3 {
+        font-size: 15px;
+        margin: 22px 0 4px;
+      }
+      p {
+        margin: 0 0 10px;
+      }
+      a {
+        color: var(--accent);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.88em;
+        background: var(--bg-elev);
+        padding: 1px 5px;
+        border-radius: 4px;
+        border: 1px solid var(--border);
+      }
+      .lede {
+        color: var(--fg-muted);
+        font-size: 15.5px;
+        max-width: 80ch;
+      }
+      .meta {
+        color: var(--fg-dim);
+        font-size: 13px;
+        margin-top: 8px;
+        font-family: var(--mono);
+      }
+      .badge {
+        display: inline-block;
+        font-size: 11px;
+        font-family: var(--mono);
+        padding: 2px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--border-strong);
+        color: var(--fg-muted);
+        background: var(--bg-elev);
+      }
+      .entry {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 18px 20px;
+        margin: 14px 0;
+      }
+      .entry.dd {
+        border-left: 3px solid var(--accent-2);
+      }
+      .entry.dev {
+        border-left: 3px solid var(--warn);
+      }
+      .entry.to {
+        border-left: 3px solid var(--accent);
+      }
+      .entry.oq {
+        border-left: 3px solid var(--bad);
+      }
+      .entry h3 {
+        margin-top: 0;
+      }
+      .tag {
+        font-family: var(--mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        padding: 2px 7px;
+        border-radius: 3px;
+        vertical-align: middle;
+        margin-left: 8px;
+      }
+      .tag.dd {
+        color: var(--accent-2);
+        border: 1px solid rgba(125, 211, 252, 0.3);
+      }
+      .tag.dev {
+        color: var(--warn);
+        border: 1px solid rgba(252, 211, 77, 0.3);
+      }
+      .tag.to {
+        color: var(--accent);
+        border: 1px solid rgba(240, 160, 114, 0.3);
+      }
+      .tag.oq {
+        color: var(--bad);
+        border: 1px solid rgba(252, 165, 165, 0.3);
+      }
+      .entry p {
+        font-size: 13.5px;
+        color: var(--fg-muted);
+      }
+      .entry b {
+        color: var(--fg);
+      }
+      ul {
+        padding-left: 20px;
+        margin: 6px 0 10px;
+      }
+      li {
+        margin: 3px 0;
+        font-size: 13.5px;
+        color: var(--fg-muted);
+      }
+      .ts {
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--fg-dim);
+      }
+      footer {
+        color: var(--fg-dim);
+        font-size: 12.5px;
+        margin-top: 56px;
+        padding-top: 20px;
+        border-top: 1px solid var(--border);
+        font-family: var(--mono);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div style="margin-bottom: 14px">
+          <span class="badge">Implementation notes</span>
+          <span class="badge">spec/041-forecast-scenario-persistence</span>
+          <span class="badge">running log</span>
+        </div>
+        <h1>Implementation notes — Saved Forecast Scenarios</h1>
+        <p class="lede">
+          A running record of where the build diverges from or interprets the
+          request: design decisions on ambiguous points, intentional deviations,
+          tradeoffs considered, and open questions for review. Entries are
+          appended as work proceeds.
+        </p>
+        <p class="meta">
+          Started 2026-06-12 · branch
+          <code>041-forecast-scenario-persistence</code> · companion:
+          <a href="./implementation-plan.html">implementation-plan.html</a>
+        </p>
+      </header>
 
-<header>
-  <div style="margin-bottom:14px"><span class="badge">Implementation notes</span> <span class="badge">spec/041-forecast-scenario-persistence</span> <span class="badge">running log</span></div>
-  <h1>Implementation notes — Saved Forecast Scenarios</h1>
-  <p class="lede">A running record of where the build diverges from or interprets the request: design decisions on ambiguous points, intentional deviations, tradeoffs considered, and open questions for review. Entries are appended as work proceeds.</p>
-  <p class="meta">Started 2026-06-12 · branch <code>041-forecast-scenario-persistence</code> · companion: <a href="./implementation-plan.html">implementation-plan.html</a></p>
-</header>
+      <!-- ========================================================= -->
+      <h2>
+        Design decisions <span class="ts">(ambiguous spots, choices made)</span>
+      </h2>
 
-<!-- ========================================================= -->
-<h2>Design decisions <span class="ts">(ambiguous spots, choices made)</span></h2>
+      <div class="entry dd">
+        <h3>
+          "Persistence of scenarios" → shared, budget-scoped, named parameter
+          sets <span class="tag dd">interpretation</span>
+        </h3>
+        <p>
+          The request says only "implement the persistence of scenarios". Three
+          readings were possible: (a) persist the user's
+          <i>current working state</i> (auto-save, like a draft), (b) per-user
+          private saved scenarios, (c) shared named scenarios.
+          <b>Decision: (c)</b> — it is what spec 036 explicitly deferred ("Save
+          &amp; name scenarios — needs a <code>forecast_scenarios</code> table
+          (JSON params + label + budget_id)"), and the calculator is a
+          team-alignment tool for admins: a saved plan everyone can open beats a
+          private draft. <code>created_by</code> records attribution.
+          Auto-saving working state (a) was rejected as silent magic; explicit
+          save/load matches the rest of the app.
+        </p>
+      </div>
 
-<div class="entry dd">
-  <h3>"Persistence of scenarios" → shared, budget-scoped, named parameter sets <span class="tag dd">interpretation</span></h3>
-  <p>The request says only "implement the persistence of scenarios". Three readings were possible: (a) persist the
-    user's <i>current working state</i> (auto-save, like a draft), (b) per-user private saved scenarios, (c) shared
-    named scenarios. <b>Decision: (c)</b> — it is what spec 036 explicitly deferred ("Save &amp; name scenarios —
-    needs a <code>forecast_scenarios</code> table (JSON params + label + budget_id)"), and the calculator is a
-    team-alignment tool for admins: a saved plan everyone can open beats a private draft. <code>created_by</code>
-    records attribution. Auto-saving working state (a) was rejected as silent magic; explicit save/load matches the
-    rest of the app.</p>
-</div>
+      <div class="entry dd">
+        <h3>
+          Assumptions are stored, results are recomputed
+          <span class="tag dd">semantics</span>
+        </h3>
+        <p>
+          A saved scenario stores the <code>ForecastInputs</code> parameter set
+          (edited ceiling + per-tool levers incl. billing cadence) — never
+          year-end figures. On load, params are re-based onto the current
+          dataset (<code>inputsFromSaved</code>: extinct tool keys dropped, new
+          tools defaulted) and re-projected against live data, exactly like a
+          preset. The saved-list rows show <i>recomputed</i> year-end / Δ so the
+          list answers "what would this plan mean today", not "what did it mean
+          when saved".
+        </p>
+      </div>
 
-<div class="entry dd">
-  <h3>Assumptions are stored, results are recomputed <span class="tag dd">semantics</span></h3>
-  <p>A saved scenario stores the <code>ForecastInputs</code> parameter set (edited ceiling + per-tool levers incl.
-    billing cadence) — never year-end figures. On load, params are re-based onto the current dataset
-    (<code>inputsFromSaved</code>: extinct tool keys dropped, new tools defaulted) and re-projected against live
-    data, exactly like a preset. The saved-list rows show <i>recomputed</i> year-end / Δ so the list answers
-    "what would this plan mean today", not "what did it mean when saved".</p>
-</div>
+      <div class="entry dd">
+        <h3>
+          Load restores the saved ceiling; preset tiles keep resetting it
+          <span class="tag dd">ux</span>
+        </h3>
+        <p>
+          040 established a deliberate asymmetry: clicking a preset tile resets
+          the edited ceiling to the live one but keeps the billing cadence.
+          Saved scenarios get the opposite:
+          <b
+            >loading restores the full assumption set, including the saved
+            ceiling and cadence</b
+          >
+          — the user saved a complete what-if and expects it back verbatim. The
+          two affordances answer different questions ("this preset against the
+          live budget" vs "this plan as I tuned it"), so the asymmetry is
+          intentional, not accidental. Saved rows are likewise scored against
+          <b>their own saved ceiling</b>, not the page's transient edited one.
+        </p>
+      </div>
 
-<div class="entry dd">
-  <h3>Load restores the saved ceiling; preset tiles keep resetting it <span class="tag dd">ux</span></h3>
-  <p>040 established a deliberate asymmetry: clicking a preset tile resets the edited ceiling to the live one but
-    keeps the billing cadence. Saved scenarios get the opposite: <b>loading restores the full assumption set,
-    including the saved ceiling and cadence</b> — the user saved a complete what-if and expects it back verbatim.
-    The two affordances answer different questions ("this preset against the live budget" vs "this plan as I tuned
-    it"), so the asymmetry is intentional, not accidental. Saved rows are likewise scored against <b>their own
-    saved ceiling</b>, not the page's transient edited one.</p>
-</div>
+      <div class="entry dd">
+        <h3>List card, not extra tiles <span class="tag dd">ux</span></h3>
+        <p>
+          Saved scenarios render as a card of rows between the preset tiles and
+          the Assumptions panel, not as additional tiles in the preset grid: the
+          tile grid is a fixed comparison frame (3 presets + Custom), a tile is
+          a single <code>&lt;button&gt;</code> and cannot legally nest a delete
+          button, and a grid doesn't scale to N saved entries. The card is
+          hidden when empty (the "Save scenario" button in the Assumptions
+          header is the discovery point).
+        </p>
+      </div>
 
-<div class="entry dd">
-  <h3>List card, not extra tiles <span class="tag dd">ux</span></h3>
-  <p>Saved scenarios render as a card of rows between the preset tiles and the Assumptions panel, not as additional
-    tiles in the preset grid: the tile grid is a fixed comparison frame (3 presets + Custom), a tile is a single
-    <code>&lt;button&gt;</code> and cannot legally nest a delete button, and a grid doesn't scale to N saved entries.
-    The card is hidden when empty (the "Save scenario" button in the Assumptions header is the discovery point).</p>
-</div>
+      <div class="entry dd">
+        <h3>
+          Validate on write AND on read; strip semantics, not strict
+          <span class="tag dd">robustness</span>
+        </h3>
+        <p>
+          The jsonb column is an open contract. Writes
+          <code>safeParse</code> and store <code>parsed.data</code> (canonical);
+          reads re-validate each row and skip non-conforming ones with a
+          <code>console.error</code> instead of crashing the page.
+          <b>Revised in the challenge pass:</b> plain <code>z.object</code> (Zod
+          default strip semantics — the only style used in
+          <code>validators.ts</code>) instead of <code>.strict()</code>: unknown
+          keys are dropped, keeping rows loadable across schema evolution, where
+          strict would turn drift into save failures and skipped rows.
+          <code>.finite()</code> was also dropped — Zod 4's
+          <code>z.number()</code> already rejects NaN/Infinity by default (the
+          original rationale was stale). Bounds are generous modelling limits
+          (ceiling ≤ $1B, |growth| ≤ 100k, ≤ 20 tool entries), not business
+          rules.
+        </p>
+      </div>
 
-<div class="entry dd">
-  <h3>Validate on write AND on read; strip semantics, not strict <span class="tag dd">robustness</span></h3>
-  <p>The jsonb column is an open contract. Writes <code>safeParse</code> and store <code>parsed.data</code>
-    (canonical); reads re-validate each row and skip non-conforming ones with a <code>console.error</code> instead
-    of crashing the page. <b>Revised in the challenge pass:</b> plain <code>z.object</code> (Zod default strip
-    semantics — the only style used in <code>validators.ts</code>) instead of <code>.strict()</code>: unknown keys
-    are dropped, keeping rows loadable across schema evolution, where strict would turn drift into save failures and
-    skipped rows. <code>.finite()</code> was also dropped — Zod 4's <code>z.number()</code> already rejects
-    NaN/Infinity by default (the original rationale was stale). Bounds are generous modelling limits (ceiling ≤ $1B,
-    |growth| ≤ 100k, ≤ 20 tool entries), not business rules.</p>
-</div>
+      <div class="entry dd">
+        <h3>Uncached list read <span class="tag dd">caching</span></h3>
+        <p>
+          The dataset loader stays behind <code>unstable_cache</code> (1h TTL) —
+          scenario writes don't change cost data. The scenario list itself is a
+          plain uncached select on an already-dynamic page: freshness matters
+          after every save/delete, the query is one indexed select, and skipping
+          the cache avoids tag-invalidation choreography. Mutations
+          <code>revalidatePath("/scenarios/budget-forecast")</code> + client
+          <code>router.refresh()</code>.
+        </p>
+      </div>
 
-<div class="entry dd">
-  <h3>Uncached list read <span class="tag dd">caching</span></h3>
-  <p>The dataset loader stays behind <code>unstable_cache</code> (1h TTL) — scenario writes don't change cost data.
-    The scenario list itself is a plain uncached select on an already-dynamic page: freshness matters after every
-    save/delete, the query is one indexed select, and skipping the cache avoids tag-invalidation choreography.
-    Mutations <code>revalidatePath("/scenarios/budget-forecast")</code> + client <code>router.refresh()</code>.</p>
-</div>
+      <!-- ========================================================= -->
+      <h2>
+        Deviations
+        <span class="ts">(intentional departures from the request)</span>
+      </h2>
 
-<!-- ========================================================= -->
-<h2>Deviations <span class="ts">(intentional departures from the request)</span></h2>
+      <div class="entry dev">
+        <h3>None yet <span class="tag dev">placeholder</span></h3>
+        <p>
+          No intentional departures from the request so far; this section will
+          be updated if any arise during implementation.
+        </p>
+      </div>
 
-<div class="entry dev">
-  <h3>None yet <span class="tag dev">placeholder</span></h3>
-  <p>No intentional departures from the request so far; this section will be updated if any arise during implementation.</p>
-</div>
+      <!-- ========================================================= -->
+      <h2>Tradeoffs <span class="ts">(alternatives weighed)</span></h2>
 
-<!-- ========================================================= -->
-<h2>Tradeoffs <span class="ts">(alternatives weighed)</span></h2>
+      <div class="entry to">
+        <h3>
+          jsonb params vs normalized columns <span class="tag to">schema</span>
+        </h3>
+        <p>
+          A normalized design (one row per tool per scenario, typed columns per
+          lever) would give SQL-queryable levers — but nothing queries levers
+          server-side; the engine consumes the whole
+          <code>ForecastInputs</code> object, the shape already proved it
+          evolves (040 added <code>billing</code> without a migration), and
+          036's own sketch said "JSON params". jsonb + Zod-at-the-boundary gets
+          evolution for free; the cost (no per-lever SQL) buys nothing we need.
+          Type safety is kept via
+          <code>$type&lt;ForecastInputs&gt;()</code> (type-only import, no
+          runtime cycle).
+        </p>
+      </div>
 
-<div class="entry to">
-  <h3>jsonb params vs normalized columns <span class="tag to">schema</span></h3>
-  <p>A normalized design (one row per tool per scenario, typed columns per lever) would give SQL-queryable levers —
-    but nothing queries levers server-side; the engine consumes the whole <code>ForecastInputs</code> object, the
-    shape already proved it evolves (040 added <code>billing</code> without a migration), and 036's own sketch said
-    "JSON params". jsonb + Zod-at-the-boundary gets evolution for free; the cost (no per-lever SQL) buys nothing we
-    need. Type safety is kept via <code>$type&lt;ForecastInputs&gt;()</code> (type-only import, no runtime cycle).</p>
-</div>
+      <div class="entry to">
+        <h3>
+          Budget-scoped vs global scenarios <span class="tag to">schema</span>
+        </h3>
+        <p>
+          Global scenarios (no FK) would survive fiscal-year rollover — but a
+          plan tuned against FY2026's ceiling, periods, and seat counts is
+          meaningless against FY2027 without review, and the list would accrete
+          forever. Scoping to <code>budget_id</code> (cascade) keeps the list
+          relevant and gives natural lifecycle cleanup; old-year scenarios stay
+          in the table for audit until their budget is deleted. The save action
+          resolves the active budget server-side — a client-supplied budget id
+          was rejected as an unnecessary trust surface.
+        </p>
+      </div>
 
-<div class="entry to">
-  <h3>Budget-scoped vs global scenarios <span class="tag to">schema</span></h3>
-  <p>Global scenarios (no FK) would survive fiscal-year rollover — but a plan tuned against FY2026's ceiling,
-    periods, and seat counts is meaningless against FY2027 without review, and the list would accrete forever.
-    Scoping to <code>budget_id</code> (cascade) keeps the list relevant and gives natural lifecycle cleanup;
-    old-year scenarios stay in the table for audit until their budget is deleted. The save action resolves the
-    active budget server-side — a client-supplied budget id was rejected as an unnecessary trust surface.</p>
-</div>
+      <div class="entry to">
+        <h3>
+          Update-in-place vs save-as-copy semantics
+          <span class="tag to">ux</span>
+        </h3>
+        <p>
+          The dialog offers both: "Update '&lt;name&gt;'" (when a saved scenario
+          was loaded this session — tracked by a <code>loadedSavedId</code> that
+          survives the active-tile flipping to Custom on first edit) and "Save
+          as new". Pure copy-on-save was rejected (name collisions, list
+          litter); silent update-only was rejected (no way to fork a variant).
+          No version history — update overwrites; the audit trail records the
+          event, not a restorable diff.
+        </p>
+      </div>
 
-<div class="entry to">
-  <h3>Update-in-place vs save-as-copy semantics <span class="tag to">ux</span></h3>
-  <p>The dialog offers both: "Update '&lt;name&gt;'" (when a saved scenario was loaded this session — tracked by a
-    <code>loadedSavedId</code> that survives the active-tile flipping to Custom on first edit) and "Save as new".
-    Pure copy-on-save was rejected (name collisions, list litter); silent update-only was rejected (no way to fork
-    a variant). No version history — update overwrites; the audit trail records the event, not a restorable diff.</p>
-</div>
+      <!-- ========================================================= -->
+      <h2>
+        Challenge pass
+        <span class="ts">(5-lens adversarial plan review → revisions)</span>
+      </h2>
 
-<!-- ========================================================= -->
-<h2>Challenge pass <span class="ts">(5-lens adversarial plan review → revisions)</span></h2>
+      <div class="entry to">
+        <h3>
+          Plan challenged before implementation; 1 unanimous must-fix + 10
+          adopted should-fixes <span class="tag to">process</span>
+        </h3>
+        <p>
+          Five parallel adversarial reviewers (conventions / correctness / UX /
+          tests / spec-fidelity) verified every factual claim against the repo —
+          almost all held (migration numbering, audit conventions,
+          StatusText-not-Sonner, the <code>$type</code> precedent, the
+          expression-index SQL emitted by the installed drizzle-kit 0.31.9, the
+          JSON-round-trip safety of <code>undefined ≡ monthly</code>) — and
+          found real holes, all folded into the plan:
+        </p>
+        <ul>
+          <li>
+            <b>Must-fix (found independently by 4 of 5 lenses):</b> the actions
+            resolved "the active budget" via an unordered
+            <code>findFirst</code> — nondeterministic when the schema's
+            permitted multiple-active state occurs, and fatal to the planned
+            integration test (seeding a second active budget could route test
+            writes onto the REAL dev budget). <b>Fix:</b> a documented
+            resolution contract — <code>status='active'</code> ordered by
+            <code>fiscal_year DESC</code>, <code>LIMIT 1</code> — plus FY ≥ 3000
+            test seeding and budget-scoped assertions.
+          </li>
+          <li>
+            <b>Audit gap:</b> <code>recordUpdate</code> early-returns on an
+            empty diff, so a params-only update would have recorded nothing.
+            Fix: updates always record a full params snapshot
+            (<code>old</code>/<code>new</code> objects), which also makes
+            teammate overwrites recoverable — answering the
+            shared-pool/last-write-wins concern.
+          </li>
+          <li>
+            <b>Race honesty:</b> the unique-index "backstop" would have surfaced
+            as a raw Next.js digest error; create and update now catch PG 23505
+            and return the same friendly duplicate-name
+            <code>ActionResult</code>.
+          </li>
+          <li>
+            <b>State-model holes:</b> <code>saved:&lt;id&gt;</code> left the
+            comparison table with no active row (fix:
+            <code>saved:*</code> activates "Your plan");
+            <code>loadedSavedId</code> surviving a preset-tile click enabled a
+            one-click overwrite of a shared row with preset params (fix: tile
+            clicks clear it); the Update offer could go stale after a concurrent
+            delete (fix: derived live from the
+            <code>savedScenarios</code> prop).
+          </li>
+          <li>
+            <b>Newly-reachable bug:</b> <code>router.refresh()</code> (this
+            page's first) can deliver a changed dataset under surviving client
+            state — a new tool key would be engine-projected at defaults yet
+            hidden from the controls. Fix: re-base surviving inputs through
+            <code>inputsFromSaved(dataset, prev)</code> on dataset change.
+          </li>
+          <li>
+            <b>Silent $0 ceiling:</b> clearing the ceiling field then saving
+            would persist <code>ceilingCents: 0</code>; the save dialog now
+            echoes exactly what will be saved and blocks an empty ceiling field.
+          </li>
+          <li>
+            <b>UX conventions:</b> the two-commit-button dialog footer had no
+            precedent anywhere in the app — replaced with the house
+            single-primary pattern + an in-dialog mode toggle; the
+            hidden-when-empty card contradicted the plan's own acceptance
+            wording and created a focus/status dead end — now persistent with a
+            mono empty state; a11y spec added (aria-pressed load buttons,
+            labelled icon buttons, list semantics, focus-to-heading after
+            delete) that is deliberately better than the precedent it cites
+            (ingestion's icon buttons are unlabelled).
+          </li>
+          <li>
+            <b>Missing affordance:</b> rename-without-resaving-params didn't
+            exist (and load-then-rename would have silently rewritten stored
+            params via re-basing). Fix: <code>params</code> optional in the
+            update schema + a pencil rename dialog per row.
+          </li>
+          <li>
+            <b>Test feasibility:</b> the 50-cap test as 50 action calls ≈ 250
+            serialized Neon round trips (brushing the 30s timeout) → bulk-seed
+            50 rows + one action call; the validator test couldn't import the
+            module-local <code>makeDataset</code> fixture → colocated with
+            inline fixtures; added the missing coverage the plan's own text
+            demanded: safeParse-on-read skipping, auth gating, audit-row
+            assertions, and a direct case-variant insert proving the expression
+            index itself fires.
+          </li>
+          <li>
+            <b>Two Δ semantics on one page:</b> saved rows score against their
+            own saved ceiling while everything else scores against the edited
+            one — now labelled explicitly ("vs saved $X") instead of relying on
+            a caption.
+          </li>
+        </ul>
+      </div>
 
-<div class="entry to">
-  <h3>Plan challenged before implementation; 1 unanimous must-fix + 10 adopted should-fixes <span class="tag to">process</span></h3>
-  <p>Five parallel adversarial reviewers (conventions / correctness / UX / tests / spec-fidelity) verified every
-    factual claim against the repo — almost all held (migration numbering, audit conventions, StatusText-not-Sonner,
-    the <code>$type</code> precedent, the expression-index SQL emitted by the installed drizzle-kit 0.31.9, the
-    JSON-round-trip safety of <code>undefined ≡ monthly</code>) — and found real holes, all folded into the plan:</p>
-  <ul>
-    <li><b>Must-fix (found independently by 4 of 5 lenses):</b> the actions resolved "the active budget" via an
-      unordered <code>findFirst</code> — nondeterministic when the schema's permitted multiple-active state occurs,
-      and fatal to the planned integration test (seeding a second active budget could route test writes onto the
-      REAL dev budget). <b>Fix:</b> a documented resolution contract — <code>status='active'</code> ordered by
-      <code>fiscal_year DESC</code>, <code>LIMIT 1</code> — plus FY ≥ 3000 test seeding and budget-scoped assertions.</li>
-    <li><b>Audit gap:</b> <code>recordUpdate</code> early-returns on an empty diff, so a params-only update would have
-      recorded nothing. Fix: updates always record a full params snapshot (<code>old</code>/<code>new</code> objects),
-      which also makes teammate overwrites recoverable — answering the shared-pool/last-write-wins concern.</li>
-    <li><b>Race honesty:</b> the unique-index "backstop" would have surfaced as a raw Next.js digest error; create and
-      update now catch PG 23505 and return the same friendly duplicate-name <code>ActionResult</code>.</li>
-    <li><b>State-model holes:</b> <code>saved:&lt;id&gt;</code> left the comparison table with no active row (fix:
-      <code>saved:*</code> activates "Your plan"); <code>loadedSavedId</code> surviving a preset-tile click enabled a
-      one-click overwrite of a shared row with preset params (fix: tile clicks clear it); the Update offer could go
-      stale after a concurrent delete (fix: derived live from the <code>savedScenarios</code> prop).</li>
-    <li><b>Newly-reachable bug:</b> <code>router.refresh()</code> (this page's first) can deliver a changed dataset
-      under surviving client state — a new tool key would be engine-projected at defaults yet hidden from the
-      controls. Fix: re-base surviving inputs through <code>inputsFromSaved(dataset, prev)</code> on dataset change.</li>
-    <li><b>Silent $0 ceiling:</b> clearing the ceiling field then saving would persist <code>ceilingCents: 0</code>;
-      the save dialog now echoes exactly what will be saved and blocks an empty ceiling field.</li>
-    <li><b>UX conventions:</b> the two-commit-button dialog footer had no precedent anywhere in the app — replaced
-      with the house single-primary pattern + an in-dialog mode toggle; the hidden-when-empty card contradicted the
-      plan's own acceptance wording and created a focus/status dead end — now persistent with a mono empty state;
-      a11y spec added (aria-pressed load buttons, labelled icon buttons, list semantics, focus-to-heading after
-      delete) that is deliberately better than the precedent it cites (ingestion's icon buttons are unlabelled).</li>
-    <li><b>Missing affordance:</b> rename-without-resaving-params didn't exist (and load-then-rename would have
-      silently rewritten stored params via re-basing). Fix: <code>params</code> optional in the update schema + a
-      pencil rename dialog per row.</li>
-    <li><b>Test feasibility:</b> the 50-cap test as 50 action calls ≈ 250 serialized Neon round trips (brushing the
-      30s timeout) → bulk-seed 50 rows + one action call; the validator test couldn't import the module-local
-      <code>makeDataset</code> fixture → colocated with inline fixtures; added the missing coverage the plan's own
-      text demanded: safeParse-on-read skipping, auth gating, audit-row assertions, and a direct case-variant insert
-      proving the expression index itself fires.</li>
-    <li><b>Two Δ semantics on one page:</b> saved rows score against their own saved ceiling while everything else
-      scores against the edited one — now labelled explicitly ("vs saved $X") instead of relying on a caption.</li>
-  </ul>
-</div>
+      <!-- ========================================================= -->
+      <h2>Open questions <span class="ts">(for review)</span></h2>
 
-<!-- ========================================================= -->
-<h2>Open questions <span class="ts">(for review)</span></h2>
+      <div class="entry oq">
+        <h3>
+          Shared pool + last-write-wins
+          <span class="tag oq">needs your nod</span>
+        </h3>
+        <p>
+          Any admin can overwrite or delete any other admin's scenario;
+          concurrent edits are last-write-wins with no conflict detection. The
+          challenge panel flagged this as the one interpretive decision that
+          genuinely deserves explicit sign-off. Mitigations shipped: creator
+          attribution in the list and delete confirm; full params snapshots in
+          <code>change_history</code> on update and delete (overwrites are
+          forensically recoverable); the accidental-overwrite guards above. If
+          you want optimistic concurrency (reject when
+          <code>updatedAt</code> changed underneath) or private-by-default
+          scenarios, both fit the schema without migration — say the word.
+        </p>
+      </div>
 
-<div class="entry oq">
-  <h3>Shared pool + last-write-wins <span class="tag oq">needs your nod</span></h3>
-  <p>Any admin can overwrite or delete any other admin's scenario; concurrent edits are last-write-wins with no
-    conflict detection. The challenge panel flagged this as the one interpretive decision that genuinely deserves
-    explicit sign-off. Mitigations shipped: creator attribution in the list and delete confirm; full params
-    snapshots in <code>change_history</code> on update and delete (overwrites are forensically recoverable); the
-    accidental-overwrite guards above. If you want optimistic concurrency (reject when <code>updatedAt</code>
-    changed underneath) or private-by-default scenarios, both fit the schema without migration — say the word.</p>
-</div>
+      <div class="entry oq">
+        <h3>
+          Cap of 50 scenarios per budget <span class="tag oq">limit</span>
+        </h3>
+        <p>
+          Chosen to keep the list a working set rather than an archive, with an
+          explicit "delete one first" error at the cap. If you expect heavier
+          use (e.g. scripted scenario generation), say so and the cap moves or
+          goes.
+        </p>
+      </div>
 
-<div class="entry oq">
-  <h3>Cap of 50 scenarios per budget <span class="tag oq">limit</span></h3>
-  <p>Chosen to keep the list a working set rather than an archive, with an explicit "delete one first" error at the
-    cap. If you expect heavier use (e.g. scripted scenario generation), say so and the cap moves or goes.</p>
-</div>
+      <div class="entry oq">
+        <h3>
+          Case-insensitive name uniqueness <span class="tag oq">naming</span>
+        </h3>
+        <p>
+          "Plan B" and "plan b" are treated as the same name (app pre-check +
+          <code>lower(name)</code> unique index). Friendlier for a shared pool,
+          but if you want exact-case distinctness, the index drops to a plain
+          <code>(budget_id, name)</code> unique.
+        </p>
+      </div>
 
-<div class="entry oq">
-  <h3>Case-insensitive name uniqueness <span class="tag oq">naming</span></h3>
-  <p>"Plan B" and "plan b" are treated as the same name (app pre-check + <code>lower(name)</code> unique index).
-    Friendlier for a shared pool, but if you want exact-case distinctness, the index drops to a plain
-    <code>(budget_id, name)</code> unique.</p>
-</div>
+      <!-- ========================================================= -->
+      <h2>Verification <span class="ts">(what was checked)</span></h2>
 
-<!-- ========================================================= -->
-<h2>Verification <span class="ts">(what was checked)</span></h2>
+      <div class="entry to">
+        <h3>Status <span class="tag to">pending</span></h3>
+        <p>
+          To be filled as implementation proceeds: unit suite, integration round
+          trip, lint/typecheck, Playwright browser pass, migration review.
+        </p>
+      </div>
 
-<div class="entry to">
-  <h3>Status <span class="tag to">pending</span></h3>
-  <p>To be filled as implementation proceeds: unit suite, integration round trip, lint/typecheck, Playwright browser
-    pass, migration review.</p>
-</div>
-
-<footer>
-  AI Developer Hub · spec/041-forecast-scenario-persistence · implementation notes · running log started 2026-06-12
-</footer>
-
-</main>
-</body>
+      <footer>
+        AI Developer Hub · spec/041-forecast-scenario-persistence ·
+        implementation notes · running log started 2026-06-12
+      </footer>
+    </main>
+  </body>
 </html>

--- a/specs/041-forecast-scenario-persistence/implementation-notes.html
+++ b/specs/041-forecast-scenario-persistence/implementation-notes.html
@@ -1,0 +1,242 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Implementation Notes — Saved Forecast Scenarios (041)</title>
+  <style>
+    :root {
+      --bg:#0b0d12; --bg-elev:#11141b; --bg-card:#161a24; --border:#232938; --border-strong:#2f3850;
+      --fg:#e7ebf3; --fg-muted:#9aa3b5; --fg-dim:#6b7488;
+      --accent:#f0a072; --accent-2:#7dd3fc; --good:#86efac; --warn:#fcd34d; --bad:#fca5a5;
+      --mono: ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+      --sans: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    }
+    * { box-sizing:border-box; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--fg); font-family:var(--sans); line-height:1.55; }
+    body { padding:48px 24px 96px; }
+    main { max-width:1000px; margin:0 auto; }
+    h1 { font-size:30px; margin:0 0 6px; letter-spacing:-0.01em; }
+    h2 { font-size:20px; margin:44px 0 4px; padding-bottom:8px; border-bottom:1px solid var(--border); }
+    h3 { font-size:15px; margin:22px 0 4px; }
+    p { margin:0 0 10px; }
+    a { color:var(--accent); }
+    code { font-family:var(--mono); font-size:0.88em; background:var(--bg-elev); padding:1px 5px; border-radius:4px; border:1px solid var(--border); }
+    .lede { color:var(--fg-muted); font-size:15.5px; max-width:80ch; }
+    .meta { color:var(--fg-dim); font-size:13px; margin-top:8px; font-family:var(--mono); }
+    .badge { display:inline-block; font-size:11px; font-family:var(--mono); padding:2px 8px; border-radius:999px; border:1px solid var(--border-strong); color:var(--fg-muted); background:var(--bg-elev); }
+    .entry { background:var(--bg-card); border:1px solid var(--border); border-radius:10px; padding:18px 20px; margin:14px 0; }
+    .entry.dd { border-left:3px solid var(--accent-2); }
+    .entry.dev { border-left:3px solid var(--warn); }
+    .entry.to { border-left:3px solid var(--accent); }
+    .entry.oq { border-left:3px solid var(--bad); }
+    .entry h3 { margin-top:0; }
+    .tag { font-family:var(--mono); font-size:10px; text-transform:uppercase; letter-spacing:0.1em; padding:2px 7px; border-radius:3px; vertical-align:middle; margin-left:8px; }
+    .tag.dd { color:var(--accent-2); border:1px solid rgba(125,211,252,0.3); }
+    .tag.dev { color:var(--warn); border:1px solid rgba(252,211,77,0.3); }
+    .tag.to { color:var(--accent); border:1px solid rgba(240,160,114,0.3); }
+    .tag.oq { color:var(--bad); border:1px solid rgba(252,165,165,0.3); }
+    .entry p { font-size:13.5px; color:var(--fg-muted); }
+    .entry b { color:var(--fg); }
+    ul { padding-left:20px; margin:6px 0 10px; } li { margin:3px 0; font-size:13.5px; color:var(--fg-muted); }
+    .ts { font-family:var(--mono); font-size:11px; color:var(--fg-dim); }
+    footer { color:var(--fg-dim); font-size:12.5px; margin-top:56px; padding-top:20px; border-top:1px solid var(--border); font-family:var(--mono); }
+  </style>
+</head>
+<body>
+<main>
+
+<header>
+  <div style="margin-bottom:14px"><span class="badge">Implementation notes</span> <span class="badge">spec/041-forecast-scenario-persistence</span> <span class="badge">running log</span></div>
+  <h1>Implementation notes — Saved Forecast Scenarios</h1>
+  <p class="lede">A running record of where the build diverges from or interprets the request: design decisions on ambiguous points, intentional deviations, tradeoffs considered, and open questions for review. Entries are appended as work proceeds.</p>
+  <p class="meta">Started 2026-06-12 · branch <code>041-forecast-scenario-persistence</code> · companion: <a href="./implementation-plan.html">implementation-plan.html</a></p>
+</header>
+
+<!-- ========================================================= -->
+<h2>Design decisions <span class="ts">(ambiguous spots, choices made)</span></h2>
+
+<div class="entry dd">
+  <h3>"Persistence of scenarios" → shared, budget-scoped, named parameter sets <span class="tag dd">interpretation</span></h3>
+  <p>The request says only "implement the persistence of scenarios". Three readings were possible: (a) persist the
+    user's <i>current working state</i> (auto-save, like a draft), (b) per-user private saved scenarios, (c) shared
+    named scenarios. <b>Decision: (c)</b> — it is what spec 036 explicitly deferred ("Save &amp; name scenarios —
+    needs a <code>forecast_scenarios</code> table (JSON params + label + budget_id)"), and the calculator is a
+    team-alignment tool for admins: a saved plan everyone can open beats a private draft. <code>created_by</code>
+    records attribution. Auto-saving working state (a) was rejected as silent magic; explicit save/load matches the
+    rest of the app.</p>
+</div>
+
+<div class="entry dd">
+  <h3>Assumptions are stored, results are recomputed <span class="tag dd">semantics</span></h3>
+  <p>A saved scenario stores the <code>ForecastInputs</code> parameter set (edited ceiling + per-tool levers incl.
+    billing cadence) — never year-end figures. On load, params are re-based onto the current dataset
+    (<code>inputsFromSaved</code>: extinct tool keys dropped, new tools defaulted) and re-projected against live
+    data, exactly like a preset. The saved-list rows show <i>recomputed</i> year-end / Δ so the list answers
+    "what would this plan mean today", not "what did it mean when saved".</p>
+</div>
+
+<div class="entry dd">
+  <h3>Load restores the saved ceiling; preset tiles keep resetting it <span class="tag dd">ux</span></h3>
+  <p>040 established a deliberate asymmetry: clicking a preset tile resets the edited ceiling to the live one but
+    keeps the billing cadence. Saved scenarios get the opposite: <b>loading restores the full assumption set,
+    including the saved ceiling and cadence</b> — the user saved a complete what-if and expects it back verbatim.
+    The two affordances answer different questions ("this preset against the live budget" vs "this plan as I tuned
+    it"), so the asymmetry is intentional, not accidental. Saved rows are likewise scored against <b>their own
+    saved ceiling</b>, not the page's transient edited one.</p>
+</div>
+
+<div class="entry dd">
+  <h3>List card, not extra tiles <span class="tag dd">ux</span></h3>
+  <p>Saved scenarios render as a card of rows between the preset tiles and the Assumptions panel, not as additional
+    tiles in the preset grid: the tile grid is a fixed comparison frame (3 presets + Custom), a tile is a single
+    <code>&lt;button&gt;</code> and cannot legally nest a delete button, and a grid doesn't scale to N saved entries.
+    The card is hidden when empty (the "Save scenario" button in the Assumptions header is the discovery point).</p>
+</div>
+
+<div class="entry dd">
+  <h3>Validate on write AND on read; strip semantics, not strict <span class="tag dd">robustness</span></h3>
+  <p>The jsonb column is an open contract. Writes <code>safeParse</code> and store <code>parsed.data</code>
+    (canonical); reads re-validate each row and skip non-conforming ones with a <code>console.error</code> instead
+    of crashing the page. <b>Revised in the challenge pass:</b> plain <code>z.object</code> (Zod default strip
+    semantics — the only style used in <code>validators.ts</code>) instead of <code>.strict()</code>: unknown keys
+    are dropped, keeping rows loadable across schema evolution, where strict would turn drift into save failures and
+    skipped rows. <code>.finite()</code> was also dropped — Zod 4's <code>z.number()</code> already rejects
+    NaN/Infinity by default (the original rationale was stale). Bounds are generous modelling limits (ceiling ≤ $1B,
+    |growth| ≤ 100k, ≤ 20 tool entries), not business rules.</p>
+</div>
+
+<div class="entry dd">
+  <h3>Uncached list read <span class="tag dd">caching</span></h3>
+  <p>The dataset loader stays behind <code>unstable_cache</code> (1h TTL) — scenario writes don't change cost data.
+    The scenario list itself is a plain uncached select on an already-dynamic page: freshness matters after every
+    save/delete, the query is one indexed select, and skipping the cache avoids tag-invalidation choreography.
+    Mutations <code>revalidatePath("/scenarios/budget-forecast")</code> + client <code>router.refresh()</code>.</p>
+</div>
+
+<!-- ========================================================= -->
+<h2>Deviations <span class="ts">(intentional departures from the request)</span></h2>
+
+<div class="entry dev">
+  <h3>None yet <span class="tag dev">placeholder</span></h3>
+  <p>No intentional departures from the request so far; this section will be updated if any arise during implementation.</p>
+</div>
+
+<!-- ========================================================= -->
+<h2>Tradeoffs <span class="ts">(alternatives weighed)</span></h2>
+
+<div class="entry to">
+  <h3>jsonb params vs normalized columns <span class="tag to">schema</span></h3>
+  <p>A normalized design (one row per tool per scenario, typed columns per lever) would give SQL-queryable levers —
+    but nothing queries levers server-side; the engine consumes the whole <code>ForecastInputs</code> object, the
+    shape already proved it evolves (040 added <code>billing</code> without a migration), and 036's own sketch said
+    "JSON params". jsonb + Zod-at-the-boundary gets evolution for free; the cost (no per-lever SQL) buys nothing we
+    need. Type safety is kept via <code>$type&lt;ForecastInputs&gt;()</code> (type-only import, no runtime cycle).</p>
+</div>
+
+<div class="entry to">
+  <h3>Budget-scoped vs global scenarios <span class="tag to">schema</span></h3>
+  <p>Global scenarios (no FK) would survive fiscal-year rollover — but a plan tuned against FY2026's ceiling,
+    periods, and seat counts is meaningless against FY2027 without review, and the list would accrete forever.
+    Scoping to <code>budget_id</code> (cascade) keeps the list relevant and gives natural lifecycle cleanup;
+    old-year scenarios stay in the table for audit until their budget is deleted. The save action resolves the
+    active budget server-side — a client-supplied budget id was rejected as an unnecessary trust surface.</p>
+</div>
+
+<div class="entry to">
+  <h3>Update-in-place vs save-as-copy semantics <span class="tag to">ux</span></h3>
+  <p>The dialog offers both: "Update '&lt;name&gt;'" (when a saved scenario was loaded this session — tracked by a
+    <code>loadedSavedId</code> that survives the active-tile flipping to Custom on first edit) and "Save as new".
+    Pure copy-on-save was rejected (name collisions, list litter); silent update-only was rejected (no way to fork
+    a variant). No version history — update overwrites; the audit trail records the event, not a restorable diff.</p>
+</div>
+
+<!-- ========================================================= -->
+<h2>Challenge pass <span class="ts">(5-lens adversarial plan review → revisions)</span></h2>
+
+<div class="entry to">
+  <h3>Plan challenged before implementation; 1 unanimous must-fix + 10 adopted should-fixes <span class="tag to">process</span></h3>
+  <p>Five parallel adversarial reviewers (conventions / correctness / UX / tests / spec-fidelity) verified every
+    factual claim against the repo — almost all held (migration numbering, audit conventions, StatusText-not-Sonner,
+    the <code>$type</code> precedent, the expression-index SQL emitted by the installed drizzle-kit 0.31.9, the
+    JSON-round-trip safety of <code>undefined ≡ monthly</code>) — and found real holes, all folded into the plan:</p>
+  <ul>
+    <li><b>Must-fix (found independently by 4 of 5 lenses):</b> the actions resolved "the active budget" via an
+      unordered <code>findFirst</code> — nondeterministic when the schema's permitted multiple-active state occurs,
+      and fatal to the planned integration test (seeding a second active budget could route test writes onto the
+      REAL dev budget). <b>Fix:</b> a documented resolution contract — <code>status='active'</code> ordered by
+      <code>fiscal_year DESC</code>, <code>LIMIT 1</code> — plus FY ≥ 3000 test seeding and budget-scoped assertions.</li>
+    <li><b>Audit gap:</b> <code>recordUpdate</code> early-returns on an empty diff, so a params-only update would have
+      recorded nothing. Fix: updates always record a full params snapshot (<code>old</code>/<code>new</code> objects),
+      which also makes teammate overwrites recoverable — answering the shared-pool/last-write-wins concern.</li>
+    <li><b>Race honesty:</b> the unique-index "backstop" would have surfaced as a raw Next.js digest error; create and
+      update now catch PG 23505 and return the same friendly duplicate-name <code>ActionResult</code>.</li>
+    <li><b>State-model holes:</b> <code>saved:&lt;id&gt;</code> left the comparison table with no active row (fix:
+      <code>saved:*</code> activates "Your plan"); <code>loadedSavedId</code> surviving a preset-tile click enabled a
+      one-click overwrite of a shared row with preset params (fix: tile clicks clear it); the Update offer could go
+      stale after a concurrent delete (fix: derived live from the <code>savedScenarios</code> prop).</li>
+    <li><b>Newly-reachable bug:</b> <code>router.refresh()</code> (this page's first) can deliver a changed dataset
+      under surviving client state — a new tool key would be engine-projected at defaults yet hidden from the
+      controls. Fix: re-base surviving inputs through <code>inputsFromSaved(dataset, prev)</code> on dataset change.</li>
+    <li><b>Silent $0 ceiling:</b> clearing the ceiling field then saving would persist <code>ceilingCents: 0</code>;
+      the save dialog now echoes exactly what will be saved and blocks an empty ceiling field.</li>
+    <li><b>UX conventions:</b> the two-commit-button dialog footer had no precedent anywhere in the app — replaced
+      with the house single-primary pattern + an in-dialog mode toggle; the hidden-when-empty card contradicted the
+      plan's own acceptance wording and created a focus/status dead end — now persistent with a mono empty state;
+      a11y spec added (aria-pressed load buttons, labelled icon buttons, list semantics, focus-to-heading after
+      delete) that is deliberately better than the precedent it cites (ingestion's icon buttons are unlabelled).</li>
+    <li><b>Missing affordance:</b> rename-without-resaving-params didn't exist (and load-then-rename would have
+      silently rewritten stored params via re-basing). Fix: <code>params</code> optional in the update schema + a
+      pencil rename dialog per row.</li>
+    <li><b>Test feasibility:</b> the 50-cap test as 50 action calls ≈ 250 serialized Neon round trips (brushing the
+      30s timeout) → bulk-seed 50 rows + one action call; the validator test couldn't import the module-local
+      <code>makeDataset</code> fixture → colocated with inline fixtures; added the missing coverage the plan's own
+      text demanded: safeParse-on-read skipping, auth gating, audit-row assertions, and a direct case-variant insert
+      proving the expression index itself fires.</li>
+    <li><b>Two Δ semantics on one page:</b> saved rows score against their own saved ceiling while everything else
+      scores against the edited one — now labelled explicitly ("vs saved $X") instead of relying on a caption.</li>
+  </ul>
+</div>
+
+<!-- ========================================================= -->
+<h2>Open questions <span class="ts">(for review)</span></h2>
+
+<div class="entry oq">
+  <h3>Shared pool + last-write-wins <span class="tag oq">needs your nod</span></h3>
+  <p>Any admin can overwrite or delete any other admin's scenario; concurrent edits are last-write-wins with no
+    conflict detection. The challenge panel flagged this as the one interpretive decision that genuinely deserves
+    explicit sign-off. Mitigations shipped: creator attribution in the list and delete confirm; full params
+    snapshots in <code>change_history</code> on update and delete (overwrites are forensically recoverable); the
+    accidental-overwrite guards above. If you want optimistic concurrency (reject when <code>updatedAt</code>
+    changed underneath) or private-by-default scenarios, both fit the schema without migration — say the word.</p>
+</div>
+
+<div class="entry oq">
+  <h3>Cap of 50 scenarios per budget <span class="tag oq">limit</span></h3>
+  <p>Chosen to keep the list a working set rather than an archive, with an explicit "delete one first" error at the
+    cap. If you expect heavier use (e.g. scripted scenario generation), say so and the cap moves or goes.</p>
+</div>
+
+<div class="entry oq">
+  <h3>Case-insensitive name uniqueness <span class="tag oq">naming</span></h3>
+  <p>"Plan B" and "plan b" are treated as the same name (app pre-check + <code>lower(name)</code> unique index).
+    Friendlier for a shared pool, but if you want exact-case distinctness, the index drops to a plain
+    <code>(budget_id, name)</code> unique.</p>
+</div>
+
+<!-- ========================================================= -->
+<h2>Verification <span class="ts">(what was checked)</span></h2>
+
+<div class="entry to">
+  <h3>Status <span class="tag to">pending</span></h3>
+  <p>To be filled as implementation proceeds: unit suite, integration round trip, lint/typecheck, Playwright browser
+    pass, migration review.</p>
+</div>
+
+<footer>
+  AI Developer Hub · spec/041-forecast-scenario-persistence · implementation notes · running log started 2026-06-12
+</footer>
+
+</main>
+</body>
+</html>

--- a/specs/041-forecast-scenario-persistence/implementation-plan.html
+++ b/specs/041-forecast-scenario-persistence/implementation-plan.html
@@ -1,0 +1,476 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Implementation Plan — Saved Forecast Scenarios (041)</title>
+  <style>
+    :root {
+      --bg: #0b0d12;
+      --bg-elev: #11141b;
+      --bg-card: #161a24;
+      --border: #232938;
+      --border-strong: #2f3850;
+      --fg: #e7ebf3;
+      --fg-muted: #9aa3b5;
+      --fg-dim: #6b7488;
+      --accent: #f0a072;
+      --accent-2: #7dd3fc;
+      --good: #86efac;
+      --warn: #fcd34d;
+      --bad: #fca5a5;
+      --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); font-family: var(--sans); line-height: 1.55; }
+    body { padding: 48px 24px 96px; }
+    main { max-width: 1100px; margin: 0 auto; }
+    h1, h2, h3, h4 { font-weight: 600; letter-spacing: -0.01em; }
+    h1 { font-size: 32px; margin: 0 0 8px; }
+    h2 { font-size: 22px; margin: 52px 0 16px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+    h3 { font-size: 17px; margin: 0 0 6px; }
+    h4 { font-size: 13px; margin: 16px 0 6px; color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.08em; }
+    p { margin: 0 0 12px; }
+    a { color: var(--accent); }
+    code { font-family: var(--mono); font-size: 0.88em; background: var(--bg-elev); padding: 1px 5px; border-radius: 4px; border: 1px solid var(--border); }
+    pre { font-family: var(--mono); font-size: 12.5px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; overflow-x: auto; line-height: 1.5; }
+    pre code { background: transparent; border: 0; padding: 0; font-size: inherit; }
+    .lede { color: var(--fg-muted); font-size: 16px; max-width: 820px; }
+    .meta { color: var(--fg-dim); font-size: 13px; margin-top: 8px; font-family: var(--mono); }
+    .badge { display: inline-block; font-size: 11px; font-family: var(--mono); padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border-strong); color: var(--fg-muted); background: var(--bg-elev); }
+    .badge.accent { color: var(--accent); border-color: rgba(240,160,114,0.35); }
+    .card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin: 16px 0; }
+    .card.accent { border-left: 3px solid var(--accent); }
+    .card.accent-2 { border-left: 3px solid var(--accent-2); }
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    @media (max-width: 760px) { .grid-2 { grid-template-columns: 1fr; } }
+    .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+    ul { padding-left: 20px; margin: 8px 0 12px; }
+    li { margin: 4px 0; }
+    li.pro::marker { content: "+ "; color: var(--good); font-weight: 700; }
+    li.con::marker { content: "− "; color: var(--bad); font-weight: 700; }
+    li.note::marker { content: "› "; color: var(--fg-dim); }
+    li.check::marker { content: "\2610  "; color: var(--fg-muted); }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; margin: 12px 0; }
+    th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+    th { color: var(--fg-muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; background: var(--bg-elev); }
+    td code { white-space: nowrap; }
+    .pill { display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 11.5px; font-family: var(--mono); }
+    .pill.warn { background: rgba(252,211,77,0.12); color: var(--warn); }
+    .pill.new { background: rgba(240,160,114,0.14); color: var(--accent); }
+    .pill.neutral { background: var(--bg-elev); color: var(--fg-muted); border: 1px solid var(--border); }
+    .callout { border: 1px solid var(--border-strong); border-left: 3px solid var(--warn); background: rgba(252,211,77,0.04); padding: 14px 16px; border-radius: 8px; margin: 16px 0; font-size: 14px; }
+    .callout.info { border-left-color: var(--accent-2); background: rgba(125,211,252,0.04); }
+    .callout.accent { border-left-color: var(--accent); background: rgba(240,160,114,0.05); }
+    .toc { columns: 2; column-gap: 32px; font-size: 14px; }
+    @media (max-width: 760px) { .toc { columns: 1; } }
+    .toc a { display: block; padding: 3px 0; color: var(--fg-muted); text-decoration: none; }
+    .toc a:hover { color: var(--accent); }
+    footer { color: var(--fg-dim); font-size: 12.5px; margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--border); font-family: var(--mono); }
+    .s { color: var(--good); }
+    .c { color: var(--fg-dim); font-style: italic; }
+    .k { color: var(--accent-2); }
+  </style>
+</head>
+<body>
+<main>
+
+<header>
+  <div class="row" style="margin-bottom: 16px;">
+    <span class="badge">Implementation plan</span>
+    <span class="badge">spec/041-forecast-scenario-persistence</span>
+    <span class="badge accent">Challenged &amp; revised — ready to implement</span>
+  </div>
+  <h1>Saved Forecast Scenarios</h1>
+  <p class="lede">
+    Ship the follow-up that spec 036 explicitly deferred: <strong>persisting named scenarios</strong> for the
+    Budget / Cost Forecast Simulation. An admin who has tuned a plan — levers, edited ceiling, billing cadence —
+    can save it under a name, reload it later (or in another browser, or as another admin), rename it, update it
+    after refinement, and delete it when it has served its purpose. Saved scenarios are shared across all admins
+    and scoped to the active fiscal-year budget, exactly the <code>forecast_scenarios</code> table
+    (&ldquo;JSON params + label + budget_id&rdquo;) the 036 plan sketched for this follow-up.
+  </p>
+  <p class="meta">Drafted 2026-06-12 · challenged by a 5-lens adversarial panel, revised same day · author: T. Studer · branch: <code>041-forecast-scenario-persistence</code> · builds on specs 036 + 040 · estimate: ~1.5–2 dev days</p>
+</header>
+
+<div class="callout info" style="margin-top: 24px;">
+  <strong>First write path in the Scenarios section.</strong> 036 and 040 were read-only; this spec adds one new
+  table (migration <code>0026</code>), one new server-action file, and a save/load/rename/delete UI — while the
+  projection engine&rsquo;s existing functions, the data loader, and every existing figure remain untouched. A saved
+  scenario stores <em>assumptions</em> (the <code>ForecastInputs</code> parameter set), never computed results: on
+  load it is re-projected against whatever the live dataset says today.
+</div>
+
+<h2 id="toc">Contents</h2>
+<div class="toc card">
+  <a href="#goal">1 · Goal &amp; scope</a>
+  <a href="#semantics">2 · What a saved scenario is</a>
+  <a href="#schema">3 · Data model &amp; migration</a>
+  <a href="#validation">4 · Validation &amp; (de)serialization</a>
+  <a href="#actions">5 · Server actions</a>
+  <a href="#engine">6 · Engine changes</a>
+  <a href="#ui">7 · UI changes</a>
+  <a href="#tests">8 · Test plan</a>
+  <a href="#manifest">9 · File manifest</a>
+  <a href="#risks">10 · Risks &amp; decisions</a>
+  <a href="#accept">11 · Acceptance checklist</a>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="goal">1 · Goal &amp; scope</h2>
+
+<div class="card accent">
+  <h4>In scope</h4>
+  <ul>
+    <li class="note">A <code>forecast_scenarios</code> table (new migration <code>0026</code>): <code>budget_id</code> FK, unique name per budget (case-insensitive, expression index), <code>params</code> jsonb holding the full <code>ForecastInputs</code>, <code>created_by</code> attribution, timestamps.</li>
+    <li class="note">Server actions: <code>listForecastScenarios</code> (read, active budget, creator name joined), <code>createForecastScenario</code>, <code>updateForecastScenario</code> (overwrite params and/or rename; <strong>params optional</strong> so rename never silently rewrites assumptions), <code>deleteForecastScenario</code> — all admin-gated, Zod-validated, following the <code>ActionResult</code> + <code>revalidatePath</code> + audit-history conventions. Unique-violation races are caught and mapped to the same friendly duplicate-name error as the pre-check.</li>
+    <li class="note">A <strong>deterministic active-budget resolution contract</strong>: <code>status = 'active'</code> ordered by <code>fiscal_year DESC</code>, <code>LIMIT 1</code> — hardens the two-active-budgets state the schema permits and makes the integration tests deterministic.</li>
+    <li class="note">A pure engine helper <code>inputsFromSaved(ds, saved)</code> that re-bases any <code>ForecastInputs</code> onto the <em>current</em> dataset: tools that disappeared are dropped, tools that appeared get defaults. Used for loading saved scenarios <em>and</em> for re-basing surviving client state when the dataset prop refreshes.</li>
+    <li class="note">UI: a persistent <strong>Saved scenarios</strong> card (load / rename / delete, mono empty state), a <strong>Save scenario</strong> dialog (single primary button; Update-vs-new resolved by an in-dialog mode toggle), active-state tracking (<code>saved:&lt;id&gt;</code> activates the &ldquo;Your plan&rdquo; comparison row), inline <code>StatusText</code> feedback (the Nothing-system replacement for toasts).</li>
+    <li class="note">Unit tests (engine merge incl. billing round-trip, Zod schema matrix, auth gating), an integration test (real-DB CRUD round trip with audit + index assertions, deterministic seeding), and a manual Playwright browser pass against live data.</li>
+  </ul>
+  <h4>Out of scope</h4>
+  <ul>
+    <li class="con"><strong>Applying a scenario to the budget of record</strong> (writing <code>planned_amount_cents</code>) — still the separate follow-up 036 named; saving assumptions is modelling, not budget editing.</li>
+    <li class="con"><strong>Per-user/private scenarios, sharing controls, or roles beyond admin</strong> — the whole Scenarios section is admin-only; saved scenarios are one shared pool per budget (last-write-wins; overwrites are recoverable from the audit trail, <a href="#actions">§5</a>).</li>
+    <li class="con"><strong>Saved scenarios as extra ghost lines / comparison rows</strong> — the loaded scenario <em>is</em> the &ldquo;Your plan&rdquo; line; the three H2 presets stay the fixed comparison frame.</li>
+    <li class="con"><strong>Conflict detection / locking</strong> between admins editing the same scenario — accepted last-write-wins for v1, mitigated by audit snapshots.</li>
+    <li class="con"><strong>MCP exposure</strong> of saved scenarios — possible follow-up for the read side, not built speculatively.</li>
+    <li class="con"><strong>Scenario history / versioning UI</strong> — update overwrites; the audit trail records full param snapshots (recoverable forensically, no restore UI).</li>
+  </ul>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="semantics">2 · What a saved scenario is</h2>
+
+<p>A saved scenario is a <strong>named, shared parameter set</strong>: the exact <code>ForecastInputs</code> the client
+  already holds in state — the edited ceiling (cents) plus the per-tool levers (include / growth model / value /
+  burn growth / burn cap / premium share / billing cadence). It is deliberately <em>not</em> a snapshot of results:</p>
+
+<div class="grid-2">
+  <div class="card">
+    <h4>Stored: assumptions</h4>
+    <ul>
+      <li class="note"><code>params.ceilingCents</code> — the modeled ceiling the plan was tuned against (may differ from the live budget ceiling).</li>
+      <li class="note"><code>params.tools[key]</code> — one <code>ToolParams</code> per tool key (<code>api</code>, <code>claude</code>, <code>copilot</code>, <code>cursor</code>, <code>mscopilot</code>), including the Claude <code>billing</code> cadence when yearly (<code>undefined ≡ monthly</code> survives the JSON round trip — <code>JSON.stringify</code> drops undefined keys).</li>
+      <li class="note">A <code>name</code> (≤ 60 chars, unique per budget, case-insensitive) and <code>created_by</code> attribution (surfaced in the list and the delete confirm).</li>
+    </ul>
+  </div>
+  <div class="card">
+    <h4>Recomputed: everything else</h4>
+    <ul>
+      <li class="note">On load, the engine re-projects the saved params against the <em>current</em> dataset — seats, prices, burn, and elapsed actuals as of today. Year-end, breach, drivers all shift with live data, exactly like a preset.</li>
+      <li class="note">The saved-scenarios list shows each entry&rsquo;s <em>recomputed</em> year-end and Δ explicitly labelled against <strong>its own saved ceiling</strong> (&ldquo;vs saved $X&rdquo;), so the list reads as &ldquo;what would this plan mean today&rdquo; and the differing denominator is visible.</li>
+      <li class="note">A saved scenario whose tool keys drift from the live tool set still loads (<a href="#engine">§6</a>) — extinct keys dropped, new tools defaulted.</li>
+    </ul>
+  </div>
+</div>
+
+<p class="c">Scope rule: scenarios belong to the budget they were tuned against (<code>budget_id</code> FK). The page
+  always lists scenarios for the <em>active</em> budget — when FY2027 activates, FY2026 scenarios disappear from view
+  but survive in the table (and cascade away only if the budget row itself is deleted).</p>
+
+<!-- ============================================================ -->
+<h2 id="schema">3 · Data model &amp; migration</h2>
+
+<p>One table, following the house style (snake_case DB names, camelCase TS, array-form third argument,
+  <code>&lt;table&gt;_&lt;cols&gt;_idx</code> index names). Next journal entry: <code>0026</code>.</p>
+
+<pre><code><span class="c">// Forecast Scenarios (041-forecast-scenario-persistence)</span>
+export const forecastScenarios = pgTable(
+  "forecast_scenarios",
+  {
+    id: serial("id").primaryKey(),
+    budgetId: integer("budget_id")
+      .notNull()
+      .references(() =&gt; annualBudgets.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 60 }).notNull(),
+    <span class="c">// The full ForecastInputs parameter set (type-only import — no runtime dep).</span>
+    params: jsonb("params").$type&lt;ForecastInputs&gt;().notNull(),
+    createdBy: integer("created_by").references(() =&gt; users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) =&gt; [
+    index("forecast_scenarios_budget_id_idx").on(table.budgetId),
+    <span class="c">// One name per budget, case-insensitive ("Plan B" ≡ "plan b").</span>
+    uniqueIndex("forecast_scenarios_budget_name_idx").on(
+      table.budgetId,
+      sql`lower(${table.name})`,
+    ),
+  ],
+);</code></pre>
+
+<ul>
+  <li class="note"><strong>FK choices.</strong> <code>budget_id → cascade</code>: scenarios are owned what-ifs of a budget, worthless without it (matches <code>budget_periods</code>). <code>created_by → set null</code>: attribution is informational; deleting a user must not destroy shared scenarios (so the column is nullable; precedent: <code>ingestion_log.uploadedBy</code>).</li>
+  <li class="note"><strong>jsonb typing.</strong> <code>$type&lt;ForecastInputs&gt;()</code> with <code>import type { ForecastInputs } from "@/lib/scenarios/budget-forecast"</code> — type-only, erased at compile time, no runtime cycle (the engine itself imports nothing from <code>db</code>). Precedent: <code>users.preferences</code> is <code>$type&lt;UserPreferences&gt;()</code>.</li>
+  <li class="note"><strong>updatedAt</strong> maintained in app code on update (house convention — no <code>$onUpdate</code>).</li>
+  <li class="note"><strong>relations()</strong> block: <code>budget: one(annualBudgets)</code>, <code>creator: one(users)</code>, mirroring <code>inviteTokensRelations</code>.</li>
+  <li class="note"><strong>Migration workflow:</strong> <code>pnpm db:generate</code> → review the emitted SQL (additive only: 1 CREATE TABLE, 2 FKs, 2 indexes) with the <code>drizzle-migration-reviewer</code> agent → <code>pnpm db:migrate</code> against the dev DB. Verified against the installed drizzle-kit 0.31.9: the expression index emits as <code>USING btree ("budget_id", lower("name"))</code>.</li>
+  <li class="note"><strong><code>db:push</code> caveat (challenge finding):</strong> this is the repo&rsquo;s first expression index, and drizzle-kit&rsquo;s <code>push</code> diffing does not reliably detect expression changes inside index definitions — this table must go through <code>generate</code>/<code>migrate</code>, and a push-based dev loop should be sanity-checked once against the dev DB.</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2 id="validation">4 · Validation &amp; (de)serialization</h2>
+
+<div class="callout">
+  <strong>The boundary rule: validate on write <em>and</em> on read.</strong> The jsonb column is an open contract —
+  a row written by an older/newer build, or edited by hand, must never crash the page or feed the engine
+  <code>NaN</code>/<code>Infinity</code>. Writes <code>safeParse</code> the params and store <code>parsed.data</code>
+  (canonical shape); reads <code>safeParse</code> each row and <em>skip</em> (with a <code>console.error</code>) any
+  row that no longer conforms.
+</div>
+
+<p>Schemas live in <code>src/lib/validators.ts</code> (shared client/server, per house rules):</p>
+
+<pre><code>export const toolParamsSchema = z.object({
+  include: z.boolean(),
+  model: z.enum(["flat", "linear", "compound"]),
+  val: z.number().min(-100_000).max(100_000),
+  burnPct: z.number().min(-100).max(100_000).optional(),
+  burnCap: z.number().int().min(0).max(100_000_000).optional(),      <span class="c">// ≤ $1M/user/period</span>
+  premShare: z.number().min(0).max(1).optional(),
+  billing: z.enum(["monthly", "yearly"]).optional(),
+});
+
+export const forecastInputsSchema = z
+  .object({
+    ceilingCents: z.number().int().min(0).max(100_000_000_000),      <span class="c">// ≤ $1B</span>
+    tools: z.record(z.string().min(1).max(40), toolParamsSchema),
+  })
+  .refine((v) =&gt; Object.keys(v.tools).length &lt;= 20, {
+    message: "Too many tool entries",
+  });
+
+export const forecastScenarioNameSchema = z.string().trim().min(1).max(60);
+
+export const createForecastScenarioSchema = z.object({
+  name: forecastScenarioNameSchema,
+  params: forecastInputsSchema,
+});
+export const updateForecastScenarioSchema = z.object({
+  id: z.number().int().positive(),
+  name: forecastScenarioNameSchema,
+  params: forecastInputsSchema.optional(),   <span class="c">// omitted = rename-only, stored params untouched</span>
+});
+export const deleteForecastScenarioSchema = z.object({
+  id: z.number().int().positive(),
+});</code></pre>
+
+<ul>
+  <li class="note"><strong>Strip, don&rsquo;t strict (challenge revision).</strong> Plain <code>z.object</code> (Zod&rsquo;s default strip semantics, the only style used in <code>validators.ts</code>): unknown keys are dropped, not rejected. On write that keeps the stored shape canonical (we insert <code>parsed.data</code>); on read it keeps rows loadable if a future build adds-then-removes a field. <code>.strict()</code> would turn schema drift into save failures and skipped rows — worse availability for zero practical safety gain.</li>
+  <li class="note"><strong>Non-finite protection is built in:</strong> Zod 4&rsquo;s <code>z.number()</code> rejects <code>NaN</code>/<code>Infinity</code> by default (<code>.finite()</code> is a documented no-op in v4 and is not used). Nothing non-finite can reach <code>Math.pow</code>.</li>
+  <li class="note">Bounds are generous modelling limits, not business rules — wide enough for any sane what-if, tight enough to keep arithmetic and rendering safe. <code>ceilingCents: 0</code> is deliberately accepted (the UI guards the accidental-empty-field path, <a href="#ui">§7</a>).</li>
+  <li class="note"><strong>Type-level round trip:</strong> two type-only assignments (schema output → <code>ForecastInputs</code>, <code>ForecastInputs</code> → schema input) live in the validator test file and are enforced by <code>pnpm typecheck</code> (tests are in the tsconfig include), not by the vitest run.</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2 id="actions">5 · Server actions</h2>
+
+<p>New file <code>src/actions/forecast-scenarios.ts</code> (<code>"use server"</code>) — CRUD stays out of
+  <code>scenarios.ts</code>, which holds only the cached dataset loaders. All four follow the house conventions:
+  <code>requireAdmin()</code> first, <code>safeParse</code> against <code>unknown</code>, <code>ActionResult&lt;T&gt;</code>
+  result shape, audit history, <code>revalidatePath("/scenarios/budget-forecast")</code> after writes.</p>
+
+<div class="callout accent">
+  <strong>Active-budget resolution contract (challenge must-fix).</strong> All actions resolve the active budget
+  server-side — never trusted from the client — as <code>status = 'active'</code> <strong>ordered by
+  <code>fiscal_year DESC</code>, <code>LIMIT 1</code></strong>. The schema permits multiple active rows; an unordered
+  <code>findFirst</code> would be nondeterministic there (and made the integration-test seeding pattern unsafe).
+  Ordering by fiscal year makes production behaviour well-defined and lets tests seed a far-future active budget
+  that deterministically wins resolution.
+</div>
+
+<table>
+  <thead><tr><th>Action</th><th>Behaviour</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>listForecastScenarios()</code></td>
+      <td>Read. Admin gate returns <code>[]</code> — defense-in-depth only: the <code>/scenarios</code> layout already redirects non-admins and the sibling dataset loader throws first in <code>Promise.all</code>. Resolves the active budget (contract above); returns its scenarios ordered by name, each row&rsquo;s <code>params</code> re-validated with <code>safeParse</code> (invalid → skipped + <code>console.error</code>). Returns <code>{ id, name, params, creatorName, updatedAt }</code> (<code>users</code> left-joined, <code>updatedAt</code> as ISO string). <strong>Uncached</strong> — the page is already dynamic (auth) and the query is a single indexed select; freshness beats a cache here.</td>
+    </tr>
+    <tr>
+      <td><code>createForecastScenario(input: unknown)</code></td>
+      <td>Validate → resolve active budget (<code>error: "No active budget"</code> if none) → cap check (<strong>≤ 50 per budget</strong>, pre-check only — see §10) → case-insensitive duplicate-name pre-check (friendly <code>error</code>) → insert with <code>createdBy: Number(admin.id)</code>, <strong>unique-violation (PG 23505) caught and mapped to the same duplicate-name error</strong> (the race path must honour the <code>ActionResult</code> contract too) → <code>recordCreation("forecast_scenario", id, adminId)</code> → revalidate. Returns <code>{ id }</code>.</td>
+    </tr>
+    <tr>
+      <td><code>updateForecastScenario(input: unknown)</code></td>
+      <td>Validate → load row (<code>error: "Scenario not found"</code>) → duplicate-name pre-check excluding self → update <code>name</code>, <code>params</code> (only when provided — rename-only leaves stored params untouched), <code>updatedAt: new Date()</code>, 23505 caught as above → <code>recordUpdate(...)</code> with a name diff when renamed <strong>and a full params snapshot</strong> (<code>{ params: { old: &lt;previous object&gt;, new: &lt;next object&gt; } }</code>) when params change — so a teammate&rsquo;s overwritten plan is recoverable from <code>change_history</code>, and a params-only update never hits <code>recordUpdate</code>&rsquo;s empty-diff early-return (challenge finding) → revalidate. Returns <code>{ id }</code>.</td>
+    </tr>
+    <tr>
+      <td><code>deleteForecastScenario(id: number)</code></td>
+      <td>Validate id → load row → snapshot into the audit trail (<code>deleteBilledCost</code> pattern: name + params recorded as <code>previousValue</code> before <code>db.delete</code>) → delete → revalidate. Returns <code>{ id }</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+<ul>
+  <li class="note"><code>change_history.entity_type</code> is a free-form <code>varchar(50)</code> — <code>"forecast_scenario"</code> needs no enum migration.</li>
+  <li class="note"><code>page.tsx</code> loads the list alongside the dataset (<code>Promise.all</code>); after a mutation, <code>revalidatePath</code> + the client&rsquo;s <code>router.refresh()</code> re-render the page with the fresh list while client state (the user&rsquo;s current inputs) survives — and is re-based if the dataset itself changed (<a href="#ui">§7</a>).</li>
+</ul>
+
+<!-- ============================================================ -->
+<h2 id="engine">6 · Engine changes</h2>
+
+<p>One additive pure function in <code>src/lib/scenarios/budget-forecast.ts</code> — no signature changes, no new imports:</p>
+
+<pre><code><span class="c">/**
+ * Re-base a parameter set onto the current dataset. Tools that no longer
+ * exist are dropped; tools that appeared since the params were captured get
+ * DEFAULT_PARAMS — so a stale scenario (or surviving client state after a
+ * dataset refresh) always yields a complete, renderable input set.
+ */</span>
+export function inputsFromSaved(
+  ds: ForecastDataset,
+  saved: ForecastInputs,
+): ForecastInputs {
+  const tools: Record&lt;string, ToolParams&gt; = {};
+  for (const tool of ds.tools) {
+    const p = saved.tools[tool.key];
+    tools[tool.key] = p ? { ...p } : { ...DEFAULT_PARAMS };
+  }
+  return { ceilingCents: saved.ceilingCents, tools };
+}</code></pre>
+
+<p class="c">Mirrors <code>inputsFromPreset</code>&rsquo;s shape (copy semantics, dataset-scoped keys) so the client can
+  treat presets and saved scenarios uniformly. Params are copied verbatim — including the claudeSeats
+  <code>billing</code> cadence, which is what makes &ldquo;load restores the cadence&rdquo; true (pinned by a unit
+  test). <code>projectForecast</code>, the presets, and all result types are untouched.</p>
+
+<!-- ============================================================ -->
+<h2 id="ui">7 · UI changes</h2>
+
+<p>All in <code>src/app/scenarios/budget-forecast/</code>. The client gains a <code>savedScenarios</code> prop
+  (<code>{ id, name, params, creatorName, updatedAt }[]</code>, already validated server-side).</p>
+
+<table>
+  <thead><tr><th>Where</th><th>Change</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>page.tsx</code></td>
+      <td><code>Promise.all([loadBudgetForecastDataset(), listForecastScenarios()])</code>; pass both to the client.</td>
+    </tr>
+    <tr>
+      <td>Active-state model</td>
+      <td><code>ActiveScenario</code> widens to <code>PresetKey | "custom" | `saved:${number}`</code>. <strong>Mapping (challenge fix):</strong> when active is <code>saved:*</code>, the <strong>&ldquo;Your plan&rdquo; comparison row renders as active</strong> (it is showing exactly the loaded scenario&rsquo;s numbers: <code>isPlanActive = active === "custom" || active.startsWith("saved:")</code>); preset tiles stay inactive; the Custom tile also stays inactive (the saved card row carries the specific identity). A separate <code>loadedSavedId</code> powers the Update offer and <strong>is cleared by Reset <em>and</em> by clicking any preset tile</strong> (a preset is a new starting point, not a refinement of the loaded scenario — prevents one-click overwrite of a shared row with preset params); plain control edits keep it (flipping <code>active</code> to <code>"custom"</code> as today). The Update offer is derived live from <code>savedScenarios.find(s =&gt; s.id === loadedSavedId)</code> — if another admin deleted the row, the offer disappears instead of going stale.</td>
+    </tr>
+    <tr>
+      <td>Dataset-refresh re-base (challenge fix)</td>
+      <td><code>router.refresh()</code> after mutations is the page&rsquo;s first path to a <em>changed dataset prop under surviving client state</em> (the loader&rsquo;s 1h cache can expire mid-session). A dataset tool key absent from <code>inputs.tools</code> would be hidden by the controls (<code>if (!p) return null</code>) yet projected at defaults by the engine. Fix: an effect keyed on <code>dataset.generatedAt</code> re-bases surviving inputs through <code>inputsFromSaved(dataset, prev)</code> (skipping the initial mount) — same helper, same semantics.</td>
+    </tr>
+    <tr>
+      <td><strong>Saved scenarios card</strong> (new, between the preset tiles and Assumptions; <strong>always rendered</strong>)</td>
+      <td>Header: mono &ldquo;Saved scenarios&rdquo; microlabel + the page-level <code>StatusText</code> (a stable landing spot for save/delete feedback even when the list empties). Empty state: one mono line, house style — <code>[ NO SAVED SCENARIOS — SAVE YOUR CURRENT PLAN ]</code> (persistent card fixes first-use discoverability and the delete-the-last-row focus dead end). Rows as a <code>ul</code>/<code>li</code> list, <code>max-h</code> + internal scroll beyond ~6 rows: a load <code>&lt;button aria-pressed&gt;</code> whose accessible name is the scenario name (ink-bar active treatment mirroring the comparison table, but on a real pressed state, not aria-hidden decoration); outside the button: recomputed year-end + Δ <strong>labelled &ldquo;vs saved $X&rdquo;</strong> (different denominator than the page&rsquo;s edited ceiling — made visible, challenge finding), creator + updated caption (<code>T. Studer · 2026-06-12</code>); a pencil icon-button (<code>aria-label="Rename scenario &lt;name&gt;"</code>) and a <code>Trash2</code> ghost icon-button (<code>aria-label="Delete scenario &lt;name&gt;"</code>).</td>
+    </tr>
+    <tr>
+      <td>Load behaviour</td>
+      <td><code>setInputs(inputsFromSaved(dataset, s.params))</code> + sync <code>ceilingDollars</code> with the <em>exact</em> value (<code>String(cents / 100)</code> — no rounding, so a fractional saved ceiling round-trips; challenge finding) + <code>setActive(`saved:${id}`)</code> + <code>setLoadedSavedId(id)</code>. Loading restores the <em>full</em> assumption set including the saved ceiling and billing cadence — unlike preset tiles, which deliberately reset the ceiling (040&rsquo;s asymmetry stays preset-only).</td>
+    </tr>
+    <tr>
+      <td><strong>Save dialog</strong> (trigger: &ldquo;Save scenario&rdquo; button in the Assumptions header, next to &ldquo;Reset to H2 Plan&rdquo;)</td>
+      <td>House dialog pattern (plain-state controlled <code>Dialog</code>, <code>Label</code> + <code>Input</code>, footer with <code>StatusText</code> on the left, <strong>one primary button</strong> — two commit buttons have no precedent; challenge finding). When a loaded scenario exists, a segmented mode toggle (the page&rsquo;s own <code>ToggleButton</code> pattern) selects <em>Update &ldquo;name&rdquo;</em> vs <em>Save as new</em>; otherwise create-only, no toggle. Name field pre-filled from the <em>live</em> row in update mode. A mono summary line echoes exactly what will be saved: <code>Ceiling $X · Claude billing monthly/yearly · N of M tools included</code> — the user sees a $0 ceiling before committing one. Primary label <em>Update</em>/<em>Create</em>, pending label <em>Saving...</em>; submit disabled while pending, when the name is empty, or when the ceiling field is empty/cleared (prevents silently persisting <code>ceilingCents: 0</code>; challenge finding). <strong>Update always saves the CURRENT inputs and ceiling.</strong> Errors render inside the dialog (two-channel pattern); on success: close → <code>status.ok("SAVED")</code> on the card header → <code>router.refresh()</code>.</td>
+    </tr>
+    <tr>
+      <td><strong>Rename dialog</strong> (pencil on each row)</td>
+      <td>Small name-only dialog → <code>updateForecastScenario({ id, name })</code> (params omitted — stored assumptions untouched; closes the &ldquo;rename forces a params rewrite&rdquo; hole the panel found). Same footer conventions.</td>
+    </tr>
+    <tr>
+      <td>Delete confirm</td>
+      <td>House <code>AlertDialog</code> with nullable <code>deleteTarget</code> naming the scenario (and its creator); destructive action button with pending label <em>Deleting...</em>, <strong>disabled while pending</strong> (no double-fire); errors render via <code>StatusText</code> in the <code>AlertDialogFooter</code> (two-channel). On success: clear target, <code>status.ok("DELETED")</code> on the card header, <code>router.refresh()</code>, move focus to the card heading (the trigger row is gone — don&rsquo;t drop focus to <code>&lt;body&gt;</code>); if the deleted scenario was loaded, drop <code>loadedSavedId</code> (current inputs stay — deleting the record doesn&rsquo;t yank the user&rsquo;s working state).</td>
+    </tr>
+    <tr>
+      <td>Feedback</td>
+      <td><code>useInlineStatus</code> + <code>StatusText</code> everywhere — <strong>no Sonner</strong> (deprecated by the Nothing design system; bracketed mono <code>[SAVED]</code> text is the convention).</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2 id="tests">8 · Test plan</h2>
+
+<div class="grid-2">
+  <div class="card accent-2">
+    <h4>Unit (Vitest, no DB)</h4>
+    <ul>
+      <li class="check"><code>inputsFromSaved</code> on the frozen 036 fixture (extended in place in <code>tests/unit/scenarios/budget-forecast.test.ts</code>): carries the saved ceiling (incl. the 0 boundary); copies params per tool; <strong>drops extinct keys</strong>; <strong>defaults new tools</strong>; returned objects are copies; <strong>yearly billing round-trips unchanged</strong> (the only automated check of &ldquo;load restores the cadence&rdquo;); a <code>billing</code> value stranded on a non-claudeSeats key copies through but is provably cost-neutral; <code>saved.tools = {}</code> yields all-defaults with the saved ceiling.</li>
+      <li class="check"><code>tests/unit/scenarios/forecast-scenario-validators.test.ts</code> (colocated with the engine tests — no cross-test-file fixture imports; challenge finding): schema matrix — accepts a realistic inputs literal and a yearly-billing variant and <code>ceilingCents: 0</code>; rejects negative/fractional/over-cap ceilings, <code>premShare &gt; 1</code>, unknown <code>billing</code> values, <code>NaN</code>/<code>Infinity</code> <code>val</code>, &gt; 20 tool entries; strips unknown keys; rename-only update parse (params omitted). Plus the two type-only round-trip assignments (enforced by <code>pnpm typecheck</code>).</li>
+      <li class="check"><code>tests/unit/actions/forecast-scenarios-auth.test.ts</code> (precedent: <code>assignments-export.test.ts</code>): <code>requireAdmin → null</code> ⇒ list returns <code>[]</code>, all three mutations return <code>{ success: false, error: "Unauthorized" }</code>, DB never touched.</li>
+    </ul>
+  </div>
+  <div class="card accent-2">
+    <h4>Integration + browser</h4>
+    <ul>
+      <li class="check"><code>tests/integration/forecast-scenarios.test.ts</code> (real Neon DB, mocked <code>requireAdmin</code>, teardown deletes): seeds an active budget at <strong>FY ≥ 3000</strong> — deterministically the resolution winner under the §5 ordering contract even with the dev DB&rsquo;s real active budget present (challenge must-fix; assertions additionally scoped by the seeded <code>budgetId</code>). Flow: create → list (creator name, ISO dates) → update (rename + params, <strong>audit rows asserted</strong>: created/updated incl. the params snapshot, <code>budget-extensions</code> precedent) → rename-only (stored params unchanged) → duplicate-name rejection (case-insensitive, via the action) → <strong>direct case-variant insert asserting the expression index itself fires</strong> (proves migration 0026&rsquo;s SQL + the race backstop) → <strong>malformed-params row inserted directly is skipped by list</strong> (the safeParse-on-read rule gets coverage) → cap: <strong>bulk-seed 50 rows in one insert</strong>, then one action call asserts the friendly cap error (not 50 action calls ≈ 250 round trips; challenge finding) → delete (audit snapshot round-trips name + params) → list scoped to the seeded budget is empty.</li>
+      <li class="check"><strong>Manual</strong> Playwright pass against the dev server (agent session — the seeded agent user must be an admin; any stranded test scenario is cleaned up at the end): save a tuned custom plan → row appears with recomputed figures → tweak controls → load restores ceiling + cadence + levers exactly → preset tile click clears the Update offer → update overwrites → rename-only → delete with confirm → persistent card shows the empty state. Screenshots reviewed. Manual-only, consistent with 036/040 (no committed e2e file).</li>
+      <li class="check"><code>pnpm lint</code> zero warnings · <code>pnpm typecheck</code> · full unit suite green.</li>
+    </ul>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<h2 id="manifest">9 · File manifest</h2>
+
+<table>
+  <thead><tr><th>File</th><th></th><th>Purpose</th></tr></thead>
+  <tbody>
+    <tr><td><code>src/lib/db/schema.ts</code></td><td><span class="pill warn">edit</span></td><td><code>forecast_scenarios</code> table + relations block.</td></tr>
+    <tr><td><code>src/lib/db/migrations/0026_*.sql</code></td><td><span class="pill new">new</span></td><td>Generated additive migration (table + FKs + indexes).</td></tr>
+    <tr><td><code>src/lib/validators.ts</code></td><td><span class="pill warn">edit</span></td><td><code>toolParamsSchema</code>, <code>forecastInputsSchema</code>, create/update/delete scenario schemas.</td></tr>
+    <tr><td><code>src/actions/forecast-scenarios.ts</code></td><td><span class="pill new">new</span></td><td>List / create / update / delete server actions (+ deterministic active-budget resolution).</td></tr>
+    <tr><td><code>src/lib/scenarios/budget-forecast.ts</code></td><td><span class="pill warn">edit</span></td><td>Add pure <code>inputsFromSaved()</code>.</td></tr>
+    <tr><td><code>src/app/scenarios/budget-forecast/page.tsx</code></td><td><span class="pill warn">edit</span></td><td>Load saved scenarios alongside the dataset.</td></tr>
+    <tr><td><code>src/app/scenarios/budget-forecast/budget-forecast-client.tsx</code></td><td><span class="pill warn">edit</span></td><td>Saved-scenarios card, save/rename dialogs, delete confirm, active/loaded tracking, dataset re-base effect.</td></tr>
+    <tr><td><code>tests/unit/scenarios/budget-forecast.test.ts</code></td><td><span class="pill warn">edit</span></td><td><code>inputsFromSaved</code> coverage.</td></tr>
+    <tr><td><code>tests/unit/scenarios/forecast-scenario-validators.test.ts</code></td><td><span class="pill new">new</span></td><td>Schema accept/reject/strip matrix + type-level round trip.</td></tr>
+    <tr><td><code>tests/unit/actions/forecast-scenarios-auth.test.ts</code></td><td><span class="pill new">new</span></td><td>Auth-gating contract for all four actions.</td></tr>
+    <tr><td><code>tests/integration/forecast-scenarios.test.ts</code></td><td><span class="pill new">new</span></td><td>Real-DB CRUD round trip + audit + index + read-skip assertions.</td></tr>
+    <tr><td><code>CLAUDE.md</code></td><td><span class="pill warn">edit</span></td><td>&ldquo;Recent Changes&rdquo; line for 041.</td></tr>
+    <tr><td><code>specs/041-forecast-scenario-persistence/*</code></td><td><span class="pill new">new</span></td><td>This plan + running implementation notes.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2 id="risks">10 · Risks &amp; decisions</h2>
+
+<table>
+  <thead><tr><th>Topic</th><th>Decision / mitigation</th></tr></thead>
+  <tbody>
+    <tr><td>Shared vs per-user scenarios</td><td><strong>Shared pool per budget, last-write-wins.</strong> The tool exists so budget owners can align on a plan; private drafts would fragment that. Mitigations: creator attribution surfaced in the list and delete confirm; full params snapshots in <code>change_history</code> on update and delete, so an overwritten plan is recoverable forensically. Flagged in the notes as the one interpretive call worth explicit user confirmation.</td></tr>
+    <tr><td>Stale params vs live dataset</td><td>Saved params are re-based on load (<code>inputsFromSaved</code>) and re-projected against live data — never stored results. Extinct tool keys dropped, new tools defaulted. The same helper re-bases surviving client state when the dataset prop refreshes mid-session (closes the hidden-tool hole <code>router.refresh()</code> would otherwise open).</td></tr>
+    <tr><td>jsonb rot</td><td>Zod <code>safeParse</code> on every read; non-conforming rows are skipped with a logged error instead of crashing the page (covered by an integration case). Strip semantics keep rows loadable across schema evolution; writes store <code>parsed.data</code>, keeping the stored shape canonical.</td></tr>
+    <tr><td>Duplicate names / races</td><td>App-level case-insensitive pre-check for a friendly message; <code>uniqueIndex(budget_id, lower(name))</code> as the DB backstop — and the backstop&rsquo;s 23505 is <strong>caught and mapped to the same friendly error</strong>, so the race path honours the <code>ActionResult</code> contract instead of surfacing a Next.js digest (challenge finding).</td></tr>
+    <tr><td>Unbounded growth</td><td>Cap of <strong>50 scenarios per budget</strong> with an explicit error. Pre-check only — two concurrent creates at 49 can land 51 rows; accepted as harmless (no DB backstop by design; the cap is a UX guardrail, not an invariant).</td></tr>
+    <tr><td>Active-budget race / split-brain</td><td>Saving resolves the active budget server-side at write time under the §5 ordering contract. If another admin activates a different budget mid-session, the save lands on the new active budget and the refreshed list shows it; the <em>charts</em> may keep rendering the old budget&rsquo;s cached dataset for up to 1h (the dataset cache is not tag-invalidated by budget activation — pre-existing). Accepted: budget activation is a rare, admin-driven event; a hard refresh resolves the split view. Documented rather than hidden.</td></tr>
+    <tr><td>Ceiling semantics on load</td><td>Loading a saved scenario restores its <em>saved</em> ceiling (full assumption set, exact string sync — no rounding drift). Preset tiles keep 040&rsquo;s reset-to-live-ceiling behaviour. The two affordances answer different questions (&ldquo;this plan as tuned&rdquo; vs &ldquo;this preset against the live budget&rdquo;).</td></tr>
+    <tr><td>Saved-row scoring</td><td>Rows are scored against <strong>their own saved ceiling</strong>, with the denominator made explicit in the row (&ldquo;vs saved $X&rdquo;) so the two Δ semantics on one page can&rsquo;t be misread (challenge finding). Scoring against the page&rsquo;s transient edited ceiling would make the list jitter.</td></tr>
+    <tr><td>Accidental shared-row overwrite</td><td>Three guards (challenge findings): preset-tile clicks clear <code>loadedSavedId</code> (no &ldquo;Update&rdquo; offer for preset params); the Update offer is derived from the live <code>savedScenarios</code> prop (a concurrently-deleted row withdraws the offer); the save dialog echoes exactly what will be saved and blocks an empty/cleared ceiling field.</td></tr>
+    <tr><td>Feedback affordance</td><td><code>StatusText</code>/<code>useInlineStatus</code>, not Sonner — toasts are deprecated in the Nothing design system (one legacy usage left app-wide). Card-header status + in-dialog status (two-channel house pattern).</td></tr>
+    <tr><td>Cache coherence</td><td>The scenario list is an uncached read on a dynamic page; mutations <code>revalidatePath</code>. The dataset loader&rsquo;s <code>unstable_cache</code> is untouched (scenario writes don&rsquo;t change live cost data).</td></tr>
+    <tr><td>Role &amp; sensitivity</td><td>Admin-only end to end (<code>requireAdmin</code> in every action; the layout already gates). Params contain no secrets — growth assumptions and a ceiling.</td></tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2 id="accept">11 · Acceptance checklist</h2>
+<ul>
+  <li class="check">Migration <code>0026</code> applies cleanly (additive only); <code>db:generate</code> output reviewed (expression index emits correctly).</li>
+  <li class="check">Save: a tuned Custom plan (edited ceiling, yearly billing, tweaked levers) saves under a name; the row appears with recomputed year-end and Δ labelled &ldquo;vs saved $X&rdquo;, plus creator + updated caption.</li>
+  <li class="check">Load: selecting a saved scenario restores every lever, the saved ceiling (exactly), and the billing cadence; the row shows pressed; the &ldquo;Your plan&rdquo; comparison row carries the active treatment; editing any control flips to Custom but keeps the Update offer.</li>
+  <li class="check">Preset tile click while a saved scenario is loaded clears the Update offer (no one-click overwrite with preset params).</li>
+  <li class="check">Update: overwrites params and/or renames via the mode toggle; rename-only (pencil) leaves stored params untouched; duplicate names (case-insensitive) rejected with a friendly inline error — including the race path.</li>
+  <li class="check">Delete: AlertDialog confirm naming scenario + creator; pending-disabled action; the list refreshes; focus moves to the card heading; a loaded-then-deleted scenario leaves the working state intact.</li>
+  <li class="check">The saved card renders persistently with a mono empty state; two admins see the same shared list.</li>
+  <li class="check">No active budget → saving fails with a clear error; the page&rsquo;s existing empty state is unchanged.</li>
+  <li class="check">Unit + integration suites green (incl. audit, expression-index, and read-skip assertions); lint zero warnings; typecheck clean; Playwright pass recorded in the notes.</li>
+  <li class="check">036/040 behaviour untouched: presets, billing toggle, charts, tables, and all existing regression anchors unchanged.</li>
+</ul>
+
+<footer>
+  AI Developer Hub · spec/041-forecast-scenario-persistence · implementation plan · drafted &amp; challenged 2026-06-12 · companion: implementation-notes.html
+</footer>
+
+</main>
+</body>
+</html>

--- a/specs/041-forecast-scenario-persistence/implementation-plan.html
+++ b/specs/041-forecast-scenario-persistence/implementation-plan.html
@@ -1,183 +1,520 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Implementation Plan — Saved Forecast Scenarios (041)</title>
-  <style>
-    :root {
-      --bg: #0b0d12;
-      --bg-elev: #11141b;
-      --bg-card: #161a24;
-      --border: #232938;
-      --border-strong: #2f3850;
-      --fg: #e7ebf3;
-      --fg-muted: #9aa3b5;
-      --fg-dim: #6b7488;
-      --accent: #f0a072;
-      --accent-2: #7dd3fc;
-      --good: #86efac;
-      --warn: #fcd34d;
-      --bad: #fca5a5;
-      --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
-      --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    }
-    * { box-sizing: border-box; }
-    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); font-family: var(--sans); line-height: 1.55; }
-    body { padding: 48px 24px 96px; }
-    main { max-width: 1100px; margin: 0 auto; }
-    h1, h2, h3, h4 { font-weight: 600; letter-spacing: -0.01em; }
-    h1 { font-size: 32px; margin: 0 0 8px; }
-    h2 { font-size: 22px; margin: 52px 0 16px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
-    h3 { font-size: 17px; margin: 0 0 6px; }
-    h4 { font-size: 13px; margin: 16px 0 6px; color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.08em; }
-    p { margin: 0 0 12px; }
-    a { color: var(--accent); }
-    code { font-family: var(--mono); font-size: 0.88em; background: var(--bg-elev); padding: 1px 5px; border-radius: 4px; border: 1px solid var(--border); }
-    pre { font-family: var(--mono); font-size: 12.5px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; overflow-x: auto; line-height: 1.5; }
-    pre code { background: transparent; border: 0; padding: 0; font-size: inherit; }
-    .lede { color: var(--fg-muted); font-size: 16px; max-width: 820px; }
-    .meta { color: var(--fg-dim); font-size: 13px; margin-top: 8px; font-family: var(--mono); }
-    .badge { display: inline-block; font-size: 11px; font-family: var(--mono); padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border-strong); color: var(--fg-muted); background: var(--bg-elev); }
-    .badge.accent { color: var(--accent); border-color: rgba(240,160,114,0.35); }
-    .card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin: 16px 0; }
-    .card.accent { border-left: 3px solid var(--accent); }
-    .card.accent-2 { border-left: 3px solid var(--accent-2); }
-    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-    @media (max-width: 760px) { .grid-2 { grid-template-columns: 1fr; } }
-    .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
-    ul { padding-left: 20px; margin: 8px 0 12px; }
-    li { margin: 4px 0; }
-    li.pro::marker { content: "+ "; color: var(--good); font-weight: 700; }
-    li.con::marker { content: "− "; color: var(--bad); font-weight: 700; }
-    li.note::marker { content: "› "; color: var(--fg-dim); }
-    li.check::marker { content: "\2610  "; color: var(--fg-muted); }
-    table { width: 100%; border-collapse: collapse; font-size: 14px; margin: 12px 0; }
-    th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
-    th { color: var(--fg-muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; background: var(--bg-elev); }
-    td code { white-space: nowrap; }
-    .pill { display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 11.5px; font-family: var(--mono); }
-    .pill.warn { background: rgba(252,211,77,0.12); color: var(--warn); }
-    .pill.new { background: rgba(240,160,114,0.14); color: var(--accent); }
-    .pill.neutral { background: var(--bg-elev); color: var(--fg-muted); border: 1px solid var(--border); }
-    .callout { border: 1px solid var(--border-strong); border-left: 3px solid var(--warn); background: rgba(252,211,77,0.04); padding: 14px 16px; border-radius: 8px; margin: 16px 0; font-size: 14px; }
-    .callout.info { border-left-color: var(--accent-2); background: rgba(125,211,252,0.04); }
-    .callout.accent { border-left-color: var(--accent); background: rgba(240,160,114,0.05); }
-    .toc { columns: 2; column-gap: 32px; font-size: 14px; }
-    @media (max-width: 760px) { .toc { columns: 1; } }
-    .toc a { display: block; padding: 3px 0; color: var(--fg-muted); text-decoration: none; }
-    .toc a:hover { color: var(--accent); }
-    footer { color: var(--fg-dim); font-size: 12.5px; margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--border); font-family: var(--mono); }
-    .s { color: var(--good); }
-    .c { color: var(--fg-dim); font-style: italic; }
-    .k { color: var(--accent-2); }
-  </style>
-</head>
-<body>
-<main>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Implementation Plan — Saved Forecast Scenarios (041)</title>
+    <style>
+      :root {
+        --bg: #0b0d12;
+        --bg-elev: #11141b;
+        --bg-card: #161a24;
+        --border: #232938;
+        --border-strong: #2f3850;
+        --fg: #e7ebf3;
+        --fg-muted: #9aa3b5;
+        --fg-dim: #6b7488;
+        --accent: #f0a072;
+        --accent-2: #7dd3fc;
+        --good: #86efac;
+        --warn: #fcd34d;
+        --bad: #fca5a5;
+        --mono:
+          ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+        --sans:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--sans);
+        line-height: 1.55;
+      }
+      body {
+        padding: 48px 24px 96px;
+      }
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+      h1,
+      h2,
+      h3,
+      h4 {
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      h1 {
+        font-size: 32px;
+        margin: 0 0 8px;
+      }
+      h2 {
+        font-size: 22px;
+        margin: 52px 0 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border);
+      }
+      h3 {
+        font-size: 17px;
+        margin: 0 0 6px;
+      }
+      h4 {
+        font-size: 13px;
+        margin: 16px 0 6px;
+        color: var(--fg-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      p {
+        margin: 0 0 12px;
+      }
+      a {
+        color: var(--accent);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.88em;
+        background: var(--bg-elev);
+        padding: 1px 5px;
+        border-radius: 4px;
+        border: 1px solid var(--border);
+      }
+      pre {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 14px 16px;
+        overflow-x: auto;
+        line-height: 1.5;
+      }
+      pre code {
+        background: transparent;
+        border: 0;
+        padding: 0;
+        font-size: inherit;
+      }
+      .lede {
+        color: var(--fg-muted);
+        font-size: 16px;
+        max-width: 820px;
+      }
+      .meta {
+        color: var(--fg-dim);
+        font-size: 13px;
+        margin-top: 8px;
+        font-family: var(--mono);
+      }
+      .badge {
+        display: inline-block;
+        font-size: 11px;
+        font-family: var(--mono);
+        padding: 2px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--border-strong);
+        color: var(--fg-muted);
+        background: var(--bg-elev);
+      }
+      .badge.accent {
+        color: var(--accent);
+        border-color: rgba(240, 160, 114, 0.35);
+      }
+      .card {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 24px;
+        margin: 16px 0;
+      }
+      .card.accent {
+        border-left: 3px solid var(--accent);
+      }
+      .card.accent-2 {
+        border-left: 3px solid var(--accent-2);
+      }
+      .grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+      @media (max-width: 760px) {
+        .grid-2 {
+          grid-template-columns: 1fr;
+        }
+      }
+      .row {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      ul {
+        padding-left: 20px;
+        margin: 8px 0 12px;
+      }
+      li {
+        margin: 4px 0;
+      }
+      li.pro::marker {
+        content: "+ ";
+        color: var(--good);
+        font-weight: 700;
+      }
+      li.con::marker {
+        content: "− ";
+        color: var(--bad);
+        font-weight: 700;
+      }
+      li.note::marker {
+        content: "› ";
+        color: var(--fg-dim);
+      }
+      li.check::marker {
+        content: "\2610  ";
+        color: var(--fg-muted);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+        margin: 12px 0;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--border);
+        vertical-align: top;
+      }
+      th {
+        color: var(--fg-muted);
+        font-weight: 500;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: var(--bg-elev);
+      }
+      td code {
+        white-space: nowrap;
+      }
+      .pill {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 6px;
+        font-size: 11.5px;
+        font-family: var(--mono);
+      }
+      .pill.warn {
+        background: rgba(252, 211, 77, 0.12);
+        color: var(--warn);
+      }
+      .pill.new {
+        background: rgba(240, 160, 114, 0.14);
+        color: var(--accent);
+      }
+      .pill.neutral {
+        background: var(--bg-elev);
+        color: var(--fg-muted);
+        border: 1px solid var(--border);
+      }
+      .callout {
+        border: 1px solid var(--border-strong);
+        border-left: 3px solid var(--warn);
+        background: rgba(252, 211, 77, 0.04);
+        padding: 14px 16px;
+        border-radius: 8px;
+        margin: 16px 0;
+        font-size: 14px;
+      }
+      .callout.info {
+        border-left-color: var(--accent-2);
+        background: rgba(125, 211, 252, 0.04);
+      }
+      .callout.accent {
+        border-left-color: var(--accent);
+        background: rgba(240, 160, 114, 0.05);
+      }
+      .toc {
+        columns: 2;
+        column-gap: 32px;
+        font-size: 14px;
+      }
+      @media (max-width: 760px) {
+        .toc {
+          columns: 1;
+        }
+      }
+      .toc a {
+        display: block;
+        padding: 3px 0;
+        color: var(--fg-muted);
+        text-decoration: none;
+      }
+      .toc a:hover {
+        color: var(--accent);
+      }
+      footer {
+        color: var(--fg-dim);
+        font-size: 12.5px;
+        margin-top: 64px;
+        padding-top: 24px;
+        border-top: 1px solid var(--border);
+        font-family: var(--mono);
+      }
+      .s {
+        color: var(--good);
+      }
+      .c {
+        color: var(--fg-dim);
+        font-style: italic;
+      }
+      .k {
+        color: var(--accent-2);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="row" style="margin-bottom: 16px">
+          <span class="badge">Implementation plan</span>
+          <span class="badge">spec/041-forecast-scenario-persistence</span>
+          <span class="badge accent"
+            >Challenged &amp; revised — ready to implement</span
+          >
+        </div>
+        <h1>Saved Forecast Scenarios</h1>
+        <p class="lede">
+          Ship the follow-up that spec 036 explicitly deferred:
+          <strong>persisting named scenarios</strong> for the Budget / Cost
+          Forecast Simulation. An admin who has tuned a plan — levers, edited
+          ceiling, billing cadence — can save it under a name, reload it later
+          (or in another browser, or as another admin), rename it, update it
+          after refinement, and delete it when it has served its purpose. Saved
+          scenarios are shared across all admins and scoped to the active
+          fiscal-year budget, exactly the <code>forecast_scenarios</code> table
+          (&ldquo;JSON params + label + budget_id&rdquo;) the 036 plan sketched
+          for this follow-up.
+        </p>
+        <p class="meta">
+          Drafted 2026-06-12 · challenged by a 5-lens adversarial panel, revised
+          same day · author: T. Studer · branch:
+          <code>041-forecast-scenario-persistence</code> · builds on specs 036 +
+          040 · estimate: ~1.5–2 dev days
+        </p>
+      </header>
 
-<header>
-  <div class="row" style="margin-bottom: 16px;">
-    <span class="badge">Implementation plan</span>
-    <span class="badge">spec/041-forecast-scenario-persistence</span>
-    <span class="badge accent">Challenged &amp; revised — ready to implement</span>
-  </div>
-  <h1>Saved Forecast Scenarios</h1>
-  <p class="lede">
-    Ship the follow-up that spec 036 explicitly deferred: <strong>persisting named scenarios</strong> for the
-    Budget / Cost Forecast Simulation. An admin who has tuned a plan — levers, edited ceiling, billing cadence —
-    can save it under a name, reload it later (or in another browser, or as another admin), rename it, update it
-    after refinement, and delete it when it has served its purpose. Saved scenarios are shared across all admins
-    and scoped to the active fiscal-year budget, exactly the <code>forecast_scenarios</code> table
-    (&ldquo;JSON params + label + budget_id&rdquo;) the 036 plan sketched for this follow-up.
-  </p>
-  <p class="meta">Drafted 2026-06-12 · challenged by a 5-lens adversarial panel, revised same day · author: T. Studer · branch: <code>041-forecast-scenario-persistence</code> · builds on specs 036 + 040 · estimate: ~1.5–2 dev days</p>
-</header>
+      <div class="callout info" style="margin-top: 24px">
+        <strong>First write path in the Scenarios section.</strong> 036 and 040
+        were read-only; this spec adds one new table (migration
+        <code>0026</code>), one new server-action file, and a
+        save/load/rename/delete UI — while the projection engine&rsquo;s
+        existing functions, the data loader, and every existing figure remain
+        untouched. A saved scenario stores <em>assumptions</em> (the
+        <code>ForecastInputs</code> parameter set), never computed results: on
+        load it is re-projected against whatever the live dataset says today.
+      </div>
 
-<div class="callout info" style="margin-top: 24px;">
-  <strong>First write path in the Scenarios section.</strong> 036 and 040 were read-only; this spec adds one new
-  table (migration <code>0026</code>), one new server-action file, and a save/load/rename/delete UI — while the
-  projection engine&rsquo;s existing functions, the data loader, and every existing figure remain untouched. A saved
-  scenario stores <em>assumptions</em> (the <code>ForecastInputs</code> parameter set), never computed results: on
-  load it is re-projected against whatever the live dataset says today.
-</div>
+      <h2 id="toc">Contents</h2>
+      <div class="toc card">
+        <a href="#goal">1 · Goal &amp; scope</a>
+        <a href="#semantics">2 · What a saved scenario is</a>
+        <a href="#schema">3 · Data model &amp; migration</a>
+        <a href="#validation">4 · Validation &amp; (de)serialization</a>
+        <a href="#actions">5 · Server actions</a>
+        <a href="#engine">6 · Engine changes</a>
+        <a href="#ui">7 · UI changes</a>
+        <a href="#tests">8 · Test plan</a>
+        <a href="#manifest">9 · File manifest</a>
+        <a href="#risks">10 · Risks &amp; decisions</a>
+        <a href="#accept">11 · Acceptance checklist</a>
+      </div>
 
-<h2 id="toc">Contents</h2>
-<div class="toc card">
-  <a href="#goal">1 · Goal &amp; scope</a>
-  <a href="#semantics">2 · What a saved scenario is</a>
-  <a href="#schema">3 · Data model &amp; migration</a>
-  <a href="#validation">4 · Validation &amp; (de)serialization</a>
-  <a href="#actions">5 · Server actions</a>
-  <a href="#engine">6 · Engine changes</a>
-  <a href="#ui">7 · UI changes</a>
-  <a href="#tests">8 · Test plan</a>
-  <a href="#manifest">9 · File manifest</a>
-  <a href="#risks">10 · Risks &amp; decisions</a>
-  <a href="#accept">11 · Acceptance checklist</a>
-</div>
+      <!-- ============================================================ -->
+      <h2 id="goal">1 · Goal &amp; scope</h2>
 
-<!-- ============================================================ -->
-<h2 id="goal">1 · Goal &amp; scope</h2>
+      <div class="card accent">
+        <h4>In scope</h4>
+        <ul>
+          <li class="note">
+            A <code>forecast_scenarios</code> table (new migration
+            <code>0026</code>): <code>budget_id</code> FK, unique name per
+            budget (case-insensitive, expression index),
+            <code>params</code> jsonb holding the full
+            <code>ForecastInputs</code>, <code>created_by</code> attribution,
+            timestamps.
+          </li>
+          <li class="note">
+            Server actions: <code>listForecastScenarios</code> (read, active
+            budget, creator name joined), <code>createForecastScenario</code>,
+            <code>updateForecastScenario</code> (overwrite params and/or rename;
+            <strong>params optional</strong> so rename never silently rewrites
+            assumptions), <code>deleteForecastScenario</code> — all admin-gated,
+            Zod-validated, following the <code>ActionResult</code> +
+            <code>revalidatePath</code> + audit-history conventions.
+            Unique-violation races are caught and mapped to the same friendly
+            duplicate-name error as the pre-check.
+          </li>
+          <li class="note">
+            A <strong>deterministic active-budget resolution contract</strong>:
+            <code>status = 'active'</code> ordered by
+            <code>fiscal_year DESC</code>, <code>LIMIT 1</code> — hardens the
+            two-active-budgets state the schema permits and makes the
+            integration tests deterministic.
+          </li>
+          <li class="note">
+            A pure engine helper <code>inputsFromSaved(ds, saved)</code> that
+            re-bases any <code>ForecastInputs</code> onto the
+            <em>current</em> dataset: tools that disappeared are dropped, tools
+            that appeared get defaults. Used for loading saved scenarios
+            <em>and</em> for re-basing surviving client state when the dataset
+            prop refreshes.
+          </li>
+          <li class="note">
+            UI: a persistent <strong>Saved scenarios</strong> card (load /
+            rename / delete, mono empty state), a
+            <strong>Save scenario</strong> dialog (single primary button;
+            Update-vs-new resolved by an in-dialog mode toggle), active-state
+            tracking (<code>saved:&lt;id&gt;</code> activates the &ldquo;Your
+            plan&rdquo; comparison row), inline <code>StatusText</code> feedback
+            (the Nothing-system replacement for toasts).
+          </li>
+          <li class="note">
+            Unit tests (engine merge incl. billing round-trip, Zod schema
+            matrix, auth gating), an integration test (real-DB CRUD round trip
+            with audit + index assertions, deterministic seeding), and a manual
+            Playwright browser pass against live data.
+          </li>
+        </ul>
+        <h4>Out of scope</h4>
+        <ul>
+          <li class="con">
+            <strong>Applying a scenario to the budget of record</strong>
+            (writing <code>planned_amount_cents</code>) — still the separate
+            follow-up 036 named; saving assumptions is modelling, not budget
+            editing.
+          </li>
+          <li class="con">
+            <strong
+              >Per-user/private scenarios, sharing controls, or roles beyond
+              admin</strong
+            >
+            — the whole Scenarios section is admin-only; saved scenarios are one
+            shared pool per budget (last-write-wins; overwrites are recoverable
+            from the audit trail, <a href="#actions">§5</a>).
+          </li>
+          <li class="con">
+            <strong
+              >Saved scenarios as extra ghost lines / comparison rows</strong
+            >
+            — the loaded scenario <em>is</em> the &ldquo;Your plan&rdquo; line;
+            the three H2 presets stay the fixed comparison frame.
+          </li>
+          <li class="con">
+            <strong>Conflict detection / locking</strong> between admins editing
+            the same scenario — accepted last-write-wins for v1, mitigated by
+            audit snapshots.
+          </li>
+          <li class="con">
+            <strong>MCP exposure</strong> of saved scenarios — possible
+            follow-up for the read side, not built speculatively.
+          </li>
+          <li class="con">
+            <strong>Scenario history / versioning UI</strong> — update
+            overwrites; the audit trail records full param snapshots
+            (recoverable forensically, no restore UI).
+          </li>
+        </ul>
+      </div>
 
-<div class="card accent">
-  <h4>In scope</h4>
-  <ul>
-    <li class="note">A <code>forecast_scenarios</code> table (new migration <code>0026</code>): <code>budget_id</code> FK, unique name per budget (case-insensitive, expression index), <code>params</code> jsonb holding the full <code>ForecastInputs</code>, <code>created_by</code> attribution, timestamps.</li>
-    <li class="note">Server actions: <code>listForecastScenarios</code> (read, active budget, creator name joined), <code>createForecastScenario</code>, <code>updateForecastScenario</code> (overwrite params and/or rename; <strong>params optional</strong> so rename never silently rewrites assumptions), <code>deleteForecastScenario</code> — all admin-gated, Zod-validated, following the <code>ActionResult</code> + <code>revalidatePath</code> + audit-history conventions. Unique-violation races are caught and mapped to the same friendly duplicate-name error as the pre-check.</li>
-    <li class="note">A <strong>deterministic active-budget resolution contract</strong>: <code>status = 'active'</code> ordered by <code>fiscal_year DESC</code>, <code>LIMIT 1</code> — hardens the two-active-budgets state the schema permits and makes the integration tests deterministic.</li>
-    <li class="note">A pure engine helper <code>inputsFromSaved(ds, saved)</code> that re-bases any <code>ForecastInputs</code> onto the <em>current</em> dataset: tools that disappeared are dropped, tools that appeared get defaults. Used for loading saved scenarios <em>and</em> for re-basing surviving client state when the dataset prop refreshes.</li>
-    <li class="note">UI: a persistent <strong>Saved scenarios</strong> card (load / rename / delete, mono empty state), a <strong>Save scenario</strong> dialog (single primary button; Update-vs-new resolved by an in-dialog mode toggle), active-state tracking (<code>saved:&lt;id&gt;</code> activates the &ldquo;Your plan&rdquo; comparison row), inline <code>StatusText</code> feedback (the Nothing-system replacement for toasts).</li>
-    <li class="note">Unit tests (engine merge incl. billing round-trip, Zod schema matrix, auth gating), an integration test (real-DB CRUD round trip with audit + index assertions, deterministic seeding), and a manual Playwright browser pass against live data.</li>
-  </ul>
-  <h4>Out of scope</h4>
-  <ul>
-    <li class="con"><strong>Applying a scenario to the budget of record</strong> (writing <code>planned_amount_cents</code>) — still the separate follow-up 036 named; saving assumptions is modelling, not budget editing.</li>
-    <li class="con"><strong>Per-user/private scenarios, sharing controls, or roles beyond admin</strong> — the whole Scenarios section is admin-only; saved scenarios are one shared pool per budget (last-write-wins; overwrites are recoverable from the audit trail, <a href="#actions">§5</a>).</li>
-    <li class="con"><strong>Saved scenarios as extra ghost lines / comparison rows</strong> — the loaded scenario <em>is</em> the &ldquo;Your plan&rdquo; line; the three H2 presets stay the fixed comparison frame.</li>
-    <li class="con"><strong>Conflict detection / locking</strong> between admins editing the same scenario — accepted last-write-wins for v1, mitigated by audit snapshots.</li>
-    <li class="con"><strong>MCP exposure</strong> of saved scenarios — possible follow-up for the read side, not built speculatively.</li>
-    <li class="con"><strong>Scenario history / versioning UI</strong> — update overwrites; the audit trail records full param snapshots (recoverable forensically, no restore UI).</li>
-  </ul>
-</div>
+      <!-- ============================================================ -->
+      <h2 id="semantics">2 · What a saved scenario is</h2>
 
-<!-- ============================================================ -->
-<h2 id="semantics">2 · What a saved scenario is</h2>
+      <p>
+        A saved scenario is a <strong>named, shared parameter set</strong>: the
+        exact <code>ForecastInputs</code> the client already holds in state —
+        the edited ceiling (cents) plus the per-tool levers (include / growth
+        model / value / burn growth / burn cap / premium share / billing
+        cadence). It is deliberately <em>not</em> a snapshot of results:
+      </p>
 
-<p>A saved scenario is a <strong>named, shared parameter set</strong>: the exact <code>ForecastInputs</code> the client
-  already holds in state — the edited ceiling (cents) plus the per-tool levers (include / growth model / value /
-  burn growth / burn cap / premium share / billing cadence). It is deliberately <em>not</em> a snapshot of results:</p>
+      <div class="grid-2">
+        <div class="card">
+          <h4>Stored: assumptions</h4>
+          <ul>
+            <li class="note">
+              <code>params.ceilingCents</code> — the modeled ceiling the plan
+              was tuned against (may differ from the live budget ceiling).
+            </li>
+            <li class="note">
+              <code>params.tools[key]</code> — one <code>ToolParams</code> per
+              tool key (<code>api</code>, <code>claude</code>,
+              <code>copilot</code>, <code>cursor</code>,
+              <code>mscopilot</code>), including the Claude
+              <code>billing</code> cadence when yearly (<code
+                >undefined ≡ monthly</code
+              >
+              survives the JSON round trip — <code>JSON.stringify</code> drops
+              undefined keys).
+            </li>
+            <li class="note">
+              A <code>name</code> (≤ 60 chars, unique per budget,
+              case-insensitive) and <code>created_by</code> attribution
+              (surfaced in the list and the delete confirm).
+            </li>
+          </ul>
+        </div>
+        <div class="card">
+          <h4>Recomputed: everything else</h4>
+          <ul>
+            <li class="note">
+              On load, the engine re-projects the saved params against the
+              <em>current</em> dataset — seats, prices, burn, and elapsed
+              actuals as of today. Year-end, breach, drivers all shift with live
+              data, exactly like a preset.
+            </li>
+            <li class="note">
+              The saved-scenarios list shows each entry&rsquo;s
+              <em>recomputed</em> year-end and Δ explicitly labelled against
+              <strong>its own saved ceiling</strong> (&ldquo;vs saved
+              $X&rdquo;), so the list reads as &ldquo;what would this plan mean
+              today&rdquo; and the differing denominator is visible.
+            </li>
+            <li class="note">
+              A saved scenario whose tool keys drift from the live tool set
+              still loads (<a href="#engine">§6</a>) — extinct keys dropped, new
+              tools defaulted.
+            </li>
+          </ul>
+        </div>
+      </div>
 
-<div class="grid-2">
-  <div class="card">
-    <h4>Stored: assumptions</h4>
-    <ul>
-      <li class="note"><code>params.ceilingCents</code> — the modeled ceiling the plan was tuned against (may differ from the live budget ceiling).</li>
-      <li class="note"><code>params.tools[key]</code> — one <code>ToolParams</code> per tool key (<code>api</code>, <code>claude</code>, <code>copilot</code>, <code>cursor</code>, <code>mscopilot</code>), including the Claude <code>billing</code> cadence when yearly (<code>undefined ≡ monthly</code> survives the JSON round trip — <code>JSON.stringify</code> drops undefined keys).</li>
-      <li class="note">A <code>name</code> (≤ 60 chars, unique per budget, case-insensitive) and <code>created_by</code> attribution (surfaced in the list and the delete confirm).</li>
-    </ul>
-  </div>
-  <div class="card">
-    <h4>Recomputed: everything else</h4>
-    <ul>
-      <li class="note">On load, the engine re-projects the saved params against the <em>current</em> dataset — seats, prices, burn, and elapsed actuals as of today. Year-end, breach, drivers all shift with live data, exactly like a preset.</li>
-      <li class="note">The saved-scenarios list shows each entry&rsquo;s <em>recomputed</em> year-end and Δ explicitly labelled against <strong>its own saved ceiling</strong> (&ldquo;vs saved $X&rdquo;), so the list reads as &ldquo;what would this plan mean today&rdquo; and the differing denominator is visible.</li>
-      <li class="note">A saved scenario whose tool keys drift from the live tool set still loads (<a href="#engine">§6</a>) — extinct keys dropped, new tools defaulted.</li>
-    </ul>
-  </div>
-</div>
+      <p class="c">
+        Scope rule: scenarios belong to the budget they were tuned against
+        (<code>budget_id</code> FK). The page always lists scenarios for the
+        <em>active</em> budget — when FY2027 activates, FY2026 scenarios
+        disappear from view but survive in the table (and cascade away only if
+        the budget row itself is deleted).
+      </p>
 
-<p class="c">Scope rule: scenarios belong to the budget they were tuned against (<code>budget_id</code> FK). The page
-  always lists scenarios for the <em>active</em> budget — when FY2027 activates, FY2026 scenarios disappear from view
-  but survive in the table (and cascade away only if the budget row itself is deleted).</p>
+      <!-- ============================================================ -->
+      <h2 id="schema">3 · Data model &amp; migration</h2>
 
-<!-- ============================================================ -->
-<h2 id="schema">3 · Data model &amp; migration</h2>
+      <p>
+        One table, following the house style (snake_case DB names, camelCase TS,
+        array-form third argument,
+        <code>&lt;table&gt;_&lt;cols&gt;_idx</code> index names). Next journal
+        entry: <code>0026</code>.
+      </p>
 
-<p>One table, following the house style (snake_case DB names, camelCase TS, array-form third argument,
-  <code>&lt;table&gt;_&lt;cols&gt;_idx</code> index names). Next journal entry: <code>0026</code>.</p>
-
-<pre><code><span class="c">// Forecast Scenarios (041-forecast-scenario-persistence)</span>
+      <pre><code><span class="c">// Forecast Scenarios (041-forecast-scenario-persistence)</span>
 export const forecastScenarios = pgTable(
   "forecast_scenarios",
   {
@@ -204,29 +541,77 @@ export const forecastScenarios = pgTable(
   ],
 );</code></pre>
 
-<ul>
-  <li class="note"><strong>FK choices.</strong> <code>budget_id → cascade</code>: scenarios are owned what-ifs of a budget, worthless without it (matches <code>budget_periods</code>). <code>created_by → set null</code>: attribution is informational; deleting a user must not destroy shared scenarios (so the column is nullable; precedent: <code>ingestion_log.uploadedBy</code>).</li>
-  <li class="note"><strong>jsonb typing.</strong> <code>$type&lt;ForecastInputs&gt;()</code> with <code>import type { ForecastInputs } from "@/lib/scenarios/budget-forecast"</code> — type-only, erased at compile time, no runtime cycle (the engine itself imports nothing from <code>db</code>). Precedent: <code>users.preferences</code> is <code>$type&lt;UserPreferences&gt;()</code>.</li>
-  <li class="note"><strong>updatedAt</strong> maintained in app code on update (house convention — no <code>$onUpdate</code>).</li>
-  <li class="note"><strong>relations()</strong> block: <code>budget: one(annualBudgets)</code>, <code>creator: one(users)</code>, mirroring <code>inviteTokensRelations</code>.</li>
-  <li class="note"><strong>Migration workflow:</strong> <code>pnpm db:generate</code> → review the emitted SQL (additive only: 1 CREATE TABLE, 2 FKs, 2 indexes) with the <code>drizzle-migration-reviewer</code> agent → <code>pnpm db:migrate</code> against the dev DB. Verified against the installed drizzle-kit 0.31.9: the expression index emits as <code>USING btree ("budget_id", lower("name"))</code>.</li>
-  <li class="note"><strong><code>db:push</code> caveat (challenge finding):</strong> this is the repo&rsquo;s first expression index, and drizzle-kit&rsquo;s <code>push</code> diffing does not reliably detect expression changes inside index definitions — this table must go through <code>generate</code>/<code>migrate</code>, and a push-based dev loop should be sanity-checked once against the dev DB.</li>
-</ul>
+      <ul>
+        <li class="note">
+          <strong>FK choices.</strong> <code>budget_id → cascade</code>:
+          scenarios are owned what-ifs of a budget, worthless without it
+          (matches <code>budget_periods</code>).
+          <code>created_by → set null</code>: attribution is informational;
+          deleting a user must not destroy shared scenarios (so the column is
+          nullable; precedent: <code>ingestion_log.uploadedBy</code>).
+        </li>
+        <li class="note">
+          <strong>jsonb typing.</strong>
+          <code>$type&lt;ForecastInputs&gt;()</code> with
+          <code
+            >import type { ForecastInputs } from
+            "@/lib/scenarios/budget-forecast"</code
+          >
+          — type-only, erased at compile time, no runtime cycle (the engine
+          itself imports nothing from <code>db</code>). Precedent:
+          <code>users.preferences</code> is
+          <code>$type&lt;UserPreferences&gt;()</code>.
+        </li>
+        <li class="note">
+          <strong>updatedAt</strong> maintained in app code on update (house
+          convention — no <code>$onUpdate</code>).
+        </li>
+        <li class="note">
+          <strong>relations()</strong> block:
+          <code>budget: one(annualBudgets)</code>,
+          <code>creator: one(users)</code>, mirroring
+          <code>inviteTokensRelations</code>.
+        </li>
+        <li class="note">
+          <strong>Migration workflow:</strong> <code>pnpm db:generate</code> →
+          review the emitted SQL (additive only: 1 CREATE TABLE, 2 FKs, 2
+          indexes) with the <code>drizzle-migration-reviewer</code> agent →
+          <code>pnpm db:migrate</code> against the dev DB. Verified against the
+          installed drizzle-kit 0.31.9: the expression index emits as
+          <code>USING btree ("budget_id", lower("name"))</code>.
+        </li>
+        <li class="note">
+          <strong><code>db:push</code> caveat (challenge finding):</strong> this
+          is the repo&rsquo;s first expression index, and drizzle-kit&rsquo;s
+          <code>push</code> diffing does not reliably detect expression changes
+          inside index definitions — this table must go through
+          <code>generate</code>/<code>migrate</code>, and a push-based dev loop
+          should be sanity-checked once against the dev DB.
+        </li>
+      </ul>
 
-<!-- ============================================================ -->
-<h2 id="validation">4 · Validation &amp; (de)serialization</h2>
+      <!-- ============================================================ -->
+      <h2 id="validation">4 · Validation &amp; (de)serialization</h2>
 
-<div class="callout">
-  <strong>The boundary rule: validate on write <em>and</em> on read.</strong> The jsonb column is an open contract —
-  a row written by an older/newer build, or edited by hand, must never crash the page or feed the engine
-  <code>NaN</code>/<code>Infinity</code>. Writes <code>safeParse</code> the params and store <code>parsed.data</code>
-  (canonical shape); reads <code>safeParse</code> each row and <em>skip</em> (with a <code>console.error</code>) any
-  row that no longer conforms.
-</div>
+      <div class="callout">
+        <strong
+          >The boundary rule: validate on write <em>and</em> on read.</strong
+        >
+        The jsonb column is an open contract — a row written by an older/newer
+        build, or edited by hand, must never crash the page or feed the engine
+        <code>NaN</code>/<code>Infinity</code>. Writes
+        <code>safeParse</code> the params and store
+        <code>parsed.data</code> (canonical shape); reads
+        <code>safeParse</code> each row and <em>skip</em> (with a
+        <code>console.error</code>) any row that no longer conforms.
+      </div>
 
-<p>Schemas live in <code>src/lib/validators.ts</code> (shared client/server, per house rules):</p>
+      <p>
+        Schemas live in <code>src/lib/validators.ts</code> (shared
+        client/server, per house rules):
+      </p>
 
-<pre><code>export const toolParamsSchema = z.object({
+      <pre><code>export const toolParamsSchema = z.object({
   include: z.boolean(),
   model: z.enum(["flat", "linear", "compound"]),
   val: z.number().min(-100_000).max(100_000),
@@ -260,63 +645,173 @@ export const deleteForecastScenarioSchema = z.object({
   id: z.number().int().positive(),
 });</code></pre>
 
-<ul>
-  <li class="note"><strong>Strip, don&rsquo;t strict (challenge revision).</strong> Plain <code>z.object</code> (Zod&rsquo;s default strip semantics, the only style used in <code>validators.ts</code>): unknown keys are dropped, not rejected. On write that keeps the stored shape canonical (we insert <code>parsed.data</code>); on read it keeps rows loadable if a future build adds-then-removes a field. <code>.strict()</code> would turn schema drift into save failures and skipped rows — worse availability for zero practical safety gain.</li>
-  <li class="note"><strong>Non-finite protection is built in:</strong> Zod 4&rsquo;s <code>z.number()</code> rejects <code>NaN</code>/<code>Infinity</code> by default (<code>.finite()</code> is a documented no-op in v4 and is not used). Nothing non-finite can reach <code>Math.pow</code>.</li>
-  <li class="note">Bounds are generous modelling limits, not business rules — wide enough for any sane what-if, tight enough to keep arithmetic and rendering safe. <code>ceilingCents: 0</code> is deliberately accepted (the UI guards the accidental-empty-field path, <a href="#ui">§7</a>).</li>
-  <li class="note"><strong>Type-level round trip:</strong> two type-only assignments (schema output → <code>ForecastInputs</code>, <code>ForecastInputs</code> → schema input) live in the validator test file and are enforced by <code>pnpm typecheck</code> (tests are in the tsconfig include), not by the vitest run.</li>
-</ul>
+      <ul>
+        <li class="note">
+          <strong>Strip, don&rsquo;t strict (challenge revision).</strong> Plain
+          <code>z.object</code> (Zod&rsquo;s default strip semantics, the only
+          style used in <code>validators.ts</code>): unknown keys are dropped,
+          not rejected. On write that keeps the stored shape canonical (we
+          insert <code>parsed.data</code>); on read it keeps rows loadable if a
+          future build adds-then-removes a field. <code>.strict()</code> would
+          turn schema drift into save failures and skipped rows — worse
+          availability for zero practical safety gain.
+        </li>
+        <li class="note">
+          <strong>Non-finite protection is built in:</strong> Zod 4&rsquo;s
+          <code>z.number()</code> rejects <code>NaN</code>/<code>Infinity</code>
+          by default (<code>.finite()</code> is a documented no-op in v4 and is
+          not used). Nothing non-finite can reach <code>Math.pow</code>.
+        </li>
+        <li class="note">
+          Bounds are generous modelling limits, not business rules — wide enough
+          for any sane what-if, tight enough to keep arithmetic and rendering
+          safe. <code>ceilingCents: 0</code> is deliberately accepted (the UI
+          guards the accidental-empty-field path, <a href="#ui">§7</a>).
+        </li>
+        <li class="note">
+          <strong>Type-level round trip:</strong> two type-only assignments
+          (schema output → <code>ForecastInputs</code>,
+          <code>ForecastInputs</code> → schema input) live in the validator test
+          file and are enforced by <code>pnpm typecheck</code> (tests are in the
+          tsconfig include), not by the vitest run.
+        </li>
+      </ul>
 
-<!-- ============================================================ -->
-<h2 id="actions">5 · Server actions</h2>
+      <!-- ============================================================ -->
+      <h2 id="actions">5 · Server actions</h2>
 
-<p>New file <code>src/actions/forecast-scenarios.ts</code> (<code>"use server"</code>) — CRUD stays out of
-  <code>scenarios.ts</code>, which holds only the cached dataset loaders. All four follow the house conventions:
-  <code>requireAdmin()</code> first, <code>safeParse</code> against <code>unknown</code>, <code>ActionResult&lt;T&gt;</code>
-  result shape, audit history, <code>revalidatePath("/scenarios/budget-forecast")</code> after writes.</p>
+      <p>
+        New file <code>src/actions/forecast-scenarios.ts</code> (<code
+          >"use server"</code
+        >) — CRUD stays out of <code>scenarios.ts</code>, which holds only the
+        cached dataset loaders. All four follow the house conventions:
+        <code>requireAdmin()</code> first, <code>safeParse</code> against
+        <code>unknown</code>, <code>ActionResult&lt;T&gt;</code> result shape,
+        audit history,
+        <code>revalidatePath("/scenarios/budget-forecast")</code> after writes.
+      </p>
 
-<div class="callout accent">
-  <strong>Active-budget resolution contract (challenge must-fix).</strong> All actions resolve the active budget
-  server-side — never trusted from the client — as <code>status = 'active'</code> <strong>ordered by
-  <code>fiscal_year DESC</code>, <code>LIMIT 1</code></strong>. The schema permits multiple active rows; an unordered
-  <code>findFirst</code> would be nondeterministic there (and made the integration-test seeding pattern unsafe).
-  Ordering by fiscal year makes production behaviour well-defined and lets tests seed a far-future active budget
-  that deterministically wins resolution.
-</div>
+      <div class="callout accent">
+        <strong>Active-budget resolution contract (challenge must-fix).</strong>
+        All actions resolve the active budget server-side — never trusted from
+        the client — as <code>status = 'active'</code>
+        <strong
+          >ordered by <code>fiscal_year DESC</code>,
+          <code>LIMIT 1</code></strong
+        >. The schema permits multiple active rows; an unordered
+        <code>findFirst</code> would be nondeterministic there (and made the
+        integration-test seeding pattern unsafe). Ordering by fiscal year makes
+        production behaviour well-defined and lets tests seed a far-future
+        active budget that deterministically wins resolution.
+      </div>
 
-<table>
-  <thead><tr><th>Action</th><th>Behaviour</th></tr></thead>
-  <tbody>
-    <tr>
-      <td><code>listForecastScenarios()</code></td>
-      <td>Read. Admin gate returns <code>[]</code> — defense-in-depth only: the <code>/scenarios</code> layout already redirects non-admins and the sibling dataset loader throws first in <code>Promise.all</code>. Resolves the active budget (contract above); returns its scenarios ordered by name, each row&rsquo;s <code>params</code> re-validated with <code>safeParse</code> (invalid → skipped + <code>console.error</code>). Returns <code>{ id, name, params, creatorName, updatedAt }</code> (<code>users</code> left-joined, <code>updatedAt</code> as ISO string). <strong>Uncached</strong> — the page is already dynamic (auth) and the query is a single indexed select; freshness beats a cache here.</td>
-    </tr>
-    <tr>
-      <td><code>createForecastScenario(input: unknown)</code></td>
-      <td>Validate → resolve active budget (<code>error: "No active budget"</code> if none) → cap check (<strong>≤ 50 per budget</strong>, pre-check only — see §10) → case-insensitive duplicate-name pre-check (friendly <code>error</code>) → insert with <code>createdBy: Number(admin.id)</code>, <strong>unique-violation (PG 23505) caught and mapped to the same duplicate-name error</strong> (the race path must honour the <code>ActionResult</code> contract too) → <code>recordCreation("forecast_scenario", id, adminId)</code> → revalidate. Returns <code>{ id }</code>.</td>
-    </tr>
-    <tr>
-      <td><code>updateForecastScenario(input: unknown)</code></td>
-      <td>Validate → load row (<code>error: "Scenario not found"</code>) → duplicate-name pre-check excluding self → update <code>name</code>, <code>params</code> (only when provided — rename-only leaves stored params untouched), <code>updatedAt: new Date()</code>, 23505 caught as above → <code>recordUpdate(...)</code> with a name diff when renamed <strong>and a full params snapshot</strong> (<code>{ params: { old: &lt;previous object&gt;, new: &lt;next object&gt; } }</code>) when params change — so a teammate&rsquo;s overwritten plan is recoverable from <code>change_history</code>, and a params-only update never hits <code>recordUpdate</code>&rsquo;s empty-diff early-return (challenge finding) → revalidate. Returns <code>{ id }</code>.</td>
-    </tr>
-    <tr>
-      <td><code>deleteForecastScenario(id: number)</code></td>
-      <td>Validate id → load row → snapshot into the audit trail (<code>deleteBilledCost</code> pattern: name + params recorded as <code>previousValue</code> before <code>db.delete</code>) → delete → revalidate. Returns <code>{ id }</code>.</td>
-    </tr>
-  </tbody>
-</table>
+      <table>
+        <thead>
+          <tr>
+            <th>Action</th>
+            <th>Behaviour</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>listForecastScenarios()</code></td>
+            <td>
+              Read. Admin gate returns <code>[]</code> — defense-in-depth only:
+              the <code>/scenarios</code> layout already redirects non-admins
+              and the sibling dataset loader throws first in
+              <code>Promise.all</code>. Resolves the active budget (contract
+              above); returns its scenarios ordered by name, each row&rsquo;s
+              <code>params</code> re-validated with
+              <code>safeParse</code> (invalid → skipped +
+              <code>console.error</code>). Returns
+              <code>{ id, name, params, creatorName, updatedAt }</code> (<code
+                >users</code
+              >
+              left-joined, <code>updatedAt</code> as ISO string).
+              <strong>Uncached</strong> — the page is already dynamic (auth) and
+              the query is a single indexed select; freshness beats a cache
+              here.
+            </td>
+          </tr>
+          <tr>
+            <td><code>createForecastScenario(input: unknown)</code></td>
+            <td>
+              Validate → resolve active budget (<code
+                >error: "No active budget"</code
+              >
+              if none) → cap check (<strong>≤ 50 per budget</strong>, pre-check
+              only — see §10) → case-insensitive duplicate-name pre-check
+              (friendly <code>error</code>) → insert with
+              <code>createdBy: Number(admin.id)</code>,
+              <strong
+                >unique-violation (PG 23505) caught and mapped to the same
+                duplicate-name error</strong
+              >
+              (the race path must honour the <code>ActionResult</code> contract
+              too) →
+              <code>recordCreation("forecast_scenario", id, adminId)</code> →
+              revalidate. Returns <code>{ id }</code>.
+            </td>
+          </tr>
+          <tr>
+            <td><code>updateForecastScenario(input: unknown)</code></td>
+            <td>
+              Validate → load row (<code>error: "Scenario not found"</code>) →
+              duplicate-name pre-check excluding self → update
+              <code>name</code>, <code>params</code> (only when provided —
+              rename-only leaves stored params untouched),
+              <code>updatedAt: new Date()</code>, 23505 caught as above →
+              <code>recordUpdate(...)</code> with a name diff when renamed
+              <strong>and a full params snapshot</strong> (<code
+                >{ params: { old: &lt;previous object&gt;, new: &lt;next
+                object&gt; } }</code
+              >) when params change — so a teammate&rsquo;s overwritten plan is
+              recoverable from <code>change_history</code>, and a params-only
+              update never hits <code>recordUpdate</code>&rsquo;s empty-diff
+              early-return (challenge finding) → revalidate. Returns
+              <code>{ id }</code>.
+            </td>
+          </tr>
+          <tr>
+            <td><code>deleteForecastScenario(id: number)</code></td>
+            <td>
+              Validate id → load row → snapshot into the audit trail (<code
+                >deleteBilledCost</code
+              >
+              pattern: name + params recorded as
+              <code>previousValue</code> before <code>db.delete</code>) → delete
+              → revalidate. Returns <code>{ id }</code>.
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-<ul>
-  <li class="note"><code>change_history.entity_type</code> is a free-form <code>varchar(50)</code> — <code>"forecast_scenario"</code> needs no enum migration.</li>
-  <li class="note"><code>page.tsx</code> loads the list alongside the dataset (<code>Promise.all</code>); after a mutation, <code>revalidatePath</code> + the client&rsquo;s <code>router.refresh()</code> re-render the page with the fresh list while client state (the user&rsquo;s current inputs) survives — and is re-based if the dataset itself changed (<a href="#ui">§7</a>).</li>
-</ul>
+      <ul>
+        <li class="note">
+          <code>change_history.entity_type</code> is a free-form
+          <code>varchar(50)</code> — <code>"forecast_scenario"</code> needs no
+          enum migration.
+        </li>
+        <li class="note">
+          <code>page.tsx</code> loads the list alongside the dataset
+          (<code>Promise.all</code>); after a mutation,
+          <code>revalidatePath</code> + the client&rsquo;s
+          <code>router.refresh()</code> re-render the page with the fresh list
+          while client state (the user&rsquo;s current inputs) survives — and is
+          re-based if the dataset itself changed (<a href="#ui">§7</a>).
+        </li>
+      </ul>
 
-<!-- ============================================================ -->
-<h2 id="engine">6 · Engine changes</h2>
+      <!-- ============================================================ -->
+      <h2 id="engine">6 · Engine changes</h2>
 
-<p>One additive pure function in <code>src/lib/scenarios/budget-forecast.ts</code> — no signature changes, no new imports:</p>
+      <p>
+        One additive pure function in
+        <code>src/lib/scenarios/budget-forecast.ts</code> — no signature
+        changes, no new imports:
+      </p>
 
-<pre><code><span class="c">/**
+      <pre><code><span class="c">/**
  * Re-base a parameter set onto the current dataset. Tools that no longer
  * exist are dropped; tools that appeared since the params were captured get
  * DEFAULT_PARAMS — so a stale scenario (or surviving client state after a
@@ -334,143 +829,607 @@ export function inputsFromSaved(
   return { ceilingCents: saved.ceilingCents, tools };
 }</code></pre>
 
-<p class="c">Mirrors <code>inputsFromPreset</code>&rsquo;s shape (copy semantics, dataset-scoped keys) so the client can
-  treat presets and saved scenarios uniformly. Params are copied verbatim — including the claudeSeats
-  <code>billing</code> cadence, which is what makes &ldquo;load restores the cadence&rdquo; true (pinned by a unit
-  test). <code>projectForecast</code>, the presets, and all result types are untouched.</p>
+      <p class="c">
+        Mirrors <code>inputsFromPreset</code>&rsquo;s shape (copy semantics,
+        dataset-scoped keys) so the client can treat presets and saved scenarios
+        uniformly. Params are copied verbatim — including the claudeSeats
+        <code>billing</code> cadence, which is what makes &ldquo;load restores
+        the cadence&rdquo; true (pinned by a unit test).
+        <code>projectForecast</code>, the presets, and all result types are
+        untouched.
+      </p>
 
-<!-- ============================================================ -->
-<h2 id="ui">7 · UI changes</h2>
+      <!-- ============================================================ -->
+      <h2 id="ui">7 · UI changes</h2>
 
-<p>All in <code>src/app/scenarios/budget-forecast/</code>. The client gains a <code>savedScenarios</code> prop
-  (<code>{ id, name, params, creatorName, updatedAt }[]</code>, already validated server-side).</p>
+      <p>
+        All in <code>src/app/scenarios/budget-forecast/</code>. The client gains
+        a <code>savedScenarios</code> prop (<code
+          >{ id, name, params, creatorName, updatedAt }[]</code
+        >, already validated server-side).
+      </p>
 
-<table>
-  <thead><tr><th>Where</th><th>Change</th></tr></thead>
-  <tbody>
-    <tr>
-      <td><code>page.tsx</code></td>
-      <td><code>Promise.all([loadBudgetForecastDataset(), listForecastScenarios()])</code>; pass both to the client.</td>
-    </tr>
-    <tr>
-      <td>Active-state model</td>
-      <td><code>ActiveScenario</code> widens to <code>PresetKey | "custom" | `saved:${number}`</code>. <strong>Mapping (challenge fix):</strong> when active is <code>saved:*</code>, the <strong>&ldquo;Your plan&rdquo; comparison row renders as active</strong> (it is showing exactly the loaded scenario&rsquo;s numbers: <code>isPlanActive = active === "custom" || active.startsWith("saved:")</code>); preset tiles stay inactive; the Custom tile also stays inactive (the saved card row carries the specific identity). A separate <code>loadedSavedId</code> powers the Update offer and <strong>is cleared by Reset <em>and</em> by clicking any preset tile</strong> (a preset is a new starting point, not a refinement of the loaded scenario — prevents one-click overwrite of a shared row with preset params); plain control edits keep it (flipping <code>active</code> to <code>"custom"</code> as today). The Update offer is derived live from <code>savedScenarios.find(s =&gt; s.id === loadedSavedId)</code> — if another admin deleted the row, the offer disappears instead of going stale.</td>
-    </tr>
-    <tr>
-      <td>Dataset-refresh re-base (challenge fix)</td>
-      <td><code>router.refresh()</code> after mutations is the page&rsquo;s first path to a <em>changed dataset prop under surviving client state</em> (the loader&rsquo;s 1h cache can expire mid-session). A dataset tool key absent from <code>inputs.tools</code> would be hidden by the controls (<code>if (!p) return null</code>) yet projected at defaults by the engine. Fix: an effect keyed on <code>dataset.generatedAt</code> re-bases surviving inputs through <code>inputsFromSaved(dataset, prev)</code> (skipping the initial mount) — same helper, same semantics.</td>
-    </tr>
-    <tr>
-      <td><strong>Saved scenarios card</strong> (new, between the preset tiles and Assumptions; <strong>always rendered</strong>)</td>
-      <td>Header: mono &ldquo;Saved scenarios&rdquo; microlabel + the page-level <code>StatusText</code> (a stable landing spot for save/delete feedback even when the list empties). Empty state: one mono line, house style — <code>[ NO SAVED SCENARIOS — SAVE YOUR CURRENT PLAN ]</code> (persistent card fixes first-use discoverability and the delete-the-last-row focus dead end). Rows as a <code>ul</code>/<code>li</code> list, <code>max-h</code> + internal scroll beyond ~6 rows: a load <code>&lt;button aria-pressed&gt;</code> whose accessible name is the scenario name (ink-bar active treatment mirroring the comparison table, but on a real pressed state, not aria-hidden decoration); outside the button: recomputed year-end + Δ <strong>labelled &ldquo;vs saved $X&rdquo;</strong> (different denominator than the page&rsquo;s edited ceiling — made visible, challenge finding), creator + updated caption (<code>T. Studer · 2026-06-12</code>); a pencil icon-button (<code>aria-label="Rename scenario &lt;name&gt;"</code>) and a <code>Trash2</code> ghost icon-button (<code>aria-label="Delete scenario &lt;name&gt;"</code>).</td>
-    </tr>
-    <tr>
-      <td>Load behaviour</td>
-      <td><code>setInputs(inputsFromSaved(dataset, s.params))</code> + sync <code>ceilingDollars</code> with the <em>exact</em> value (<code>String(cents / 100)</code> — no rounding, so a fractional saved ceiling round-trips; challenge finding) + <code>setActive(`saved:${id}`)</code> + <code>setLoadedSavedId(id)</code>. Loading restores the <em>full</em> assumption set including the saved ceiling and billing cadence — unlike preset tiles, which deliberately reset the ceiling (040&rsquo;s asymmetry stays preset-only).</td>
-    </tr>
-    <tr>
-      <td><strong>Save dialog</strong> (trigger: &ldquo;Save scenario&rdquo; button in the Assumptions header, next to &ldquo;Reset to H2 Plan&rdquo;)</td>
-      <td>House dialog pattern (plain-state controlled <code>Dialog</code>, <code>Label</code> + <code>Input</code>, footer with <code>StatusText</code> on the left, <strong>one primary button</strong> — two commit buttons have no precedent; challenge finding). When a loaded scenario exists, a segmented mode toggle (the page&rsquo;s own <code>ToggleButton</code> pattern) selects <em>Update &ldquo;name&rdquo;</em> vs <em>Save as new</em>; otherwise create-only, no toggle. Name field pre-filled from the <em>live</em> row in update mode. A mono summary line echoes exactly what will be saved: <code>Ceiling $X · Claude billing monthly/yearly · N of M tools included</code> — the user sees a $0 ceiling before committing one. Primary label <em>Update</em>/<em>Create</em>, pending label <em>Saving...</em>; submit disabled while pending, when the name is empty, or when the ceiling field is empty/cleared (prevents silently persisting <code>ceilingCents: 0</code>; challenge finding). <strong>Update always saves the CURRENT inputs and ceiling.</strong> Errors render inside the dialog (two-channel pattern); on success: close → <code>status.ok("SAVED")</code> on the card header → <code>router.refresh()</code>.</td>
-    </tr>
-    <tr>
-      <td><strong>Rename dialog</strong> (pencil on each row)</td>
-      <td>Small name-only dialog → <code>updateForecastScenario({ id, name })</code> (params omitted — stored assumptions untouched; closes the &ldquo;rename forces a params rewrite&rdquo; hole the panel found). Same footer conventions.</td>
-    </tr>
-    <tr>
-      <td>Delete confirm</td>
-      <td>House <code>AlertDialog</code> with nullable <code>deleteTarget</code> naming the scenario (and its creator); destructive action button with pending label <em>Deleting...</em>, <strong>disabled while pending</strong> (no double-fire); errors render via <code>StatusText</code> in the <code>AlertDialogFooter</code> (two-channel). On success: clear target, <code>status.ok("DELETED")</code> on the card header, <code>router.refresh()</code>, move focus to the card heading (the trigger row is gone — don&rsquo;t drop focus to <code>&lt;body&gt;</code>); if the deleted scenario was loaded, drop <code>loadedSavedId</code> (current inputs stay — deleting the record doesn&rsquo;t yank the user&rsquo;s working state).</td>
-    </tr>
-    <tr>
-      <td>Feedback</td>
-      <td><code>useInlineStatus</code> + <code>StatusText</code> everywhere — <strong>no Sonner</strong> (deprecated by the Nothing design system; bracketed mono <code>[SAVED]</code> text is the convention).</td>
-    </tr>
-  </tbody>
-</table>
+      <table>
+        <thead>
+          <tr>
+            <th>Where</th>
+            <th>Change</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>page.tsx</code></td>
+            <td>
+              <code
+                >Promise.all([loadBudgetForecastDataset(),
+                listForecastScenarios()])</code
+              >; pass both to the client.
+            </td>
+          </tr>
+          <tr>
+            <td>Active-state model</td>
+            <td>
+              <code>ActiveScenario</code> widens to
+              <code>PresetKey | "custom" | `saved:${number}`</code>.
+              <strong>Mapping (challenge fix):</strong> when active is
+              <code>saved:*</code>, the
+              <strong
+                >&ldquo;Your plan&rdquo; comparison row renders as
+                active</strong
+              >
+              (it is showing exactly the loaded scenario&rsquo;s numbers:
+              <code
+                >isPlanActive = active === "custom" ||
+                active.startsWith("saved:")</code
+              >); preset tiles stay inactive; the Custom tile also stays
+              inactive (the saved card row carries the specific identity). A
+              separate <code>loadedSavedId</code> powers the Update offer and
+              <strong
+                >is cleared by Reset <em>and</em> by clicking any preset
+                tile</strong
+              >
+              (a preset is a new starting point, not a refinement of the loaded
+              scenario — prevents one-click overwrite of a shared row with
+              preset params); plain control edits keep it (flipping
+              <code>active</code> to <code>"custom"</code> as today). The Update
+              offer is derived live from
+              <code>savedScenarios.find(s =&gt; s.id === loadedSavedId)</code> —
+              if another admin deleted the row, the offer disappears instead of
+              going stale.
+            </td>
+          </tr>
+          <tr>
+            <td>Dataset-refresh re-base (challenge fix)</td>
+            <td>
+              <code>router.refresh()</code> after mutations is the page&rsquo;s
+              first path to a
+              <em>changed dataset prop under surviving client state</em> (the
+              loader&rsquo;s 1h cache can expire mid-session). A dataset tool
+              key absent from <code>inputs.tools</code> would be hidden by the
+              controls (<code>if (!p) return null</code>) yet projected at
+              defaults by the engine. Fix: an effect keyed on
+              <code>dataset.generatedAt</code> re-bases surviving inputs through
+              <code>inputsFromSaved(dataset, prev)</code> (skipping the initial
+              mount) — same helper, same semantics.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Saved scenarios card</strong> (new, between the preset
+              tiles and Assumptions; <strong>always rendered</strong>)
+            </td>
+            <td>
+              Header: mono &ldquo;Saved scenarios&rdquo; microlabel + the
+              page-level <code>StatusText</code> (a stable landing spot for
+              save/delete feedback even when the list empties). Empty state: one
+              mono line, house style —
+              <code>[ NO SAVED SCENARIOS — SAVE YOUR CURRENT PLAN ]</code>
+              (persistent card fixes first-use discoverability and the
+              delete-the-last-row focus dead end). Rows as a
+              <code>ul</code>/<code>li</code> list, <code>max-h</code> +
+              internal scroll beyond ~6 rows: a load
+              <code>&lt;button aria-pressed&gt;</code> whose accessible name is
+              the scenario name (ink-bar active treatment mirroring the
+              comparison table, but on a real pressed state, not aria-hidden
+              decoration); outside the button: recomputed year-end + Δ
+              <strong>labelled &ldquo;vs saved $X&rdquo;</strong> (different
+              denominator than the page&rsquo;s edited ceiling — made visible,
+              challenge finding), creator + updated caption (<code
+                >T. Studer · 2026-06-12</code
+              >); a pencil icon-button (<code
+                >aria-label="Rename scenario &lt;name&gt;"</code
+              >) and a <code>Trash2</code> ghost icon-button (<code
+                >aria-label="Delete scenario &lt;name&gt;"</code
+              >).
+            </td>
+          </tr>
+          <tr>
+            <td>Load behaviour</td>
+            <td>
+              <code>setInputs(inputsFromSaved(dataset, s.params))</code> + sync
+              <code>ceilingDollars</code> with the <em>exact</em> value (<code
+                >String(cents / 100)</code
+              >
+              — no rounding, so a fractional saved ceiling round-trips;
+              challenge finding) + <code>setActive(`saved:${id}`)</code> +
+              <code>setLoadedSavedId(id)</code>. Loading restores the
+              <em>full</em> assumption set including the saved ceiling and
+              billing cadence — unlike preset tiles, which deliberately reset
+              the ceiling (040&rsquo;s asymmetry stays preset-only).
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Save dialog</strong> (trigger: &ldquo;Save scenario&rdquo;
+              button in the Assumptions header, next to &ldquo;Reset to H2
+              Plan&rdquo;)
+            </td>
+            <td>
+              House dialog pattern (plain-state controlled <code>Dialog</code>,
+              <code>Label</code> + <code>Input</code>, footer with
+              <code>StatusText</code> on the left,
+              <strong>one primary button</strong> — two commit buttons have no
+              precedent; challenge finding). When a loaded scenario exists, a
+              segmented mode toggle (the page&rsquo;s own
+              <code>ToggleButton</code> pattern) selects
+              <em>Update &ldquo;name&rdquo;</em> vs <em>Save as new</em>;
+              otherwise create-only, no toggle. Name field pre-filled from the
+              <em>live</em> row in update mode. A mono summary line echoes
+              exactly what will be saved:
+              <code
+                >Ceiling $X · Claude billing monthly/yearly · N of M tools
+                included</code
+              >
+              — the user sees a $0 ceiling before committing one. Primary label
+              <em>Update</em>/<em>Create</em>, pending label <em>Saving...</em>;
+              submit disabled while pending, when the name is empty, or when the
+              ceiling field is empty/cleared (prevents silently persisting
+              <code>ceilingCents: 0</code>; challenge finding).
+              <strong
+                >Update always saves the CURRENT inputs and ceiling.</strong
+              >
+              Errors render inside the dialog (two-channel pattern); on success:
+              close → <code>status.ok("SAVED")</code> on the card header →
+              <code>router.refresh()</code>.
+            </td>
+          </tr>
+          <tr>
+            <td><strong>Rename dialog</strong> (pencil on each row)</td>
+            <td>
+              Small name-only dialog →
+              <code>updateForecastScenario({ id, name })</code> (params omitted
+              — stored assumptions untouched; closes the &ldquo;rename forces a
+              params rewrite&rdquo; hole the panel found). Same footer
+              conventions.
+            </td>
+          </tr>
+          <tr>
+            <td>Delete confirm</td>
+            <td>
+              House <code>AlertDialog</code> with nullable
+              <code>deleteTarget</code> naming the scenario (and its creator);
+              destructive action button with pending label <em>Deleting...</em>,
+              <strong>disabled while pending</strong> (no double-fire); errors
+              render via <code>StatusText</code> in the
+              <code>AlertDialogFooter</code> (two-channel). On success: clear
+              target, <code>status.ok("DELETED")</code> on the card header,
+              <code>router.refresh()</code>, move focus to the card heading (the
+              trigger row is gone — don&rsquo;t drop focus to
+              <code>&lt;body&gt;</code>); if the deleted scenario was loaded,
+              drop <code>loadedSavedId</code> (current inputs stay — deleting
+              the record doesn&rsquo;t yank the user&rsquo;s working state).
+            </td>
+          </tr>
+          <tr>
+            <td>Feedback</td>
+            <td>
+              <code>useInlineStatus</code> + <code>StatusText</code> everywhere
+              — <strong>no Sonner</strong> (deprecated by the Nothing design
+              system; bracketed mono <code>[SAVED]</code> text is the
+              convention).
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-<!-- ============================================================ -->
-<h2 id="tests">8 · Test plan</h2>
+      <!-- ============================================================ -->
+      <h2 id="tests">8 · Test plan</h2>
 
-<div class="grid-2">
-  <div class="card accent-2">
-    <h4>Unit (Vitest, no DB)</h4>
-    <ul>
-      <li class="check"><code>inputsFromSaved</code> on the frozen 036 fixture (extended in place in <code>tests/unit/scenarios/budget-forecast.test.ts</code>): carries the saved ceiling (incl. the 0 boundary); copies params per tool; <strong>drops extinct keys</strong>; <strong>defaults new tools</strong>; returned objects are copies; <strong>yearly billing round-trips unchanged</strong> (the only automated check of &ldquo;load restores the cadence&rdquo;); a <code>billing</code> value stranded on a non-claudeSeats key copies through but is provably cost-neutral; <code>saved.tools = {}</code> yields all-defaults with the saved ceiling.</li>
-      <li class="check"><code>tests/unit/scenarios/forecast-scenario-validators.test.ts</code> (colocated with the engine tests — no cross-test-file fixture imports; challenge finding): schema matrix — accepts a realistic inputs literal and a yearly-billing variant and <code>ceilingCents: 0</code>; rejects negative/fractional/over-cap ceilings, <code>premShare &gt; 1</code>, unknown <code>billing</code> values, <code>NaN</code>/<code>Infinity</code> <code>val</code>, &gt; 20 tool entries; strips unknown keys; rename-only update parse (params omitted). Plus the two type-only round-trip assignments (enforced by <code>pnpm typecheck</code>).</li>
-      <li class="check"><code>tests/unit/actions/forecast-scenarios-auth.test.ts</code> (precedent: <code>assignments-export.test.ts</code>): <code>requireAdmin → null</code> ⇒ list returns <code>[]</code>, all three mutations return <code>{ success: false, error: "Unauthorized" }</code>, DB never touched.</li>
-    </ul>
-  </div>
-  <div class="card accent-2">
-    <h4>Integration + browser</h4>
-    <ul>
-      <li class="check"><code>tests/integration/forecast-scenarios.test.ts</code> (real Neon DB, mocked <code>requireAdmin</code>, teardown deletes): seeds an active budget at <strong>FY ≥ 3000</strong> — deterministically the resolution winner under the §5 ordering contract even with the dev DB&rsquo;s real active budget present (challenge must-fix; assertions additionally scoped by the seeded <code>budgetId</code>). Flow: create → list (creator name, ISO dates) → update (rename + params, <strong>audit rows asserted</strong>: created/updated incl. the params snapshot, <code>budget-extensions</code> precedent) → rename-only (stored params unchanged) → duplicate-name rejection (case-insensitive, via the action) → <strong>direct case-variant insert asserting the expression index itself fires</strong> (proves migration 0026&rsquo;s SQL + the race backstop) → <strong>malformed-params row inserted directly is skipped by list</strong> (the safeParse-on-read rule gets coverage) → cap: <strong>bulk-seed 50 rows in one insert</strong>, then one action call asserts the friendly cap error (not 50 action calls ≈ 250 round trips; challenge finding) → delete (audit snapshot round-trips name + params) → list scoped to the seeded budget is empty.</li>
-      <li class="check"><strong>Manual</strong> Playwright pass against the dev server (agent session — the seeded agent user must be an admin; any stranded test scenario is cleaned up at the end): save a tuned custom plan → row appears with recomputed figures → tweak controls → load restores ceiling + cadence + levers exactly → preset tile click clears the Update offer → update overwrites → rename-only → delete with confirm → persistent card shows the empty state. Screenshots reviewed. Manual-only, consistent with 036/040 (no committed e2e file).</li>
-      <li class="check"><code>pnpm lint</code> zero warnings · <code>pnpm typecheck</code> · full unit suite green.</li>
-    </ul>
-  </div>
-</div>
+      <div class="grid-2">
+        <div class="card accent-2">
+          <h4>Unit (Vitest, no DB)</h4>
+          <ul>
+            <li class="check">
+              <code>inputsFromSaved</code> on the frozen 036 fixture (extended
+              in place in
+              <code>tests/unit/scenarios/budget-forecast.test.ts</code>):
+              carries the saved ceiling (incl. the 0 boundary); copies params
+              per tool; <strong>drops extinct keys</strong>;
+              <strong>defaults new tools</strong>; returned objects are copies;
+              <strong>yearly billing round-trips unchanged</strong> (the only
+              automated check of &ldquo;load restores the cadence&rdquo;); a
+              <code>billing</code> value stranded on a non-claudeSeats key
+              copies through but is provably cost-neutral;
+              <code>saved.tools = {}</code> yields all-defaults with the saved
+              ceiling.
+            </li>
+            <li class="check">
+              <code
+                >tests/unit/scenarios/forecast-scenario-validators.test.ts</code
+              >
+              (colocated with the engine tests — no cross-test-file fixture
+              imports; challenge finding): schema matrix — accepts a realistic
+              inputs literal and a yearly-billing variant and
+              <code>ceilingCents: 0</code>; rejects negative/fractional/over-cap
+              ceilings, <code>premShare &gt; 1</code>, unknown
+              <code>billing</code> values, <code>NaN</code>/<code
+                >Infinity</code
+              >
+              <code>val</code>, &gt; 20 tool entries; strips unknown keys;
+              rename-only update parse (params omitted). Plus the two type-only
+              round-trip assignments (enforced by <code>pnpm typecheck</code>).
+            </li>
+            <li class="check">
+              <code>tests/unit/actions/forecast-scenarios-auth.test.ts</code>
+              (precedent: <code>assignments-export.test.ts</code>):
+              <code>requireAdmin → null</code> ⇒ list returns <code>[]</code>,
+              all three mutations return
+              <code>{ success: false, error: "Unauthorized" }</code>, DB never
+              touched.
+            </li>
+          </ul>
+        </div>
+        <div class="card accent-2">
+          <h4>Integration + browser</h4>
+          <ul>
+            <li class="check">
+              <code>tests/integration/forecast-scenarios.test.ts</code> (real
+              Neon DB, mocked <code>requireAdmin</code>, teardown deletes):
+              seeds an active budget at <strong>FY ≥ 3000</strong> —
+              deterministically the resolution winner under the §5 ordering
+              contract even with the dev DB&rsquo;s real active budget present
+              (challenge must-fix; assertions additionally scoped by the seeded
+              <code>budgetId</code>). Flow: create → list (creator name, ISO
+              dates) → update (rename + params,
+              <strong>audit rows asserted</strong>: created/updated incl. the
+              params snapshot, <code>budget-extensions</code> precedent) →
+              rename-only (stored params unchanged) → duplicate-name rejection
+              (case-insensitive, via the action) →
+              <strong
+                >direct case-variant insert asserting the expression index
+                itself fires</strong
+              >
+              (proves migration 0026&rsquo;s SQL + the race backstop) →
+              <strong
+                >malformed-params row inserted directly is skipped by
+                list</strong
+              >
+              (the safeParse-on-read rule gets coverage) → cap:
+              <strong>bulk-seed 50 rows in one insert</strong>, then one action
+              call asserts the friendly cap error (not 50 action calls ≈ 250
+              round trips; challenge finding) → delete (audit snapshot
+              round-trips name + params) → list scoped to the seeded budget is
+              empty.
+            </li>
+            <li class="check">
+              <strong>Manual</strong> Playwright pass against the dev server
+              (agent session — the seeded agent user must be an admin; any
+              stranded test scenario is cleaned up at the end): save a tuned
+              custom plan → row appears with recomputed figures → tweak controls
+              → load restores ceiling + cadence + levers exactly → preset tile
+              click clears the Update offer → update overwrites → rename-only →
+              delete with confirm → persistent card shows the empty state.
+              Screenshots reviewed. Manual-only, consistent with 036/040 (no
+              committed e2e file).
+            </li>
+            <li class="check">
+              <code>pnpm lint</code> zero warnings ·
+              <code>pnpm typecheck</code> · full unit suite green.
+            </li>
+          </ul>
+        </div>
+      </div>
 
-<!-- ============================================================ -->
-<h2 id="manifest">9 · File manifest</h2>
+      <!-- ============================================================ -->
+      <h2 id="manifest">9 · File manifest</h2>
 
-<table>
-  <thead><tr><th>File</th><th></th><th>Purpose</th></tr></thead>
-  <tbody>
-    <tr><td><code>src/lib/db/schema.ts</code></td><td><span class="pill warn">edit</span></td><td><code>forecast_scenarios</code> table + relations block.</td></tr>
-    <tr><td><code>src/lib/db/migrations/0026_*.sql</code></td><td><span class="pill new">new</span></td><td>Generated additive migration (table + FKs + indexes).</td></tr>
-    <tr><td><code>src/lib/validators.ts</code></td><td><span class="pill warn">edit</span></td><td><code>toolParamsSchema</code>, <code>forecastInputsSchema</code>, create/update/delete scenario schemas.</td></tr>
-    <tr><td><code>src/actions/forecast-scenarios.ts</code></td><td><span class="pill new">new</span></td><td>List / create / update / delete server actions (+ deterministic active-budget resolution).</td></tr>
-    <tr><td><code>src/lib/scenarios/budget-forecast.ts</code></td><td><span class="pill warn">edit</span></td><td>Add pure <code>inputsFromSaved()</code>.</td></tr>
-    <tr><td><code>src/app/scenarios/budget-forecast/page.tsx</code></td><td><span class="pill warn">edit</span></td><td>Load saved scenarios alongside the dataset.</td></tr>
-    <tr><td><code>src/app/scenarios/budget-forecast/budget-forecast-client.tsx</code></td><td><span class="pill warn">edit</span></td><td>Saved-scenarios card, save/rename dialogs, delete confirm, active/loaded tracking, dataset re-base effect.</td></tr>
-    <tr><td><code>tests/unit/scenarios/budget-forecast.test.ts</code></td><td><span class="pill warn">edit</span></td><td><code>inputsFromSaved</code> coverage.</td></tr>
-    <tr><td><code>tests/unit/scenarios/forecast-scenario-validators.test.ts</code></td><td><span class="pill new">new</span></td><td>Schema accept/reject/strip matrix + type-level round trip.</td></tr>
-    <tr><td><code>tests/unit/actions/forecast-scenarios-auth.test.ts</code></td><td><span class="pill new">new</span></td><td>Auth-gating contract for all four actions.</td></tr>
-    <tr><td><code>tests/integration/forecast-scenarios.test.ts</code></td><td><span class="pill new">new</span></td><td>Real-DB CRUD round trip + audit + index + read-skip assertions.</td></tr>
-    <tr><td><code>CLAUDE.md</code></td><td><span class="pill warn">edit</span></td><td>&ldquo;Recent Changes&rdquo; line for 041.</td></tr>
-    <tr><td><code>specs/041-forecast-scenario-persistence/*</code></td><td><span class="pill new">new</span></td><td>This plan + running implementation notes.</td></tr>
-  </tbody>
-</table>
+      <table>
+        <thead>
+          <tr>
+            <th>File</th>
+            <th></th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>src/lib/db/schema.ts</code></td>
+            <td><span class="pill warn">edit</span></td>
+            <td><code>forecast_scenarios</code> table + relations block.</td>
+          </tr>
+          <tr>
+            <td><code>src/lib/db/migrations/0026_*.sql</code></td>
+            <td><span class="pill new">new</span></td>
+            <td>Generated additive migration (table + FKs + indexes).</td>
+          </tr>
+          <tr>
+            <td><code>src/lib/validators.ts</code></td>
+            <td><span class="pill warn">edit</span></td>
+            <td>
+              <code>toolParamsSchema</code>, <code>forecastInputsSchema</code>,
+              create/update/delete scenario schemas.
+            </td>
+          </tr>
+          <tr>
+            <td><code>src/actions/forecast-scenarios.ts</code></td>
+            <td><span class="pill new">new</span></td>
+            <td>
+              List / create / update / delete server actions (+ deterministic
+              active-budget resolution).
+            </td>
+          </tr>
+          <tr>
+            <td><code>src/lib/scenarios/budget-forecast.ts</code></td>
+            <td><span class="pill warn">edit</span></td>
+            <td>Add pure <code>inputsFromSaved()</code>.</td>
+          </tr>
+          <tr>
+            <td><code>src/app/scenarios/budget-forecast/page.tsx</code></td>
+            <td><span class="pill warn">edit</span></td>
+            <td>Load saved scenarios alongside the dataset.</td>
+          </tr>
+          <tr>
+            <td>
+              <code
+                >src/app/scenarios/budget-forecast/budget-forecast-client.tsx</code
+              >
+            </td>
+            <td><span class="pill warn">edit</span></td>
+            <td>
+              Saved-scenarios card, save/rename dialogs, delete confirm,
+              active/loaded tracking, dataset re-base effect.
+            </td>
+          </tr>
+          <tr>
+            <td><code>tests/unit/scenarios/budget-forecast.test.ts</code></td>
+            <td><span class="pill warn">edit</span></td>
+            <td><code>inputsFromSaved</code> coverage.</td>
+          </tr>
+          <tr>
+            <td>
+              <code
+                >tests/unit/scenarios/forecast-scenario-validators.test.ts</code
+              >
+            </td>
+            <td><span class="pill new">new</span></td>
+            <td>Schema accept/reject/strip matrix + type-level round trip.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>tests/unit/actions/forecast-scenarios-auth.test.ts</code>
+            </td>
+            <td><span class="pill new">new</span></td>
+            <td>Auth-gating contract for all four actions.</td>
+          </tr>
+          <tr>
+            <td><code>tests/integration/forecast-scenarios.test.ts</code></td>
+            <td><span class="pill new">new</span></td>
+            <td>
+              Real-DB CRUD round trip + audit + index + read-skip assertions.
+            </td>
+          </tr>
+          <tr>
+            <td><code>CLAUDE.md</code></td>
+            <td><span class="pill warn">edit</span></td>
+            <td>&ldquo;Recent Changes&rdquo; line for 041.</td>
+          </tr>
+          <tr>
+            <td><code>specs/041-forecast-scenario-persistence/*</code></td>
+            <td><span class="pill new">new</span></td>
+            <td>This plan + running implementation notes.</td>
+          </tr>
+        </tbody>
+      </table>
 
-<!-- ============================================================ -->
-<h2 id="risks">10 · Risks &amp; decisions</h2>
+      <!-- ============================================================ -->
+      <h2 id="risks">10 · Risks &amp; decisions</h2>
 
-<table>
-  <thead><tr><th>Topic</th><th>Decision / mitigation</th></tr></thead>
-  <tbody>
-    <tr><td>Shared vs per-user scenarios</td><td><strong>Shared pool per budget, last-write-wins.</strong> The tool exists so budget owners can align on a plan; private drafts would fragment that. Mitigations: creator attribution surfaced in the list and delete confirm; full params snapshots in <code>change_history</code> on update and delete, so an overwritten plan is recoverable forensically. Flagged in the notes as the one interpretive call worth explicit user confirmation.</td></tr>
-    <tr><td>Stale params vs live dataset</td><td>Saved params are re-based on load (<code>inputsFromSaved</code>) and re-projected against live data — never stored results. Extinct tool keys dropped, new tools defaulted. The same helper re-bases surviving client state when the dataset prop refreshes mid-session (closes the hidden-tool hole <code>router.refresh()</code> would otherwise open).</td></tr>
-    <tr><td>jsonb rot</td><td>Zod <code>safeParse</code> on every read; non-conforming rows are skipped with a logged error instead of crashing the page (covered by an integration case). Strip semantics keep rows loadable across schema evolution; writes store <code>parsed.data</code>, keeping the stored shape canonical.</td></tr>
-    <tr><td>Duplicate names / races</td><td>App-level case-insensitive pre-check for a friendly message; <code>uniqueIndex(budget_id, lower(name))</code> as the DB backstop — and the backstop&rsquo;s 23505 is <strong>caught and mapped to the same friendly error</strong>, so the race path honours the <code>ActionResult</code> contract instead of surfacing a Next.js digest (challenge finding).</td></tr>
-    <tr><td>Unbounded growth</td><td>Cap of <strong>50 scenarios per budget</strong> with an explicit error. Pre-check only — two concurrent creates at 49 can land 51 rows; accepted as harmless (no DB backstop by design; the cap is a UX guardrail, not an invariant).</td></tr>
-    <tr><td>Active-budget race / split-brain</td><td>Saving resolves the active budget server-side at write time under the §5 ordering contract. If another admin activates a different budget mid-session, the save lands on the new active budget and the refreshed list shows it; the <em>charts</em> may keep rendering the old budget&rsquo;s cached dataset for up to 1h (the dataset cache is not tag-invalidated by budget activation — pre-existing). Accepted: budget activation is a rare, admin-driven event; a hard refresh resolves the split view. Documented rather than hidden.</td></tr>
-    <tr><td>Ceiling semantics on load</td><td>Loading a saved scenario restores its <em>saved</em> ceiling (full assumption set, exact string sync — no rounding drift). Preset tiles keep 040&rsquo;s reset-to-live-ceiling behaviour. The two affordances answer different questions (&ldquo;this plan as tuned&rdquo; vs &ldquo;this preset against the live budget&rdquo;).</td></tr>
-    <tr><td>Saved-row scoring</td><td>Rows are scored against <strong>their own saved ceiling</strong>, with the denominator made explicit in the row (&ldquo;vs saved $X&rdquo;) so the two Δ semantics on one page can&rsquo;t be misread (challenge finding). Scoring against the page&rsquo;s transient edited ceiling would make the list jitter.</td></tr>
-    <tr><td>Accidental shared-row overwrite</td><td>Three guards (challenge findings): preset-tile clicks clear <code>loadedSavedId</code> (no &ldquo;Update&rdquo; offer for preset params); the Update offer is derived from the live <code>savedScenarios</code> prop (a concurrently-deleted row withdraws the offer); the save dialog echoes exactly what will be saved and blocks an empty/cleared ceiling field.</td></tr>
-    <tr><td>Feedback affordance</td><td><code>StatusText</code>/<code>useInlineStatus</code>, not Sonner — toasts are deprecated in the Nothing design system (one legacy usage left app-wide). Card-header status + in-dialog status (two-channel house pattern).</td></tr>
-    <tr><td>Cache coherence</td><td>The scenario list is an uncached read on a dynamic page; mutations <code>revalidatePath</code>. The dataset loader&rsquo;s <code>unstable_cache</code> is untouched (scenario writes don&rsquo;t change live cost data).</td></tr>
-    <tr><td>Role &amp; sensitivity</td><td>Admin-only end to end (<code>requireAdmin</code> in every action; the layout already gates). Params contain no secrets — growth assumptions and a ceiling.</td></tr>
-  </tbody>
-</table>
+      <table>
+        <thead>
+          <tr>
+            <th>Topic</th>
+            <th>Decision / mitigation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Shared vs per-user scenarios</td>
+            <td>
+              <strong>Shared pool per budget, last-write-wins.</strong> The tool
+              exists so budget owners can align on a plan; private drafts would
+              fragment that. Mitigations: creator attribution surfaced in the
+              list and delete confirm; full params snapshots in
+              <code>change_history</code> on update and delete, so an
+              overwritten plan is recoverable forensically. Flagged in the notes
+              as the one interpretive call worth explicit user confirmation.
+            </td>
+          </tr>
+          <tr>
+            <td>Stale params vs live dataset</td>
+            <td>
+              Saved params are re-based on load (<code>inputsFromSaved</code>)
+              and re-projected against live data — never stored results. Extinct
+              tool keys dropped, new tools defaulted. The same helper re-bases
+              surviving client state when the dataset prop refreshes mid-session
+              (closes the hidden-tool hole <code>router.refresh()</code> would
+              otherwise open).
+            </td>
+          </tr>
+          <tr>
+            <td>jsonb rot</td>
+            <td>
+              Zod <code>safeParse</code> on every read; non-conforming rows are
+              skipped with a logged error instead of crashing the page (covered
+              by an integration case). Strip semantics keep rows loadable across
+              schema evolution; writes store <code>parsed.data</code>, keeping
+              the stored shape canonical.
+            </td>
+          </tr>
+          <tr>
+            <td>Duplicate names / races</td>
+            <td>
+              App-level case-insensitive pre-check for a friendly message;
+              <code>uniqueIndex(budget_id, lower(name))</code> as the DB
+              backstop — and the backstop&rsquo;s 23505 is
+              <strong>caught and mapped to the same friendly error</strong>, so
+              the race path honours the <code>ActionResult</code> contract
+              instead of surfacing a Next.js digest (challenge finding).
+            </td>
+          </tr>
+          <tr>
+            <td>Unbounded growth</td>
+            <td>
+              Cap of <strong>50 scenarios per budget</strong> with an explicit
+              error. Pre-check only — two concurrent creates at 49 can land 51
+              rows; accepted as harmless (no DB backstop by design; the cap is a
+              UX guardrail, not an invariant).
+            </td>
+          </tr>
+          <tr>
+            <td>Active-budget race / split-brain</td>
+            <td>
+              Saving resolves the active budget server-side at write time under
+              the §5 ordering contract. If another admin activates a different
+              budget mid-session, the save lands on the new active budget and
+              the refreshed list shows it; the <em>charts</em> may keep
+              rendering the old budget&rsquo;s cached dataset for up to 1h (the
+              dataset cache is not tag-invalidated by budget activation —
+              pre-existing). Accepted: budget activation is a rare, admin-driven
+              event; a hard refresh resolves the split view. Documented rather
+              than hidden.
+            </td>
+          </tr>
+          <tr>
+            <td>Ceiling semantics on load</td>
+            <td>
+              Loading a saved scenario restores its <em>saved</em> ceiling (full
+              assumption set, exact string sync — no rounding drift). Preset
+              tiles keep 040&rsquo;s reset-to-live-ceiling behaviour. The two
+              affordances answer different questions (&ldquo;this plan as
+              tuned&rdquo; vs &ldquo;this preset against the live
+              budget&rdquo;).
+            </td>
+          </tr>
+          <tr>
+            <td>Saved-row scoring</td>
+            <td>
+              Rows are scored against <strong>their own saved ceiling</strong>,
+              with the denominator made explicit in the row (&ldquo;vs saved
+              $X&rdquo;) so the two Δ semantics on one page can&rsquo;t be
+              misread (challenge finding). Scoring against the page&rsquo;s
+              transient edited ceiling would make the list jitter.
+            </td>
+          </tr>
+          <tr>
+            <td>Accidental shared-row overwrite</td>
+            <td>
+              Three guards (challenge findings): preset-tile clicks clear
+              <code>loadedSavedId</code> (no &ldquo;Update&rdquo; offer for
+              preset params); the Update offer is derived from the live
+              <code>savedScenarios</code> prop (a concurrently-deleted row
+              withdraws the offer); the save dialog echoes exactly what will be
+              saved and blocks an empty/cleared ceiling field.
+            </td>
+          </tr>
+          <tr>
+            <td>Feedback affordance</td>
+            <td>
+              <code>StatusText</code>/<code>useInlineStatus</code>, not Sonner —
+              toasts are deprecated in the Nothing design system (one legacy
+              usage left app-wide). Card-header status + in-dialog status
+              (two-channel house pattern).
+            </td>
+          </tr>
+          <tr>
+            <td>Cache coherence</td>
+            <td>
+              The scenario list is an uncached read on a dynamic page; mutations
+              <code>revalidatePath</code>. The dataset loader&rsquo;s
+              <code>unstable_cache</code> is untouched (scenario writes
+              don&rsquo;t change live cost data).
+            </td>
+          </tr>
+          <tr>
+            <td>Role &amp; sensitivity</td>
+            <td>
+              Admin-only end to end (<code>requireAdmin</code> in every action;
+              the layout already gates). Params contain no secrets — growth
+              assumptions and a ceiling.
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-<!-- ============================================================ -->
-<h2 id="accept">11 · Acceptance checklist</h2>
-<ul>
-  <li class="check">Migration <code>0026</code> applies cleanly (additive only); <code>db:generate</code> output reviewed (expression index emits correctly).</li>
-  <li class="check">Save: a tuned Custom plan (edited ceiling, yearly billing, tweaked levers) saves under a name; the row appears with recomputed year-end and Δ labelled &ldquo;vs saved $X&rdquo;, plus creator + updated caption.</li>
-  <li class="check">Load: selecting a saved scenario restores every lever, the saved ceiling (exactly), and the billing cadence; the row shows pressed; the &ldquo;Your plan&rdquo; comparison row carries the active treatment; editing any control flips to Custom but keeps the Update offer.</li>
-  <li class="check">Preset tile click while a saved scenario is loaded clears the Update offer (no one-click overwrite with preset params).</li>
-  <li class="check">Update: overwrites params and/or renames via the mode toggle; rename-only (pencil) leaves stored params untouched; duplicate names (case-insensitive) rejected with a friendly inline error — including the race path.</li>
-  <li class="check">Delete: AlertDialog confirm naming scenario + creator; pending-disabled action; the list refreshes; focus moves to the card heading; a loaded-then-deleted scenario leaves the working state intact.</li>
-  <li class="check">The saved card renders persistently with a mono empty state; two admins see the same shared list.</li>
-  <li class="check">No active budget → saving fails with a clear error; the page&rsquo;s existing empty state is unchanged.</li>
-  <li class="check">Unit + integration suites green (incl. audit, expression-index, and read-skip assertions); lint zero warnings; typecheck clean; Playwright pass recorded in the notes.</li>
-  <li class="check">036/040 behaviour untouched: presets, billing toggle, charts, tables, and all existing regression anchors unchanged.</li>
-</ul>
+      <!-- ============================================================ -->
+      <h2 id="accept">11 · Acceptance checklist</h2>
+      <ul>
+        <li class="check">
+          Migration <code>0026</code> applies cleanly (additive only);
+          <code>db:generate</code> output reviewed (expression index emits
+          correctly).
+        </li>
+        <li class="check">
+          Save: a tuned Custom plan (edited ceiling, yearly billing, tweaked
+          levers) saves under a name; the row appears with recomputed year-end
+          and Δ labelled &ldquo;vs saved $X&rdquo;, plus creator + updated
+          caption.
+        </li>
+        <li class="check">
+          Load: selecting a saved scenario restores every lever, the saved
+          ceiling (exactly), and the billing cadence; the row shows pressed; the
+          &ldquo;Your plan&rdquo; comparison row carries the active treatment;
+          editing any control flips to Custom but keeps the Update offer.
+        </li>
+        <li class="check">
+          Preset tile click while a saved scenario is loaded clears the Update
+          offer (no one-click overwrite with preset params).
+        </li>
+        <li class="check">
+          Update: overwrites params and/or renames via the mode toggle;
+          rename-only (pencil) leaves stored params untouched; duplicate names
+          (case-insensitive) rejected with a friendly inline error — including
+          the race path.
+        </li>
+        <li class="check">
+          Delete: AlertDialog confirm naming scenario + creator;
+          pending-disabled action; the list refreshes; focus moves to the card
+          heading; a loaded-then-deleted scenario leaves the working state
+          intact.
+        </li>
+        <li class="check">
+          The saved card renders persistently with a mono empty state; two
+          admins see the same shared list.
+        </li>
+        <li class="check">
+          No active budget → saving fails with a clear error; the page&rsquo;s
+          existing empty state is unchanged.
+        </li>
+        <li class="check">
+          Unit + integration suites green (incl. audit, expression-index, and
+          read-skip assertions); lint zero warnings; typecheck clean; Playwright
+          pass recorded in the notes.
+        </li>
+        <li class="check">
+          036/040 behaviour untouched: presets, billing toggle, charts, tables,
+          and all existing regression anchors unchanged.
+        </li>
+      </ul>
 
-<footer>
-  AI Developer Hub · spec/041-forecast-scenario-persistence · implementation plan · drafted &amp; challenged 2026-06-12 · companion: implementation-notes.html
-</footer>
-
-</main>
-</body>
+      <footer>
+        AI Developer Hub · spec/041-forecast-scenario-persistence ·
+        implementation plan · drafted &amp; challenged 2026-06-12 · companion:
+        implementation-notes.html
+      </footer>
+    </main>
+  </body>
 </html>

--- a/src/actions/budget.ts
+++ b/src/actions/budget.ts
@@ -20,13 +20,24 @@ import {
   updateBilledCostSchema,
   deleteBilledCostSchema,
 } from "@/lib/validators";
-import type { ActionResult, AnnualBudget, BudgetPeriod, BudgetWithCosts, PeriodSpendPoint, BudgetForecast } from "@/types";
+import type {
+  ActionResult,
+  AnnualBudget,
+  BudgetPeriod,
+  BudgetWithCosts,
+  PeriodSpendPoint,
+  BudgetForecast,
+} from "@/types";
 import { buildBudgetForecast } from "@/lib/forecast";
 import { getRunningCostsForPeriod } from "@/lib/budget-utils";
-import { recordCreation, recordUpdate, recordStatusChange } from "@/actions/history";
+import {
+  recordCreation,
+  recordUpdate,
+  recordStatusChange,
+} from "@/actions/history";
 
 export async function createBudget(
-  input: unknown
+  input: unknown,
 ): Promise<ActionResult<{ id: number }>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
@@ -89,7 +100,7 @@ export async function createBudget(
 function generatePeriods(
   year: number,
   type: "monthly" | "quarterly",
-  budgetId: number
+  budgetId: number,
 ) {
   const months = [
     "Jan",
@@ -159,7 +170,7 @@ function generatePeriods(
 }
 
 export async function updateBudgetAllocations(
-  input: unknown
+  input: unknown,
 ): Promise<ActionResult<void>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
@@ -174,7 +185,7 @@ export async function updateBudgetAllocations(
   const budget = await db.query.annualBudgets.findFirst({
     where: and(
       eq(annualBudgets.id, budgetId),
-      eq(annualBudgets.status, "active")
+      eq(annualBudgets.status, "active"),
     ),
   });
   if (!budget) {
@@ -184,7 +195,7 @@ export async function updateBudgetAllocations(
   // FR-010: Validate sum does not exceed total
   const totalAllocated = allocations.reduce(
     (sum, a) => sum + a.plannedAmountCents,
-    0
+    0,
   );
   if (totalAllocated > budget.totalAmountCents) {
     return {
@@ -246,7 +257,7 @@ export async function archiveBudget(input: {
     input.id,
     Number(admin.id),
     existing.status,
-    "archived"
+    "archived",
   );
 
   revalidatePath("/budget");
@@ -259,6 +270,10 @@ export async function archiveBudget(input: {
 export async function getActiveBudget() {
   return db.query.annualBudgets.findFirst({
     where: eq(annualBudgets.status, "active"),
+    // Deterministic resolution contract (see getActiveBudgetId in
+    // lib/budget-utils.ts): the schema permits multiple active rows, and
+    // every consumer must agree on which one wins.
+    orderBy: (b, { desc }) => [desc(b.fiscalYear)],
     with: {
       periods: {
         orderBy: (p, { asc }) => [asc(p.periodIndex)],
@@ -299,7 +314,10 @@ export async function getBudgets(): Promise<
       .groupBy(budgetExtensions.budgetId),
   ]);
   const byBudget = new Map(
-    extensions.map((e) => [e.budgetId, { count: e.count, net: e.netCents ?? 0 }])
+    extensions.map((e) => [
+      e.budgetId,
+      { count: e.count, net: e.netCents ?? 0 },
+    ]),
   );
   return budgets.map((b) => ({
     ...b,
@@ -311,7 +329,7 @@ export async function getBudgets(): Promise<
 // US5: Expected spend calculation for a budget period (based on active license assignments)
 export async function getExpectedSpendForPeriod(
   startDate: string,
-  endDate: string
+  endDate: string,
 ): Promise<number> {
   const result = await db
     .select({
@@ -324,9 +342,9 @@ export async function getExpectedSpendForPeriod(
         lte(licenseAssignments.assignedAt, new Date(endDate)),
         or(
           isNull(licenseAssignments.revokedAt),
-          gte(licenseAssignments.revokedAt, new Date(startDate))
-        )
-      )
+          gte(licenseAssignments.revokedAt, new Date(startDate)),
+        ),
+      ),
     );
 
   return Number(result[0]?.total ?? 0);
@@ -345,7 +363,7 @@ async function requireActivePeriod(periodId: number) {
 
 // US6: Create a billed cost entry
 export async function createBilledCost(
-  input: unknown
+  input: unknown,
 ): Promise<ActionResult<{ id: number }>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
@@ -368,7 +386,13 @@ export async function createBilledCost(
 
   const [billedCost] = await db
     .insert(billedCosts)
-    .values({ periodId, amountCents, invoiceDate, description, vendorReference })
+    .values({
+      periodId,
+      amountCents,
+      invoiceDate,
+      description,
+      vendorReference,
+    })
     .returning({ id: billedCosts.id });
 
   await recordCreation("billed_cost", billedCost.id, Number(admin.id));
@@ -382,7 +406,7 @@ export async function createBilledCost(
 
 // US6: Update an existing billed cost entry
 export async function updateBilledCost(
-  input: unknown
+  input: unknown,
 ): Promise<ActionResult<void>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
@@ -403,35 +427,63 @@ export async function updateBilledCost(
     return { success: false, error: "Billed cost not found" };
   }
   if (existing.period.budget.status === "archived") {
-    return { success: false, error: "Cannot modify costs on an archived budget" };
+    return {
+      success: false,
+      error: "Cannot modify costs on an archived budget",
+    };
   }
 
   // Build changes record for history
   const changes: Record<string, { old: unknown; new: unknown }> = {};
-  if (updates.amountCents !== undefined && updates.amountCents !== existing.amountCents) {
-    changes.amountCents = { old: existing.amountCents, new: updates.amountCents };
+  if (
+    updates.amountCents !== undefined &&
+    updates.amountCents !== existing.amountCents
+  ) {
+    changes.amountCents = {
+      old: existing.amountCents,
+      new: updates.amountCents,
+    };
   }
-  if (updates.invoiceDate !== undefined && updates.invoiceDate !== existing.invoiceDate) {
-    changes.invoiceDate = { old: existing.invoiceDate, new: updates.invoiceDate };
+  if (
+    updates.invoiceDate !== undefined &&
+    updates.invoiceDate !== existing.invoiceDate
+  ) {
+    changes.invoiceDate = {
+      old: existing.invoiceDate,
+      new: updates.invoiceDate,
+    };
   }
-  if (updates.description !== undefined && updates.description !== existing.description) {
-    changes.description = { old: existing.description, new: updates.description };
+  if (
+    updates.description !== undefined &&
+    updates.description !== existing.description
+  ) {
+    changes.description = {
+      old: existing.description,
+      new: updates.description,
+    };
   }
-  if (updates.vendorReference !== undefined && updates.vendorReference !== existing.vendorReference) {
-    changes.vendorReference = { old: existing.vendorReference, new: updates.vendorReference };
+  if (
+    updates.vendorReference !== undefined &&
+    updates.vendorReference !== existing.vendorReference
+  ) {
+    changes.vendorReference = {
+      old: existing.vendorReference,
+      new: updates.vendorReference,
+    };
   }
 
   // Filter out undefined values for the update
   const setValues: Record<string, unknown> = { updatedAt: new Date() };
-  if (updates.amountCents !== undefined) setValues.amountCents = updates.amountCents;
-  if (updates.invoiceDate !== undefined) setValues.invoiceDate = updates.invoiceDate;
-  if (updates.description !== undefined) setValues.description = updates.description;
-  if (updates.vendorReference !== undefined) setValues.vendorReference = updates.vendorReference;
+  if (updates.amountCents !== undefined)
+    setValues.amountCents = updates.amountCents;
+  if (updates.invoiceDate !== undefined)
+    setValues.invoiceDate = updates.invoiceDate;
+  if (updates.description !== undefined)
+    setValues.description = updates.description;
+  if (updates.vendorReference !== undefined)
+    setValues.vendorReference = updates.vendorReference;
 
-  await db
-    .update(billedCosts)
-    .set(setValues)
-    .where(eq(billedCosts.id, id));
+  await db.update(billedCosts).set(setValues).where(eq(billedCosts.id, id));
 
   if (Object.keys(changes).length > 0) {
     await recordUpdate("billed_cost", id, Number(admin.id), changes);
@@ -446,7 +498,7 @@ export async function updateBilledCost(
 
 // US6: Delete a billed cost entry
 export async function deleteBilledCost(
-  input: unknown
+  input: unknown,
 ): Promise<ActionResult<void>> {
   const admin = await requireAdmin();
   if (!admin) return { success: false, error: "Unauthorized" };
@@ -467,7 +519,10 @@ export async function deleteBilledCost(
     return { success: false, error: "Billed cost not found" };
   }
   if (existing.period.budget.status === "archived") {
-    return { success: false, error: "Cannot delete costs on an archived budget" };
+    return {
+      success: false,
+      error: "Cannot delete costs on an archived budget",
+    };
   }
 
   // Record deletion with previous value snapshot
@@ -496,7 +551,7 @@ export async function deleteBilledCost(
 
 // US6: Load budget with computed cost data per period
 export async function getBudgetWithCosts(
-  budgetId: number
+  budgetId: number,
 ): Promise<BudgetWithCosts | null> {
   const budget = await db.query.annualBudgets.findFirst({
     where: eq(annualBudgets.id, budgetId),
@@ -523,11 +578,11 @@ export async function getBudgetWithCosts(
   // Batch: compute expected spend for all periods in a single query
   const overallStart = budget.periods.reduce(
     (min, p) => (p.startDate < min ? p.startDate : min),
-    budget.periods[0].startDate
+    budget.periods[0].startDate,
   );
   const overallEnd = budget.periods.reduce(
     (max, p) => (p.endDate > max ? p.endDate : max),
-    budget.periods[0].endDate
+    budget.periods[0].endDate,
   );
 
   // Fetch all assignments that overlap with the full budget date range
@@ -543,9 +598,9 @@ export async function getBudgetWithCosts(
         lte(licenseAssignments.assignedAt, new Date(overallEnd)),
         or(
           isNull(licenseAssignments.revokedAt),
-          gte(licenseAssignments.revokedAt, new Date(overallStart))
-        )
-      )
+          gte(licenseAssignments.revokedAt, new Date(overallStart)),
+        ),
+      ),
     );
 
   // Sum extension allocations per period for the "+€X from extension" sub-label
@@ -566,13 +621,13 @@ export async function getBudgetWithCosts(
       .filter(
         (a) =>
           a.assignedAt <= periodEnd &&
-          (a.revokedAt === null || a.revokedAt >= periodStart)
+          (a.revokedAt === null || a.revokedAt >= periodStart),
       )
       .reduce((total, a) => total + a.costAtAssignmentCents, 0);
 
     const billedTotalCents = period.billedCosts.reduce(
       (s, bc) => s + bc.amountCents,
-      0
+      0,
     );
 
     return {
@@ -600,7 +655,7 @@ export async function getBudgetWithCosts(
 
 // 005-rich-reports: Time-series spend data per period
 export async function getBilledCostsTimeSeries(
-  budgetId: number
+  budgetId: number,
 ): Promise<PeriodSpendPoint[]> {
   try {
     const budgetWithCosts = await getBudgetWithCosts(budgetId);
@@ -623,13 +678,16 @@ export async function getBilledCostsTimeSeries(
 // 005-rich-reports: Budget forecast using OLS linear regression.
 // Spec 028: Actual = billed + running Anthropic API costs (matches budget detail page).
 export async function getBudgetForecast(
-  budgetId: number
+  budgetId: number,
 ): Promise<ActionResult<BudgetForecast>> {
   const budget = await getBudgetWithCosts(budgetId);
   if (!budget) return { success: false, error: "Budget not found" };
   const today = new Date();
   const actualByPeriod = await fetchActualByPeriod(budget, today);
-  return { success: true, data: buildBudgetForecast(budget, actualByPeriod, today) };
+  return {
+    success: true,
+    data: buildBudgetForecast(budget, actualByPeriod, today),
+  };
 }
 
 /**
@@ -639,13 +697,13 @@ export async function getBudgetForecast(
  */
 export async function fetchActualByPeriod(
   budget: BudgetWithCosts,
-  today: Date = new Date()
+  today: Date = new Date(),
 ): Promise<Map<number, number>> {
   const pastOrCurrent = budget.periods.filter(
-    (p) => new Date(p.startDate) <= today
+    (p) => new Date(p.startDate) <= today,
   );
   const runningResults = await Promise.all(
-    pastOrCurrent.map((p) => getRunningCostsForPeriod(p.id))
+    pastOrCurrent.map((p) => getRunningCostsForPeriod(p.id)),
   );
   const actualByPeriod = new Map<number, number>();
   for (const p of budget.periods) {

--- a/src/actions/forecast-scenarios.ts
+++ b/src/actions/forecast-scenarios.ts
@@ -1,16 +1,16 @@
 "use server";
 
 import { db } from "@/lib/db";
-import {
-  annualBudgets,
-  changeHistory,
-  forecastScenarios,
-  users,
-} from "@/lib/db/schema";
-import { and, asc, desc, eq, ne, sql } from "drizzle-orm";
+import { forecastScenarios, users } from "@/lib/db/schema";
+import { asc, eq, sql } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth-helpers";
-import { recordCreation, recordUpdate } from "@/actions/history";
+import { getActiveBudgetId } from "@/lib/budget-utils";
+import {
+  recordCreation,
+  recordDeletion,
+  recordUpdate,
+} from "@/actions/history";
 import {
   createForecastScenarioSchema,
   deleteForecastScenarioSchema,
@@ -40,49 +40,21 @@ export interface SavedForecastScenario {
 }
 
 /**
- * Resolve the budget scenarios attach to. The schema permits multiple
- * status='active' rows, so the contract is deterministic: the active budget
- * with the highest fiscal year wins.
+ * True when an error is the unique-index violation on (budget_id, lower(name)).
+ * The index is the single source of duplicate-name rejection: a violation maps
+ * back to the same friendly ActionResult error a pre-check would have given,
+ * with no race window. Drizzle wraps the Postgres error (the 23505 code lives
+ * on the cause), so the whole cause chain is checked.
  */
-async function resolveActiveBudgetId(): Promise<number | null> {
-  const [budget] = await db
-    .select({ id: annualBudgets.id })
-    .from(annualBudgets)
-    .where(eq(annualBudgets.status, "active"))
-    .orderBy(desc(annualBudgets.fiscalYear))
-    .limit(1);
-  return budget?.id ?? null;
-}
-
-/** Case-insensitive duplicate-name probe, optionally excluding a row (update). */
-async function nameTaken(
-  budgetId: number,
-  name: string,
-  excludeId?: number,
-): Promise<boolean> {
-  const conditions = [
-    eq(forecastScenarios.budgetId, budgetId),
-    sql`lower(${forecastScenarios.name}) = lower(${name})`,
-  ];
-  if (excludeId !== undefined) {
-    conditions.push(ne(forecastScenarios.id, excludeId));
-  }
-  const [existing] = await db
-    .select({ id: forecastScenarios.id })
-    .from(forecastScenarios)
-    .where(and(...conditions))
-    .limit(1);
-  return existing !== undefined;
-}
-
-/** True when an error is the unique-index violation on (budget_id, lower(name)). */
 function isDuplicateNameViolation(e: unknown): boolean {
-  return (
-    typeof e === "object" &&
-    e !== null &&
-    "code" in e &&
-    (e as { code?: unknown }).code === "23505"
-  );
+  for (
+    let err = e;
+    typeof err === "object" && err !== null;
+    err = (err as { cause?: unknown }).cause
+  ) {
+    if ((err as { code?: unknown }).code === "23505") return true;
+  }
+  return false;
 }
 
 const DUPLICATE_NAME_ERROR =
@@ -99,7 +71,7 @@ export async function listForecastScenarios(): Promise<
   const admin = await requireAdmin();
   if (!admin) return [];
 
-  const budgetId = await resolveActiveBudgetId();
+  const budgetId = await getActiveBudgetId();
   if (budgetId === null) return [];
 
   const rows = await db
@@ -155,7 +127,7 @@ export async function createForecastScenario(
     };
   }
 
-  const budgetId = await resolveActiveBudgetId();
+  const budgetId = await getActiveBudgetId();
   if (budgetId === null) {
     return { success: false, error: "No active budget" };
   }
@@ -171,10 +143,6 @@ export async function createForecastScenario(
     };
   }
 
-  if (await nameTaken(budgetId, parsed.data.name)) {
-    return { success: false, error: DUPLICATE_NAME_ERROR };
-  }
-
   let created: { id: number };
   try {
     [created] = await db
@@ -187,8 +155,6 @@ export async function createForecastScenario(
       })
       .returning({ id: forecastScenarios.id });
   } catch (e) {
-    // The unique index is the race backstop behind the pre-check; its
-    // violation must honour the ActionResult contract, not surface a digest.
     if (isDuplicateNameViolation(e)) {
       return { success: false, error: DUPLICATE_NAME_ERROR };
     }
@@ -224,10 +190,6 @@ export async function updateForecastScenario(
     where: eq(forecastScenarios.id, id),
   });
   if (!scenario) return { success: false, error: "Scenario not found" };
-
-  if (await nameTaken(scenario.budgetId, name, id)) {
-    return { success: false, error: DUPLICATE_NAME_ERROR };
-  }
 
   try {
     await db
@@ -273,28 +235,18 @@ export async function deleteForecastScenario(
     return { success: false, error: "Invalid scenario ID" };
   }
 
-  const scenario = await db.query.forecastScenarios.findFirst({
-    where: eq(forecastScenarios.id, parsed.data.id),
-  });
+  // Delete-and-fetch in one statement; the returned row is the audit snapshot.
+  const [scenario] = await db
+    .delete(forecastScenarios)
+    .where(eq(forecastScenarios.id, parsed.data.id))
+    .returning();
   if (!scenario) return { success: false, error: "Scenario not found" };
 
-  // Record deletion with a previous-value snapshot (deleteBilledCost pattern)
-  // so the audit trail can reconstruct what was removed.
-  await db.insert(changeHistory).values({
-    entityType: ENTITY_TYPE,
-    entityId: scenario.id,
-    changeType: "deleted",
-    previousValue: JSON.stringify({
-      budgetId: scenario.budgetId,
-      name: scenario.name,
-      params: scenario.params,
-    }),
-    changedBy: Number(admin.id),
+  await recordDeletion(ENTITY_TYPE, scenario.id, Number(admin.id), {
+    budgetId: scenario.budgetId,
+    name: scenario.name,
+    params: scenario.params,
   });
-
-  await db
-    .delete(forecastScenarios)
-    .where(eq(forecastScenarios.id, scenario.id));
 
   revalidatePath(SCENARIO_PAGE);
   return { success: true, data: { id: scenario.id } };

--- a/src/actions/forecast-scenarios.ts
+++ b/src/actions/forecast-scenarios.ts
@@ -1,0 +1,301 @@
+"use server";
+
+import { db } from "@/lib/db";
+import {
+  annualBudgets,
+  changeHistory,
+  forecastScenarios,
+  users,
+} from "@/lib/db/schema";
+import { and, asc, desc, eq, ne, sql } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/lib/auth-helpers";
+import { recordCreation, recordUpdate } from "@/actions/history";
+import {
+  createForecastScenarioSchema,
+  deleteForecastScenarioSchema,
+  forecastInputsSchema,
+  updateForecastScenarioSchema,
+} from "@/lib/validators";
+import type { ForecastInputs } from "@/lib/scenarios/budget-forecast";
+import type { ActionResult } from "@/types";
+
+/**
+ * CRUD for saved forecast scenarios (spec 041) — named, shared ForecastInputs
+ * parameter sets scoped to the active budget. The cached dataset loaders stay
+ * in scenarios.ts; this file owns the section's first write path.
+ */
+
+const SCENARIO_PAGE = "/scenarios/budget-forecast";
+const ENTITY_TYPE = "forecast_scenario";
+/** UX guardrail, pre-check only (no DB backstop — a racy 51st row is harmless). */
+const MAX_SCENARIOS_PER_BUDGET = 50;
+
+export interface SavedForecastScenario {
+  id: number;
+  name: string;
+  params: ForecastInputs;
+  creatorName: string | null;
+  updatedAt: string;
+}
+
+/**
+ * Resolve the budget scenarios attach to. The schema permits multiple
+ * status='active' rows, so the contract is deterministic: the active budget
+ * with the highest fiscal year wins.
+ */
+async function resolveActiveBudgetId(): Promise<number | null> {
+  const [budget] = await db
+    .select({ id: annualBudgets.id })
+    .from(annualBudgets)
+    .where(eq(annualBudgets.status, "active"))
+    .orderBy(desc(annualBudgets.fiscalYear))
+    .limit(1);
+  return budget?.id ?? null;
+}
+
+/** Case-insensitive duplicate-name probe, optionally excluding a row (update). */
+async function nameTaken(
+  budgetId: number,
+  name: string,
+  excludeId?: number,
+): Promise<boolean> {
+  const conditions = [
+    eq(forecastScenarios.budgetId, budgetId),
+    sql`lower(${forecastScenarios.name}) = lower(${name})`,
+  ];
+  if (excludeId !== undefined) {
+    conditions.push(ne(forecastScenarios.id, excludeId));
+  }
+  const [existing] = await db
+    .select({ id: forecastScenarios.id })
+    .from(forecastScenarios)
+    .where(and(...conditions))
+    .limit(1);
+  return existing !== undefined;
+}
+
+/** True when an error is the unique-index violation on (budget_id, lower(name)). */
+function isDuplicateNameViolation(e: unknown): boolean {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    "code" in e &&
+    (e as { code?: unknown }).code === "23505"
+  );
+}
+
+const DUPLICATE_NAME_ERROR =
+  "A scenario with this name already exists for this budget";
+
+/**
+ * Saved scenarios for the active budget, ordered by name. The admin gate
+ * returning [] is defense-in-depth only — the /scenarios layout already
+ * redirects non-admins, and the page's dataset loader throws first.
+ */
+export async function listForecastScenarios(): Promise<
+  SavedForecastScenario[]
+> {
+  const admin = await requireAdmin();
+  if (!admin) return [];
+
+  const budgetId = await resolveActiveBudgetId();
+  if (budgetId === null) return [];
+
+  const rows = await db
+    .select({
+      id: forecastScenarios.id,
+      name: forecastScenarios.name,
+      params: forecastScenarios.params,
+      creatorName: users.name,
+      updatedAt: forecastScenarios.updatedAt,
+    })
+    .from(forecastScenarios)
+    .leftJoin(users, eq(forecastScenarios.createdBy, users.id))
+    .where(eq(forecastScenarios.budgetId, budgetId))
+    .orderBy(asc(forecastScenarios.name));
+
+  // Validate on read: the jsonb column is an open contract — a row that no
+  // longer conforms is skipped (loudly), never allowed to crash the page.
+  const out: SavedForecastScenario[] = [];
+  for (const row of rows) {
+    const parsed = forecastInputsSchema.safeParse(row.params);
+    if (!parsed.success) {
+      console.error(
+        `[forecast-scenarios] Skipping scenario ${row.id} ("${row.name}"): stored params no longer conform`,
+      );
+      continue;
+    }
+    out.push({
+      id: row.id,
+      name: row.name,
+      params: parsed.data,
+      creatorName: row.creatorName,
+      updatedAt: row.updatedAt.toISOString(),
+    });
+  }
+  return out;
+}
+
+export async function createForecastScenario(
+  input: unknown,
+): Promise<ActionResult<{ id: number }>> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  const parsed = createForecastScenarioSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "Validation failed",
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<
+        string,
+        string[]
+      >,
+    };
+  }
+
+  const budgetId = await resolveActiveBudgetId();
+  if (budgetId === null) {
+    return { success: false, error: "No active budget" };
+  }
+
+  const [{ count }] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(forecastScenarios)
+    .where(eq(forecastScenarios.budgetId, budgetId));
+  if (count >= MAX_SCENARIOS_PER_BUDGET) {
+    return {
+      success: false,
+      error: `Scenario limit reached (${MAX_SCENARIOS_PER_BUDGET}) — delete one first`,
+    };
+  }
+
+  if (await nameTaken(budgetId, parsed.data.name)) {
+    return { success: false, error: DUPLICATE_NAME_ERROR };
+  }
+
+  let created: { id: number };
+  try {
+    [created] = await db
+      .insert(forecastScenarios)
+      .values({
+        budgetId,
+        name: parsed.data.name,
+        params: parsed.data.params,
+        createdBy: Number(admin.id),
+      })
+      .returning({ id: forecastScenarios.id });
+  } catch (e) {
+    // The unique index is the race backstop behind the pre-check; its
+    // violation must honour the ActionResult contract, not surface a digest.
+    if (isDuplicateNameViolation(e)) {
+      return { success: false, error: DUPLICATE_NAME_ERROR };
+    }
+    throw e;
+  }
+
+  await recordCreation(ENTITY_TYPE, created.id, Number(admin.id));
+
+  revalidatePath(SCENARIO_PAGE);
+  return { success: true, data: { id: created.id } };
+}
+
+export async function updateForecastScenario(
+  input: unknown,
+): Promise<ActionResult<{ id: number }>> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  const parsed = updateForecastScenarioSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "Validation failed",
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<
+        string,
+        string[]
+      >,
+    };
+  }
+  const { id, name, params } = parsed.data;
+
+  const scenario = await db.query.forecastScenarios.findFirst({
+    where: eq(forecastScenarios.id, id),
+  });
+  if (!scenario) return { success: false, error: "Scenario not found" };
+
+  if (await nameTaken(scenario.budgetId, name, id)) {
+    return { success: false, error: DUPLICATE_NAME_ERROR };
+  }
+
+  try {
+    await db
+      .update(forecastScenarios)
+      .set({
+        name,
+        // Omitted params = rename-only; stored assumptions stay untouched.
+        ...(params !== undefined ? { params } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(forecastScenarios.id, id));
+  } catch (e) {
+    if (isDuplicateNameViolation(e)) {
+      return { success: false, error: DUPLICATE_NAME_ERROR };
+    }
+    throw e;
+  }
+
+  // Full params snapshots make a teammate's overwritten plan recoverable from
+  // change_history — and guarantee a params-only update still records a row
+  // (recordUpdate early-returns on an empty diff).
+  const changes: Record<string, { old: unknown; new: unknown }> = {};
+  if (name !== scenario.name) {
+    changes.name = { old: scenario.name, new: name };
+  }
+  if (params !== undefined) {
+    changes.params = { old: scenario.params, new: params };
+  }
+  await recordUpdate(ENTITY_TYPE, id, Number(admin.id), changes);
+
+  revalidatePath(SCENARIO_PAGE);
+  return { success: true, data: { id } };
+}
+
+export async function deleteForecastScenario(
+  id: number,
+): Promise<ActionResult<{ id: number }>> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  const parsed = deleteForecastScenarioSchema.safeParse({ id });
+  if (!parsed.success) {
+    return { success: false, error: "Invalid scenario ID" };
+  }
+
+  const scenario = await db.query.forecastScenarios.findFirst({
+    where: eq(forecastScenarios.id, parsed.data.id),
+  });
+  if (!scenario) return { success: false, error: "Scenario not found" };
+
+  // Record deletion with a previous-value snapshot (deleteBilledCost pattern)
+  // so the audit trail can reconstruct what was removed.
+  await db.insert(changeHistory).values({
+    entityType: ENTITY_TYPE,
+    entityId: scenario.id,
+    changeType: "deleted",
+    previousValue: JSON.stringify({
+      budgetId: scenario.budgetId,
+      name: scenario.name,
+      params: scenario.params,
+    }),
+    changedBy: Number(admin.id),
+  });
+
+  await db
+    .delete(forecastScenarios)
+    .where(eq(forecastScenarios.id, scenario.id));
+
+  revalidatePath(SCENARIO_PAGE);
+  return { success: true, data: { id: scenario.id } };
+}

--- a/src/actions/history.ts
+++ b/src/actions/history.ts
@@ -9,7 +9,7 @@ export async function recordCreation(
   entityType: string,
   entityId: number,
   changedBy: number,
-  txClient?: Pick<typeof db, "insert">
+  txClient?: Pick<typeof db, "insert">,
 ) {
   await (txClient ?? db).insert(changeHistory).values({
     entityType,
@@ -24,7 +24,7 @@ export async function recordUpdate(
   entityId: number,
   changedBy: number,
   changes: Record<string, { old: unknown; new: unknown }>,
-  txClient?: Pick<typeof db, "insert">
+  txClient?: Pick<typeof db, "insert">,
 ) {
   const entries = Object.entries(changes);
   if (entries.length === 0) return;
@@ -38,8 +38,28 @@ export async function recordUpdate(
       previousValue: JSON.stringify(values.old),
       newValue: JSON.stringify(values.new),
       changedBy,
-    }))
+    })),
   );
+}
+
+/**
+ * Record a deletion with a previous-value snapshot so the audit trail can
+ * reconstruct what was removed (the deleteBilledCost pattern).
+ */
+export async function recordDeletion(
+  entityType: string,
+  entityId: number,
+  changedBy: number,
+  previousValue: unknown,
+  txClient?: Pick<typeof db, "insert">,
+) {
+  await (txClient ?? db).insert(changeHistory).values({
+    entityType,
+    entityId,
+    changeType: "deleted",
+    previousValue: JSON.stringify(previousValue),
+    changedBy,
+  });
 }
 
 export async function recordStatusChange(
@@ -47,7 +67,7 @@ export async function recordStatusChange(
   entityId: number,
   changedBy: number,
   previousStatus: string,
-  newStatus: string
+  newStatus: string,
 ) {
   await db.insert(changeHistory).values({
     entityType,
@@ -64,15 +84,13 @@ export async function getEntityHistory(
   entityType: string,
   entityId: number,
   limit = 50,
-  offset = 0
-): Promise<
-  ActionResult<{ records: ChangeHistoryRecord[]; total: number }>
-> {
+  offset = 0,
+): Promise<ActionResult<{ records: ChangeHistoryRecord[]; total: number }>> {
   const [records, [totalRow]] = await Promise.all([
     db.query.changeHistory.findMany({
       where: and(
         eq(changeHistory.entityType, entityType),
-        eq(changeHistory.entityId, entityId)
+        eq(changeHistory.entityId, entityId),
       ),
       orderBy: desc(changeHistory.createdAt),
       limit,
@@ -84,8 +102,8 @@ export async function getEntityHistory(
       .where(
         and(
           eq(changeHistory.entityType, entityType),
-          eq(changeHistory.entityId, entityId)
-        )
+          eq(changeHistory.entityId, entityId),
+        ),
       ),
   ]);
 

--- a/src/app/scenarios/budget-forecast/budget-forecast-client.tsx
+++ b/src/app/scenarios/budget-forecast/budget-forecast-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { RotateCcw } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Bookmark, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import {
   Area,
   Bar,
@@ -17,12 +18,33 @@ import {
 } from "recharts";
 
 import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogCancel,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { StatusText, useInlineStatus } from "@/components/ui/status-text";
 import {
   Table,
   TableBody,
@@ -52,6 +74,7 @@ import {
   defaultInputs,
   FORECAST_PRESETS,
   inputsFromPreset,
+  inputsFromSaved,
   projectForecast,
   type ClaudeBilling,
   type ForecastDataset,
@@ -62,8 +85,14 @@ import {
   type ScenarioResult,
   type ToolParams,
 } from "@/lib/scenarios/budget-forecast";
+import {
+  createForecastScenario,
+  deleteForecastScenario,
+  updateForecastScenario,
+  type SavedForecastScenario,
+} from "@/actions/forecast-scenarios";
 
-type ActiveScenario = PresetKey | "custom";
+type ActiveScenario = PresetKey | "custom" | `saved:${number}`;
 
 // Greyscale per-tool series tokens (chart-1..5), assigned in dataset tool order
 // so the stacked-bar forecast and the per-tool table stay visually consistent.
@@ -99,9 +128,12 @@ function pct(part: number, whole: number): number | null {
 
 export function BudgetForecastClient({
   dataset,
+  savedScenarios,
 }: {
   dataset: ForecastDataset;
+  savedScenarios: SavedForecastScenario[];
 }) {
+  const router = useRouter();
   const [inputs, setInputs] = useState<ForecastInputs>(() =>
     defaultInputs(dataset),
   );
@@ -111,6 +143,23 @@ export function BudgetForecastClient({
   const [ceilingDollars, setCeilingDollars] = useState(
     String(Math.round(dataset.liveCeilingCents / 100)),
   );
+  // The saved scenario the user started from this session. Survives control
+  // edits (which flip `active` to "custom") so the save dialog can keep
+  // offering "Update"; cleared by Reset and by preset-tile clicks (a preset is
+  // a new starting point, not a refinement of the loaded scenario).
+  const [loadedSavedId, setLoadedSavedId] = useState<number | null>(null);
+
+  // Mutations land via router.refresh(), so client state survives a dataset
+  // prop change (the loader's 1h cache can expire mid-session). Re-base the
+  // surviving inputs onto the fresh dataset: a tool key the dataset gained
+  // would otherwise be projected at defaults by the engine while the controls
+  // hide it (`if (!p) return null`).
+  const datasetStamp = useRef(dataset.generatedAt);
+  useEffect(() => {
+    if (datasetStamp.current === dataset.generatedAt) return;
+    datasetStamp.current = dataset.generatedAt;
+    setInputs((prev) => inputsFromSaved(dataset, prev));
+  }, [dataset]);
 
   const plan = useMemo(
     () => projectForecast(dataset, inputs),
@@ -164,6 +213,138 @@ export function BudgetForecastClient({
     return map;
   }, [dataset.tools]);
 
+  /* ------------------------ saved scenarios (spec 041) --------------------- */
+
+  // The loaded scenario is derived from the live prop, not cached at load time
+  // — if another admin renamed or deleted it, the Update offer follows suit.
+  const loadedScenario = useMemo(
+    () => savedScenarios.find((s) => s.id === loadedSavedId) ?? null,
+    [savedScenarios, loadedSavedId],
+  );
+
+  // Each saved row shows its params re-projected against the CURRENT dataset,
+  // scored against its own saved ceiling ("what would this plan mean today").
+  const savedComputed = useMemo(
+    () =>
+      savedScenarios.map((scenario) => ({
+        scenario,
+        result: projectForecast(
+          dataset,
+          inputsFromSaved(dataset, scenario.params),
+        ),
+      })),
+    [savedScenarios, dataset],
+  );
+
+  const [isPending, startTransition] = useTransition();
+  // Two-channel feedback (house pattern): per-dialog status for errors while
+  // the overlay is open, card-header status for success after it closes.
+  const cardStatus = useInlineStatus();
+  const saveDialogStatus = useInlineStatus();
+  const renameDialogStatus = useInlineStatus();
+  const deleteDialogStatus = useInlineStatus();
+
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [saveMode, setSaveMode] = useState<"update" | "new">("new");
+  const [saveName, setSaveName] = useState("");
+  const [renameTarget, setRenameTarget] = useState<{
+    id: number;
+    name: string;
+  } | null>(null);
+  const [renameName, setRenameName] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: number;
+    name: string;
+    creatorName: string | null;
+  } | null>(null);
+
+  // Focus lands here after a delete — the trigger row is gone by then.
+  const savedHeadingRef = useRef<HTMLParagraphElement>(null);
+
+  function loadScenario(s: SavedForecastScenario) {
+    setInputs(inputsFromSaved(dataset, s.params));
+    // Exact string (no rounding) so a fractional saved ceiling round-trips.
+    setCeilingDollars(String(s.params.ceilingCents / 100));
+    setActive(`saved:${s.id}`);
+    setLoadedSavedId(s.id);
+  }
+
+  function openSaveDialog() {
+    saveDialogStatus.clear();
+    setSaveMode(loadedScenario ? "update" : "new");
+    setSaveName(loadedScenario ? loadedScenario.name : "");
+    setSaveOpen(true);
+  }
+
+  function submitSave() {
+    const name = saveName.trim();
+    if (!name) return;
+    startTransition(async () => {
+      const result =
+        saveMode === "update" && loadedScenario
+          ? await updateForecastScenario({
+              id: loadedScenario.id,
+              name,
+              params: inputs,
+            })
+          : await createForecastScenario({ name, params: inputs });
+      if (result.success) {
+        setSaveOpen(false);
+        // The current inputs now match the saved row — mark it loaded/active.
+        setLoadedSavedId(result.data.id);
+        setActive(`saved:${result.data.id}`);
+        cardStatus.ok("SAVED");
+        router.refresh();
+      } else {
+        saveDialogStatus.error(result.error);
+      }
+    });
+  }
+
+  function openRenameDialog(s: SavedForecastScenario) {
+    renameDialogStatus.clear();
+    setRenameTarget({ id: s.id, name: s.name });
+    setRenameName(s.name);
+  }
+
+  function submitRename() {
+    const target = renameTarget;
+    const name = renameName.trim();
+    if (!target || !name) return;
+    startTransition(async () => {
+      // params omitted — rename-only, stored assumptions untouched.
+      const result = await updateForecastScenario({ id: target.id, name });
+      if (result.success) {
+        setRenameTarget(null);
+        cardStatus.ok("RENAMED");
+        router.refresh();
+      } else {
+        renameDialogStatus.error(result.error);
+      }
+    });
+  }
+
+  function confirmDelete() {
+    const target = deleteTarget;
+    if (!target) return;
+    startTransition(async () => {
+      const result = await deleteForecastScenario(target.id);
+      if (result.success) {
+        setDeleteTarget(null);
+        if (loadedSavedId === target.id) {
+          // The record is gone but the user's working state stays.
+          setLoadedSavedId(null);
+          if (active === `saved:${target.id}`) setActive("custom");
+        }
+        cardStatus.ok("DELETED");
+        router.refresh();
+        savedHeadingRef.current?.focus();
+      } else {
+        deleteDialogStatus.error(result.error);
+      }
+    });
+  }
+
   /* ---------------------------- mutation helpers --------------------------- */
 
   function applyPreset(key: PresetKey) {
@@ -174,6 +355,9 @@ export function BudgetForecastClient({
     setInputs(next);
     setCeilingDollars(String(Math.round(next.ceilingCents / 100)));
     setActive(key);
+    // A preset is a new starting point — withdraw the "Update" offer so one
+    // click can't overwrite a shared scenario with preset params.
+    setLoadedSavedId(null);
   }
 
   function patchTool(key: string, patch: Partial<ToolParams>) {
@@ -204,6 +388,7 @@ export function BudgetForecastClient({
     setInputs(next);
     setCeilingDollars(String(Math.round(next.ceilingCents / 100)));
     setActive("h2Plan");
+    setLoadedSavedId(null);
   }
 
   /* ------------------------------- derived UI ------------------------------ */
@@ -447,6 +632,108 @@ export function BudgetForecastClient({
         />
       </div>
 
+      {/* 2b — SAVED SCENARIOS (spec 041) */}
+      <Card>
+        <CardContent className="p-5">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <p
+              ref={savedHeadingRef}
+              tabIndex={-1}
+              className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground outline-none"
+            >
+              Saved scenarios
+            </p>
+            <StatusText status={cardStatus.status} />
+          </div>
+          {savedComputed.length === 0 ? (
+            <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-faint">
+              [ No saved scenarios — save your current plan ]
+            </p>
+          ) : (
+            <ul className="max-h-72 divide-y divide-border overflow-y-auto">
+              {savedComputed.map(({ scenario, result }) => {
+                const isLoaded = active === `saved:${scenario.id}`;
+                // Scored against the scenario's OWN saved ceiling (a saved row
+                // is a self-contained what-if), with the denominator labelled
+                // — the rest of the page scores against the edited ceiling.
+                const d = result.yearEndCents - scenario.params.ceilingCents;
+                const rowOver = d > 0;
+                return (
+                  <li
+                    key={scenario.id}
+                    className="flex flex-wrap items-center gap-x-4 gap-y-1 py-2.5"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => loadScenario(scenario)}
+                      aria-pressed={isLoaded}
+                      className={cn(
+                        "relative flex min-w-0 flex-1 items-center py-0.5 pl-2 text-left text-sm font-medium transition-colors",
+                        isLoaded
+                          ? "text-ink"
+                          : "text-muted-foreground hover:text-foreground",
+                      )}
+                    >
+                      {isLoaded ? (
+                        <span
+                          className="absolute bottom-1 left-0 top-1 w-0.5 bg-ink"
+                          aria-hidden
+                        />
+                      ) : null}
+                      <span className="truncate">{scenario.name}</span>
+                    </button>
+                    <span className="font-mono text-sm tabular-nums text-ink">
+                      {formatUSD0(result.yearEndCents)}
+                    </span>
+                    <span
+                      className={cn(
+                        "font-mono text-xs tabular-nums",
+                        rowOver ? "text-destructive" : "text-success",
+                      )}
+                    >
+                      {rowOver ? "+" : "−"}
+                      {formatUSD0(Math.abs(d))} vs saved{" "}
+                      {formatUSD0(scenario.params.ceilingCents)}
+                    </span>
+                    <span className="font-mono text-[10px] uppercase tracking-wide text-faint">
+                      {scenario.creatorName ?? "Unknown"} ·{" "}
+                      {scenario.updatedAt.slice(0, 10)}
+                    </span>
+                    <span className="flex shrink-0 items-center">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        aria-label={`Rename scenario ${scenario.name}`}
+                        onClick={() => openRenameDialog(scenario)}
+                      >
+                        <Pencil className="size-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8 text-destructive"
+                        aria-label={`Delete scenario ${scenario.name}`}
+                        onClick={() => {
+                          deleteDialogStatus.clear();
+                          setDeleteTarget({
+                            id: scenario.id,
+                            name: scenario.name,
+                            creatorName: scenario.creatorName,
+                          });
+                        }}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
       {/* 3 — CONTROLS PANEL */}
       <Card>
         <CardContent className="p-5">
@@ -454,13 +741,22 @@ export function BudgetForecastClient({
             <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
               Assumptions
             </span>
-            <button
-              type="button"
-              onClick={reset}
-              className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <RotateCcw className="size-3" aria-hidden /> Reset to H2 Plan
-            </button>
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={openSaveDialog}
+                className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <Bookmark className="size-3" aria-hidden /> Save scenario
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+                className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <RotateCcw className="size-3" aria-hidden /> Reset to H2 Plan
+              </button>
+            </div>
           </div>
 
           {/* Budget ceiling */}
@@ -802,7 +1098,12 @@ export function BudgetForecastClient({
                   const driver = row.result.topDriverKey
                     ? toolByKey[row.result.topDriverKey]?.label
                     : null;
-                  const isActiveRow = active === row.id;
+                  // A loaded saved scenario IS the "Your plan" row (the chart
+                  // line and these figures are its numbers), so saved:* keeps
+                  // the table's one-active-row invariant via the custom row.
+                  const isActiveRow =
+                    active === row.id ||
+                    (row.id === "custom" && active.startsWith("saved:"));
                   return (
                     <TableRow
                       key={row.id}
@@ -966,6 +1267,174 @@ export function BudgetForecastClient({
           : ""}{" "}
         · assembled {dataset.generatedAt.slice(0, 16).replace("T", " ")} UTC
       </p>
+
+      {/* 10 — SAVE / RENAME / DELETE DIALOGS (spec 041) */}
+      <Dialog
+        open={saveOpen}
+        onOpenChange={(open) => {
+          if (!isPending) setSaveOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Save scenario</DialogTitle>
+            <DialogDescription>
+              Persist the current assumption set for the FY {dataset.fiscalYear}{" "}
+              budget — shared with all admins.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            {loadedScenario ? (
+              <div>
+                <ControlLabel>Mode</ControlLabel>
+                <div
+                  role="group"
+                  aria-label="Save mode"
+                  className="mt-2 inline-flex w-full overflow-hidden rounded-[6px] border border-input"
+                >
+                  <ToggleButton
+                    active={saveMode === "update"}
+                    onClick={() => {
+                      if (saveMode !== "update") {
+                        setSaveMode("update");
+                        setSaveName(loadedScenario.name);
+                      }
+                    }}
+                  >
+                    <span className="block truncate">
+                      Update &ldquo;{loadedScenario.name}&rdquo;
+                    </span>
+                  </ToggleButton>
+                  <ToggleButton
+                    active={saveMode === "new"}
+                    onClick={() => saveMode !== "new" && setSaveMode("new")}
+                  >
+                    Save as new
+                  </ToggleButton>
+                </div>
+              </div>
+            ) : null}
+            <div className="space-y-2">
+              <Label htmlFor="scenario-name">Name</Label>
+              <Input
+                id="scenario-name"
+                placeholder="e.g., Console sunset + yearly commit"
+                value={saveName}
+                onChange={(e) => setSaveName(e.target.value)}
+                maxLength={60}
+              />
+            </div>
+            {/* Echo exactly what will be saved — a cleared ceiling field or a
+                forgotten yearly toggle is visible before committing. */}
+            <p className="font-mono text-[11px] uppercase tracking-[0.06em] text-muted-foreground">
+              Ceiling {formatUSD0(inputs.ceilingCents)} · Claude billing{" "}
+              {claudeBilling} · {includedTools.length} of {dataset.tools.length}{" "}
+              tools included
+            </p>
+          </div>
+          <DialogFooter className="items-center">
+            <StatusText status={saveDialogStatus.status} className="mr-auto" />
+            <Button
+              variant="outline"
+              onClick={() => setSaveOpen(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={submitSave}
+              disabled={
+                isPending || !saveName.trim() || ceilingDollars.trim() === ""
+              }
+            >
+              {isPending
+                ? "Saving..."
+                : saveMode === "update" && loadedScenario
+                  ? "Update"
+                  : "Create"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={renameTarget !== null}
+        onOpenChange={(open) => {
+          if (!open && !isPending) setRenameTarget(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Rename scenario &ldquo;{renameTarget?.name}&rdquo;
+            </DialogTitle>
+            <DialogDescription>
+              Stored assumptions stay untouched — only the name changes.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor="scenario-rename">Name</Label>
+            <Input
+              id="scenario-rename"
+              value={renameName}
+              onChange={(e) => setRenameName(e.target.value)}
+              maxLength={60}
+            />
+          </div>
+          <DialogFooter className="items-center">
+            <StatusText
+              status={renameDialogStatus.status}
+              className="mr-auto"
+            />
+            <Button
+              variant="outline"
+              onClick={() => setRenameTarget(null)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={submitRename}
+              disabled={isPending || !renameName.trim()}
+            >
+              {isPending ? "Saving..." : "Rename"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open && !isPending) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete scenario &ldquo;{deleteTarget?.name}&rdquo;?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Saved by {deleteTarget?.creatorName ?? "Unknown"} and shared with
+              all admins. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="items-center">
+            <StatusText
+              status={deleteDialogStatus.status}
+              className="mr-auto"
+            />
+            <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+            <Button
+              variant="destructive"
+              onClick={confirmDelete}
+              disabled={isPending}
+            >
+              {isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/app/scenarios/budget-forecast/budget-forecast-client.tsx
+++ b/src/app/scenarios/budget-forecast/budget-forecast-client.tsx
@@ -237,26 +237,21 @@ export function BudgetForecastClient({
   );
 
   const [isPending, startTransition] = useTransition();
-  // Two-channel feedback (house pattern): per-dialog status for errors while
-  // the overlay is open, card-header status for success after it closes.
+  // Two-channel feedback (house pattern): one dialog status for errors while
+  // an overlay is open (the three dialogs are mutually exclusive, so they
+  // share it; each opener clears it), card-header status for success after
+  // the overlay closes.
   const cardStatus = useInlineStatus();
-  const saveDialogStatus = useInlineStatus();
-  const renameDialogStatus = useInlineStatus();
-  const deleteDialogStatus = useInlineStatus();
+  const dialogStatus = useInlineStatus();
 
   const [saveOpen, setSaveOpen] = useState(false);
   const [saveMode, setSaveMode] = useState<"update" | "new">("new");
   const [saveName, setSaveName] = useState("");
-  const [renameTarget, setRenameTarget] = useState<{
-    id: number;
-    name: string;
-  } | null>(null);
+  const [renameTarget, setRenameTarget] =
+    useState<SavedForecastScenario | null>(null);
   const [renameName, setRenameName] = useState("");
-  const [deleteTarget, setDeleteTarget] = useState<{
-    id: number;
-    name: string;
-    creatorName: string | null;
-  } | null>(null);
+  const [deleteTarget, setDeleteTarget] =
+    useState<SavedForecastScenario | null>(null);
 
   // Focus lands here after a delete — the trigger row is gone by then.
   const savedHeadingRef = useRef<HTMLParagraphElement>(null);
@@ -270,7 +265,7 @@ export function BudgetForecastClient({
   }
 
   function openSaveDialog() {
-    saveDialogStatus.clear();
+    dialogStatus.clear();
     setSaveMode(loadedScenario ? "update" : "new");
     setSaveName(loadedScenario ? loadedScenario.name : "");
     setSaveOpen(true);
@@ -296,14 +291,14 @@ export function BudgetForecastClient({
         cardStatus.ok("SAVED");
         router.refresh();
       } else {
-        saveDialogStatus.error(result.error);
+        dialogStatus.error(result.error);
       }
     });
   }
 
   function openRenameDialog(s: SavedForecastScenario) {
-    renameDialogStatus.clear();
-    setRenameTarget({ id: s.id, name: s.name });
+    dialogStatus.clear();
+    setRenameTarget(s);
     setRenameName(s.name);
   }
 
@@ -319,7 +314,7 @@ export function BudgetForecastClient({
         cardStatus.ok("RENAMED");
         router.refresh();
       } else {
-        renameDialogStatus.error(result.error);
+        dialogStatus.error(result.error);
       }
     });
   }
@@ -340,7 +335,7 @@ export function BudgetForecastClient({
         router.refresh();
         savedHeadingRef.current?.focus();
       } else {
-        deleteDialogStatus.error(result.error);
+        dialogStatus.error(result.error);
       }
     });
   }
@@ -715,12 +710,8 @@ export function BudgetForecastClient({
                         className="size-8 text-destructive"
                         aria-label={`Delete scenario ${scenario.name}`}
                         onClick={() => {
-                          deleteDialogStatus.clear();
-                          setDeleteTarget({
-                            id: scenario.id,
-                            name: scenario.name,
-                            creatorName: scenario.creatorName,
-                          });
+                          dialogStatus.clear();
+                          setDeleteTarget(scenario);
                         }}
                       >
                         <Trash2 className="size-4" />
@@ -1333,7 +1324,7 @@ export function BudgetForecastClient({
             </p>
           </div>
           <DialogFooter className="items-center">
-            <StatusText status={saveDialogStatus.status} className="mr-auto" />
+            <StatusText status={dialogStatus.status} className="mr-auto" />
             <Button
               variant="outline"
               onClick={() => setSaveOpen(false)}
@@ -1382,10 +1373,7 @@ export function BudgetForecastClient({
             />
           </div>
           <DialogFooter className="items-center">
-            <StatusText
-              status={renameDialogStatus.status}
-              className="mr-auto"
-            />
+            <StatusText status={dialogStatus.status} className="mr-auto" />
             <Button
               variant="outline"
               onClick={() => setRenameTarget(null)}
@@ -1420,10 +1408,7 @@ export function BudgetForecastClient({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter className="items-center">
-            <StatusText
-              status={deleteDialogStatus.status}
-              className="mr-auto"
-            />
+            <StatusText status={dialogStatus.status} className="mr-auto" />
             <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
             <Button
               variant="destructive"

--- a/src/app/scenarios/budget-forecast/budget-forecast-client.tsx
+++ b/src/app/scenarios/budget-forecast/budget-forecast-client.tsx
@@ -284,12 +284,17 @@ export function BudgetForecastClient({
             })
           : await createForecastScenario({ name, params: inputs });
       if (result.success) {
-        setSaveOpen(false);
-        // The current inputs now match the saved row — mark it loaded/active.
-        setLoadedSavedId(result.data.id);
-        setActive(`saved:${result.data.id}`);
-        cardStatus.ok("SAVED");
-        router.refresh();
+        // React 19 caveat: state updates after an await need their own
+        // startTransition to stay part of the Transition (isPending already
+        // spans the whole async Action either way).
+        startTransition(() => {
+          setSaveOpen(false);
+          // The current inputs now match the saved row — mark it loaded/active.
+          setLoadedSavedId(result.data.id);
+          setActive(`saved:${result.data.id}`);
+          cardStatus.ok("SAVED");
+          router.refresh();
+        });
       } else {
         dialogStatus.error(result.error);
       }
@@ -310,9 +315,11 @@ export function BudgetForecastClient({
       // params omitted — rename-only, stored assumptions untouched.
       const result = await updateForecastScenario({ id: target.id, name });
       if (result.success) {
-        setRenameTarget(null);
-        cardStatus.ok("RENAMED");
-        router.refresh();
+        startTransition(() => {
+          setRenameTarget(null);
+          cardStatus.ok("RENAMED");
+          router.refresh();
+        });
       } else {
         dialogStatus.error(result.error);
       }
@@ -325,14 +332,16 @@ export function BudgetForecastClient({
     startTransition(async () => {
       const result = await deleteForecastScenario(target.id);
       if (result.success) {
-        setDeleteTarget(null);
-        if (loadedSavedId === target.id) {
-          // The record is gone but the user's working state stays.
-          setLoadedSavedId(null);
-          if (active === `saved:${target.id}`) setActive("custom");
-        }
-        cardStatus.ok("DELETED");
-        router.refresh();
+        startTransition(() => {
+          setDeleteTarget(null);
+          if (loadedSavedId === target.id) {
+            // The record is gone but the user's working state stays.
+            setLoadedSavedId(null);
+            if (active === `saved:${target.id}`) setActive("custom");
+          }
+          cardStatus.ok("DELETED");
+          router.refresh();
+        });
         savedHeadingRef.current?.focus();
       } else {
         dialogStatus.error(result.error);

--- a/src/app/scenarios/budget-forecast/page.tsx
+++ b/src/app/scenarios/budget-forecast/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 
 import { loadBudgetForecastDataset } from "@/actions/scenarios";
+import { listForecastScenarios } from "@/actions/forecast-scenarios";
 import { BudgetForecastClient } from "./budget-forecast-client";
 
 export const metadata: Metadata = {
@@ -10,7 +11,10 @@ export const metadata: Metadata = {
 };
 
 export default async function BudgetForecastScenarioPage() {
-  const dataset = await loadBudgetForecastDataset();
+  const [dataset, savedScenarios] = await Promise.all([
+    loadBudgetForecastDataset(),
+    listForecastScenarios(),
+  ]);
 
   return (
     <div className="space-y-6">
@@ -36,7 +40,10 @@ export default async function BudgetForecastScenarioPage() {
       {dataset.periods.length === 0 ? (
         <EmptyState />
       ) : (
-        <BudgetForecastClient dataset={dataset} />
+        <BudgetForecastClient
+          dataset={dataset}
+          savedScenarios={savedScenarios}
+        />
       )}
     </div>
   );

--- a/src/lib/budget-utils.ts
+++ b/src/lib/budget-utils.ts
@@ -8,11 +8,27 @@ import {
 import { eq, and, lte, gte, desc, sql } from "drizzle-orm";
 
 /**
+ * Resolve the active budget new writes attach to (spec 041). The schema
+ * permits multiple status='active' rows, so the contract is deterministic:
+ * the active budget with the highest fiscal year wins. getActiveBudget() in
+ * actions/budget.ts orders by the same rule — keep them in sync.
+ */
+export async function getActiveBudgetId(): Promise<number | null> {
+  const [budget] = await db
+    .select({ id: annualBudgets.id })
+    .from(annualBudgets)
+    .where(eq(annualBudgets.status, "active"))
+    .orderBy(desc(annualBudgets.fiscalYear))
+    .limit(1);
+  return budget?.id ?? null;
+}
+
+/**
  * Find the active budget period that covers a given date.
  * Returns the period id and label, or null if no period matches.
  */
 export async function findActivePeriodForDate(
-  invoiceDate: string
+  invoiceDate: string,
 ): Promise<{ id: number; periodLabel: string } | null> {
   const rows = await db
     .select({
@@ -25,8 +41,8 @@ export async function findActivePeriodForDate(
       and(
         eq(annualBudgets.status, "active"),
         lte(budgetPeriods.startDate, invoiceDate),
-        gte(budgetPeriods.endDate, invoiceDate)
-      )
+        gte(budgetPeriods.endDate, invoiceDate),
+      ),
     )
     .orderBy(desc(annualBudgets.createdAt))
     .limit(1);
@@ -39,7 +55,7 @@ export async function findActivePeriodForDate(
  * Searches all budgets (active + archived), preferring active budgets.
  */
 export async function findPeriodForDate(
-  invoiceDate: string
+  invoiceDate: string,
 ): Promise<{ id: number; periodLabel: string } | null> {
   const rows = await db
     .select({
@@ -49,17 +65,16 @@ export async function findPeriodForDate(
     .from(budgetPeriods)
     .innerJoin(annualBudgets, eq(budgetPeriods.budgetId, annualBudgets.id))
     .where(
-      sql`${budgetPeriods.startDate} <= ${invoiceDate} AND ${budgetPeriods.endDate} >= ${invoiceDate}`
+      sql`${budgetPeriods.startDate} <= ${invoiceDate} AND ${budgetPeriods.endDate} >= ${invoiceDate}`,
     )
     .orderBy(
       sql`CASE WHEN ${annualBudgets.status} = 'active' THEN 0 ELSE 1 END ASC`,
-      desc(annualBudgets.createdAt)
+      desc(annualBudgets.createdAt),
     )
     .limit(1);
 
   return rows[0] ?? null;
 }
-
 
 /** Return type for getRunningCostsForPeriod */
 export interface RunningCostsResult {
@@ -81,7 +96,7 @@ export interface RunningCostsResult {
  * can simply skip rendering when there are no running costs.
  */
 export async function getRunningCostsForPeriod(
-  periodId: number
+  periodId: number,
 ): Promise<RunningCostsResult | null> {
   // 1. Look up the period's start/end dates
   const period = await db.query.budgetPeriods.findFirst({
@@ -95,18 +110,20 @@ export async function getRunningCostsForPeriod(
       workspaceId: anthropicWorkspaceCosts.workspaceId,
       name: sql<string>`COALESCE(${anthropicWorkspaces.name}, 'Default')`,
       costCents: sql<number>`CAST(SUM(${anthropicWorkspaceCosts.costCents}) AS integer)`,
-      lastUpdatedAt: sql<string | null>`MAX(${anthropicWorkspaceCosts.updatedAt})`,
+      lastUpdatedAt: sql<
+        string | null
+      >`MAX(${anthropicWorkspaceCosts.updatedAt})`,
     })
     .from(anthropicWorkspaceCosts)
     .leftJoin(
       anthropicWorkspaces,
-      sql`${anthropicWorkspaceCosts.workspaceId} IS NOT DISTINCT FROM ${anthropicWorkspaces.workspaceId}`
+      sql`${anthropicWorkspaceCosts.workspaceId} IS NOT DISTINCT FROM ${anthropicWorkspaces.workspaceId}`,
     )
     .where(
       and(
         sql`${anthropicWorkspaceCosts.date} >= ${period.startDate}`,
-        sql`${anthropicWorkspaceCosts.date} <= ${period.endDate}`
-      )
+        sql`${anthropicWorkspaceCosts.date} <= ${period.endDate}`,
+      ),
     )
     .groupBy(anthropicWorkspaceCosts.workspaceId, anthropicWorkspaces.name);
 
@@ -125,9 +142,9 @@ export async function getRunningCostsForPeriod(
   return {
     runningCostCents,
     lastUpdatedAt: lastUpdatedAt
-      ? ((lastUpdatedAt as unknown) instanceof Date
-          ? (lastUpdatedAt as unknown as Date).toISOString()
-          : new Date(lastUpdatedAt).toISOString())
+      ? (lastUpdatedAt as unknown) instanceof Date
+        ? (lastUpdatedAt as unknown as Date).toISOString()
+        : new Date(lastUpdatedAt).toISOString()
       : null,
     source: "anthropic_workspace_costs",
     ...(breakdown.length > 1

--- a/src/lib/budget-utils.ts
+++ b/src/lib/budget-utils.ts
@@ -44,7 +44,9 @@ export async function findActivePeriodForDate(
         gte(budgetPeriods.endDate, invoiceDate),
       ),
     )
-    .orderBy(desc(annualBudgets.createdAt))
+    // Tie-break between multiple active budgets by the same deterministic
+    // rule as getActiveBudgetId(): highest fiscal year wins.
+    .orderBy(desc(annualBudgets.fiscalYear))
     .limit(1);
 
   return rows[0] ?? null;
@@ -69,7 +71,8 @@ export async function findPeriodForDate(
     )
     .orderBy(
       sql`CASE WHEN ${annualBudgets.status} = 'active' THEN 0 ELSE 1 END ASC`,
-      desc(annualBudgets.createdAt),
+      // Same deterministic tie-break as getActiveBudgetId().
+      desc(annualBudgets.fiscalYear),
     )
     .limit(1);
 

--- a/src/lib/db/migrations/0026_nebulous_shadow_king.sql
+++ b/src/lib/db/migrations/0026_nebulous_shadow_king.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "forecast_scenarios" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"budget_id" integer NOT NULL,
+	"name" varchar(60) NOT NULL,
+	"params" jsonb NOT NULL,
+	"created_by" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "forecast_scenarios" ADD CONSTRAINT "forecast_scenarios_budget_id_annual_budgets_id_fk" FOREIGN KEY ("budget_id") REFERENCES "public"."annual_budgets"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_scenarios" ADD CONSTRAINT "forecast_scenarios_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "forecast_scenarios_budget_id_idx" ON "forecast_scenarios" USING btree ("budget_id");--> statement-breakpoint
+CREATE INDEX "forecast_scenarios_created_by_idx" ON "forecast_scenarios" USING btree ("created_by");--> statement-breakpoint
+CREATE UNIQUE INDEX "forecast_scenarios_budget_name_idx" ON "forecast_scenarios" USING btree ("budget_id",lower("name"));

--- a/src/lib/db/migrations/meta/0026_snapshot.json
+++ b/src/lib/db/migrations/meta/0026_snapshot.json
@@ -1,0 +1,5110 @@
+{
+  "id": "b2c01d4b-c3ab-45da-bb7f-3d3761989f64",
+  "prevId": "aa0d3cdb-3366-4dba-b396-94b67e267dd8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_tiers": {
+      "name": "access_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_cost_cents": {
+          "name": "monthly_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_tiers_tool_id_idx": {
+          "name": "access_tiers_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_tiers_tool_name_idx": {
+          "name": "access_tiers_tool_name_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_tiers_tool_id_ai_tools_id_fk": {
+          "name": "access_tiers_tool_id_ai_tools_id_fk",
+          "tableFrom": "access_tiers",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_tools": {
+      "name": "ai_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_licenses": {
+          "name": "max_licenses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tool_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_tools_name_idx": {
+          "name": "ai_tools_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_tools_vendor_idx": {
+          "name": "ai_tools_vendor_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.annual_budgets": {
+      "name": "annual_budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fiscal_year": {
+          "name": "fiscal_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount_cents": {
+          "name": "total_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount_cents": {
+          "name": "original_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "budget_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annual_budgets_fiscal_year_idx": {
+          "name": "annual_budgets_fiscal_year_idx",
+          "columns": [
+            {
+              "expression": "fiscal_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annual_budgets_status_idx": {
+          "name": "annual_budgets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_alert_state": {
+      "name": "anthropic_alert_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_month": {
+          "name": "billing_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold_80_fired_at": {
+          "name": "threshold_80_fired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_100_fired_at": {
+          "name": "threshold_100_fired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_120_fired_at": {
+          "name": "threshold_120_fired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forecast_at_risk": {
+          "name": "forecast_at_risk",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forecast_changed_at": {
+          "name": "forecast_changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_alert_state_workspace_month_idx": {
+          "name": "anthropic_alert_state_workspace_month_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_alert_state\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_alert_state_default_month_idx": {
+          "name": "anthropic_alert_state_default_month_idx",
+          "columns": [
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_alert_state\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_alert_state_month_idx": {
+          "name": "anthropic_alert_state_month_idx",
+          "columns": [
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_alert_state_billing_month_format": {
+          "name": "anthropic_alert_state_billing_month_format",
+          "value": "\"anthropic_alert_state\".\"billing_month\" ~ '^[0-9]{4}-(0[1-9]|1[0-2])$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_org_config": {
+      "name": "anthropic_org_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "billing_budget_limit_cents": {
+          "name": "billing_budget_limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anthropic_org_config_updated_by_users_id_fk": {
+          "name": "anthropic_org_config_updated_by_users_id_fk",
+          "tableFrom": "anthropic_org_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_org_config_id_check": {
+          "name": "anthropic_org_config_id_check",
+          "value": "\"anthropic_org_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_sync_status": {
+      "name": "anthropic_sync_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_days": {
+          "name": "synced_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_api_key_id": {
+          "name": "resolved_api_key_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_workspace_id": {
+          "name": "resolved_workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_sync_completed_at": {
+          "name": "workspace_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "anthropic_sync_status_user_id_idx": {
+          "name": "anthropic_sync_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_usage_metrics": {
+      "name": "anthropic_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncached_input_tokens": {
+          "name": "uncached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_cost_cents": {
+          "name": "computed_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pricing_resolved": {
+          "name": "pricing_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_usage_metrics_user_date_model_idx": {
+          "name": "anthropic_usage_metrics_user_date_model_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_user_date_idx": {
+          "name": "anthropic_usage_metrics_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_date_idx": {
+          "name": "anthropic_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_usage_metrics_pricing_resolved_idx": {
+          "name": "anthropic_usage_metrics_pricing_resolved_idx",
+          "columns": [
+            {
+              "expression": "pricing_resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anthropic_usage_metrics_user_id_users_id_fk": {
+          "name": "anthropic_usage_metrics_user_id_users_id_fk",
+          "tableFrom": "anthropic_usage_metrics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_costs": {
+      "name": "anthropic_workspace_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_costs_workspace_date_idx": {
+          "name": "anthropic_workspace_costs_workspace_date_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_default_date_idx": {
+          "name": "anthropic_workspace_costs_default_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_costs\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_date_idx": {
+          "name": "anthropic_workspace_costs_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_costs_workspace_id_idx": {
+          "name": "anthropic_workspace_costs_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anthropic_workspace_costs_cost_cents_check": {
+          "name": "anthropic_workspace_costs_cost_cents_check",
+          "value": "\"anthropic_workspace_costs\".\"cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspace_limits": {
+      "name": "anthropic_workspace_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_cents": {
+          "name": "limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspace_limits_workspace_id_idx": {
+          "name": "anthropic_workspace_limits_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspace_limits_default_idx": {
+          "name": "anthropic_workspace_limits_default_idx",
+          "columns": [
+            {
+              "expression": "(1)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspace_limits\".\"workspace_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anthropic_workspaces": {
+      "name": "anthropic_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_color": {
+          "name": "display_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_created_at": {
+          "name": "anthropic_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anthropic_workspaces_workspace_id_idx": {
+          "name": "anthropic_workspaces_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspaces\".\"workspace_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspaces_is_default_idx": {
+          "name": "anthropic_workspaces_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anthropic_workspaces\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anthropic_workspaces_archived_idx": {
+          "name": "anthropic_workspaces_archived_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assignment_comments": {
+      "name": "assignment_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assignment_comments_assignment_id_idx": {
+          "name": "assignment_comments_assignment_id_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_comments_author_id_idx": {
+          "name": "assignment_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assignment_comments_created_at_idx": {
+          "name": "assignment_comments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assignment_comments_assignment_id_license_assignments_id_fk": {
+          "name": "assignment_comments_assignment_id_license_assignments_id_fk",
+          "tableFrom": "assignment_comments",
+          "tableTo": "license_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assignment_comments_author_id_users_id_fk": {
+          "name": "assignment_comments_author_id_users_id_fk",
+          "tableFrom": "assignment_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billed_costs": {
+      "name": "billed_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor_reference": {
+          "name": "vendor_reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billed_costs_period_id_idx": {
+          "name": "billed_costs_period_id_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billed_costs_invoice_date_idx": {
+          "name": "billed_costs_invoice_date_idx",
+          "columns": [
+            {
+              "expression": "invoice_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billed_costs_period_id_budget_periods_id_fk": {
+          "name": "billed_costs_period_id_budget_periods_id_fk",
+          "tableFrom": "billed_costs",
+          "tableTo": "budget_periods",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_extension_period_allocations": {
+      "name": "budget_extension_period_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extension_id": {
+          "name": "extension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_id": {
+          "name": "period_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bepa_unique_ext_period": {
+          "name": "bepa_unique_ext_period",
+          "columns": [
+            {
+              "expression": "extension_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bepa_period_idx": {
+          "name": "bepa_period_idx",
+          "columns": [
+            {
+              "expression": "period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_extension_period_allocations_extension_id_budget_extensions_id_fk": {
+          "name": "budget_extension_period_allocations_extension_id_budget_extensions_id_fk",
+          "tableFrom": "budget_extension_period_allocations",
+          "tableTo": "budget_extensions",
+          "columnsFrom": [
+            "extension_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budget_extension_period_allocations_period_id_budget_periods_id_fk": {
+          "name": "budget_extension_period_allocations_period_id_budget_periods_id_fk",
+          "tableFrom": "budget_extension_period_allocations",
+          "tableTo": "budget_periods",
+          "columnsFrom": [
+            "period_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_extensions": {
+      "name": "budget_extensions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "budget_extension_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_tool_id": {
+          "name": "linked_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_extensions_budget_idx": {
+          "name": "budget_extensions_budget_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_extensions_effective_idx": {
+          "name": "budget_extensions_effective_idx",
+          "columns": [
+            {
+              "expression": "effective_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_extensions_linked_tool_idx": {
+          "name": "budget_extensions_linked_tool_idx",
+          "columns": [
+            {
+              "expression": "linked_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_extensions_created_by_idx": {
+          "name": "budget_extensions_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_extensions_budget_id_annual_budgets_id_fk": {
+          "name": "budget_extensions_budget_id_annual_budgets_id_fk",
+          "tableFrom": "budget_extensions",
+          "tableTo": "annual_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budget_extensions_linked_tool_id_ai_tools_id_fk": {
+          "name": "budget_extensions_linked_tool_id_ai_tools_id_fk",
+          "tableFrom": "budget_extensions",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "linked_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "budget_extensions_created_by_users_id_fk": {
+          "name": "budget_extensions_created_by_users_id_fk",
+          "tableFrom": "budget_extensions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "budget_extensions_amount_non_zero": {
+          "name": "budget_extensions_amount_non_zero",
+          "value": "\"budget_extensions\".\"amount_cents\" <> 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.budget_periods": {
+      "name": "budget_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_index": {
+          "name": "period_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_amount_cents": {
+          "name": "planned_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_periods_budget_id_idx": {
+          "name": "budget_periods_budget_id_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "budget_periods_budget_period_idx": {
+          "name": "budget_periods_budget_period_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_periods_budget_id_annual_budgets_id_fk": {
+          "name": "budget_periods_budget_id_annual_budgets_id_fk",
+          "tableFrom": "budget_periods",
+          "tableTo": "annual_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_history": {
+      "name": "change_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "change_history_entity_idx": {
+          "name": "change_history_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_history_changed_by_idx": {
+          "name": "change_history_changed_by_idx",
+          "columns": [
+            {
+              "expression": "changed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_history_created_at_idx": {
+          "name": "change_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_history_changed_by_users_id_fk": {
+          "name": "change_history_changed_by_users_id_fk",
+          "tableFrom": "change_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_billing_snapshots": {
+      "name": "copilot_billing_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_month": {
+          "name": "billing_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seats": {
+          "name": "total_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_seats": {
+          "name": "active_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_cost_cents": {
+          "name": "seat_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost_cents": {
+          "name": "total_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_billing_snapshots_connection_month_idx": {
+          "name": "copilot_billing_snapshots_connection_month_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "billing_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_billing_snapshots_connection_id_github_connections_id_fk": {
+          "name": "copilot_billing_snapshots_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_billing_snapshots",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_usage_metrics": {
+      "name": "copilot_usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_engaged_users": {
+          "name": "total_engaged_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_suggestions": {
+          "name": "total_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_acceptances": {
+          "name": "total_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_suggested": {
+          "name": "total_lines_suggested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lines_accepted": {
+          "name": "total_lines_accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_chat_turns": {
+          "name": "total_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_chat_acceptances": {
+          "name": "total_chat_acceptances",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_dotcom_chat_turns": {
+          "name": "total_dotcom_chat_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pr_summaries": {
+          "name": "total_pr_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_breakdown": {
+          "name": "language_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_breakdown": {
+          "name": "editor_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_cli": {
+          "name": "used_cli",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_agent": {
+          "name": "used_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_edit_count": {
+          "name": "agent_edit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_breakdown": {
+          "name": "cli_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_usage_metrics_connection_date_idx": {
+          "name": "copilot_usage_metrics_connection_date_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_usage_metrics_date_idx": {
+          "name": "copilot_usage_metrics_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_usage_metrics_connection_id_github_connections_id_fk": {
+          "name": "copilot_usage_metrics_connection_id_github_connections_id_fk",
+          "tableFrom": "copilot_usage_metrics",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forecast_scenarios": {
+      "name": "forecast_scenarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forecast_scenarios_budget_id_idx": {
+          "name": "forecast_scenarios_budget_id_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forecast_scenarios_created_by_idx": {
+          "name": "forecast_scenarios_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forecast_scenarios_budget_name_idx": {
+          "name": "forecast_scenarios_budget_name_idx",
+          "columns": [
+            {
+              "expression": "budget_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forecast_scenarios_budget_id_annual_budgets_id_fk": {
+          "name": "forecast_scenarios_budget_id_annual_budgets_id_fk",
+          "tableFrom": "forecast_scenarios",
+          "tableTo": "annual_budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forecast_scenarios_created_by_users_id_fk": {
+          "name": "forecast_scenarios_created_by_users_id_fk",
+          "tableFrom": "forecast_scenarios",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_login": {
+          "name": "org_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_avatar_url": {
+          "name": "org_avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_scopes_csv": {
+          "name": "token_scopes_csv",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disconnected_at": {
+          "name": "disconnected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_sync_enabled": {
+          "name": "copilot_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "copilot_sync_schedule": {
+          "name": "copilot_sync_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        }
+      },
+      "indexes": {
+        "github_connections_status_idx": {
+          "name": "github_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_connections_connected_by_users_id_fk": {
+          "name": "github_connections_connected_by_users_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_profiles": {
+      "name": "github_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_profiles_user_id_idx": {
+          "name": "github_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_profiles_github_id_idx": {
+          "name": "github_profiles_github_id_idx",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_profiles_github_login_idx": {
+          "name": "github_profiles_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_profiles_user_id_users_id_fk": {
+          "name": "github_profiles_user_id_users_id_fk",
+          "tableFrom": "github_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sync_events": {
+      "name": "github_sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_members": {
+          "name": "total_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manually_matched_count": {
+          "name": "manually_matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "copilot_sync_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "seats_processed": {
+          "name": "seats_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_processed": {
+          "name": "metrics_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_processed": {
+          "name": "billing_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_linked": {
+          "name": "billing_linked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_skipped": {
+          "name": "billing_skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_sync_events_connection_id_idx": {
+          "name": "github_sync_events_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_sync_events_triggered_by_idx": {
+          "name": "github_sync_events_triggered_by_idx",
+          "columns": [
+            {
+              "expression": "triggered_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sync_events_connection_id_github_connections_id_fk": {
+          "name": "github_sync_events_connection_id_github_connections_id_fk",
+          "tableFrom": "github_sync_events",
+          "tableTo": "github_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_sync_events_triggered_by_users_id_fk": {
+          "name": "github_sync_events_triggered_by_users_id_fk",
+          "tableFrom": "github_sync_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_filters": {
+      "name": "ingestion_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "filter_field",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "filter_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_filters_enabled_idx": {
+          "name": "ingestion_filters_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_filters_created_by_users_id_fk": {
+          "name": "ingestion_filters_created_by_users_id_fk",
+          "tableFrom": "ingestion_filters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingestion_log": {
+      "name": "ingestion_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "ingestion_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "ingestion_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_invoice_id": {
+          "name": "linked_invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingestion_log_outcome_idx": {
+          "name": "ingestion_log_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_log_created_at_idx": {
+          "name": "ingestion_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_log_vendor_idx": {
+          "name": "ingestion_log_vendor_idx",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingestion_log_channel_idx": {
+          "name": "ingestion_log_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingestion_log_linked_invoice_id_invoices_id_fk": {
+          "name": "ingestion_log_linked_invoice_id_invoices_id_fk",
+          "tableFrom": "ingestion_log",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "linked_invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ingestion_log_uploaded_by_users_id_fk": {
+          "name": "ingestion_log_uploaded_by_users_id_fk",
+          "tableFrom": "ingestion_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_tokens": {
+      "name": "invite_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_token_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invite_tokens_token_hash_idx": {
+          "name": "invite_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_tokens_user_id_idx": {
+          "name": "invite_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_tokens_active_user_idx": {
+          "name": "invite_tokens_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invite_tokens\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_tokens_user_id_users_id_fk": {
+          "name": "invite_tokens_user_id_users_id_fk",
+          "tableFrom": "invite_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_billed_cost_id": {
+          "name": "linked_billed_cost_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filtered_out": {
+          "name": "filtered_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_created_at_idx": {
+          "name": "invoices_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_linked_billed_cost_id_idx": {
+          "name": "invoices_linked_billed_cost_id_idx",
+          "columns": [
+            {
+              "expression": "linked_billed_cost_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_billed_cost_id_billed_costs_id_fk": {
+          "name": "invoices_linked_billed_cost_id_billed_costs_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "billed_costs",
+          "columnsFrom": [
+            "linked_billed_cost_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invoices_uploaded_by_users_id_fk": {
+          "name": "invoices_uploaded_by_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_assignments": {
+      "name": "license_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_at_assignment_cents": {
+          "name": "cost_at_assignment_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace": {
+          "name": "workspace",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "varchar(700)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "license_assignments_user_id_idx": {
+          "name": "license_assignments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_tool_id_idx": {
+          "name": "license_assignments_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_tier_id_idx": {
+          "name": "license_assignments_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_status_idx": {
+          "name": "license_assignments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_assignments_active_lookup_idx": {
+          "name": "license_assignments_active_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_assignments_user_id_users_id_fk": {
+          "name": "license_assignments_user_id_users_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_assignments_tool_id_ai_tools_id_fk": {
+          "name": "license_assignments_tool_id_ai_tools_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_assignments_tier_id_access_tiers_id_fk": {
+          "name": "license_assignments_tier_id_access_tiers_id_fk",
+          "tableFrom": "license_assignments",
+          "tableTo": "access_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_requests": {
+      "name": "license_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "form_response_id": {
+          "name": "form_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_email": {
+          "name": "requester_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_name": {
+          "name": "requester_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_user_id": {
+          "name": "requester_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_tool_id": {
+          "name": "requested_tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_tier_id": {
+          "name": "requested_tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_payload": {
+          "name": "form_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_team_id": {
+          "name": "teams_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_channel_id": {
+          "name": "teams_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_parent_message_id": {
+          "name": "teams_parent_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_chat_id": {
+          "name": "teams_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "license_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_message_md": {
+          "name": "approval_message_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_message_md": {
+          "name": "completion_message_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "license_requests_requester_user_id_idx": {
+          "name": "license_requests_requester_user_id_idx",
+          "columns": [
+            {
+              "expression": "requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_requested_tool_id_idx": {
+          "name": "license_requests_requested_tool_id_idx",
+          "columns": [
+            {
+              "expression": "requested_tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_status_idx": {
+          "name": "license_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_decided_by_idx": {
+          "name": "license_requests_decided_by_idx",
+          "columns": [
+            {
+              "expression": "decided_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_assignment_id_idx": {
+          "name": "license_requests_assignment_id_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "license_requests_created_at_idx": {
+          "name": "license_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_requests_requester_user_id_users_id_fk": {
+          "name": "license_requests_requester_user_id_users_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requester_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "license_requests_requested_tool_id_ai_tools_id_fk": {
+          "name": "license_requests_requested_tool_id_ai_tools_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "requested_tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "license_requests_requested_tier_id_access_tiers_id_fk": {
+          "name": "license_requests_requested_tier_id_access_tiers_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "access_tiers",
+          "columnsFrom": [
+            "requested_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "license_requests_decided_by_users_id_fk": {
+          "name": "license_requests_decided_by_users_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "license_requests_completed_by_users_id_fk": {
+          "name": "license_requests_completed_by_users_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "license_requests_assignment_id_license_assignments_id_fk": {
+          "name": "license_requests_assignment_id_license_assignments_id_fk",
+          "tableFrom": "license_requests",
+          "tableTo": "license_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "license_requests_form_response_id_unique": {
+          "name": "license_requests_form_response_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_response_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_oauth_clients_client_id_idx": {
+          "name": "mcp_oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_codes": {
+      "name": "mcp_oauth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_codes_code_hash_idx": {
+          "name": "mcp_oauth_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_codes_user_id_idx": {
+          "name": "mcp_oauth_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_codes_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_codes_user_id_users_id_fk": {
+          "name": "mcp_oauth_codes_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_access_token_hash_idx": {
+          "name": "mcp_oauth_tokens_access_token_hash_idx",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_refresh_token_hash_idx": {
+          "name": "mcp_oauth_tokens_refresh_token_hash_idx",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_user_id_idx": {
+          "name": "mcp_oauth_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_oauth_tokens_family_id_idx": {
+          "name": "mcp_oauth_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk": {
+          "name": "mcp_oauth_tokens_client_id_mcp_oauth_clients_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_oauth_tokens_user_id_users_id_fk": {
+          "name": "mcp_oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_templates": {
+      "name": "message_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "message_template_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_md": {
+          "name": "body_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_templates_tool_id_idx": {
+          "name": "message_templates_tool_id_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_templates_tier_id_idx": {
+          "name": "message_templates_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_templates_tool_default_kind_idx": {
+          "name": "message_templates_tool_default_kind_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"message_templates\".\"tier_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_templates_tool_tier_kind_idx": {
+          "name": "message_templates_tool_tier_kind_idx",
+          "columns": [
+            {
+              "expression": "tool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"message_templates\".\"tier_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_templates_tool_id_ai_tools_id_fk": {
+          "name": "message_templates_tool_id_ai_tools_id_fk",
+          "tableFrom": "message_templates",
+          "tableTo": "ai_tools",
+          "columnsFrom": [
+            "tool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_templates_tier_id_access_tiers_id_fk": {
+          "name": "message_templates_tier_id_access_tiers_id_fk",
+          "tableFrom": "message_templates",
+          "tableTo": "access_tiers",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_events": {
+      "name": "sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "sync_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "backfill_start_date": {
+          "name": "backfill_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sync_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_events_source_type_idx": {
+          "name": "sync_events_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_outcome_idx": {
+          "name": "sync_events_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_started_at_idx": {
+          "name": "sync_events_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_events_source_started_idx": {
+          "name": "sync_events_source_started_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_events_triggered_by_users_id_fk": {
+          "name": "sync_events_triggered_by_users_id_fk",
+          "tableFrom": "sync_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_sources": {
+      "name": "sync_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "sync_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cron_schedule": {
+          "name": "cron_schedule",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_sources_source_type_idx": {
+          "name": "sync_sources_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circle": {
+          "name": "circle",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"theme\":\"system\"}'::jsonb"
+        },
+        "profile": {
+          "name": "profile",
+          "type": "user_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline": {
+          "name": "discipline",
+          "type": "user_discipline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'developer'"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_agent": {
+          "name": "is_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_circle_idx": {
+          "name": "users_circle_idx",
+          "columns": [
+            {
+              "expression": "circle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_status_idx": {
+          "name": "users_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.budget_extension_category": {
+      "name": "budget_extension_category",
+      "schema": "public",
+      "values": [
+        "new_tool",
+        "scope_increase",
+        "seat_increase",
+        "vendor_price_increase",
+        "reallocation",
+        "other"
+      ]
+    },
+    "public.budget_status": {
+      "name": "budget_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.change_type": {
+      "name": "change_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "deleted",
+        "status_change"
+      ]
+    },
+    "public.copilot_sync_type": {
+      "name": "copilot_sync_type",
+      "schema": "public",
+      "values": [
+        "members",
+        "copilot"
+      ]
+    },
+    "public.filter_field": {
+      "name": "filter_field",
+      "schema": "public",
+      "values": [
+        "vendor",
+        "invoice_number"
+      ]
+    },
+    "public.filter_mode": {
+      "name": "filter_mode",
+      "schema": "public",
+      "values": [
+        "whitelist",
+        "blacklist"
+      ]
+    },
+    "public.github_connection_status": {
+      "name": "github_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disconnected"
+      ]
+    },
+    "public.github_sync_status": {
+      "name": "github_sync_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.ingestion_channel": {
+      "name": "ingestion_channel",
+      "schema": "public",
+      "values": [
+        "manual",
+        "api",
+        "bulk"
+      ]
+    },
+    "public.ingestion_outcome": {
+      "name": "ingestion_outcome",
+      "schema": "public",
+      "values": [
+        "success",
+        "failed",
+        "filtered"
+      ]
+    },
+    "public.invite_token_status": {
+      "name": "invite_token_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "consumed",
+        "invalidated"
+      ]
+    },
+    "public.license_request_status": {
+      "name": "license_request_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "approved",
+        "rejected",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.message_template_kind": {
+      "name": "message_template_kind",
+      "schema": "public",
+      "values": [
+        "approval",
+        "completion"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "quarterly"
+      ]
+    },
+    "public.sync_operation_type": {
+      "name": "sync_operation_type",
+      "schema": "public",
+      "values": [
+        "regular",
+        "backfill"
+      ]
+    },
+    "public.sync_outcome": {
+      "name": "sync_outcome",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "success",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.sync_source_type": {
+      "name": "sync_source_type",
+      "schema": "public",
+      "values": [
+        "github_copilot_billing",
+        "anthropic_api_usage",
+        "anthropic_team_invoices",
+        "github_members",
+        "invoice_period_matching",
+        "anthropic_api_costs"
+      ]
+    },
+    "public.tool_status": {
+      "name": "tool_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.user_discipline": {
+      "name": "user_discipline",
+      "schema": "public",
+      "values": [
+        "developer",
+        "conception",
+        "business"
+      ]
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "public",
+      "values": [
+        "boost",
+        "maxed",
+        "indie"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "viewer"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1781171027885,
       "tag": "0025_colorful_vector",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1781270007485,
+      "tag": "0026_nebulous_shadow_king",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1388,9 +1388,9 @@ export const forecastScenarios = pgTable(
   (table) => [
     index("forecast_scenarios_budget_id_idx").on(table.budgetId),
     index("forecast_scenarios_created_by_idx").on(table.createdBy),
-    // One name per budget, case-insensitive ("Plan B" ≡ "plan b"). The
-    // application pre-checks for a friendly error; this is the race backstop
-    // (create/update map its violation back to the same friendly error).
+    // One name per budget, case-insensitive ("Plan B" ≡ "plan b"). This index
+    // is the single source of duplicate-name rejection — create/update map
+    // its violation (23505) to a friendly ActionResult error, race-free.
     uniqueIndex("forecast_scenarios_budget_name_idx").on(
       table.budgetId,
       sql`lower(${table.name})`,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -15,6 +15,7 @@ import {
   check,
 } from "drizzle-orm/pg-core";
 import type { UserPreferences } from "@/types";
+import type { ForecastInputs } from "@/lib/scenarios/budget-forecast";
 import { relations, sql } from "drizzle-orm";
 
 // Enums
@@ -25,22 +26,16 @@ export const assignmentStatusEnum = pgEnum("assignment_status", [
   "active",
   "inactive",
 ]);
-export const budgetStatusEnum = pgEnum("budget_status", [
-  "active",
-  "archived",
-]);
+export const budgetStatusEnum = pgEnum("budget_status", ["active", "archived"]);
 export const periodTypeEnum = pgEnum("period_type", ["monthly", "quarterly"]);
-export const budgetExtensionCategoryEnum = pgEnum(
-  "budget_extension_category",
-  [
-    "new_tool",
-    "scope_increase",
-    "seat_increase",
-    "vendor_price_increase",
-    "reallocation",
-    "other",
-  ]
-);
+export const budgetExtensionCategoryEnum = pgEnum("budget_extension_category", [
+  "new_tool",
+  "scope_increase",
+  "seat_increase",
+  "vendor_price_increase",
+  "reallocation",
+  "other",
+]);
 export const changeTypeEnum = pgEnum("change_type", [
   "created",
   "updated",
@@ -83,10 +78,7 @@ export const filterFieldEnum = pgEnum("filter_field", [
   "invoice_number",
 ]);
 
-export const filterModeEnum = pgEnum("filter_mode", [
-  "whitelist",
-  "blacklist",
-]);
+export const filterModeEnum = pgEnum("filter_mode", ["whitelist", "blacklist"]);
 
 // Ingestion log enums (023-ingestion-history)
 export const ingestionOutcomeEnum = pgEnum("ingestion_outcome", [
@@ -163,7 +155,7 @@ export const users = pgTable(
     uniqueIndex("users_email_idx").on(table.email),
     index("users_circle_idx").on(table.circle),
     index("users_status_idx").on(table.status),
-  ]
+  ],
 );
 
 // Invite Tokens
@@ -189,7 +181,7 @@ export const inviteTokens = pgTable(
     uniqueIndex("invite_tokens_active_user_idx")
       .on(table.userId)
       .where(sql`${table.status} = 'active'`),
-  ]
+  ],
 );
 
 // AI Tools
@@ -208,7 +200,7 @@ export const aiTools = pgTable(
   (table) => [
     uniqueIndex("ai_tools_name_idx").on(table.name),
     index("ai_tools_vendor_idx").on(table.vendor),
-  ]
+  ],
 );
 
 // Access Tiers
@@ -229,7 +221,7 @@ export const accessTiers = pgTable(
   (table) => [
     index("access_tiers_tool_id_idx").on(table.toolId),
     uniqueIndex("access_tiers_tool_name_idx").on(table.toolId, table.name),
-  ]
+  ],
 );
 
 // License Assignments
@@ -264,9 +256,9 @@ export const licenseAssignments = pgTable(
     index("license_assignments_active_lookup_idx").on(
       table.userId,
       table.toolId,
-      table.status
+      table.status,
     ),
-  ]
+  ],
 );
 
 // Annual Budgets
@@ -289,7 +281,7 @@ export const annualBudgets = pgTable(
   (table) => [
     uniqueIndex("annual_budgets_fiscal_year_idx").on(table.fiscalYear),
     index("annual_budgets_status_idx").on(table.status),
-  ]
+  ],
 );
 
 // Budget Periods
@@ -312,9 +304,9 @@ export const budgetPeriods = pgTable(
     index("budget_periods_budget_id_idx").on(table.budgetId),
     uniqueIndex("budget_periods_budget_period_idx").on(
       table.budgetId,
-      table.periodIndex
+      table.periodIndex,
     ),
-  ]
+  ],
 );
 
 // Budget Extensions — first-class record of mid-year ceiling changes.
@@ -350,7 +342,7 @@ export const budgetExtensions = pgTable(
     index("budget_extensions_linked_tool_idx").on(table.linkedToolId),
     index("budget_extensions_created_by_idx").on(table.createdBy),
     check("budget_extensions_amount_non_zero", sql`${table.amountCents} <> 0`),
-  ]
+  ],
 );
 
 // Budget Extension Period Allocations — which periods absorbed an extension.
@@ -370,12 +362,9 @@ export const budgetExtensionPeriodAllocations = pgTable(
     createdAt: timestamp("created_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("bepa_unique_ext_period").on(
-      table.extensionId,
-      table.periodId
-    ),
+    uniqueIndex("bepa_unique_ext_period").on(table.extensionId, table.periodId),
     index("bepa_period_idx").on(table.periodId),
-  ]
+  ],
 );
 
 // Change History
@@ -398,7 +387,7 @@ export const changeHistory = pgTable(
     index("change_history_entity_idx").on(table.entityType, table.entityId),
     index("change_history_changed_by_idx").on(table.changedBy),
     index("change_history_created_at_idx").on(table.createdAt),
-  ]
+  ],
 );
 
 // Assignment Comments
@@ -420,7 +409,7 @@ export const assignmentComments = pgTable(
     index("assignment_comments_assignment_id_idx").on(table.assignmentId),
     index("assignment_comments_author_id_idx").on(table.authorId),
     index("assignment_comments_created_at_idx").on(table.createdAt),
-  ]
+  ],
 );
 
 // Billed Costs
@@ -443,7 +432,7 @@ export const billedCosts = pgTable(
   (table) => [
     index("billed_costs_period_id_idx").on(table.periodId),
     index("billed_costs_invoice_date_idx").on(table.invoiceDate),
-  ]
+  ],
 );
 
 // Invoices
@@ -457,7 +446,7 @@ export const invoices = pgTable(
     vendor: varchar("vendor", { length: 255 }),
     linkedBilledCostId: integer("linked_billed_cost_id").references(
       () => billedCosts.id,
-      { onDelete: "set null" }
+      { onDelete: "set null" },
     ),
     blobUrl: text("blob_url").notNull(),
     blobPathname: text("blob_pathname").notNull(),
@@ -472,7 +461,7 @@ export const invoices = pgTable(
     index("invoices_invoice_number_idx").on(t.invoiceNumber),
     index("invoices_created_at_idx").on(t.createdAt),
     index("invoices_linked_billed_cost_id_idx").on(t.linkedBilledCostId),
-  ]
+  ],
 );
 
 // GitHub Connections
@@ -492,12 +481,14 @@ export const githubConnections = pgTable(
     connectedAt: timestamp("connected_at").notNull().defaultNow(),
     disconnectedAt: timestamp("disconnected_at"),
     lastSyncAt: timestamp("last_sync_at"),
-    copilotSyncEnabled: boolean("copilot_sync_enabled").notNull().default(false),
+    copilotSyncEnabled: boolean("copilot_sync_enabled")
+      .notNull()
+      .default(false),
     copilotSyncSchedule: varchar("copilot_sync_schedule", { length: 50 })
       .notNull()
       .default("daily"),
   },
-  (table) => [index("github_connections_status_idx").on(table.status)]
+  (table) => [index("github_connections_status_idx").on(table.status)],
 );
 
 // GitHub Profiles
@@ -524,7 +515,7 @@ export const githubProfiles = pgTable(
     uniqueIndex("github_profiles_user_id_idx").on(table.userId),
     index("github_profiles_github_id_idx").on(table.githubId),
     index("github_profiles_github_login_idx").on(table.githubLogin),
-  ]
+  ],
 );
 
 // GitHub Sync Events
@@ -559,7 +550,7 @@ export const githubSyncEvents = pgTable(
   (table) => [
     index("github_sync_events_connection_id_idx").on(table.connectionId),
     index("github_sync_events_triggered_by_idx").on(table.triggeredBy),
-  ]
+  ],
 );
 
 // Copilot Usage Metrics
@@ -595,10 +586,10 @@ export const copilotUsageMetrics = pgTable(
   (table) => [
     uniqueIndex("copilot_usage_metrics_connection_date_idx").on(
       table.connectionId,
-      table.date
+      table.date,
     ),
     index("copilot_usage_metrics_date_idx").on(table.date),
-  ]
+  ],
 );
 
 // Copilot Billing Snapshots
@@ -621,9 +612,9 @@ export const copilotBillingSnapshots = pgTable(
   (table) => [
     uniqueIndex("copilot_billing_snapshots_connection_month_idx").on(
       table.connectionId,
-      table.billingMonth
+      table.billingMonth,
     ),
-  ]
+  ],
 );
 
 // Anthropic Usage Metrics (daily token usage per user per model)
@@ -659,12 +650,14 @@ export const anthropicUsageMetrics = pgTable(
     uniqueIndex("anthropic_usage_metrics_user_date_model_idx").on(
       table.userId,
       table.date,
-      table.model
+      table.model,
     ),
     index("anthropic_usage_metrics_user_date_idx").on(table.userId, table.date),
     index("anthropic_usage_metrics_date_idx").on(table.date),
-    index("anthropic_usage_metrics_pricing_resolved_idx").on(table.pricingResolved),
-  ]
+    index("anthropic_usage_metrics_pricing_resolved_idx").on(
+      table.pricingResolved,
+    ),
+  ],
 );
 
 // Anthropic Sync Status (per-user sync tracking + cached API key ID)
@@ -682,7 +675,9 @@ export const anthropicSyncStatus = pgTable(
     resolvedWorkspaceId: varchar("resolved_workspace_id", { length: 100 }),
     workspaceSyncCompletedAt: timestamp("workspace_sync_completed_at"),
   },
-  (table) => [uniqueIndex("anthropic_sync_status_user_id_idx").on(table.userId)]
+  (table) => [
+    uniqueIndex("anthropic_sync_status_user_id_idx").on(table.userId),
+  ],
 );
 
 // Sync Sources (019-invoice-automations)
@@ -696,7 +691,7 @@ export const syncSources = pgTable(
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
-  (table) => [uniqueIndex("sync_sources_source_type_idx").on(table.sourceType)]
+  (table) => [uniqueIndex("sync_sources_source_type_idx").on(table.sourceType)],
 );
 
 // Sync Events (019-invoice-automations)
@@ -726,9 +721,9 @@ export const syncEvents = pgTable(
     index("sync_events_started_at_idx").on(table.startedAt),
     index("sync_events_source_started_idx").on(
       table.sourceType,
-      table.startedAt
+      table.startedAt,
     ),
-  ]
+  ],
 );
 
 // Ingestion Log (023-ingestion-history)
@@ -747,7 +742,7 @@ export const ingestionLog = pgTable(
     blobPathname: text("blob_pathname"),
     linkedInvoiceId: integer("linked_invoice_id").references(
       () => invoices.id,
-      { onDelete: "set null" }
+      { onDelete: "set null" },
     ),
     uploadedBy: integer("uploaded_by").references(() => users.id, {
       onDelete: "set null",
@@ -759,7 +754,7 @@ export const ingestionLog = pgTable(
     index("ingestion_log_created_at_idx").on(table.createdAt),
     index("ingestion_log_vendor_idx").on(table.vendor),
     index("ingestion_log_channel_idx").on(table.channel),
-  ]
+  ],
 );
 
 // Anthropic Workspaces (workspace metadata from Anthropic Admin API)
@@ -786,7 +781,7 @@ export const anthropicWorkspaces = pgTable(
       .on(table.isDefault)
       .where(sql`${table.isDefault} = true`),
     index("anthropic_workspaces_archived_idx").on(table.isArchived),
-  ]
+  ],
 );
 
 // Anthropic Workspace Costs (daily cost per workspace from cost_report API)
@@ -809,8 +804,11 @@ export const anthropicWorkspaceCosts = pgTable(
       .where(sql`${table.workspaceId} IS NULL`),
     index("anthropic_workspace_costs_date_idx").on(table.date),
     index("anthropic_workspace_costs_workspace_id_idx").on(table.workspaceId),
-    check("anthropic_workspace_costs_cost_cents_check", sql`${table.costCents} >= 0`),
-  ]
+    check(
+      "anthropic_workspace_costs_cost_cents_check",
+      sql`${table.costCents} >= 0`,
+    ),
+  ],
 );
 
 // Anthropic Workspace Limits (admin-configured monthly spending limits)
@@ -830,7 +828,7 @@ export const anthropicWorkspaceLimits = pgTable(
     uniqueIndex("anthropic_workspace_limits_default_idx")
       .on(sql`(1)`)
       .where(sql`${table.workspaceId} IS NULL`),
-  ]
+  ],
 );
 
 // Anthropic Org Config (singleton row, id always = 1)
@@ -842,9 +840,7 @@ export const anthropicOrgConfig = pgTable(
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
     updatedBy: integer("updated_by").references(() => users.id),
   },
-  (table) => [
-    check("anthropic_org_config_id_check", sql`${table.id} = 1`),
-  ]
+  (table) => [check("anthropic_org_config_id_check", sql`${table.id} = 1`)],
 );
 
 // Anthropic Alert State — idempotency ledger for Teams alert posts.
@@ -877,9 +873,9 @@ export const anthropicAlertState = pgTable(
     index("anthropic_alert_state_month_idx").on(table.billingMonth),
     check(
       "anthropic_alert_state_billing_month_format",
-      sql`${table.billingMonth} ~ '^[0-9]{4}-(0[1-9]|1[0-2])$'`
+      sql`${table.billingMonth} ~ '^[0-9]{4}-(0[1-9]|1[0-2])$'`,
     ),
-  ]
+  ],
 );
 
 // License Requests (032-automation-workflow)
@@ -898,7 +894,7 @@ export const licenseRequests = pgTable(
       .references(() => aiTools.id, { onDelete: "restrict" }),
     requestedTierId: integer("requested_tier_id").references(
       () => accessTiers.id,
-      { onDelete: "set null" }
+      { onDelete: "set null" },
     ),
     formPayload: jsonb("form_payload")
       .$type<Record<string, unknown>>()
@@ -923,7 +919,7 @@ export const licenseRequests = pgTable(
     completedAt: timestamp("completed_at"),
     assignmentId: integer("assignment_id").references(
       () => licenseAssignments.id,
-      { onDelete: "set null" }
+      { onDelete: "set null" },
     ),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
@@ -935,7 +931,7 @@ export const licenseRequests = pgTable(
     index("license_requests_decided_by_idx").on(table.decidedBy),
     index("license_requests_assignment_id_idx").on(table.assignmentId),
     index("license_requests_created_at_idx").on(table.createdAt),
-  ]
+  ],
 );
 
 // Message Templates (032-automation-workflow)
@@ -967,7 +963,7 @@ export const messageTemplates = pgTable(
     uniqueIndex("message_templates_tool_tier_kind_idx")
       .on(table.toolId, table.tierId, table.kind)
       .where(sql`${table.tierId} IS NOT NULL`),
-  ]
+  ],
 );
 
 // MCP OAuth (038-mcp-v2) — minimal embedded OAuth 2.1 authorization server so
@@ -984,7 +980,9 @@ export const mcpOauthClients = pgTable(
     createdAt: timestamp("created_at").notNull().defaultNow(),
     lastUsedAt: timestamp("last_used_at"),
   },
-  (table) => [uniqueIndex("mcp_oauth_clients_client_id_idx").on(table.clientId)]
+  (table) => [
+    uniqueIndex("mcp_oauth_clients_client_id_idx").on(table.clientId),
+  ],
 );
 
 export const mcpOauthCodes = pgTable(
@@ -1010,7 +1008,7 @@ export const mcpOauthCodes = pgTable(
   (table) => [
     uniqueIndex("mcp_oauth_codes_code_hash_idx").on(table.codeHash),
     index("mcp_oauth_codes_user_id_idx").on(table.userId),
-  ]
+  ],
 );
 
 export const mcpOauthTokens = pgTable(
@@ -1038,14 +1036,14 @@ export const mcpOauthTokens = pgTable(
   },
   (table) => [
     uniqueIndex("mcp_oauth_tokens_access_token_hash_idx").on(
-      table.accessTokenHash
+      table.accessTokenHash,
     ),
     uniqueIndex("mcp_oauth_tokens_refresh_token_hash_idx").on(
-      table.refreshTokenHash
+      table.refreshTokenHash,
     ),
     index("mcp_oauth_tokens_user_id_idx").on(table.userId),
     index("mcp_oauth_tokens_family_id_idx").on(table.familyId),
-  ]
+  ],
 );
 
 // Relations
@@ -1104,7 +1102,7 @@ export const licenseAssignmentsRelations = relations(
       references: [accessTiers.id],
     }),
     comments: many(assignmentComments),
-  })
+  }),
 );
 
 export const annualBudgetsRelations = relations(annualBudgets, ({ many }) => ({
@@ -1112,14 +1110,17 @@ export const annualBudgetsRelations = relations(annualBudgets, ({ many }) => ({
   extensions: many(budgetExtensions),
 }));
 
-export const budgetPeriodsRelations = relations(budgetPeriods, ({ one, many }) => ({
-  budget: one(annualBudgets, {
-    fields: [budgetPeriods.budgetId],
-    references: [annualBudgets.id],
+export const budgetPeriodsRelations = relations(
+  budgetPeriods,
+  ({ one, many }) => ({
+    budget: one(annualBudgets, {
+      fields: [budgetPeriods.budgetId],
+      references: [annualBudgets.id],
+    }),
+    billedCosts: many(billedCosts),
+    extensionAllocations: many(budgetExtensionPeriodAllocations),
   }),
-  billedCosts: many(billedCosts),
-  extensionAllocations: many(budgetExtensionPeriodAllocations),
-}));
+);
 
 export const budgetExtensionsRelations = relations(
   budgetExtensions,
@@ -1137,7 +1138,7 @@ export const budgetExtensionsRelations = relations(
       references: [users.id],
     }),
     allocations: many(budgetExtensionPeriodAllocations),
-  })
+  }),
 );
 
 export const budgetExtensionPeriodAllocationsRelations = relations(
@@ -1151,7 +1152,7 @@ export const budgetExtensionPeriodAllocationsRelations = relations(
       fields: [budgetExtensionPeriodAllocations.periodId],
       references: [budgetPeriods.id],
     }),
-  })
+  }),
 );
 
 export const assignmentCommentsRelations = relations(
@@ -1165,7 +1166,7 @@ export const assignmentCommentsRelations = relations(
       fields: [assignmentComments.authorId],
       references: [users.id],
     }),
-  })
+  }),
 );
 
 export const billedCostsRelations = relations(billedCosts, ({ one, many }) => ({
@@ -1204,7 +1205,7 @@ export const githubConnectionsRelations = relations(
     syncEvents: many(githubSyncEvents),
     copilotUsageMetrics: many(copilotUsageMetrics),
     copilotBillingSnapshots: many(copilotBillingSnapshots),
-  })
+  }),
 );
 
 export const githubProfilesRelations = relations(githubProfiles, ({ one }) => ({
@@ -1225,7 +1226,7 @@ export const githubSyncEventsRelations = relations(
       fields: [githubSyncEvents.triggeredBy],
       references: [users.id],
     }),
-  })
+  }),
 );
 
 export const copilotUsageMetricsRelations = relations(
@@ -1235,7 +1236,7 @@ export const copilotUsageMetricsRelations = relations(
       fields: [copilotUsageMetrics.connectionId],
       references: [githubConnections.id],
     }),
-  })
+  }),
 );
 
 export const copilotBillingSnapshotsRelations = relations(
@@ -1245,7 +1246,7 @@ export const copilotBillingSnapshotsRelations = relations(
       fields: [copilotBillingSnapshots.connectionId],
       references: [githubConnections.id],
     }),
-  })
+  }),
 );
 
 export const anthropicUsageMetricsRelations = relations(
@@ -1255,7 +1256,7 @@ export const anthropicUsageMetricsRelations = relations(
       fields: [anthropicUsageMetrics.userId],
       references: [users.id],
     }),
-  })
+  }),
 );
 
 export const anthropicSyncStatusRelations = relations(
@@ -1265,7 +1266,7 @@ export const anthropicSyncStatusRelations = relations(
       fields: [anthropicSyncStatus.userId],
       references: [users.id],
     }),
-  })
+  }),
 );
 
 export const syncEventsRelations = relations(syncEvents, ({ one }) => ({
@@ -1303,7 +1304,7 @@ export const ingestionFilters = pgTable(
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
-  (table) => [index("ingestion_filters_enabled_idx").on(table.enabled)]
+  (table) => [index("ingestion_filters_enabled_idx").on(table.enabled)],
 );
 
 export const ingestionFiltersRelations = relations(
@@ -1313,47 +1314,100 @@ export const ingestionFiltersRelations = relations(
       fields: [ingestionFilters.createdBy],
       references: [users.id],
     }),
-  })
+  }),
 );
 
 // License Requests / Message Templates relations (032-automation-workflow)
-export const licenseRequestsRelations = relations(licenseRequests, ({ one }) => ({
-  requesterUser: one(users, {
-    fields: [licenseRequests.requesterUserId],
-    references: [users.id],
-    relationName: "license_request_requester",
+export const licenseRequestsRelations = relations(
+  licenseRequests,
+  ({ one }) => ({
+    requesterUser: one(users, {
+      fields: [licenseRequests.requesterUserId],
+      references: [users.id],
+      relationName: "license_request_requester",
+    }),
+    requestedTool: one(aiTools, {
+      fields: [licenseRequests.requestedToolId],
+      references: [aiTools.id],
+    }),
+    requestedTier: one(accessTiers, {
+      fields: [licenseRequests.requestedTierId],
+      references: [accessTiers.id],
+    }),
+    decidedByUser: one(users, {
+      fields: [licenseRequests.decidedBy],
+      references: [users.id],
+      relationName: "license_request_decided_by",
+    }),
+    completedByUser: one(users, {
+      fields: [licenseRequests.completedBy],
+      references: [users.id],
+      relationName: "license_request_completed_by",
+    }),
+    assignment: one(licenseAssignments, {
+      fields: [licenseRequests.assignmentId],
+      references: [licenseAssignments.id],
+    }),
   }),
-  requestedTool: one(aiTools, {
-    fields: [licenseRequests.requestedToolId],
-    references: [aiTools.id],
-  }),
-  requestedTier: one(accessTiers, {
-    fields: [licenseRequests.requestedTierId],
-    references: [accessTiers.id],
-  }),
-  decidedByUser: one(users, {
-    fields: [licenseRequests.decidedBy],
-    references: [users.id],
-    relationName: "license_request_decided_by",
-  }),
-  completedByUser: one(users, {
-    fields: [licenseRequests.completedBy],
-    references: [users.id],
-    relationName: "license_request_completed_by",
-  }),
-  assignment: one(licenseAssignments, {
-    fields: [licenseRequests.assignmentId],
-    references: [licenseAssignments.id],
-  }),
-}));
+);
 
-export const messageTemplatesRelations = relations(messageTemplates, ({ one }) => ({
-  tool: one(aiTools, {
-    fields: [messageTemplates.toolId],
-    references: [aiTools.id],
+export const messageTemplatesRelations = relations(
+  messageTemplates,
+  ({ one }) => ({
+    tool: one(aiTools, {
+      fields: [messageTemplates.toolId],
+      references: [aiTools.id],
+    }),
+    tier: one(accessTiers, {
+      fields: [messageTemplates.tierId],
+      references: [accessTiers.id],
+    }),
   }),
-  tier: one(accessTiers, {
-    fields: [messageTemplates.tierId],
-    references: [accessTiers.id],
+);
+
+// Forecast Scenarios (041-forecast-scenario-persistence)
+// Named, shared what-if parameter sets for the Budget / Cost Forecast
+// Simulation. Stores assumptions (ForecastInputs), never computed results —
+// scenarios are re-projected against live data on load.
+export const forecastScenarios = pgTable(
+  "forecast_scenarios",
+  {
+    id: serial("id").primaryKey(),
+    budgetId: integer("budget_id")
+      .notNull()
+      .references(() => annualBudgets.id, { onDelete: "cascade" }),
+    name: varchar("name", { length: 60 }).notNull(),
+    params: jsonb("params").$type<ForecastInputs>().notNull(),
+    // Attribution only — deleting a user must not destroy shared scenarios.
+    createdBy: integer("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("forecast_scenarios_budget_id_idx").on(table.budgetId),
+    index("forecast_scenarios_created_by_idx").on(table.createdBy),
+    // One name per budget, case-insensitive ("Plan B" ≡ "plan b"). The
+    // application pre-checks for a friendly error; this is the race backstop
+    // (create/update map its violation back to the same friendly error).
+    uniqueIndex("forecast_scenarios_budget_name_idx").on(
+      table.budgetId,
+      sql`lower(${table.name})`,
+    ),
+  ],
+);
+
+export const forecastScenariosRelations = relations(
+  forecastScenarios,
+  ({ one }) => ({
+    budget: one(annualBudgets, {
+      fields: [forecastScenarios.budgetId],
+      references: [annualBudgets.id],
+    }),
+    creator: one(users, {
+      fields: [forecastScenarios.createdBy],
+      references: [users.id],
+    }),
   }),
-}));
+);

--- a/src/lib/scenarios/budget-forecast.ts
+++ b/src/lib/scenarios/budget-forecast.ts
@@ -383,3 +383,24 @@ export function inputsFromPreset(
 export function defaultInputs(ds: ForecastDataset): ForecastInputs {
   return inputsFromPreset(ds, "h2Plan");
 }
+
+/**
+ * Re-base a parameter set onto the current dataset (spec 041). Tools that no
+ * longer exist are dropped; tools that appeared since the params were captured
+ * get DEFAULT_PARAMS — so a stale saved scenario (or surviving client state
+ * after a dataset refresh) always yields a complete, renderable input set.
+ *
+ * Params are copied verbatim per tool — including the claudeSeats `billing`
+ * cadence, which is what makes "load restores the cadence" hold.
+ */
+export function inputsFromSaved(
+  ds: ForecastDataset,
+  saved: ForecastInputs,
+): ForecastInputs {
+  const tools: Record<string, ToolParams> = {};
+  for (const tool of ds.tools) {
+    const p = saved.tools[tool.key];
+    tools[tool.key] = p ? { ...p } : { ...DEFAULT_PARAMS };
+  }
+  return { ceilingCents: saved.ceilingCents, tools };
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -65,7 +65,9 @@ export const bulkImportUserSchema = z.object({
 const apiKeyField = z
   .string()
   .max(500)
-  .refine((val) => val === "" || val.trim().length > 0, { message: "API key cannot be blank" })
+  .refine((val) => val === "" || val.trim().length > 0, {
+    message: "API key cannot be blank",
+  })
   .transform((val) => (val === "" ? val : val.trim()))
   .optional();
 
@@ -95,7 +97,7 @@ export const budgetAllocationSchema = z.object({
         .number()
         .int()
         .min(0, "Amount must be non-negative"),
-    })
+    }),
   ),
 });
 
@@ -109,12 +111,19 @@ export const bulkImportAssignmentRowSchema = z.object({
   assignedAt: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD format")
-    .refine((value) => {
-      const date = new Date(value);
-      if (Number.isNaN(date.getTime())) return false;
-      const [y, m, d] = value.split("-").map(Number);
-      return date.getUTCFullYear() === y && date.getUTCMonth() + 1 === m && date.getUTCDate() === d;
-    }, { message: "Invalid calendar date" }),
+    .refine(
+      (value) => {
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return false;
+        const [y, m, d] = value.split("-").map(Number);
+        return (
+          date.getUTCFullYear() === y &&
+          date.getUTCMonth() + 1 === m &&
+          date.getUTCDate() === d
+        );
+      },
+      { message: "Invalid calendar date" },
+    ),
 });
 
 // Update assignment (in-place edit)
@@ -129,14 +138,19 @@ export const updateAssignmentSchema = z.object({
 // Assignment comment
 export const assignmentCommentSchema = z.object({
   assignmentId: z.number().int().positive(),
-  body: z.string().min(1, "Comment is required").max(2000, "Comment must be 2000 characters or less"),
+  body: z
+    .string()
+    .min(1, "Comment is required")
+    .max(2000, "Comment must be 2000 characters or less"),
 });
 
 // Billed cost (create)
 export const billedCostSchema = z.object({
   periodId: z.number().int().positive(),
   amountCents: z.number().int().positive("Amount must be positive"),
-  invoiceDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD format"),
+  invoiceDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD format"),
   description: z.string().min(1, "Description is required").max(500),
   vendorReference: z.string().max(255).optional(),
 });
@@ -145,7 +159,10 @@ export const billedCostSchema = z.object({
 export const updateBilledCostSchema = z.object({
   id: z.number().int().positive(),
   amountCents: z.number().int().positive("Amount must be positive").optional(),
-  invoiceDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD format").optional(),
+  invoiceDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD format")
+    .optional(),
   description: z.string().min(1).max(500).optional(),
   vendorReference: z.string().max(255).optional().nullable(),
 });
@@ -187,7 +204,7 @@ export const budgetExtensionAllocationSchema = z.discriminatedUnion("mode", [
         z.object({
           periodId: z.number().int().positive(),
           amountCents: z.number().int(),
-        })
+        }),
       )
       .min(1),
   }),
@@ -215,7 +232,7 @@ export const createBudgetExtensionSchema = z.object({
         const d = new Date(`${s}T00:00:00Z`);
         return !isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
       },
-      { message: "Date does not exist on the calendar" }
+      { message: "Date does not exist on the calendar" },
     ),
   allocation: budgetExtensionAllocationSchema,
 });
@@ -292,7 +309,9 @@ export type UpdateAssignmentInput = z.infer<typeof updateAssignmentSchema>;
 export type AssignmentCommentInput = z.infer<typeof assignmentCommentSchema>;
 export type BilledCostInput = z.infer<typeof billedCostSchema>;
 export type UpdateBilledCostInput = z.infer<typeof updateBilledCostSchema>;
-export type BulkImportAssignmentRowInput = z.infer<typeof bulkImportAssignmentRowSchema>;
+export type BulkImportAssignmentRowInput = z.infer<
+  typeof bulkImportAssignmentRowSchema
+>;
 export type UpdateUserInput = z.infer<typeof updateUserSchema>;
 
 // Invoice (create + extraction result)
@@ -311,7 +330,10 @@ export const createInvoiceSchema = z.object({
         d.getUTCDate() === day
       );
     }, "Invalid calendar date"),
-  amountCents: z.number().int().positive("Amount must be a positive integer (cents)"),
+  amountCents: z
+    .number()
+    .int()
+    .positive("Amount must be a positive integer (cents)"),
   vendor: z.string().max(255).optional(),
   blobUrl: z.string().url(),
   blobPathname: z.string().min(1),
@@ -331,7 +353,9 @@ export const invoiceExtractionResultSchema = z.object({
 });
 
 export type CreateInvoiceInput = z.infer<typeof createInvoiceSchema>;
-export type InvoiceExtractionResult = z.infer<typeof invoiceExtractionResultSchema>;
+export type InvoiceExtractionResult = z.infer<
+  typeof invoiceExtractionResultSchema
+>;
 
 // Invoice sync schemas
 export const syncOptionsSchema = z.object({
@@ -383,7 +407,11 @@ const calendarDateSchema = z
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return false;
     const [y, m, d] = value.split("-").map(Number);
-    return date.getUTCFullYear() === y && date.getUTCMonth() + 1 === m && date.getUTCDate() === d;
+    return (
+      date.getUTCFullYear() === y &&
+      date.getUTCMonth() + 1 === m &&
+      date.getUTCDate() === d
+    );
   }, "Invalid calendar date");
 
 export const copilotDateRangeSchema = z.object({
@@ -430,7 +458,7 @@ export const invoiceNumberFilterValueSchema = z.object({
           return false;
         }
       },
-      { message: "Invalid regular expression pattern" }
+      { message: "Invalid regular expression pattern" },
     ),
 });
 
@@ -449,7 +477,7 @@ export const createIngestionFilterSchema = z
       if (data.field === "invoice_number") return "pattern" in data.value;
       return false;
     },
-    { message: "Value shape must match the selected field type" }
+    { message: "Value shape must match the selected field type" },
   );
 
 export const updateIngestionFilterSchema = z
@@ -475,7 +503,7 @@ export const updateIngestionFilterSchema = z
     {
       message:
         "When updating value, field must be provided and value shape must match the field type",
-    }
+    },
   );
 
 export const deleteIngestionFilterSchema = z.object({
@@ -499,30 +527,36 @@ export type UpdateIngestionFilterInput = z.infer<
 // Microsoft Form is submitted. PA sends tool / tier by NAME (what the form
 // shows the requester) and the Hub resolves to IDs — Form display values
 // don't change as often as DB IDs, so name-matching is the more stable contract.
-export const licenseRequestIngestSchema = z.object({
-  formResponseId: z.string().min(1).max(255),
-  requesterEmail: z.string().email(),
-  requesterName: z.string().min(1).max(255),
-  // Tool / tier — accept name or id. ID takes precedence when both supplied.
-  toolId: z.number().int().positive().optional(),
-  toolName: z.string().min(1).max(255).optional(),
-  tierId: z.number().int().positive().optional(),
-  tierName: z.string().min(1).max(255).optional(),
-  // Variable per tier; raw form payload, keyed by Form question identifier.
-  formPayload: z.record(z.string(), z.unknown()),
-  // Teams context — PA must forward these from the existing channel-post +
-  // create-chat actions so the Hub can post threaded replies + group-chat
-  // updates via Microsoft Graph.
-  teamsTeamId: z.string().min(1),
-  teamsChannelId: z.string().min(1),
-  teamsParentMessageId: z.string().min(1),
-  teamsChatId: z.string().min(1),
-}).refine(
-  (d) => d.toolId !== undefined || (d.toolName !== undefined && d.toolName.length > 0),
-  { message: "toolId or toolName is required", path: ["toolName"] },
-);
+export const licenseRequestIngestSchema = z
+  .object({
+    formResponseId: z.string().min(1).max(255),
+    requesterEmail: z.string().email(),
+    requesterName: z.string().min(1).max(255),
+    // Tool / tier — accept name or id. ID takes precedence when both supplied.
+    toolId: z.number().int().positive().optional(),
+    toolName: z.string().min(1).max(255).optional(),
+    tierId: z.number().int().positive().optional(),
+    tierName: z.string().min(1).max(255).optional(),
+    // Variable per tier; raw form payload, keyed by Form question identifier.
+    formPayload: z.record(z.string(), z.unknown()),
+    // Teams context — PA must forward these from the existing channel-post +
+    // create-chat actions so the Hub can post threaded replies + group-chat
+    // updates via Microsoft Graph.
+    teamsTeamId: z.string().min(1),
+    teamsChannelId: z.string().min(1),
+    teamsParentMessageId: z.string().min(1),
+    teamsChatId: z.string().min(1),
+  })
+  .refine(
+    (d) =>
+      d.toolId !== undefined ||
+      (d.toolName !== undefined && d.toolName.length > 0),
+    { message: "toolId or toolName is required", path: ["toolName"] },
+  );
 
-export type LicenseRequestIngestInput = z.infer<typeof licenseRequestIngestSchema>;
+export type LicenseRequestIngestInput = z.infer<
+  typeof licenseRequestIngestSchema
+>;
 
 export const messageTemplateSchema = z.object({
   toolId: z.number().int().positive(),
@@ -559,3 +593,54 @@ export const cancelRequestSchema = z.object({
   requestId: z.number().int().positive(),
 });
 export type CancelRequestInput = z.infer<typeof cancelRequestSchema>;
+
+// Forecast Scenarios — spec 041-forecast-scenario-persistence
+//
+// Boundary schemas for the forecast_scenarios jsonb params column. Plain
+// z.object (strip semantics): unknown keys are dropped rather than rejected,
+// so rows stay loadable across schema evolution; writes store parsed.data,
+// keeping the stored shape canonical. Zod 4's z.number() rejects NaN/Infinity
+// by default, so nothing non-finite can reach the projection engine's math.
+// Bounds are generous modelling limits, not business rules.
+export const toolParamsSchema = z.object({
+  include: z.boolean(),
+  model: z.enum(["flat", "linear", "compound"]),
+  val: z.number().min(-100_000).max(100_000),
+  burnPct: z.number().min(-100).max(100_000).optional(),
+  burnCap: z.number().int().min(0).max(100_000_000).optional(),
+  premShare: z.number().min(0).max(1).optional(),
+  billing: z.enum(["monthly", "yearly"]).optional(),
+});
+
+export const forecastInputsSchema = z
+  .object({
+    // ≤ $1B; 0 is accepted (the save dialog guards the accidental-empty path).
+    ceilingCents: z.number().int().min(0).max(100_000_000_000),
+    tools: z.record(z.string().min(1).max(40), toolParamsSchema),
+  })
+  .refine((v) => Object.keys(v.tools).length <= 20, {
+    message: "Too many tool entries",
+  });
+
+export const forecastScenarioNameSchema = z.string().trim().min(1).max(60);
+
+export const createForecastScenarioSchema = z.object({
+  name: forecastScenarioNameSchema,
+  params: forecastInputsSchema,
+});
+export const updateForecastScenarioSchema = z.object({
+  id: z.number().int().positive(),
+  name: forecastScenarioNameSchema,
+  // Omitted = rename-only; stored params stay untouched.
+  params: forecastInputsSchema.optional(),
+});
+export const deleteForecastScenarioSchema = z.object({
+  id: z.number().int().positive(),
+});
+
+export type CreateForecastScenarioInput = z.infer<
+  typeof createForecastScenarioSchema
+>;
+export type UpdateForecastScenarioInput = z.infer<
+  typeof updateForecastScenarioSchema
+>;

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -622,7 +622,7 @@ export const forecastInputsSchema = z
     message: "Too many tool entries",
   });
 
-export const forecastScenarioNameSchema = z.string().trim().min(1).max(60);
+const forecastScenarioNameSchema = z.string().trim().min(1).max(60);
 
 export const createForecastScenarioSchema = z.object({
   name: forecastScenarioNameSchema,
@@ -637,10 +637,3 @@ export const updateForecastScenarioSchema = z.object({
 export const deleteForecastScenarioSchema = z.object({
   id: z.number().int().positive(),
 });
-
-export type CreateForecastScenarioInput = z.infer<
-  typeof createForecastScenarioSchema
->;
-export type UpdateForecastScenarioInput = z.infer<
-  typeof updateForecastScenarioSchema
->;

--- a/tests/integration/forecast-scenarios.test.ts
+++ b/tests/integration/forecast-scenarios.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { db } from "@/lib/db";
+import {
+  annualBudgets,
+  changeHistory,
+  forecastScenarios,
+  users,
+} from "@/lib/db/schema";
+import { and, eq, like } from "drizzle-orm";
+import type { ForecastInputs } from "@/lib/scenarios/budget-forecast";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAdmin: vi.fn().mockResolvedValue({ id: "1", role: "admin" }),
+}));
+
+import {
+  createForecastScenario,
+  deleteForecastScenario,
+  listForecastScenarios,
+  updateForecastScenario,
+} from "@/actions/forecast-scenarios";
+
+let adminUserId: number;
+let budgetId: number;
+let scenarioId: number;
+
+// The actions resolve "the active budget" themselves (status='active' ordered
+// by fiscal_year DESC), so the seeded budget must deterministically win that
+// resolution against the dev DB's real active budget AND every active budget
+// other integration suites seed in parallel (budget-extensions: 2090-2098,
+// invoice-sync: up to ~30,259). This suite must own the HIGHEST fiscal year
+// in the whole integration run — keep this range above every other suite's.
+const ACTIVE_FY = 999_000 + Math.floor(Math.random() * 999);
+
+const PARAMS_V1: ForecastInputs = {
+  ceilingCents: 4_200_000,
+  tools: {
+    api: { include: true, model: "compound", val: -25, burnPct: 0 },
+    claude: {
+      include: true,
+      model: "linear",
+      val: 15,
+      premShare: 0.4,
+      billing: "yearly",
+    },
+    copilot: { include: false, model: "flat", val: 0 },
+  },
+};
+
+const PARAMS_V2: ForecastInputs = {
+  ceilingCents: 5_000_000,
+  tools: {
+    api: { include: false, model: "flat", val: 0 },
+    claude: { include: true, model: "linear", val: 20, premShare: 0.35 },
+  },
+};
+
+beforeAll(async () => {
+  const [user] = await db
+    .insert(users)
+    .values({
+      name: "Forecast Scenario Test Admin",
+      email: `forecast-scenario-test-${Date.now()}@test.local`,
+      passwordHash: "not-a-real-hash",
+      role: "admin",
+    })
+    .returning({ id: users.id });
+  adminUserId = user.id;
+  vi.mocked(
+    (await import("@/lib/auth-helpers")).requireAdmin,
+  ).mockResolvedValue({ id: String(adminUserId), role: "admin" } as never);
+
+  const [budget] = await db
+    .insert(annualBudgets)
+    .values({
+      fiscalYear: ACTIVE_FY,
+      totalAmountCents: 4_200_000,
+      originalAmountCents: 4_200_000,
+      periodType: "monthly",
+      status: "active",
+    })
+    .returning({ id: annualBudgets.id });
+  budgetId = budget.id;
+});
+
+afterAll(async () => {
+  // Cascade delete cleans up any remaining scenarios.
+  await db.delete(annualBudgets).where(eq(annualBudgets.id, budgetId));
+  await db
+    .delete(changeHistory)
+    .where(eq(changeHistory.changedBy, adminUserId));
+  await db.delete(users).where(eq(users.id, adminUserId));
+});
+
+// ── Tests (sequential within the file) ───────────────────────────────────────
+
+describe("forecast-scenario CRUD round trip", () => {
+  it("create attaches to the seeded active budget and audits creation", async () => {
+    const result = await createForecastScenario({
+      name: "Plan B",
+      params: PARAMS_V1,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    scenarioId = result.data.id;
+
+    // The action resolved the budget itself — it must be the seeded one.
+    const row = await db.query.forecastScenarios.findFirst({
+      where: eq(forecastScenarios.id, scenarioId),
+    });
+    expect(row?.budgetId).toBe(budgetId);
+    expect(row?.createdBy).toBe(adminUserId);
+
+    const audit = await db.query.changeHistory.findFirst({
+      where: and(
+        eq(changeHistory.entityType, "forecast_scenario"),
+        eq(changeHistory.entityId, scenarioId),
+        eq(changeHistory.changeType, "created"),
+      ),
+    });
+    expect(audit?.changedBy).toBe(adminUserId);
+  });
+
+  it("list returns the row with params, creator name, and ISO timestamp", async () => {
+    const list = await listForecastScenarios();
+    const entry = list.find((s) => s.id === scenarioId);
+    expect(entry).toBeDefined();
+    expect(entry?.name).toBe("Plan B");
+    expect(entry?.params).toEqual(PARAMS_V1);
+    expect(entry?.creatorName).toBe("Forecast Scenario Test Admin");
+    expect(entry?.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("update renames and overwrites params with full audit snapshots", async () => {
+    const result = await updateForecastScenario({
+      id: scenarioId,
+      name: "Console Sunset",
+      params: PARAMS_V2,
+    });
+    expect(result).toEqual({ success: true, data: { id: scenarioId } });
+
+    const row = await db.query.forecastScenarios.findFirst({
+      where: eq(forecastScenarios.id, scenarioId),
+    });
+    expect(row?.name).toBe("Console Sunset");
+    expect(row?.params).toEqual(PARAMS_V2);
+
+    const updates = await db.query.changeHistory.findMany({
+      where: and(
+        eq(changeHistory.entityType, "forecast_scenario"),
+        eq(changeHistory.entityId, scenarioId),
+        eq(changeHistory.changeType, "updated"),
+      ),
+    });
+    const nameDiff = updates.find((u) => u.fieldName === "name");
+    expect(nameDiff && JSON.parse(nameDiff.previousValue!)).toBe("Plan B");
+    expect(nameDiff && JSON.parse(nameDiff.newValue!)).toBe("Console Sunset");
+    // Full params snapshots — an overwritten plan is recoverable.
+    const paramsDiff = updates.find((u) => u.fieldName === "params");
+    expect(paramsDiff && JSON.parse(paramsDiff.previousValue!)).toEqual(
+      PARAMS_V1,
+    );
+    expect(paramsDiff && JSON.parse(paramsDiff.newValue!)).toEqual(PARAMS_V2);
+  });
+
+  it("rename-only update leaves stored params untouched", async () => {
+    const result = await updateForecastScenario({
+      id: scenarioId,
+      name: "Console Sunset v2",
+    });
+    expect(result.success).toBe(true);
+
+    const row = await db.query.forecastScenarios.findFirst({
+      where: eq(forecastScenarios.id, scenarioId),
+    });
+    expect(row?.name).toBe("Console Sunset v2");
+    expect(row?.params).toEqual(PARAMS_V2);
+  });
+
+  it("rejects a case-variant duplicate name via the action", async () => {
+    const result = await createForecastScenario({
+      name: "console sunset V2",
+      params: PARAMS_V1,
+    });
+    expect(result).toEqual({
+      success: false,
+      error: "A scenario with this name already exists for this budget",
+    });
+  });
+
+  it("allows renaming a scenario to a case variant of its own name", async () => {
+    const result = await updateForecastScenario({
+      id: scenarioId,
+      name: "CONSOLE SUNSET V2",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("the unique expression index fires on a direct case-variant insert", async () => {
+    // Bypasses the action's pre-check — proves migration 0026's index is the
+    // real race backstop.
+    await expect(
+      db.insert(forecastScenarios).values({
+        budgetId,
+        name: "Console Sunset V2",
+        params: PARAMS_V1,
+        createdBy: adminUserId,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("list skips rows whose stored params no longer conform", async () => {
+    const [corrupt] = await db
+      .insert(forecastScenarios)
+      .values({
+        budgetId,
+        name: "Corrupt Row",
+        params: { ceilingCents: "oops" } as unknown as ForecastInputs,
+        createdBy: adminUserId,
+      })
+      .returning({ id: forecastScenarios.id });
+
+    const list = await listForecastScenarios();
+    expect(list.find((s) => s.id === corrupt.id)).toBeUndefined();
+    expect(list.find((s) => s.id === scenarioId)).toBeDefined();
+
+    await db
+      .delete(forecastScenarios)
+      .where(eq(forecastScenarios.id, corrupt.id));
+  });
+
+  it("enforces the 50-per-budget cap with a friendly error", async () => {
+    const existing = await db
+      .select({ id: forecastScenarios.id })
+      .from(forecastScenarios)
+      .where(eq(forecastScenarios.budgetId, budgetId));
+    // Bulk-seed up to the cap in one insert (50 action calls would serialize
+    // ~250 Neon round trips and brush the 30s timeout).
+    const fillers = Array.from({ length: 50 - existing.length }, (_, i) => ({
+      budgetId,
+      name: `Filler ${i + 1}`,
+      params: PARAMS_V1,
+      createdBy: adminUserId,
+    }));
+    await db.insert(forecastScenarios).values(fillers);
+
+    const result = await createForecastScenario({
+      name: "One Too Many",
+      params: PARAMS_V1,
+    });
+    expect(result).toEqual({
+      success: false,
+      error: "Scenario limit reached (50) — delete one first",
+    });
+
+    await db
+      .delete(forecastScenarios)
+      .where(
+        and(
+          eq(forecastScenarios.budgetId, budgetId),
+          like(forecastScenarios.name, "Filler %"),
+        ),
+      );
+  });
+
+  it("delete snapshots the row into change_history", async () => {
+    const result = await deleteForecastScenario(scenarioId);
+    expect(result).toEqual({ success: true, data: { id: scenarioId } });
+
+    const audit = await db.query.changeHistory.findFirst({
+      where: and(
+        eq(changeHistory.entityType, "forecast_scenario"),
+        eq(changeHistory.entityId, scenarioId),
+        eq(changeHistory.changeType, "deleted"),
+      ),
+    });
+    expect(audit).toBeDefined();
+    const snapshot = JSON.parse(audit!.previousValue!);
+    expect(snapshot.budgetId).toBe(budgetId);
+    expect(snapshot.name).toBe("CONSOLE SUNSET V2");
+    expect(snapshot.params).toEqual(PARAMS_V2);
+
+    expect(await deleteForecastScenario(scenarioId)).toEqual({
+      success: false,
+      error: "Scenario not found",
+    });
+  });
+
+  it("leaves the seeded budget with no scenarios", async () => {
+    const remaining = await db
+      .select({ id: forecastScenarios.id })
+      .from(forecastScenarios)
+      .where(eq(forecastScenarios.budgetId, budgetId));
+    expect(remaining).toEqual([]);
+    expect(await listForecastScenarios()).toEqual([]);
+  });
+});

--- a/tests/integration/forecast-scenarios.test.ts
+++ b/tests/integration/forecast-scenarios.test.ts
@@ -34,7 +34,9 @@ let scenarioId: number;
 // other integration suites seed in parallel (budget-extensions: 2090-2098,
 // invoice-sync: up to ~30,259). This suite must own the HIGHEST fiscal year
 // in the whole integration run — keep this range above every other suite's.
-const ACTIVE_FY = 999_000 + Math.floor(Math.random() * 999);
+// fiscal_year is unique, so the range is wide (900k values) to keep parallel
+// or retried runs from colliding on the constraint.
+const ACTIVE_FY = 999_000 + Math.floor(Math.random() * 900_000);
 
 const PARAMS_V1: ForecastInputs = {
   ceilingCents: 4_200_000,

--- a/tests/unit/actions/forecast-scenarios-auth.test.ts
+++ b/tests/unit/actions/forecast-scenarios-auth.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdmin, mockDb } = vi.hoisted(() => {
+  const mockDb = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    query: { forecastScenarios: { findFirst: vi.fn() } },
+  };
+  return { mockRequireAdmin: vi.fn(), mockDb };
+});
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/lib/auth-helpers", () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/actions/history", () => ({
+  recordCreation: vi.fn(),
+  recordUpdate: vi.fn(),
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+import {
+  createForecastScenario,
+  deleteForecastScenario,
+  listForecastScenarios,
+  updateForecastScenario,
+} from "@/actions/forecast-scenarios";
+
+/**
+ * Auth-gating contract for the saved-forecast-scenario actions (spec 041):
+ * with no admin session, the read degrades to [] (defense-in-depth — the
+ * /scenarios layout redirects first) and every mutation returns the
+ * ActionResult failure shape. The DB must never be touched.
+ */
+describe("forecast-scenario actions without an admin session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(null);
+  });
+
+  it("listForecastScenarios returns []", async () => {
+    expect(await listForecastScenarios()).toEqual([]);
+  });
+
+  it("createForecastScenario returns Unauthorized", async () => {
+    expect(await createForecastScenario({ name: "x", params: {} })).toEqual({
+      success: false,
+      error: "Unauthorized",
+    });
+  });
+
+  it("updateForecastScenario returns Unauthorized", async () => {
+    expect(await updateForecastScenario({ id: 1, name: "x" })).toEqual({
+      success: false,
+      error: "Unauthorized",
+    });
+  });
+
+  it("deleteForecastScenario returns Unauthorized", async () => {
+    expect(await deleteForecastScenario(1)).toEqual({
+      success: false,
+      error: "Unauthorized",
+    });
+  });
+
+  it("never touches the database", async () => {
+    await listForecastScenarios();
+    await createForecastScenario({ name: "x", params: {} });
+    await updateForecastScenario({ id: 1, name: "x" });
+    await deleteForecastScenario(1);
+    expect(mockDb.select).not.toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(mockDb.delete).not.toHaveBeenCalled();
+    expect(mockDb.query.forecastScenarios.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/scenarios/budget-forecast.test.ts
+++ b/tests/unit/scenarios/budget-forecast.test.ts
@@ -6,6 +6,7 @@ import {
   projectForecast,
   computeTrendBand,
   inputsFromPreset,
+  inputsFromSaved,
   defaultInputs,
   FORECAST_PRESETS,
   type ForecastDataset,
@@ -548,5 +549,136 @@ describe("inputsFromPreset / defaultInputs", () => {
     expect(yearly.perTool.claude).toEqual([0, 0, 0, 95680, 158080, 220480]);
     // 180000 + 17344 + 474240 + 102600
     expect(yearly.yearEndCents).toBe(774184);
+  });
+});
+
+describe("inputsFromSaved (spec 041)", () => {
+  const ds = makeDataset();
+
+  /** A representative saved parameter set: edited ceiling, tuned levers. */
+  const SAVED: ForecastInputs = {
+    ceilingCents: 260000,
+    tools: {
+      api: {
+        include: true,
+        model: "compound",
+        val: -25,
+        burnPct: 5,
+        burnCap: 800,
+      },
+      copilot: { include: false, model: "flat", val: 0 },
+      claude: {
+        include: true,
+        model: "linear",
+        val: 15,
+        premShare: 0.4,
+        billing: "yearly",
+      },
+    },
+  };
+
+  it("carries the saved ceiling, including the 0 boundary", () => {
+    expect(inputsFromSaved(ds, SAVED).ceilingCents).toBe(260000);
+    expect(
+      inputsFromSaved(ds, { ...SAVED, ceilingCents: 0 }).ceilingCents,
+    ).toBe(0);
+  });
+
+  it("copies params per tool, preserving every lever", () => {
+    const rebased = inputsFromSaved(ds, SAVED);
+    expect(rebased.tools.api).toEqual(SAVED.tools.api);
+    expect(rebased.tools.copilot).toEqual(SAVED.tools.copilot);
+    expect(rebased.tools.claude).toEqual(SAVED.tools.claude);
+  });
+
+  it("preserves the yearly billing cadence through the rebase", () => {
+    // This copy is what makes "load restores the cadence" true — the client
+    // derives the toggle from the claudeSeats tool's params.
+    expect(inputsFromSaved(ds, SAVED).tools.claude.billing).toBe("yearly");
+  });
+
+  it("drops tool keys that no longer exist in the dataset", () => {
+    const withGhost: ForecastInputs = {
+      ...SAVED,
+      tools: {
+        ...SAVED.tools,
+        ghost: { include: true, model: "linear", val: 99 },
+      },
+    };
+    const rebased = inputsFromSaved(ds, withGhost);
+    expect(rebased.tools.ghost).toBeUndefined();
+    expect(Object.keys(rebased.tools).sort()).toEqual([
+      "api",
+      "claude",
+      "copilot",
+    ]);
+  });
+
+  it("defaults tools the dataset gained since the save", () => {
+    const partial: ForecastInputs = {
+      ceilingCents: 260000,
+      tools: { api: SAVED.tools.api },
+    };
+    const rebased = inputsFromSaved(ds, partial);
+    // copilot/claude were absent from the save → DEFAULT_PARAMS.
+    expect(rebased.tools.copilot).toEqual({
+      include: true,
+      model: "flat",
+      val: 0,
+    });
+    expect(rebased.tools.claude).toEqual({
+      include: true,
+      model: "flat",
+      val: 0,
+    });
+  });
+
+  it("an empty saved tools record yields all-defaults with the saved ceiling", () => {
+    const rebased = inputsFromSaved(ds, { ceilingCents: 123400, tools: {} });
+    expect(rebased.ceilingCents).toBe(123400);
+    for (const tool of ds.tools) {
+      expect(rebased.tools[tool.key]).toEqual({
+        include: true,
+        model: "flat",
+        val: 0,
+      });
+    }
+  });
+
+  it("returns copies — mutating the result never mutates the saved params", () => {
+    const rebased = inputsFromSaved(ds, SAVED);
+    rebased.tools.api.val = 999;
+    rebased.tools.claude.billing = undefined;
+    expect(SAVED.tools.api.val).toBe(-25);
+    expect(SAVED.tools.claude.billing).toBe("yearly");
+  });
+
+  it("a billing value stranded on a non-claudeSeats key copies through but is cost-neutral", () => {
+    // e.g. the claude tool's key was reused by a seat-kind tool after a reseed:
+    // the engine ignores `billing` on seat/metered kinds (pinned above), so the
+    // stranded value must not change a single figure.
+    const stranded: ForecastInputs = {
+      ceilingCents: 500000,
+      tools: {
+        api: { include: true, model: "flat", val: 0, burnPct: 0 },
+        copilot: {
+          include: true,
+          model: "flat",
+          val: 0,
+          billing: "yearly",
+        },
+        claude: { include: true, model: "flat", val: 0, premShare: 0.25 },
+      },
+    };
+    const without = projectForecast(ds, {
+      ...stranded,
+      tools: {
+        ...stranded.tools,
+        copilot: { include: true, model: "flat", val: 0 },
+      },
+    });
+    const withStranded = projectForecast(ds, inputsFromSaved(ds, stranded));
+    expect(withStranded.perTool.copilot).toEqual(without.perTool.copilot);
+    expect(withStranded.yearEndCents).toBe(without.yearEndCents);
   });
 });

--- a/tests/unit/scenarios/forecast-scenario-validators.test.ts
+++ b/tests/unit/scenarios/forecast-scenario-validators.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  createForecastScenarioSchema,
+  deleteForecastScenarioSchema,
+  forecastInputsSchema,
+  toolParamsSchema,
+  updateForecastScenarioSchema,
+} from "@/lib/validators";
+import type { ForecastInputs } from "@/lib/scenarios/budget-forecast";
+
+/**
+ * Boundary schemas for the forecast_scenarios jsonb params column (spec 041).
+ * The same schema runs on write (canonical shape) and on read (rows that no
+ * longer conform are skipped), so the accept/reject matrix below is the load-
+ * bearing safety contract for the engine's math.
+ */
+
+/** A realistic tuned parameter set, as the client would submit it. */
+const VALID_INPUTS: ForecastInputs = {
+  ceilingCents: 4200000,
+  tools: {
+    api: {
+      include: true,
+      model: "compound",
+      val: -25,
+      burnPct: 0,
+      burnCap: 5500,
+    },
+    claude: {
+      include: true,
+      model: "linear",
+      val: 15,
+      premShare: 0.4,
+      billing: "yearly",
+    },
+    copilot: { include: false, model: "flat", val: 0 },
+  },
+};
+
+// Type-level round trip, enforced by `pnpm typecheck` (tests are included in
+// the tsconfig): the schema's inferred type and the engine's hand-written
+// ForecastInputs must stay mutually assignable.
+type SchemaOutput = z.infer<typeof forecastInputsSchema>;
+const _schemaToEngine: ForecastInputs = {} as SchemaOutput;
+const _engineToSchema: SchemaOutput = {} as ForecastInputs;
+void _schemaToEngine;
+void _engineToSchema;
+
+describe("forecastInputsSchema", () => {
+  it("accepts a realistic tuned parameter set and returns it intact", () => {
+    const parsed = forecastInputsSchema.safeParse(VALID_INPUTS);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data).toEqual(VALID_INPUTS);
+  });
+
+  it("accepts a ceiling of 0 (the UI guards the accidental-empty path)", () => {
+    expect(
+      forecastInputsSchema.safeParse({ ...VALID_INPUTS, ceilingCents: 0 })
+        .success,
+    ).toBe(true);
+  });
+
+  it("accepts an empty tools record (every tool defaults on load)", () => {
+    expect(
+      forecastInputsSchema.safeParse({ ceilingCents: 100, tools: {} }).success,
+    ).toBe(true);
+  });
+
+  it("rejects negative, fractional, and over-cap ceilings", () => {
+    for (const ceilingCents of [-1, 0.5, 100_000_000_001]) {
+      expect(
+        forecastInputsSchema.safeParse({ ...VALID_INPUTS, ceilingCents })
+          .success,
+      ).toBe(false);
+    }
+  });
+
+  it("rejects more than 20 tool entries", () => {
+    const tools: Record<string, unknown> = {};
+    for (let i = 0; i < 21; i++) {
+      tools[`tool${i}`] = { include: true, model: "flat", val: 0 };
+    }
+    expect(
+      forecastInputsSchema.safeParse({ ceilingCents: 100, tools }).success,
+    ).toBe(false);
+  });
+
+  it("strips unknown keys instead of rejecting (rows stay loadable across schema evolution)", () => {
+    const parsed = forecastInputsSchema.safeParse({
+      ...VALID_INPUTS,
+      futureField: "from a newer build",
+      tools: {
+        api: {
+          include: true,
+          model: "flat",
+          val: 0,
+          futureLever: 42,
+        },
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect("futureField" in parsed.data).toBe(false);
+      expect("futureLever" in parsed.data.tools.api).toBe(false);
+    }
+  });
+});
+
+describe("toolParamsSchema", () => {
+  const base = { include: true, model: "flat", val: 0 };
+
+  it("rejects non-finite val (NaN/Infinity can never reach Math.pow)", () => {
+    // Zod 4's z.number() rejects NaN and Infinity by default.
+    for (const val of [Number.NaN, Infinity, -Infinity]) {
+      expect(toolParamsSchema.safeParse({ ...base, val }).success).toBe(false);
+    }
+  });
+
+  it("rejects out-of-bounds levers", () => {
+    expect(toolParamsSchema.safeParse({ ...base, val: 100_001 }).success).toBe(
+      false,
+    );
+    expect(
+      toolParamsSchema.safeParse({ ...base, premShare: 1.01 }).success,
+    ).toBe(false);
+    expect(toolParamsSchema.safeParse({ ...base, burnPct: -101 }).success).toBe(
+      false,
+    );
+    expect(toolParamsSchema.safeParse({ ...base, burnCap: -1 }).success).toBe(
+      false,
+    );
+    expect(toolParamsSchema.safeParse({ ...base, burnCap: 0.5 }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects unknown growth models and billing values", () => {
+    expect(
+      toolParamsSchema.safeParse({ ...base, model: "exponential" }).success,
+    ).toBe(false);
+    expect(
+      toolParamsSchema.safeParse({ ...base, billing: "weekly" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("create/update/delete scenario schemas", () => {
+  it("create requires a non-empty trimmed name of at most 60 chars", () => {
+    expect(
+      createForecastScenarioSchema.safeParse({
+        name: "  Plan B  ",
+        params: VALID_INPUTS,
+      }),
+    ).toMatchObject({ success: true, data: { name: "Plan B" } });
+    expect(
+      createForecastScenarioSchema.safeParse({
+        name: "   ",
+        params: VALID_INPUTS,
+      }).success,
+    ).toBe(false);
+    expect(
+      createForecastScenarioSchema.safeParse({
+        name: "x".repeat(61),
+        params: VALID_INPUTS,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("update accepts an omitted params (rename-only)", () => {
+    const parsed = updateForecastScenarioSchema.safeParse({
+      id: 7,
+      name: "Renamed",
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.params).toBeUndefined();
+  });
+
+  it("update and delete require a positive integer id", () => {
+    expect(
+      updateForecastScenarioSchema.safeParse({ id: 0, name: "x" }).success,
+    ).toBe(false);
+    expect(deleteForecastScenarioSchema.safeParse({ id: -1 }).success).toBe(
+      false,
+    );
+    expect(deleteForecastScenarioSchema.safeParse({ id: 3.5 }).success).toBe(
+      false,
+    );
+  });
+});

--- a/tests/unit/scenarios/forecast-scenario-validators.test.ts
+++ b/tests/unit/scenarios/forecast-scenario-validators.test.ts
@@ -47,6 +47,24 @@ const _engineToSchema: SchemaOutput = {} as ForecastInputs;
 void _schemaToEngine;
 void _engineToSchema;
 
+// Assignability alone cannot catch a forgotten OPTIONAL lever (an object
+// missing `billing?` is still assignable both ways — exactly how a new lever
+// would silently strip on save). Key-set equality does: if ToolParams gains a
+// field the schema doesn't know, this constant stops typechecking.
+type KeysMatch<A, B> = [
+  Exclude<keyof A, keyof B> | Exclude<keyof B, keyof A>,
+] extends [never]
+  ? true
+  : false;
+type SchemaToolParams = z.infer<typeof toolParamsSchema>;
+const _toolParamKeysMatch: KeysMatch<
+  SchemaToolParams,
+  ForecastInputs["tools"][string]
+> = true;
+const _inputKeysMatch: KeysMatch<SchemaOutput, ForecastInputs> = true;
+void _toolParamKeysMatch;
+void _inputKeysMatch;
+
 describe("forecastInputsSchema", () => {
   it("accepts a realistic tuned parameter set and returns it intact", () => {
     const parsed = forecastInputsSchema.safeParse(VALID_INPUTS);


### PR DESCRIPTION
## Summary

Ships the follow-up spec 036 explicitly deferred: **persistence for the Budget / Cost Forecast Simulation**. An admin who has tuned a plan (levers, edited ceiling, Claude billing cadence) can save it under a name, reload it later from any session, rename it, update it after refinement, and delete it — shared across all admins, scoped to the active fiscal-year budget. Spec folder: `specs/041-forecast-scenario-persistence/` (implementation plan — challenged by a 5-lens adversarial review before any code — plus running implementation notes covering design decisions, tradeoffs, and open questions).

### Data model (migration 0026)
One new table, `forecast_scenarios`: `budget_id` FK (cascade), `name` unique per budget **case-insensitively** via the repo's first `lower(name)` expression index, `params` jsonb holding the full `ForecastInputs`, `created_by` attribution (set null), timestamps, FK indexes. Purely additive; reviewed by the drizzle-migration-reviewer agent (its one finding — a missing `created_by` index — was fixed before the migration was committed).

### Server actions (`src/actions/forecast-scenarios.ts`)
| Action | Behaviour |
| --- | --- |
| `listForecastScenarios` | Active-budget scenarios ordered by name, creator joined; **every row's params re-validated on read** (non-conforming jsonb is skipped, never crashes the page) |
| `createForecastScenario` | Zod-validated; 50-per-budget cap; duplicate names rejected by the unique index with the 23505 mapped to a friendly `ActionResult` error (race-free single mechanism) |
| `updateForecastScenario` | Overwrite params and/or rename — `params` optional so **rename never silently rewrites assumptions**; full params snapshots in `change_history` (overwrites are recoverable) |
| `deleteForecastScenario` | `delete().returning()` + `recordDeletion()` snapshot (new shared helper in `actions/history.ts`) |

The active budget resolves deterministically (highest fiscal year wins) via a new shared `getActiveBudgetId()` in `lib/budget-utils.ts`; `getActiveBudget()` now orders by the same rule so the chart and the scenario list can never resolve different budgets.

### Engine + UI
- Pure `inputsFromSaved(ds, saved)` re-bases any saved parameter set onto the current dataset (extinct tool keys dropped, new tools defaulted) — used for loading **and** for re-basing surviving client state when the dataset prop refreshes mid-session.
- Persistent **Saved scenarios** card (mono empty state) between the preset tiles and Assumptions: rows show the **recomputed** year-end and Δ labelled "vs saved $X" (a saved row scores against its own saved ceiling), creator + updated caption, pencil rename, labelled delete with AlertDialog confirm.
- Save dialog (single primary button; Update-vs-new resolved by a segmented mode toggle) echoes exactly what will be saved — ceiling, cadence, included tools — and blocks an empty ceiling field.
- Loading restores the full assumption set including ceiling + cadence; `saved:*` activates the "Your plan" comparison row; preset-tile clicks clear the Update offer (no one-click overwrite of a shared row); `StatusText` feedback throughout (no Sonner).

### Process
Plan → 5-lens adversarial challenge (1 must-fix, 10 adopted should-fixes) → implement → 4-lens simplify pass. The simplify pass **exposed a real latent bug**: drizzle wraps driver errors, so the 23505 code lives on `error.cause` — the pre-check it removed had been masking a detector that never fired. Fixed and now covered by the integration test.

## Verification
- **Unit**: 648/648 — `inputsFromSaved` merge matrix incl. yearly-billing round trip; validator accept/reject/strip matrix + type-level round trip and key-set equality (catches a forgotten optional lever at `pnpm typecheck`); auth gating (list → `[]`, mutations → Unauthorized, DB untouched).
- **Integration** (real Neon dev DB): 11/11 — CRUD round trip with `change_history` assertions (create / rename+params snapshots / delete snapshot round-trip); case-insensitive duplicate rejected via the action **and** via direct insert (the expression index itself proven); malformed-jsonb row skipped by the read path; 50-cap via bulk seed. Suite seeds FY ≥ 999,000 so the deterministic resolution contract isolates it from every other suite's active budgets.
- **Browser** (Playwright, dev server + minted agent session, live data): 27/27 — save/load/rename/delete flows, ceiling + cadence restore exactly, Update-offer lifecycle across edits and preset clicks, duplicate inline error (re-verified through the 23505 catch path after the simplify pass), delete confirm naming scenario + creator, empty state. Full-page screenshots reviewed.
- **Lint** zero warnings · **typecheck** clean · migration applied to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)