### PR TITLE
feat(042): approvable tier changes on active licence assignments

### DIFF
--- a/specs/042-assignment-tier-change/implementation-notes.html
+++ b/specs/042-assignment-tier-change/implementation-notes.html
@@ -1251,6 +1251,89 @@
           <code>.env.local</code>.
         </li>
       </ul>
+      <h2 id="review">Review pass — PR #125</h2>
+      <p class="meta">
+        Sole reviewer: the GitHub Copilot review bot. Three inline comments, all
+        three correct, all three adopted. Fixed in <code>f4bb80b</code>.
+      </p>
+
+      <div class="callout">
+        <strong>One was a real defect this spec introduced.</strong>
+        <code>change_tier</code> never checked that the target assignment belongs
+        to the <em>selected</em> tool. <code>loadToolAndTier</code> proves the
+        tier belongs to <code>approval.toolId</code>, but nothing tied the
+        <em>assignment</em> to it — so a stale dialog or a crafted payload could
+        write another tool&rsquo;s tier onto a seat. Worse, it would
+        <strong>slip past the sync-managed refusal</strong>, because that check
+        also keys off the selected tool rather than the row&rsquo;s own: pass a
+        Copilot <code>assignmentId</code> with a non-Copilot
+        <code>toolId</code> and the gate never fires. Copilot identified both
+        consequences.
+        <br /><br />
+        Notable that the challenge pass missed this. It scrutinised the
+        <em>mode</em> matrix and the sync gate in isolation, but not the
+        interaction between them — the gate&rsquo;s input and the mutation&rsquo;s
+        target being allowed to disagree. <code>updateAssignment</code> never had
+        the hole because its tier lookup is scoped by
+        <code>assignment.toolId</code> in a single query; splitting validation
+        across two loads is what opened it.
+      </div>
+
+      <table>
+        <thead><tr><th>Finding</th><th>Verdict</th><th>Fix</th></tr></thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>license-requests.ts</code> — <code>change_tier</code> does
+              not verify <code>target.toolId === approval.toolId</code>
+            </td>
+            <td class="s">real defect</td>
+            <td>
+              Explicit guard before <code>buildTierChange</code>, mirroring the
+              same-tool rule <code>updateAssignment</code> enforces through its
+              <code>accessTiers</code> query. Unit regression test asserts both
+              the refusal <em>and</em> that nothing is written.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>history.ts</code> —
+              <code>with: { changedByUser: true }</code> selects the whole users
+              row, <code>password_hash</code> included, to render one name
+            </td>
+            <td class="s">correct</td>
+            <td>
+              Restricted to <code>{ name: true }</code>. Worth being accurate
+              about severity: the mapped result never exposed it to the client, so
+              this is hygiene, not a leak.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>assignments.ts</code> — the race-guard comment claims the
+              <code>tierId</code> predicate is an optimistic lock against the
+              tier price cascade
+            </td>
+            <td class="s">correct — my comment was wrong</td>
+            <td>
+              It is not: <code>updateTier</code> and
+              <code>syncBillingData</code> rewrite
+              <code>cost_at_assignment_cents</code> while leaving
+              <code>tier_id</code> alone, so the predicate cannot see them. The
+              comment now states what the guard really covers (status flips,
+              concurrent retiers), names the price-cascade race it does
+              <em>not</em>, and points at the compare-and-swap the plan scoped
+              out.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="meta">
+        Post-fix gates: <code>pnpm typecheck</code> clean · <code>pnpm test</code>
+        660 passed (from 659) · integration 8 files / 56 passed · eslint clean on
+        changed files.
+      </p>
     </main>
   </body>
 </html>

--- a/specs/042-assignment-tier-change/implementation-notes.html
+++ b/specs/042-assignment-tier-change/implementation-notes.html
@@ -527,17 +527,42 @@
       </table>
 
       <div class="card accent">
-        <h4>Live bug the panel surfaced, beyond the plan&rsquo;s scope</h4>
+        <h4>
+          Correction — the &ldquo;leaked Hub user&rdquo; was not real
+        </h4>
         <p>
-          Because a returned error commits, and
-          <code>ensureRequesterUser</code> runs <em>before</em>
-          <code>createAssignmentInTx</code>, <strong>today&rsquo;s
-          &ldquo;Requester already has an active assignment&rdquo; refusal leaks a
-          Hub user</strong> whenever the requester was not yet in the Hub — a
-          viewer account created and abandoned while the request stays
-          <code>pending_review</code>. That is the exact error path this spec was
-          opened to fix, so the leak is squarely in the blast radius. Fixed by the
-          throw-not-return revision; regression-tested.
+          Working from the panel&rsquo;s finding that a returned error commits, and
+          that <code>ensureRequesterUser</code> runs <em>before</em>
+          <code>createAssignmentInTx</code>, both the panel and plan v2 concluded
+          that the &ldquo;Requester already has an active assignment&rdquo;
+          refusal had been <strong>leaking an abandoned viewer account</strong> —
+          and that it was doing so on the exact error path this spec was opened to
+          fix. It was reported to the user in those terms.
+        </p>
+        <p>
+          <strong>That was wrong.</strong> Traced properly during implementation:
+          <code>ensureRequesterUser</code>
+          (<code>license-requests.ts:283-295</code>) inserts a user only when no
+          row with that e-mail exists — it early-returns on
+          <code>requesterUserId</code>, then on an e-mail match. A user who has
+          just been inserted cannot already hold an active assignment, because
+          assignments reference users. So the duplicate-seat refusal and a user
+          insert are <strong>mutually exclusive</strong>, and since that refusal
+          was the only in-transaction error return in the original code, nothing
+          was ever orphaned.
+        </p>
+        <p>
+          The throw-not-return revision is kept, and is still required — but as
+          <em>hardening</em>, not a bug fix. This spec adds in-transaction
+          rejections that <em>can</em> follow a real write (a retier that then
+          loses the request-status race), and for those a returned error would
+          commit a partial change. Corrected in plan §5 and reported to the user.
+        </p>
+        <p class="meta">
+          Worth recording as a process note: a confident, well-cited finding from
+          an adversarial reviewer still needs its <em>reachability</em> checked,
+          not just its mechanism. The mechanism here was real; the path to it was
+          not.
         </p>
       </div>
 
@@ -685,7 +710,154 @@
       </p>
 
       <h2 id="implementation">Implementation log</h2>
-      <p class="meta">In progress.</p>
+
+      <p class="meta">
+        Core logic written directly; UI wiring and the mocked-action tests
+        delegated to three parallel Sonnet agents on non-overlapping file sets.
+      </p>
+
+      <h4>What landed</h4>
+      <table>
+        <thead>
+          <tr><th>Area</th><th>Change</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>lib/assignments/tier-change.ts</code> <span class="pill new">new</span></td>
+            <td>
+              Pure tier-change semantics: <code>buildTierChange</code>,
+              <code>tierCostDeltaCents</code>, <code>SYNC_MANAGED_TIER_ERROR</code>.
+              No db, no <code>"use server"</code> — which is also what forced it out
+              of <code>actions/assignments.ts</code>: a
+              <code>"use server"</code> module may only export async functions, so
+              pure helpers cannot live there.
+            </td>
+          </tr>
+          <tr>
+            <td><code>lib/assignments/sync-authority.ts</code> <span class="pill new">new</span></td>
+            <td>
+              <code>isSyncManagedTool</code> / <code>getSyncManagedToolId</code> —
+              the tool-based gate. Returns false when no active connection has
+              <code>copilot_sync_enabled</code>, since nothing would overwrite a
+              manual change then.
+            </td>
+          </tr>
+          <tr>
+            <td><code>lib/assignments/revalidate.ts</code> <span class="pill new">new</span></td>
+            <td>Shared cost-surface revalidation, applied to every field of <code>updateAssignment</code>, not only the tier.</td>
+          </tr>
+          <tr>
+            <td><code>lib/budget-utils.ts</code></td>
+            <td>
+              <code>overlapsPeriod</code> + <code>sumExpectedSpendCents</code>
+              extracted from <code>getBudgetWithCosts</code> so the double-count
+              property is unit-testable in CI.
+            </td>
+          </tr>
+          <tr>
+            <td><code>actions/license-requests.ts</code></td>
+            <td>
+              Three approval modes; <code>ApprovalError</code> throw discipline;
+              <code>loadToolAndTier</code> gains <code>isActive</code> and a
+              <code>requireApiKey</code> parameter;
+              <code>loadTargetAssignmentInTx</code> resolves the user
+              <em>from the assignment</em> so no mode can create one;
+              <code>ActiveAssignmentSummary</code> gains
+              <code>toolId</code>/<code>tierId</code>/<code>tierCostCents</code>/<code>syncManaged</code>
+              and now matches by e-mail as well as id.
+            </td>
+          </tr>
+          <tr>
+            <td><code>actions/budget.ts</code></td>
+            <td>Dead <code>getExpectedSpendForPeriod</code> deleted; per-period sum delegated to the shared helper.</td>
+          </tr>
+          <tr>
+            <td><code>actions/history.ts</code></td>
+            <td><code>getAssignmentTierHistory</code> — resolves the log's tier IDs to names and joins the actor.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Deviation — the legacy path needed its own action</h4>
+      <div class="card accent">
+        <p>
+          Plan v2 said the legacy <code>recordAssignment</code> dead end would be
+          unstuck by <code>approveRequest</code>&rsquo;s new
+          <code>link_existing</code> mode. <strong>It cannot be.</strong> The
+          delegated agent found this and stopped rather than wiring a call that
+          would always fail — correctly.
+        </p>
+        <p>
+          <code>RecordAssignmentDialog</code> only opens for
+          <code>status === "approved"</code> rows
+          (<code>isLegacyApproved</code>), while <code>approveRequest</code>
+          rejects anything not <code>pending_review</code>. The two guards are
+          mutually exclusive, so every such call would have returned
+          <em>Cannot approve a request in status &ldquo;approved&rdquo;</em>.
+        </p>
+        <p>
+          Resolved with a dedicated <code>linkExistingAssignment</code> action
+          guarded on <code>status='approved' AND assignment_id IS NULL</code>,
+          reusing <code>loadTargetAssignmentInTx</code> for the ownership and
+          active checks and mutating nothing on the seat. The plan&rsquo;s §7 row
+          and D-C were corrected to match.
+        </p>
+      </div>
+
+      <h4>Deviation — user-detail gating is source-based</h4>
+      <p>
+        The &ldquo;Change tier&rdquo; affordance on the user detail page hides
+        itself on <code>source === 'copilot-sync'</code> rather than via the
+        tool-based <code>isSyncManagedTool</code>, because the server component
+        feeding that card was outside the delegated agent&rsquo;s file scope.
+        Cosmetic only: the mutation stays protected server-side by the tool-based
+        check, and the link lands on a page whose tier control is correctly
+        disabled. Worth tidying if that page is touched again.
+      </p>
+
+      <h4>Verification</h4>
+      <ul>
+        <li class="note"><code>pnpm typecheck</code> — clean.</li>
+        <li class="note">
+          <code>pnpm test</code> — <strong>658 passed, 53 files</strong> (baseline
+          629; +29 from this spec's two new suites). No pre-existing test needed
+          weakening.
+        </li>
+        <li class="note">eslint — clean on every changed file.</li>
+        <li class="note">
+          <code>tests/integration/actions/license-requests.test.ts</code>: its six
+          existing <code>approveRequest</code> calls had to gain
+          <code>mode: "create"</code> — the discriminated union makes the
+          discriminator mandatory, and because the action takes
+          <code>input: unknown</code> <strong>typecheck would not have caught
+          this</strong>; the calls would simply have failed validation at
+          runtime. Four 042 cases added (retier round trip, link round trip,
+          create still refused, retier onto another user&rsquo;s seat refused).
+        </li>
+        <li class="note">
+          Integration suite not executed — this worktree has no
+          <code>.env.local</code>, so there is no database to run it against. It
+          is also not run by CI. <strong>Outstanding.</strong>
+        </li>
+        <li class="note">Playwright browser pass — <strong>outstanding</strong>, same reason.</li>
+      </ul>
+
+      <h2 id="open">Open before merge</h2>
+      <ul>
+        <li class="con">
+          <strong>Confirm the costing decision (D-A).</strong> The upgrade month
+          bills entirely at the new tier, and closed periods restate. Both
+          questions put to the user went unanswered; this is a real accounting
+          choice, not an obvious default.
+        </li>
+        <li class="con">
+          <strong>Run the integration suite and the browser pass</strong> against
+          a database branch.
+        </li>
+        <li class="con">
+          <code>/simplify</code> pass, then PR with the Copilot reviewer.
+        </li>
+      </ul>
     </main>
   </body>
 </html>

--- a/specs/042-assignment-tier-change/implementation-notes.html
+++ b/specs/042-assignment-tier-change/implementation-notes.html
@@ -286,7 +286,7 @@
         <div class="row" style="margin-bottom: 16px">
           <span class="badge">Implementation notes</span>
           <span class="badge">spec/042-assignment-tier-change</span>
-          <span class="badge accent">Verified (unit + integration) — UI pass outstanding</span>
+          <span class="badge accent">Verified — unit, integration &amp; browser</span>
         </div>
         <h1>Assignment Tier Change — running log</h1>
         <p class="lede">
@@ -1113,25 +1113,139 @@
         Node version.
       </p>
 
+      <h2 id="verification-2">Verification round 2 — the real database</h2>
+      <div class="callout accent">
+        <strong>Supersedes the round-1 section above.</strong> The user created a
+        branch of the real database and swapped it into the worktree, so
+        everything below ran against production-shaped data:
+        <strong>223 users, 5 tools, 309 active assignments, 27 licence requests,
+        5 budgets, 1933 change-history rows</strong>, with
+        <code>0029_curly_strong_guy</code> applied. The synthetic
+        <code>workable</code> branch is no longer relevant except as history.
+      </div>
+
+      <table>
+        <thead><tr><th>Gate</th><th>Result</th></tr></thead>
+        <tbody>
+          <tr><td><code>pnpm typecheck</code></td><td class="s">clean</td></tr>
+          <tr><td><code>pnpm test</code></td><td class="s">659 passed, 53 files</td></tr>
+          <tr><td>eslint on changed files</td><td class="s">clean</td></tr>
+          <tr>
+            <td><code>pnpm test:integration</code> (full directory, real data)</td>
+            <td class="s">
+              8 files passed, 2 skipped · 56 passed, 7 todo — and stable rather
+              than flaky (216&thinsp;ms warm connect vs ~7&thinsp;s on the free-tier
+              branch), so no WebSocket shim was needed.
+            </td>
+          </tr>
+          <tr>
+            <td>Playwright browser pass</td>
+            <td class="s">
+              <strong>9/9 checks</strong> on the final run (13/13 on the earlier
+              one) against a real Claude seat and a real sync-managed Copilot
+              seat.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>What the browser pass actually exercised</h4>
+      <ul>
+        <li class="note">
+          A real manual Claude seat moved <strong>Standard Seat &rarr; Premium
+          Seat &rarr; Standard Seat</strong> — both directions, ending back on its
+          original tier.
+        </li>
+        <li class="note">
+          Header and cost followed the change (<code>$25.00</code> &harr;
+          <code>$125.00</code>); feedback arrived as inline
+          <code>[SAVED]</code>, not a toast.
+        </li>
+        <li class="note">
+          The <strong>tier timeline</strong> rendered both hops from
+          <code>change_history</code>, attributed and dated.
+        </li>
+        <li class="note">
+          Database end state confirmed directly: <strong>exactly one active
+          row</strong> for that user+tool (in place, no supersede, no duplicate),
+          with <code>tierId</code> 5&rarr;6 and
+          <code>costAtAssignmentCents</code> 2500&rarr;12500 written under a
+          single timestamp — the transaction of decision D-F.
+        </li>
+        <li class="note">
+          A real <code>copilot-sync</code> seat showed &ldquo;Managed by
+          sync&rdquo;, its tier control disabled but still legible, and no
+          re-pricing disclosure.
+        </li>
+      </ul>
+
+      <div class="callout">
+        <strong>The browser pass earned its place — it found two UI bugs nothing
+        else could.</strong> Typecheck, 659 unit tests and 56 integration tests
+        were all green while both of these were live.
+        <ol>
+          <li>
+            <strong>The sync-managed badge crashed the whole assignment detail
+            page</strong> (<em>&ldquo;<code>Tooltip</code> must be used within
+            <code>TooltipProvider</code>&rdquo;</em>). The assignments table only
+            works because <code>DataTable</code> happens to wrap its rows in a
+            provider; the detail page has none. So the page rendered nothing but
+            a heading for <em>every sync-managed seat</em> — exactly the case the
+            badge exists to mark. <code>SyncManagedBadge</code> now owns its own
+            provider.
+          </li>
+          <li>
+            <strong>The tier control rendered empty on every assignment.</strong>
+            Radix resolves a <code>Select</code>&rsquo;s displayed value by
+            looking up the selected <em>item&rsquo;s</em> children, and the items
+            arrive asynchronously from <code>loadTiers</code> — so the control
+            painted blank until the list happened to be ready, and stayed blank
+            whenever disabled. A placeholder does not help: it only shows for an
+            empty value, and here it is a real tier id. Pre-existing, but it is
+            this feature&rsquo;s primary control.
+          </li>
+        </ol>
+        Worth remembering next time the plan is tempted to treat a browser pass
+        as optional: <em>both</em> defects were in rendering, and no amount of
+        server-side testing would have surfaced either.
+      </div>
+
+      <p class="meta">
+        Note on reproducibility: the round-1 flakiness
+        (<code>@neondatabase/serverless</code> falling back to Node&rsquo;s undici
+        WebSocket) did not recur here — the EU endpoint connects in ~200&thinsp;ms
+        where the free-tier US branch took ~7&thinsp;s and brushed the 10&thinsp;s
+        <code>connectionTimeoutMillis</code>. The proposed <code>ws</code>
+        devDependency was declined and is not in the tree; if the slow-endpoint
+        case recurs, that is the fix.
+      </p>
+
       <h2 id="open-final">Open before merge</h2>
       <ul>
         <li class="con">
           <strong>Confirm the costing decision (D-A)</strong> — the upgrade month
-          bills entirely at the new tier and closed periods restate. Explained to
-          the user; still unconfirmed. The audit-log gaps that would let a future
-          effective-dated table be backfilled (copilot-sync writes no per-assignment
-          history; the price cascade logs against the tier) were raised and
-          <strong>explicitly declined</strong> by the user.
-        </li>
-        <li class="con"><strong>Browser pass for the UI</strong>, per the gap above.</li>
-        <li class="con">
-          Verification used a synthetic catalogue, not production data — the
-          Copilot sync-managed paths (63 live seats) were never exercised against
-          real synced rows.
+          bills entirely at the new tier and closed periods restate. Explained in
+          full to the user; still formally unconfirmed. Audit-log gaps that would
+          let a future effective-dated table be backfilled (copilot-sync writes no
+          per-assignment history; the price cascade logs against the tier) were
+          raised and <strong>explicitly declined</strong>.
         </li>
         <li class="note">
-          Neon branch <code>wt/upgrade</code> still exists in project
-          <code>blue-poetry-08641598</code>; delete when done.
+          The approval dialog&rsquo;s three modes were verified server-side
+          (integration) but not clicked through in a browser — the queue page
+          renders, and driving a specific pending request to approval was not
+          scripted.
+        </li>
+        <li class="note">
+          Test data written to the branch: RUN_TAG users/requests are cleaned up
+          by the suites; assignment #12 was returned to its original Standard
+          Seat, though its two tier-change audit rows remain.
+        </li>
+        <li class="note">
+          Disposable Neon branches to delete when done: <code>wt/upgrade</code> in
+          <code>blue-poetry-08641598</code> (the synthetic one), plus whichever
+          branch of the real project is wired into the worktree
+          <code>.env.local</code>.
         </li>
       </ul>
     </main>

--- a/specs/042-assignment-tier-change/implementation-notes.html
+++ b/specs/042-assignment-tier-change/implementation-notes.html
@@ -1,0 +1,691 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Implementation Notes — Assignment Tier Change (042)</title>
+    <style>
+      :root {
+        --bg: #0b0d12;
+        --bg-elev: #11141b;
+        --bg-card: #161a24;
+        --border: #232938;
+        --border-strong: #2f3850;
+        --fg: #e7ebf3;
+        --fg-muted: #9aa3b5;
+        --fg-dim: #6b7488;
+        --accent: #f0a072;
+        --accent-2: #7dd3fc;
+        --good: #86efac;
+        --warn: #fcd34d;
+        --bad: #fca5a5;
+        --mono:
+          ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+        --sans:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--sans);
+        line-height: 1.55;
+      }
+      body {
+        padding: 48px 24px 96px;
+      }
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+      h1,
+      h2,
+      h3,
+      h4 {
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      h1 {
+        font-size: 32px;
+        margin: 0 0 8px;
+      }
+      h2 {
+        font-size: 22px;
+        margin: 52px 0 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border);
+      }
+      h3 {
+        font-size: 17px;
+        margin: 0 0 6px;
+      }
+      h4 {
+        font-size: 13px;
+        margin: 16px 0 6px;
+        color: var(--fg-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      p {
+        margin: 0 0 12px;
+      }
+      a {
+        color: var(--accent);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.88em;
+        background: var(--bg-elev);
+        padding: 1px 5px;
+        border-radius: 4px;
+        border: 1px solid var(--border);
+      }
+      pre {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 14px 16px;
+        overflow-x: auto;
+        line-height: 1.5;
+      }
+      pre code {
+        background: transparent;
+        border: 0;
+        padding: 0;
+        font-size: inherit;
+      }
+      .lede {
+        color: var(--fg-muted);
+        font-size: 16px;
+        max-width: 820px;
+      }
+      .meta {
+        color: var(--fg-dim);
+        font-size: 13px;
+        margin-top: 8px;
+        font-family: var(--mono);
+      }
+      .badge {
+        display: inline-block;
+        font-size: 11px;
+        font-family: var(--mono);
+        padding: 2px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--border-strong);
+        color: var(--fg-muted);
+        background: var(--bg-elev);
+      }
+      .badge.accent {
+        color: var(--accent);
+        border-color: rgba(240, 160, 114, 0.35);
+      }
+      .card {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 24px;
+        margin: 16px 0;
+      }
+      .card.accent {
+        border-left: 3px solid var(--accent);
+      }
+      .card.accent-2 {
+        border-left: 3px solid var(--accent-2);
+      }
+      .grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+      @media (max-width: 760px) {
+        .grid-2 {
+          grid-template-columns: 1fr;
+        }
+      }
+      .row {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      ul {
+        padding-left: 20px;
+        margin: 8px 0 12px;
+      }
+      li {
+        margin: 4px 0;
+      }
+      li.pro::marker {
+        content: "+ ";
+        color: var(--good);
+        font-weight: 700;
+      }
+      li.con::marker {
+        content: "− ";
+        color: var(--bad);
+        font-weight: 700;
+      }
+      li.note::marker {
+        content: "› ";
+        color: var(--fg-dim);
+      }
+      li.check::marker {
+        content: "\2610  ";
+        color: var(--fg-muted);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+        margin: 12px 0;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--border);
+        vertical-align: top;
+      }
+      th {
+        color: var(--fg-muted);
+        font-weight: 500;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: var(--bg-elev);
+      }
+      td code {
+        white-space: nowrap;
+      }
+      .pill {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 6px;
+        font-size: 11.5px;
+        font-family: var(--mono);
+      }
+      .pill.warn {
+        background: rgba(252, 211, 77, 0.12);
+        color: var(--warn);
+      }
+      .pill.new {
+        background: rgba(240, 160, 114, 0.14);
+        color: var(--accent);
+      }
+      .pill.neutral {
+        background: var(--bg-elev);
+        color: var(--fg-muted);
+        border: 1px solid var(--border);
+      }
+      .callout {
+        border: 1px solid var(--border-strong);
+        border-left: 3px solid var(--warn);
+        background: rgba(252, 211, 77, 0.04);
+        padding: 14px 16px;
+        border-radius: 8px;
+        margin: 16px 0;
+        font-size: 14px;
+      }
+      .callout.info {
+        border-left-color: var(--accent-2);
+        background: rgba(125, 211, 252, 0.04);
+      }
+      .callout.accent {
+        border-left-color: var(--accent);
+        background: rgba(240, 160, 114, 0.05);
+      }
+      .toc {
+        columns: 2;
+        column-gap: 32px;
+        font-size: 14px;
+      }
+      @media (max-width: 760px) {
+        .toc {
+          columns: 1;
+        }
+      }
+      .toc a {
+        display: block;
+        padding: 3px 0;
+        color: var(--fg-muted);
+        text-decoration: none;
+      }
+      .toc a:hover {
+        color: var(--accent);
+      }
+      footer {
+        color: var(--fg-dim);
+        font-size: 12.5px;
+        margin-top: 64px;
+        padding-top: 24px;
+        border-top: 1px solid var(--border);
+        font-family: var(--mono);
+      }
+      .s {
+        color: var(--good);
+      }
+      .c {
+        color: var(--fg-dim);
+        font-style: italic;
+      }
+      .k {
+        color: var(--accent-2);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="row" style="margin-bottom: 16px">
+          <span class="badge">Implementation notes</span>
+          <span class="badge">spec/042-assignment-tier-change</span>
+          <span class="badge accent">In progress</span>
+        </div>
+        <h1>Assignment Tier Change — running log</h1>
+        <p class="lede">
+          Design decisions, deviations, tradeoffs, open questions, and the
+          challenge / simplify / review / verification passes for spec 042.
+          Appended as work proceeds. Companion to
+          <a href="implementation-plan.html">implementation-plan.html</a>.
+        </p>
+        <p class="meta">
+          Started 2026-08-03 · branch <code>042-assignment-tier-change</code> ·
+          author: T. Studer
+        </p>
+      </header>
+
+      <h2 id="trigger">The trigger</h2>
+      <p>
+        A tier-upgrade request arrived for a licence someone already held, and the
+        Hub had no way to action it. Reconnaissance established that this is not
+        one missing feature but <strong>three unreconciled implementations</strong>
+        of the same operation — see plan §2.
+      </p>
+
+      <div class="card accent">
+        <h4>The hard block</h4>
+        <p>
+          <code>createAssignmentInTx</code>
+          (<code>src/actions/license-requests.ts:266-278</code>) refuses approval
+          whenever the requester already holds an active assignment for the tool,
+          and recommends revoke-then-recreate — which routes the admin into the
+          <em>worst</em> of the three existing paths (orphaned comments, reset
+          <code>assigned_at</code>, dropped API key, double-billed switch month).
+        </p>
+      </div>
+
+      <h2 id="recon">Reconnaissance method</h2>
+      <p>
+        A dynamic workflow ran <strong>7 parallel read-only explorers</strong>
+        (assignment mutation layer · cost-snapshot semantics · licence-request
+        workflow · UI surfaces · audit/history · tests &amp; doc process · MCP and
+        API read surfaces) followed by a <strong>gap critic</strong> that was
+        allowed to read files itself to resolve contradictions between the
+        reports. 8 agents, ~873k subagent tokens, ~13 min wall clock.
+      </p>
+
+      <h4>What the critic caught that no individual explorer did</h4>
+      <table>
+        <thead>
+          <tr>
+            <th>Correction</th>
+            <th>Consequence</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <strong>Deactivate+insert double-counts the switch month.</strong>
+              Three of the seven explorers recommended that pattern for
+              &ldquo;historically accurate per-period costs&rdquo;. Both
+              non-status-filtered per-period readers count the old
+              <em>and</em> the new row for the period containing the switch.
+            </td>
+            <td>
+              Inverted the central design decision. Became plan §3 / D-A.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>The detail page does NOT gate copilot-sync rows.</strong>
+              One explorer asserted both tier-edit surfaces gate on
+              <code>source</code>; the file contains zero references to it.
+            </td>
+            <td>
+              Live bug, folded into scope as D-B. Verified independently before
+              accepting.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Migration journal ends at 0029</strong>, not 0026 as
+              CLAUDE.md&rsquo;s &ldquo;Recent changes&rdquo; note implies.
+            </td>
+            <td>This migration is 0030. Verified independently.</td>
+          </tr>
+          <tr>
+            <td>
+              <strong><code>getExpectedSpendForPeriod</code> filters
+              <code>status='active'</code></strong>; the other two per-period
+              readers do not. Several explorers had grouped all three as
+              equivalent.
+            </td>
+            <td>
+              Pre-existing divergence, explicitly scoped out as deferral D-2 with
+              a stated authoritative figure for tests.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Live tier taxonomy resolved via MCP</strong> against
+              production — every tool keeps its tiers under one
+              <code>ai_tools</code> row, so every real upgrade is a same-tool
+              <code>tier_id</code> change.
+            </td>
+            <td>
+              No cross-tool reassignment semantics needed; the existing same-tool
+              guard suffices.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Copilot is at 63/63 seats</strong> and Claude Console&rsquo;s
+              price order is non-monotonic
+              (<code>indie-profile</code> &euro;125 sits between
+              <code>boost-expert</code> &euro;100 and
+              <code>boost-leader</code> &euro;200).
+            </td>
+            <td>
+              Drove D-D (no capacity check — a create-shaped implementation would
+              reject every Copilot upgrade) and D-C (neutral wording, no
+              price-derived upgrade/downgrade labels).
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="ambiguity">Open question at drafting time</h2>
+      <div class="callout">
+        <strong>Unanswered when the plan was drafted.</strong> Two questions were
+        put to the user and went unanswered (away from keyboard), so the plan
+        proceeds on stated assumptions rather than blocking:
+        <ul>
+          <li class="note">
+            <strong>Which surface blocked them.</strong> Assumed: the licence
+            request, since the trigger was described as a
+            <em>request</em> arriving. The plan therefore covers
+            <em>both</em> the direct admin operation and the request-approval
+            path, so the assumption being wrong costs nothing.
+          </li>
+          <li class="note">
+            <strong>Upgrade-month costing.</strong> Assumed D-A (whole month at
+            the new tier). Rationale in plan §3: it is the convention spec 037
+            already established and the user already accepted. If the user wants
+            true proration, that is deferral D-1 and a materially larger spec —
+            the plan says so explicitly rather than quietly choosing for them.
+          </li>
+        </ul>
+        Both should be confirmed before merge.
+      </div>
+
+      <h2 id="challenge">Challenge pass</h2>
+      <p>
+        Five adversarial lenses ran in parallel against plan v1, each told to
+        assume the plan was wrong and prove it against the real code: <em>cost
+        &amp; reporting correctness</em>, <em>concurrency &amp; data
+        integrity</em>, <em>licence-request flow correctness</em>,
+        <em>codebase fit / simplification</em>, <em>test adequacy &amp;
+        process</em>. 5 agents, ~715k tokens, ~11 min.
+      </p>
+      <p class="meta">
+        Verdicts: 2 &times; <code>has_blocking_flaw</code> (concurrency,
+        request-flow) · 3 &times; <code>needs_revision</code> (cost,
+        simplification, tests). <strong>Nothing returned
+        <code>plan_is_sound</code>.</strong> Every blocking and major finding
+        below was verified independently against the code before being adopted.
+      </p>
+
+      <div class="callout">
+        <strong>The panel proved the plan&rsquo;s central argument
+        wrong.</strong> v1 §3 asserted deactivate+insert was &ldquo;strictly
+        worse&rdquo; than in-place mutation. It is not. Double-count =
+        <strong>1 period &times; old price</strong>. In-place restatement =
+        <strong>N closed periods &times; delta</strong> — for one Claude seat
+        held since March, +&euro;25 versus +&euro;500. The decision (in-place)
+        survived; the <em>reasoning</em> had to be replaced entirely, and the
+        retroactive blast radius enumerated by file.
+      </div>
+
+      <h4>Blocking findings adopted</h4>
+      <table>
+        <thead><tr><th>Finding</th><th>Verified</th><th>Revision</th></tr></thead>
+        <tbody>
+          <tr>
+            <td>
+              A flat <code>mode</code> flag cannot express
+              <code>change_tier</code>: <code>loadToolAndTier</code> runs before
+              the transaction and unconditionally errors on
+              <code>requiresApiKey &amp;&amp; !licenseCode</code>. v1 suppressed
+              the key field on a retier &rarr; <strong>every Claude Console
+              upgrade would die</strong> with a misleading message, and Claude
+              Console is the only <code>requires_api_key</code> tool <em>and</em>
+              has the deepest tier ladder.
+            </td>
+            <td>
+              Confirmed: <code>license-requests.ts:201-207</code>, called at
+              <code>:338</code>, transaction opens at <code>:341</code>.
+            </td>
+            <td>
+              <code>approveRequestSchema</code> becomes a
+              <strong>discriminated union</strong>; create-only validation lives
+              only on the <code>create</code> member. Key field becomes
+              <em>optional</em>, not suppressed.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Returning an error from inside the approval transaction
+              <strong>commits</strong> it — so v1&rsquo;s new in-transaction
+              rejection would have persisted an auto-created requester user.
+            </td>
+            <td>
+              Confirmed: the existing race guard <code>throw</code>s
+              <code>RACE_LOST</code> (<code>:371</code>) precisely because a
+              return would commit.
+            </td>
+            <td>
+              Every in-transaction rejection must <code>throw</code>. Called out
+              as the single most important implementation note.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              The tier UPDATE has no <code>status</code> guard, so it can retier a
+              row a concurrent revoke just closed — violating the very invariant
+              D-A&rsquo;s costing argument rests on.
+            </td>
+            <td>
+              Confirmed: unconditional
+              <code>.where(eq(id, id))</code> at
+              <code>assignments.ts:297-300</code> after a separate read at
+              <code>:191-201</code>. Five concurrent producers can close the row.
+            </td>
+            <td>
+              Conditional UPDATE guarded on <code>status</code> +
+              observed <code>tier_id</code> (doubling as an optimistic lock
+              against the price cascade) with a zero-rows sentinel.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="card accent">
+        <h4>Live bug the panel surfaced, beyond the plan&rsquo;s scope</h4>
+        <p>
+          Because a returned error commits, and
+          <code>ensureRequesterUser</code> runs <em>before</em>
+          <code>createAssignmentInTx</code>, <strong>today&rsquo;s
+          &ldquo;Requester already has an active assignment&rdquo; refusal leaks a
+          Hub user</strong> whenever the requester was not yet in the Hub — a
+          viewer account created and abandoned while the request stays
+          <code>pending_review</code>. That is the exact error path this spec was
+          opened to fix, so the leak is squarely in the blast radius. Fixed by the
+          throw-not-return revision; regression-tested.
+        </p>
+      </div>
+
+      <h4>Major findings adopted</h4>
+      <ul>
+        <li class="note">
+          <strong>Copilot had no approvable outcome at all.</strong> All 63 live
+          Copilot seats are <code>source='copilot-sync'</code>, so a Business
+          &rarr; Enterprise request would be refused by the create guard
+          <em>and</em> by D-B&rsquo;s sync block — while v1&rsquo;s acceptance
+          checklist claimed such requests were approvable. Added a third mode,
+          <code>link_existing</code>, matching 032-v2&rsquo;s provision-first
+          philosophy: upgrade in GitHub, approve as linked, tier arrives via sync.
+          It also unsticks the legacy <code>recordAssignment</code> path, which
+          shared the same dead end.
+        </li>
+        <li class="note">
+          <strong>Blocking by <code>source</code> is the wrong gate.</strong>
+          Sync <em>takes over</em> manual rows
+          (<code>needsSourceUpdate</code>), so a tier change on a
+          <code>source='manual'</code> Copilot assignment is reverted just the
+          same. The gate became <strong>tool-based</strong>.
+        </li>
+        <li class="note">
+          <strong><code>loadToolAndTier</code> never checks
+          <code>is_active</code></strong> — so v1&rsquo;s §5 callout
+          (&ldquo;all three require isActive, exactly as today&rdquo;) was simply
+          false, and the request path could put a live seat on a deactivated
+          tier. Gap closed.
+        </li>
+        <li class="note">
+          <strong>Month-over-month goes blind.</strong>
+          <code>getAssignmentSnapshotAt</code> reads the <em>current</em> cost, so
+          after an in-place change both compared months read the new price and the
+          delta contribution is exactly zero — the KPI reads 0% on the month a
+          seat&rsquo;s price quintupled. A regression specific to in-place;
+          recorded as deferral D-2 rather than hidden.
+        </li>
+        <li class="note">
+          <strong>The helper&rsquo;s invariant ordering broke every synced-row
+          edit.</strong> The detail form always submits <code>tierId</code>, so
+          refusing sync rows before the no-op check would reject workspace and
+          API-key edits too. Sync refusal now fires only when the tier actually
+          differs.
+        </li>
+        <li class="note">
+          <strong>v1 gave the shared helper two different signatures</strong>
+          (§1 <code>applyTierChangeInTx</code> vs §5
+          <code>buildTierChange</code>), which would have blocked writing the unit
+          tests. Settled on one pure, db-free signature.
+        </li>
+        <li class="note">
+          <strong>Revalidation still missed cost surfaces.</strong> v1
+          congratulated itself on adding <code>/budget</code> but omitted
+          <code>/</code> and <code>/reports/budget</code>, which the analogous
+          price cascade already revalidates. Fixed for <em>all</em>
+          <code>updateAssignment</code> fields, not just the tier.
+        </li>
+        <li class="note">
+          <strong>The dialog cannot do what v1 promised &ldquo;with no new
+          query&rdquo;.</strong> <code>ActiveAssignmentSummary</code> lacks
+          <code>toolId</code>, <code>tierId</code> and <code>source</code>, so
+          collision matching would have keyed off a display name and could not
+          distinguish a synced seat. Three columns added to the existing SELECT.
+        </li>
+        <li class="note">
+          <strong><code>tier.previousName</code> would have leaked braces.</strong>
+          <code>renderTemplate</code> leaves unresolved paths as the
+          <em>literal</em> <code>{{tier.previousName}}</code>, and one approval
+          body serves all modes — so the token is now always bound (empty when not
+          a retier). Relatedly, suppressing the key field made the pasted message
+          read <em>&ldquo;Your API key: —&rdquo;</em>.
+        </li>
+        <li class="note">
+          <strong>Same-tool/same-tier was an unhandled cell.</strong> A naive
+          copy of <code>updateAssignment</code>&rsquo;s zero-diff early return
+          would report success while stranding the request in
+          <code>pending_review</code>. The no-op contract now explicitly belongs
+          to the caller.
+        </li>
+      </ul>
+
+      <h4>Scope cut on the simplification lens&rsquo; argument</h4>
+      <p>
+        The <em>/simplify</em> lens argued — correctly — that v1 was building a
+        parallel implementation of the thing the spec exists to unify. Adopted in
+        full:
+      </p>
+      <table>
+        <thead><tr><th>Dropped</th><th>Because</th></tr></thead>
+        <tbody>
+          <tr><td>Separate <code>changeAssignmentTier</code> action + schema</td><td><code>updateAssignment</code> already does same-tool tier changes with validation, cost snapshot and audit diff, and is already wired to two of the three target surfaces.</td></tr>
+          <tr><td><code>ChangeTierDialog</code> on three surfaces</td><td>Two already have working tier-edit UI; only the missing affordance remains, and it links to the detail page rather than duplicating a dialog.</td></tr>
+          <tr><td>Migration 0030 / <code>tier_changed_at</code></td><td><code>change_history</code> already stores old/new <code>tierId</code> with actor and timestamp, and a single column could hold only the latest step. <strong>The spec is now migration-free</strong> — which also drops the <code>drizzle-migration-reviewer</code> gate.</td></tr>
+          <tr><td>Deferral &ldquo;reconcile the rival expected-spend readers&rdquo;</td><td>No rivalry: <code>getExpectedSpendForPeriod</code> has <strong>zero callers</strong>. Deleting it is a one-line simplification; v1 had documented a non-problem and invited a future reader to &ldquo;fix&rdquo; it.</td></tr>
+          <tr><td>D-C framed as a decision</td><td>Direction-derived-from-price is already how <code>updateAssignment</code> behaves; there was no live fork to decide.</td></tr>
+        </tbody>
+      </table>
+
+      <h4>Test-plan corrections</h4>
+      <ul>
+        <li class="note">
+          <strong>Integration tests do not run in CI.</strong>
+          <code>.github/workflows/ci.yml:96-117</code> has the
+          <code>integration-tests</code> job commented out — only
+          <code>pnpm test</code> gates a merge. v1 made an integration test the
+          sole guard for its central claim, so a future
+          &ldquo;just reuse assignLicense&rdquo; refactor could have reintroduced
+          double-counting with nothing blocking it. The guard is now a
+          <strong>unit</strong> test over an extracted overlap predicate.
+        </li>
+        <li class="note">
+          <strong>The integration test was racy and mis-scoped.</strong>
+          <code>getBudgetWithCosts</code> sums the whole
+          <code>license_assignments</code> table with no tool or budget scoping,
+          so a global before/after delta absorbs other suites&rsquo; concurrent
+          rows. Now asserts on the seeded tool&rsquo;s own rows.
+        </li>
+        <li class="note">
+          <strong>v1&rsquo;s fiscal-year instruction was actively
+          harmful.</strong> It told the test to claim FY &ge; 999,000 — the window
+          <code>forecast-scenarios.test.ts</code> already owns. And it was
+          unnecessary: <code>getBudgetWithCosts</code> filters on
+          <code>id</code> only (<code>budget.ts:556-557</code>) and ignores
+          <code>status</code>, so the budget can be seeded
+          <code>archived</code> outside every claimed range.
+        </li>
+      </ul>
+
+      <h4>Confirmed correct — left alone</h4>
+      <p class="meta">
+        Recorded so a later reader does not &ldquo;fix&rdquo; a non-issue. The
+        double-count in both <code>getBudgetWithCosts</code> and
+        <code>fetchPerToolByPeriod</code> is real and exactly one period wide
+        (July excludes the new row; September excludes the old). The spec-037
+        precedent is real and stronger than v1 claimed —
+        <code>tools.ts:302-305</code> states it in a comment and migration
+        <code>0024</code> backfilled production to match. No per-tier
+        <em>historical</em> breakdown exists anywhere, so in-place change
+        misreports no per-tier chart. Nothing persists a computed expected-spend
+        figure, so no stale stored number is left behind. D-D is well-founded:
+        <code>assignLicense</code>&rsquo;s minus-one capacity adjustment
+        (<code>assignments.ts:73-88</code>) means a create-shaped implementation
+        really would reject every Copilot upgrade at 63/63.
+      </p>
+
+      <h2 id="implementation">Implementation log</h2>
+      <p class="meta">In progress.</p>
+    </main>
+  </body>
+</html>

--- a/specs/042-assignment-tier-change/implementation-notes.html
+++ b/specs/042-assignment-tier-change/implementation-notes.html
@@ -1222,13 +1222,16 @@
 
       <h2 id="open-final">Open before merge</h2>
       <ul>
-        <li class="con">
-          <strong>Confirm the costing decision (D-A)</strong> — the upgrade month
-          bills entirely at the new tier and closed periods restate. Explained in
-          full to the user; still formally unconfirmed. Audit-log gaps that would
-          let a future effective-dated table be backfilled (copilot-sync writes no
-          per-assignment history; the price cascade logs against the tier) were
-          raised and <strong>explicitly declined</strong>.
+        <li class="note">
+          <strong>Costing decision D-A: confirmed by the user</strong>
+          (2026-08-04), after the trade-off was laid out in full — the upgrade
+          month bills entirely at the new tier, and closed budget periods restate
+          at the new price. The alternatives (boundary-snapped supersede, true
+          proration, or snapshotting expected spend when a period closes) stay on
+          record in plan §3 and deferral D-1. The audit-log gaps that would let a
+          future effective-dated table be backfilled — copilot-sync writes no
+          per-assignment history, and the price cascade logs against the tier —
+          were raised and <strong>explicitly declined</strong>.
         </li>
         <li class="note">
           The approval dialog&rsquo;s three modes were verified server-side

--- a/specs/042-assignment-tier-change/implementation-notes.html
+++ b/specs/042-assignment-tier-change/implementation-notes.html
@@ -286,7 +286,7 @@
         <div class="row" style="margin-bottom: 16px">
           <span class="badge">Implementation notes</span>
           <span class="badge">spec/042-assignment-tier-change</span>
-          <span class="badge accent">In progress</span>
+          <span class="badge accent">Verified (unit + integration) — UI pass outstanding</span>
         </div>
         <h1>Assignment Tier Change — running log</h1>
         <p class="lede">
@@ -1007,6 +1007,131 @@
           across the three actions. Took the catch helper, left the rest:
           boilerplate that drifts harmlessly, and collapsing it would obscure
           the genuinely different status guards each action needs.
+        </li>
+      </ul>
+      <h2 id="verification">Verification against a real database</h2>
+
+      <div class="callout info">
+        <strong>The app&rsquo;s own Neon project is not reachable from this
+        session.</strong> The connected Neon MCP sees exactly one project
+        (<code>workable</code>), whose only branch is empty — no
+        <code>ai_tools</code>, no <code>license_assignments</code>, no compute
+        usage since it was created. No shared projects either. The real database
+        (the <code>ep-little-frost</code> endpoint referenced by the main
+        checkout) lives under an account this connection cannot see, and the
+        worktree had no <code>.env.local</code> at all.
+      </div>
+
+      <p>
+        So verification ran against a <strong>synthetic branch</strong>:
+        <code>wt/upgrade</code> (<code>br-empty-pond-ayfmd73z</code>) forked from
+        <code>workable/main</code>, migrated 0000&ndash;0029, then seeded with an
+        admin plus a catalogue mirroring the live taxonomy — Claude (Standard Seat
+        &euro;25 / Premium Seat &euro;125) and Claude Console (the
+        <code>requires_api_key</code> tool). <code>workable/main</code> was never
+        touched.
+      </p>
+
+      <h4>Results</h4>
+      <table>
+        <thead><tr><th>Gate</th><th>Result</th></tr></thead>
+        <tbody>
+          <tr><td><code>pnpm typecheck</code></td><td class="s">clean</td></tr>
+          <tr><td><code>pnpm test</code> (unit, gates CI)</td><td class="s">659 passed, 53 files</td></tr>
+          <tr><td>eslint on changed files</td><td class="s">clean</td></tr>
+          <tr>
+            <td><code>pnpm test:integration</code> — full directory</td>
+            <td class="s">
+              8 files passed, 2 skipped · 56 passed, 7 todo. Includes the budget
+              suites, so the <code>getBudgetWithCosts</code> refactor onto the
+              shared overlap predicate is verified against real Postgres.
+            </td>
+          </tr>
+          <tr>
+            <td>Playwright browser pass</td>
+            <td class="con"><strong>Not completed</strong> — see below.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Two defects the integration run found that unit tests could not</h4>
+      <ol>
+        <li>
+          <strong>This spec broke the suite&rsquo;s teardown.</strong>
+          <code>change_history.changed_by</code> is <code>onDelete RESTRICT</code>,
+          and approving as a tier change now writes audit rows attributed to the
+          test admin — so <code>afterAll</code>&rsquo;s user delete failed with a
+          <code>23503</code> FK violation on every run. The suite reported
+          <em>12/12 tests passing and a failed file</em>, which is easy to skim
+          past. Audit rows for the run&rsquo;s users are now deleted first.
+        </li>
+        <li>
+          <strong>My own retier assertion tested the wrong layer.</strong> It
+          expected <code>{{tier.previousName}}</code> to be resolved in the stored
+          approval message. It never will be: <code>approveRequest</code> stores
+          <code>bodyMd</code> verbatim and rendering happens client-side in the
+          dialog — the suite already depends on that, asserting the stored message
+          deliberately <em>keeps</em> <code>{{licenseCode}}</code> so the key never
+          reaches the database. Corrected to assert verbatim storage.
+        </li>
+      </ol>
+
+      <h4>Why the browser pass did not happen</h4>
+      <p>
+        <code>@neondatabase/serverless</code> falls back to Node&rsquo;s built-in
+        (undici) WebSocket when <code>neonConfig.webSocketConstructor</code> is
+        unset, and on <strong>Node 24</strong> that connects only intermittently —
+        a raw <code>ErrorEvent</code>, then the 10s
+        <code>connectionTimeoutMillis</code> in <code>src/lib/db/index.ts</code>
+        aborts. Measured: with the <code>ws</code> package, 3/3 connections
+        succeed; without it, failures are frequent. It is not specific to this
+        feature — it also broke <code>pnpm db:seed:agent</code> and made
+        <code>drizzle-kit</code> intermittent.
+      </p>
+      <p>
+        The integration suite was made reliable with a throwaway
+        <code>setupFiles</code> shim (not committed). For <code>pnpm dev</code> the
+        documented workaround — the shim in <code>src/instrumentation.ts</code>
+        plus <code>serverExternalPackages</code> in <code>next.config.ts</code> —
+        was tried temporarily and <strong>did not</strong> take effect; the mint
+        route kept returning 500 from the same WebSocket failure, so no agent
+        session could be created and no page could be driven. Both files were
+        reverted; the tree is clean.
+      </p>
+      <div class="callout">
+        <strong>Consequence: the UI has no verification at all.</strong> The sync
+        gate on the assignment detail page, the tier timeline, the mode-aware
+        approval dialog and the legacy link path are covered by neither automated
+        tests nor a manual pass. The server actions beneath them are covered.
+        This is the largest remaining gap before merge.
+      </div>
+      <p class="meta">
+        Offered but not done, since it is a shared-harness change rather than part
+        of this spec: committing the <code>ws</code> shim so
+        <code>pnpm test:integration</code> is reliable on Node 24 for everyone.
+        Without it, the integration results above are not reproducible on this
+        Node version.
+      </p>
+
+      <h2 id="open-final">Open before merge</h2>
+      <ul>
+        <li class="con">
+          <strong>Confirm the costing decision (D-A)</strong> — the upgrade month
+          bills entirely at the new tier and closed periods restate. Explained to
+          the user; still unconfirmed. The audit-log gaps that would let a future
+          effective-dated table be backfilled (copilot-sync writes no per-assignment
+          history; the price cascade logs against the tier) were raised and
+          <strong>explicitly declined</strong> by the user.
+        </li>
+        <li class="con"><strong>Browser pass for the UI</strong>, per the gap above.</li>
+        <li class="con">
+          Verification used a synthetic catalogue, not production data — the
+          Copilot sync-managed paths (63 live seats) were never exercised against
+          real synced rows.
+        </li>
+        <li class="note">
+          Neon branch <code>wt/upgrade</code> still exists in project
+          <code>blue-poetry-08641598</code>; delete when done.
         </li>
       </ul>
     </main>

--- a/specs/042-assignment-tier-change/implementation-notes.html
+++ b/specs/042-assignment-tier-change/implementation-notes.html
@@ -858,6 +858,157 @@
           <code>/simplify</code> pass, then PR with the Copilot reviewer.
         </li>
       </ul>
+      <h2 id="simplify">Simplify pass</h2>
+      <p class="meta">
+        Four parallel lenses over the branch diff — reuse, simplification,
+        efficiency, altitude. 10 findings applied, 4 skipped. Suite went 658 →
+        659; typecheck and eslint clean throughout.
+      </p>
+
+      <h4>Applied</h4>
+      <table>
+        <thead><tr><th>Lens</th><th>Finding</th><th>Fix</th></tr></thead>
+        <tbody>
+          <tr>
+            <td>reuse · altitude</td>
+            <td>
+              <code>revalidate.ts</code> duplicated the five path literals
+              <code>actions/tools.ts</code>&rsquo;s tier price cascade already
+              revalidated — and the two lists had <em>already</em> drifted.
+            </td>
+            <td>
+              One <code>revalidateCostSurfaces()</code>;
+              <code>updateTier</code> calls it too.
+            </td>
+          </tr>
+          <tr>
+            <td>efficiency</td>
+            <td>
+              Cost invalidation fired on <em>every</em> successful update —
+              including workspace/API-key-only edits, a no-op retier, and
+              <code>link_existing</code>. Seven paths each time, and the
+              dashboard alone re-runs ~13 queries. The precedent it claimed to
+              mirror gates on <code>newCostCents !== undefined</code>; this
+              did not.
+            </td>
+            <td>
+              Gated on the tier actually moving
+              (<code>"tierId" in changes</code>), and on a
+              <code>costChanged</code> flag returned from the approval
+              transaction.
+            </td>
+          </tr>
+          <tr>
+            <td>efficiency · simplification</td>
+            <td>
+              <code>isSyncManagedTool(toolId)</code> re-queried
+              <code>ai_tools</code> at three call sites that already had the
+              tool row in memory — <code>approveRequest</code> even fetched it
+              via <code>loadToolAndTier</code> and threw it away.
+            </td>
+            <td>
+              API is now name-based:
+              <code>isCopilotSyncActive()</code> +
+              <code>isSyncManagedToolName()</code>, with
+              <code>isSyncManagedTool(name)</code> as the convenience.
+              <code>getSyncManagedToolId</code> deleted. One fewer query on
+              each of three paths.
+            </td>
+          </tr>
+          <tr>
+            <td>efficiency</td>
+            <td><code>getRequestContext</code> awaited the sync lookup before the row fetch, with no data dependency between them.</td>
+            <td><code>Promise.all</code>; <code>syncManaged</code> now derived from the tool name the join already returned.</td>
+          </tr>
+          <tr>
+            <td>reuse</td>
+            <td>
+              The &ldquo;Managed by sync&rdquo; badge existed twice with
+              <strong>two different explanations</strong> of the same condition.
+            </td>
+            <td>Shared <code>SyncManagedBadge</code>; message stays per-caller.</td>
+          </tr>
+          <tr>
+            <td>reuse · altitude</td>
+            <td>
+              <strong>Resolves the deviation logged above.</strong> The user
+              detail page gated on <code>assignment.source</code> — exactly the
+              check §6 rejects as insufficient — leaving one right and one wrong
+              example of the same decision for the next surface to copy.
+            </td>
+            <td>
+              <code>page.tsx</code> resolves it server-side and passes
+              <code>syncManagedToolNames</code>; the client no longer reads
+              <code>source</code> at all.
+            </td>
+          </tr>
+          <tr>
+            <td>altitude</td>
+            <td>
+              <code>fetchPerToolByPeriod</code> still inlined its own copy of
+              the overlap predicate — so the CI test pinned the rule for one
+              reader while the other could drift freely, defeating the point of
+              extracting it.
+            </td>
+            <td>
+              Both readers share <code>overlapsPeriod</code>, with the
+              long-standing <code>&gt;</code> vs <code>&gt;=</code> edge case
+              preserved as an explicit <code>revokedBound</code> parameter and
+              pinned by its own test.
+            </td>
+          </tr>
+          <tr>
+            <td>simplification · altitude</td>
+            <td>The <code>RACE_LOST</code>/<code>ApprovalError</code> catch body was copy-pasted into three transactions.</td>
+            <td>One <code>catchApprovalTx</code>.</td>
+          </tr>
+          <tr>
+            <td>simplification</td>
+            <td><code>hasTemplate</code> re-encoded the mode &rarr; tool/tier rule that <code>handleAdvance</code> already had.</td>
+            <td>A derived <code>effective</code> selection, read by both.</td>
+          </tr>
+          <tr>
+            <td>simplification</td>
+            <td>Unused <code>ne</code> import left over from an earlier draft of the race guard.</td>
+            <td>Removed.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Skipped, with reasons</h4>
+      <ul>
+        <li class="note">
+          <strong>Extract <code>resolveApprovalOutcome</code> from
+          <code>approveRequest</code>&rsquo;s transaction body</strong> (four
+          <code>let</code>s, 4–5 levels of nesting). A genuine readability win,
+          and I chose not to take it: this is the most delicate code in the
+          branch, its correctness rests on throw-based rollback, and the value is
+          purely presentational. Not worth re-opening freshly-verified logic at
+          the end of the pass — but it is the first thing to do if this function
+          is touched again.
+        </li>
+        <li class="note">
+          <strong><code>buildTierChange</code>&rsquo;s three-way union &rarr;
+          <code>null</code> for the no-op.</strong> The reviewer rated it low
+          urgency itself; the current shape is correct, tested, and its
+          ordering invariant is documented. Churn on tested code for a marginal
+          readability gain.
+        </li>
+        <li class="note">
+          <strong>Row-level optimistic-concurrency token</strong> covering all
+          four editable fields instead of a <code>tierId</code>-keyed guard.
+          Correct observation — only one of four fields is race-protected — but
+          deliberately out of scope: the plan scoped the guard to the tier
+          snapshot invariant. Worth its own spec.
+        </li>
+        <li class="note">
+          <strong>Factoring the request-transaction shell</strong> (request
+          fetch + catch mapping + &ldquo;actioned by another admin&rdquo; copy)
+          across the three actions. Took the catch helper, left the rest:
+          boilerplate that drifts harmlessly, and collapsing it would obscure
+          the genuinely different status guards each action needs.
+        </li>
+      </ul>
     </main>
   </body>
 </html>

--- a/specs/042-assignment-tier-change/implementation-plan.html
+++ b/specs/042-assignment-tier-change/implementation-plan.html
@@ -1,0 +1,1054 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Implementation Plan — Assignment Tier Change (042)</title>
+    <style>
+      :root {
+        --bg: #0b0d12;
+        --bg-elev: #11141b;
+        --bg-card: #161a24;
+        --border: #232938;
+        --border-strong: #2f3850;
+        --fg: #e7ebf3;
+        --fg-muted: #9aa3b5;
+        --fg-dim: #6b7488;
+        --accent: #f0a072;
+        --accent-2: #7dd3fc;
+        --good: #86efac;
+        --warn: #fcd34d;
+        --bad: #fca5a5;
+        --mono:
+          ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+        --sans:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--sans);
+        line-height: 1.55;
+      }
+      body {
+        padding: 48px 24px 96px;
+      }
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+      h1,
+      h2,
+      h3,
+      h4 {
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      h1 {
+        font-size: 32px;
+        margin: 0 0 8px;
+      }
+      h2 {
+        font-size: 22px;
+        margin: 52px 0 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border);
+      }
+      h3 {
+        font-size: 17px;
+        margin: 0 0 6px;
+      }
+      h4 {
+        font-size: 13px;
+        margin: 16px 0 6px;
+        color: var(--fg-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      p {
+        margin: 0 0 12px;
+      }
+      a {
+        color: var(--accent);
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 0.88em;
+        background: var(--bg-elev);
+        padding: 1px 5px;
+        border-radius: 4px;
+        border: 1px solid var(--border);
+      }
+      pre {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 14px 16px;
+        overflow-x: auto;
+        line-height: 1.5;
+      }
+      pre code {
+        background: transparent;
+        border: 0;
+        padding: 0;
+        font-size: inherit;
+      }
+      .lede {
+        color: var(--fg-muted);
+        font-size: 16px;
+        max-width: 820px;
+      }
+      .meta {
+        color: var(--fg-dim);
+        font-size: 13px;
+        margin-top: 8px;
+        font-family: var(--mono);
+      }
+      .badge {
+        display: inline-block;
+        font-size: 11px;
+        font-family: var(--mono);
+        padding: 2px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--border-strong);
+        color: var(--fg-muted);
+        background: var(--bg-elev);
+      }
+      .badge.accent {
+        color: var(--accent);
+        border-color: rgba(240, 160, 114, 0.35);
+      }
+      .card {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 24px;
+        margin: 16px 0;
+      }
+      .card.accent {
+        border-left: 3px solid var(--accent);
+      }
+      .card.accent-2 {
+        border-left: 3px solid var(--accent-2);
+      }
+      .grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+      @media (max-width: 760px) {
+        .grid-2 {
+          grid-template-columns: 1fr;
+        }
+      }
+      .row {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      ul {
+        padding-left: 20px;
+        margin: 8px 0 12px;
+      }
+      li {
+        margin: 4px 0;
+      }
+      li.pro::marker {
+        content: "+ ";
+        color: var(--good);
+        font-weight: 700;
+      }
+      li.con::marker {
+        content: "− ";
+        color: var(--bad);
+        font-weight: 700;
+      }
+      li.note::marker {
+        content: "› ";
+        color: var(--fg-dim);
+      }
+      li.check::marker {
+        content: "\2610  ";
+        color: var(--fg-muted);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+        margin: 12px 0;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--border);
+        vertical-align: top;
+      }
+      th {
+        color: var(--fg-muted);
+        font-weight: 500;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: var(--bg-elev);
+      }
+      td code {
+        white-space: nowrap;
+      }
+      .pill {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 6px;
+        font-size: 11.5px;
+        font-family: var(--mono);
+      }
+      .pill.warn {
+        background: rgba(252, 211, 77, 0.12);
+        color: var(--warn);
+      }
+      .pill.new {
+        background: rgba(240, 160, 114, 0.14);
+        color: var(--accent);
+      }
+      .pill.neutral {
+        background: var(--bg-elev);
+        color: var(--fg-muted);
+        border: 1px solid var(--border);
+      }
+      .callout {
+        border: 1px solid var(--border-strong);
+        border-left: 3px solid var(--warn);
+        background: rgba(252, 211, 77, 0.04);
+        padding: 14px 16px;
+        border-radius: 8px;
+        margin: 16px 0;
+        font-size: 14px;
+      }
+      .callout.info {
+        border-left-color: var(--accent-2);
+        background: rgba(125, 211, 252, 0.04);
+      }
+      .callout.accent {
+        border-left-color: var(--accent);
+        background: rgba(240, 160, 114, 0.05);
+      }
+      .toc {
+        columns: 2;
+        column-gap: 32px;
+        font-size: 14px;
+      }
+      @media (max-width: 760px) {
+        .toc {
+          columns: 1;
+        }
+      }
+      .toc a {
+        display: block;
+        padding: 3px 0;
+        color: var(--fg-muted);
+        text-decoration: none;
+      }
+      .toc a:hover {
+        color: var(--accent);
+      }
+      footer {
+        color: var(--fg-dim);
+        font-size: 12.5px;
+        margin-top: 64px;
+        padding-top: 24px;
+        border-top: 1px solid var(--border);
+        font-family: var(--mono);
+      }
+      .s {
+        color: var(--good);
+      }
+      .c {
+        color: var(--fg-dim);
+        font-style: italic;
+      }
+      .k {
+        color: var(--accent-2);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="row" style="margin-bottom: 16px">
+          <span class="badge">Implementation plan</span>
+          <span class="badge">spec/042-assignment-tier-change</span>
+          <span class="badge accent">Challenged &amp; revised — ready to implement</span>
+        </div>
+        <h1>Assignment Tier Change</h1>
+        <p class="lede">
+          A colleague asked for a <strong>tier upgrade on a licence they already
+          hold</strong>, and approving that request fails outright. This spec
+          makes a tier change on an active assignment an
+          <strong>approvable, race-safe, auditable</strong> operation — and fixes
+          two live bugs found in its blast radius along the way. It adds
+          <strong>no new table and no migration</strong>: the mechanics already
+          exist, scattered and unreconciled.
+        </p>
+        <p class="meta">
+          Drafted 2026-08-03 · revised same day after a 5-lens adversarial panel
+          (2 blocking + 4 major findings adopted; scope cut by roughly half) ·
+          author: T. Studer · branch <code>042-assignment-tier-change</code> ·
+          builds on specs 003, 032-v2, 037 · estimate: ~1.5 dev days
+        </p>
+      </header>
+
+      <div class="callout" style="margin-top: 24px">
+        <strong>The reported blocker.</strong> Approving a licence request for
+        someone who already holds that tool fails:
+        <em>&ldquo;Requester already has an active assignment for this tool
+        (assignment #N). Revoke the existing assignment first, or cancel this
+        request.&rdquo;</em>
+        (<code>src/actions/license-requests.ts:274-278</code>).
+      </div>
+
+      <div class="callout">
+        <strong>Live bug found in the blast radius — a failed approval leaks a
+        Hub user.</strong> <code>ensureRequesterUser</code> inserts the requester
+        (<code>license-requests.ts:343</code>) and
+        <code>createAssignmentInTx</code>&rsquo;s duplicate-seat refusal is then
+        returned <em>out of</em> the transaction callback
+        (<code>:351</code>). In Drizzle a returned value <strong>commits</strong>
+        — only a <code>throw</code> rolls back, which is why the race guard at
+        <code>:371</code> throws <code>RACE_LOST</code>. So every time an admin
+        hit the blocker above for a requester who was not yet a Hub user, a
+        viewer account was silently created and left behind, while the request
+        stayed <code>pending_review</code>. This violates 032-v2&rsquo;s stated
+        rule that users are created at approval and never from failed ones.
+        Fixed here (§<a href="#requests">5</a>).
+      </div>
+
+      <h2 id="toc">Contents</h2>
+      <div class="toc card">
+        <a href="#goal">1 · Goal &amp; scope</a>
+        <a href="#today">2 · Three conflicting semantics today</a>
+        <a href="#costing">3 · The costing decision (revised)</a>
+        <a href="#action">4 · The tier-change path</a>
+        <a href="#requests">5 · Licence-request approval modes</a>
+        <a href="#sync">6 · Copilot sync authority</a>
+        <a href="#ui">7 · UI changes</a>
+        <a href="#tests">8 · Test plan</a>
+        <a href="#manifest">9 · File manifest</a>
+        <a href="#risks">10 · Decisions, deferrals &amp; risks</a>
+        <a href="#accept">11 · Acceptance checklist</a>
+      </div>
+
+      <!-- ============================================================ -->
+      <h2 id="goal">1 · Goal &amp; scope</h2>
+
+      <div class="card accent">
+        <h4>In scope</h4>
+        <ul>
+          <li class="note">
+            <strong>Licence-request approval gains three modes</strong>
+            (§<a href="#requests">5</a>), as a <em>discriminated union</em> so
+            create-only validation never runs on a retier:
+            <code>create</code> (today), <code>change_tier</code> (retier the
+            seat they already hold), <code>link_existing</code> (record that the
+            seat was provisioned vendor-side; approve and link, mutate nothing).
+          </li>
+          <li class="note">
+            <code>updateAssignment</code>&rsquo;s existing tier branch made
+            <strong>race-safe</strong>: a conditional UPDATE guarded on
+            <code>status</code> and the observed <code>tier_id</code>, with a
+            zero-rows sentinel — the pattern
+            <code>license-requests.ts</code> already uses.
+          </li>
+          <li class="note">
+            One small pure helper shared by the two real call sites
+            (<code>updateAssignment</code> and <code>approveRequest</code>) that
+            validates the target tier and builds the update values + audit change
+            map.
+          </li>
+          <li class="note">
+            <strong>Two live bugs fixed:</strong> the leaked Hub user above, and
+            the unguarded tier <code>&lt;Select&gt;</code> on
+            <code>/assignments/[id]</code> that lets an admin &ldquo;change&rdquo;
+            a Copilot seat the next cron silently reverts
+            (§<a href="#sync">6</a>).
+          </li>
+          <li class="note">
+            <code>loadToolAndTier</code> gains the missing
+            <code>access_tiers.is_active</code> check — today the request path
+            can put a live seat on a deactivated tier, which both other entry
+            points forbid.
+          </li>
+          <li class="note">
+            A <strong>tier timeline read from <code>change_history</code></strong>
+            on the assignment detail page — &ldquo;Standard Seat &rarr; Premium
+            Seat, 3 Aug 2026 by T. Studer&rdquo;. No new column.
+          </li>
+          <li class="note">
+            A <strong>unit test</strong> asserting the period-overlap
+            double-count invariant — because integration tests do not run in CI
+            (<code>.github/workflows/ci.yml:96-117</code>, commented out), a
+            unit test is the only automated guard that can gate a merge.
+          </li>
+          <li class="note">
+            Delete the dead <code>getExpectedSpendForPeriod</code> (zero callers
+            repo-wide).
+          </li>
+        </ul>
+
+        <h4>Cut from v1 after the challenge pass</h4>
+        <ul>
+          <li class="con">
+            <strong>A separate <code>changeAssignmentTier</code> action.</strong>
+            <code>updateAssignment</code> already implements same-tool tier
+            changes with validation, cost snapshot and audit diff, and is already
+            wired to two of the three target surfaces. A second action would have
+            been a parallel implementation of the thing this spec exists to
+            unify.
+          </li>
+          <li class="con">
+            <strong>A <code>ChangeTierDialog</code> on three surfaces.</strong>
+            Two already have working tier-edit UI. Only the missing affordance is
+            added.
+          </li>
+          <li class="con">
+            <strong>Migration 0030 / <code>tier_changed_at</code>.</strong>
+            <code>change_history</code> already stores old/new
+            <code>tierId</code> with actor and timestamp — a column would have
+            duplicated it and could hold only the most recent step. This spec is
+            now migration-free.
+          </li>
+          <li class="con">
+            <strong>Deferral &ldquo;reconcile the two rival expected-spend
+            readers&rdquo;.</strong> There is no rivalry:
+            <code>getExpectedSpendForPeriod</code> is dead code. Deleted instead
+            of documented.
+          </li>
+        </ul>
+
+        <h4>Out of scope</h4>
+        <ul>
+          <li class="con">
+            Mid-period proration and scheduled/effective-dated changes — both
+            need effective-dated cost history (deferral D-1).
+          </li>
+          <li class="con">
+            Self-service upgrades for viewers; e-mail notification on tier
+            change.
+          </li>
+        </ul>
+      </div>
+
+      <!-- ============================================================ -->
+      <h2 id="today">2 · Three conflicting semantics today</h2>
+
+      <table>
+        <thead>
+          <tr><th>Path</th><th>What it does</th><th>Damage</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>assignLicense</code><br /><span class="meta">assignments.ts:97-133</span></td>
+            <td>Deactivates the old row, inserts a new one with fresh <code>assigned_at</code>. Also implements &ldquo;Reactivate&rdquo;.</td>
+            <td><span class="pill warn">double-bills switch month</span> orphans comments, drops <code>workspace</code>/<code>api_key_encrypted</code>, no status-change history for the closed row.</td>
+          </tr>
+          <tr>
+            <td><code>updateAssignment</code><br /><span class="meta">assignments.ts:207-230</span></td>
+            <td>Mutates <code>tier_id</code> + cost in place; clean <code>recordUpdate</code> diff.</td>
+            <td><span class="pill neutral">retroactive re-pricing</span> unguarded against a concurrent revoke; unguarded against Copilot sync.</td>
+          </tr>
+          <tr>
+            <td><code>createAssignmentInTx</code><br /><span class="meta">license-requests.ts:266-278</span></td>
+            <td>Refuses outright when an active assignment exists.</td>
+            <td><span class="pill warn">blocks the use case</span> and leaks a Hub user while doing it.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout info">
+        <strong>Live tier taxonomy</strong> (verified in production via MCP
+        <code>list_ai_tools</code>): every tool keeps its tiers as
+        <code>access_tiers</code> rows under <em>one</em> <code>ai_tools</code>
+        row, so every real upgrade is a same-tool <code>tier_id</code> change and
+        the existing same-tool guard suffices. GitHub Copilot: Business &euro;19 /
+        Enterprise &euro;39 · Claude: Standard Seat &euro;25 / Premium Seat
+        &euro;125 · Claude Console: boost-starter &euro;25 / advanced &euro;50 /
+        expert &euro;100 / leader &euro;200 / indie-profile &euro;125 · Cursor:
+        Member &euro;40 · Microsoft Copilot: Standard &euro;30.
+      </div>
+
+      <!-- ============================================================ -->
+      <h2 id="costing">3 · The costing decision (revised)</h2>
+
+      <p>
+        Per-period expected spend sums <code>cost_at_assignment_cents</code> by
+        date overlap, flat monthly price, no proration:
+      </p>
+
+      <pre><code><span class="c">// src/actions/budget.ts:620-626 — getBudgetWithCosts (no status filter)</span>
+.filter((a) =&gt; a.assignedAt &lt;= periodEnd &amp;&amp;
+               (a.revokedAt === null || a.revokedAt &gt;= periodStart))
+.reduce((total, a) =&gt; total + a.costAtAssignmentCents, 0)
+
+<span class="c">// src/actions/reports.ts:146-161 — fetchPerToolByPeriod, same but `&gt;`</span></code></pre>
+
+      <div class="callout">
+        <strong>v1 of this plan claimed deactivate+insert was &ldquo;strictly
+        worse&rdquo;. That was arithmetically false</strong> and the panel proved
+        it. Both options are wrong; they are wrong in different places and by
+        different magnitudes.
+      </div>
+
+      <h4>The actual arithmetic</h4>
+      <p>
+        One Claude seat held since March, upgraded &euro;25 &rarr; &euro;125 on
+        15 August, monthly periods:
+      </p>
+      <table>
+        <thead>
+          <tr><th>Option</th><th>Error</th><th>Where it lands</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Deactivate + insert</td>
+            <td><code>1 period &times; old price</code> = <strong>+&euro;25, August only</strong></td>
+            <td>Both rows satisfy both predicates for the period containing the switch. Verified contained: July excludes the new row, September excludes the old one.</td>
+          </tr>
+          <tr>
+            <td>In-place (D-A)</td>
+            <td><code>N closed periods &times; delta</code> = <strong>+&euro;100 &times; Mar–Jul = +&euro;500</strong></td>
+            <td>Every closed period the row spans restates upward. <strong>20&times; larger</strong> here, and it grows with tenure.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>The retroactive blast radius (v1 never enumerated this)</h4>
+      <p>In-place re-pricing moves these already-published figures:</p>
+      <ul>
+        <li class="con">
+          <strong>The budget-health status pill</strong> —
+          <code>budget-health-hero.tsx:137</code> accumulates
+          <code>closedExpected</code> over closed periods, <code>:169-170</code>
+          derive <code>closedVariance</code> and
+          <code>ratio = closedActual / closedExpected</code>. Ten upgraded seats
+          can flip the pill to <em>&ldquo;Under&rdquo;</em> — reporting an
+          under-spend that never happened. Rendered on <code>/budget</code> and
+          <code>/budget/[id]</code>.
+        </li>
+        <li class="con"><code>period-allocations-table.tsx:97,126</code> · <code>past-month-spotlight.tsx:36</code></li>
+        <li class="con">Expected-monthly sparklines: <code>dashboard.ts:221-224</code> · <code>reports/page.tsx:119-122</code></li>
+        <li class="con">Per-tool YTD: <code>reports.ts:255-262</code> · MCP <code>get_budget_report</code>: <code>mcp/data.ts:320</code></li>
+        <li class="con">
+          <strong>Month-over-month goes blind.</strong>
+          <code>getAssignmentSnapshotAt</code> reconstructs an &ldquo;as of&rdquo;
+          snapshot but reads the <em>current</em> cost, so both months read the
+          new price and the delta contribution is exactly zero: the
+          &ldquo;Expected monthly / vs &euro;X last month&rdquo; KPI reads 0% on
+          the very month a seat's price quintupled. Deactivate+insert would be
+          correct here — this regression is specific to in-place.
+        </li>
+      </ul>
+
+      <h3>Decision D-A (kept, on honest grounds)</h3>
+      <div class="card accent-2">
+        <p>
+          <strong>In-place mutation stays</strong> — not because its error is
+          smaller, but because:
+        </p>
+        <ul>
+          <li class="pro">
+            <strong>It is the convention this codebase already committed
+            to.</strong> <code>src/actions/tools.ts:302-305</code> states it in a
+            comment and migration <code>0024</code> backfilled production to
+            match: active assignments follow the current tier price; only revoked
+            rows keep a historical snapshot. Spec 037 shipped that with the
+            user&rsquo;s agreement. A feature whose purpose is to
+            <em>reconcile</em> three rival tier-change semantics must not
+            introduce a fourth costing model.
+          </li>
+          <li class="pro">
+            The double count corrupts the <strong>current</strong> month — the
+            figure people act on now — whereas restatement moves closed history
+            that the billed-cost column still anchors.
+          </li>
+          <li class="pro">
+            Preserves row identity: <code>id</code>, comment thread,
+            <code>api_key_encrypted</code>, <code>workspace</code>,
+            <code>assigned_at</code> (the seat&rsquo;s true start) and the
+            <code>license_requests.assignment_id</code> link.
+          </li>
+          <li class="pro">
+            Immune to the <code>T00:00:00Z</code> vs period-boundary timezone
+            trap a fresh insert hits
+            (<code>license-requests.ts:291</code> builds a UTC-midnight date;
+            <code>periodEnd</code> is <code>new Date('YYYY-MM-DD')</code>).
+          </li>
+          <li class="con">
+            <strong>Accepted cost:</strong> closed periods restate, and MoM goes
+            blind for that seat. Disclosed in the UI, not hidden — see
+            §<a href="#ui">7</a>.
+          </li>
+        </ul>
+      </div>
+
+      <div class="callout info">
+        <strong>The option nobody considered, recorded for the successor
+        spec.</strong> <em>Boundary-snapped supersede</em>: close the old row at
+        <code>periodStart - 1ms</code> and open the new one at
+        <code>periodStart</code>. It double-counts under <em>neither</em>
+        predicate <em>and</em> leaves closed periods at their historical price —
+        the only option here that is cost-correct on every reader, MoM included.
+        Rejected for v1 because it still breaks row/comment/API-key continuity
+        and makes <code>assigned_at</code> lie about when the seat began, which
+        would need a <code>supersedes_assignment_id</code> chain to repair.
+        Deferral D-1.
+      </div>
+
+      <!-- ============================================================ -->
+      <h2 id="action">4 · The tier-change path</h2>
+
+      <p>
+        No new action. <code>updateAssignment</code> stays the entry point; its
+        tier branch is hardened and factored so the request path can share it.
+      </p>
+
+      <h4>The shared pure helper — one signature, settled</h4>
+      <pre><code><span class="c">// src/actions/assignments.ts — pure, no db access, no tx.
+// v1 gave two conflicting signatures; this is the only one.</span>
+<span class="k">export function</span> buildTierChange(
+  current: { tierId: number; costAtAssignmentCents: number; source: string },
+  newTier: { id: number; monthlyCostCents: number },
+): { values: TierChangeValues; changes: ChangeMap }
+  | { noop: <span class="k">true</span> }
+  | { error: string }</code></pre>
+      <ul>
+        <li class="check">
+          <code>newTier.id === current.tierId</code> &rarr;
+          <code>{ noop: true }</code>. <strong>Callers decide what a no-op
+          means</strong> — <code>updateAssignment</code> skips the write;
+          <code>approveRequest</code> must <em>still</em> approve and link the
+          request (v1 would have stranded it in
+          <code>pending_review</code>).
+        </li>
+        <li class="check">
+          <code>current.source === 'copilot-sync'</code> &rarr; error. Reached
+          <strong>only when the tier actually differs</strong> — v1&rsquo;s
+          invariant ordering would have rejected <em>every</em> edit of a synced
+          assignment, because the detail form always submits
+          <code>tierId</code>.
+        </li>
+        <li class="check">
+          Otherwise returns <code>tierId</code>,
+          <code>costAtAssignmentCents</code> and the old/new change map for
+          <code>recordUpdate</code>.
+        </li>
+      </ul>
+
+      <h4>Race-safe write</h4>
+      <p>
+        The existing write is an unconditional
+        <code>.where(eq(id, id))</code> after a separate read
+        (<code>assignments.ts:191-201</code> read, <code>:297-300</code> write).
+        Five concurrent producers can close the row inside that window:
+        <code>revokeLicense</code>, <code>assignLicense</code>&rsquo;s deactivate
+        leg, <code>deactivateUser</code>&rsquo;s bulk revoke
+        (<code>users.ts:197-207</code>) and copilot-sync&rsquo;s removed-seat
+        revoke. Retiering a just-revoked row would violate the very invariant
+        D-A rests on.
+      </p>
+      <pre><code>.where(and(
+   eq(licenseAssignments.id, id),
+   eq(licenseAssignments.status, <span class="s">"active"</span>),
+   eq(licenseAssignments.tierId, observedTierId),   <span class="c">// optimistic lock</span>
+   ne(licenseAssignments.source, <span class="s">"copilot-sync"</span>),
+ ))
+ .returning({ id: licenseAssignments.id });
+
+<span class="k">if</span> (updated.length === 0) <span class="k">return</span> { success: <span class="k">false</span>,
+  error: <span class="s">"This assignment changed while you were editing it. Refresh and try again."</span> };</code></pre>
+      <p>
+        The <code>tierId</code> predicate doubles as the optimistic lock against
+        a concurrent price cascade (<code>updateTier</code> /
+        <code>syncBillingData</code>) stranding the row at a stale price.
+      </p>
+
+      <h4>Audit durability</h4>
+      <p>
+        <code>recordUpdate</code> is written after the update, matching the
+        prevailing convention. If it throws, the tier moved with no history row —
+        and the no-op early return would then make a retry <em>report
+        success</em>, falsifying the audit acceptance criterion. Mitigation:
+        write history inside the same transaction as the update for this path,
+        so either both land or neither does. This is the stricter of the two
+        conventions already present in the repo, and correctness wins here.
+      </p>
+
+      <h4>Revalidation</h4>
+      <p>
+        Today&rsquo;s list (<code>assignments.ts:310-312</code>) misses every
+        cost surface. Corrected for <strong>all</strong>
+        <code>updateAssignment</code> fields, not just the tier — matching what
+        the analogous price cascade in <code>tools.ts</code> already does:
+        <code>/assignments</code>, <code>/assignments/[id]</code>,
+        <code>/users/[userId]</code>, <code>/tools/[toolId]</code>,
+        <code>/reports</code>, <code>/reports/budget</code>,
+        <code>/budget</code>, <code>/</code>.
+      </p>
+
+      <div class="callout info">
+        <strong>No <code>maxLicenses</code> check</strong> — a same-tool tier
+        change does not alter the seat count. Stated explicitly because GitHub
+        Copilot is live at <strong>63/63</strong>: any create-shaped
+        implementation that omitted <code>assignLicense</code>&rsquo;s
+        &ldquo;minus one for the user&rsquo;s own row&rdquo; adjustment
+        (<code>assignments.ts:73-88</code>) would reject every Copilot upgrade.
+      </div>
+
+      <!-- ============================================================ -->
+      <h2 id="requests">5 · Licence-request approval modes</h2>
+
+      <div class="callout">
+        <strong>A flat <code>mode</code> flag cannot work.</strong>
+        <code>loadToolAndTier</code> runs <em>before</em> the transaction
+        (<code>:338</code> vs <code>:341</code>) and unconditionally errors when
+        <code>tool.requiresApiKey &amp;&amp; !licenseCode?.trim()</code>
+        (<code>:201-207</code>). Claude Console is the only
+        <code>requires_api_key</code> tool <em>and</em> has the deepest tier
+        ladder — so v1, which suppressed the key field on a retier, would have
+        killed exactly the upgrades most likely to happen, with a misleading
+        error.
+      </div>
+
+      <h4>A discriminated union, not a flag</h4>
+      <pre><code>approveRequestSchema = z.discriminatedUnion(<span class="s">"mode"</span>, [
+  z.object({ mode: z.literal(<span class="s">"create"</span>),        <span class="c">/* tool, tier, assignedAt, licenseCode, bodyMd */</span> }),
+  z.object({ mode: z.literal(<span class="s">"change_tier"</span>),   <span class="c">/* assignmentId, tierId, bodyMd — NO assignedAt */</span> }),
+  z.object({ mode: z.literal(<span class="s">"link_existing"</span>), <span class="c">/* assignmentId, bodyMd */</span> }),
+]);</code></pre>
+      <p>
+        Create-only validation (the API-key rule, <code>assignedAt</code>) now
+        lives only on the <code>create</code> member, so it cannot fire on the
+        other two. <code>mode</code> is destructured out before anything is
+        passed to <code>loadToolAndTier</code>.
+      </p>
+
+      <table>
+        <thead><tr><th>mode</th><th>Existing active assignment</th><th>Outcome</th></tr></thead>
+        <tbody>
+          <tr><td><code>create</code></td><td>no</td><td>Insert, as today.</td></tr>
+          <tr><td><code>create</code></td><td>yes</td><td>Today&rsquo;s error — but now <strong>thrown</strong>, so the auto-created user rolls back (live-bug fix).</td></tr>
+          <tr><td><code>change_tier</code></td><td>yes, manual</td><td><span class="pill new">new</span> retier via <code>buildTierChange</code>; link <code>assignment_id</code>; approve.</td></tr>
+          <tr><td><code>change_tier</code></td><td>yes, same tier</td><td>No-op on the row, but <strong>still approve and link</strong>.</td></tr>
+          <tr><td><code>change_tier</code></td><td>no</td><td><strong>Throw</strong> to roll back: &ldquo;No active assignment to retier.&rdquo;</td></tr>
+          <tr><td><code>link_existing</code></td><td>yes</td><td><span class="pill new">new</span> mutate nothing; link <code>assignment_id</code>; approve. The answer for Copilot (§<a href="#sync">6</a>) and for the stuck legacy path.</td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout info">
+        <strong>Every in-transaction rejection must <code>throw</code>, never
+        <code>return</code>.</strong> This is the single most important
+        implementation note in the spec: a returned error commits the
+        auto-created requester user. Use a sentinel per the existing
+        <code>RACE_LOST</code> idiom and map it to a friendly message in the
+        <code>.catch</code>.
+      </div>
+
+      <h4>Data the dialog actually needs</h4>
+      <p>
+        v1 claimed the collision could be detected &ldquo;with no new
+        query&rdquo;. Half true: <code>getRequestContext</code> does return
+        <code>activeAssignments</code>, but
+        <code>ActiveAssignmentSummary</code> is
+        <code>{ id, toolName, tierName, assignedAt }</code>
+        (<code>:583-588</code>, SQL at <code>:618-625</code>) — no
+        <code>toolId</code> (so collision matching would key off a display
+        <em>name</em>), no <code>tierId</code>, and no <code>source</code> (so it
+        cannot tell a Copilot seat from a manual one). Add
+        <code>tool_id</code>, <code>tier_id</code> and <code>source</code> to
+        that SELECT — same query, three more columns.
+      </p>
+      <p>
+        Collision detection must key off <code>toolId</code>, and note that the
+        dialog keys on <code>requesterUserId</code> while the transaction
+        resolves the requester <em>by e-mail</em>: a request whose
+        <code>requesterUserId</code> is NULL but whose e-mail already matches a
+        Hub user shows no collision in the dialog yet collides server-side. The
+        server&rsquo;s mode revalidation is therefore the authority, and its
+        error message must tell the admin to reopen the dialog.
+      </p>
+
+      <h4>Template context</h4>
+      <p>
+        <code>renderTemplate</code> leaves an unresolved path as the
+        <strong>literal</strong> <code>{{tier.previousName}}</code> in the
+        output — it does not render empty. Templates are keyed only by
+        <code>(tool_id, tier_id, kind)</code> with no tier-change kind, so the
+        same approval body serves all three modes. Therefore
+        <code>tier.previousName</code> is <strong>always bound</strong> — the
+        previous tier name on a retier, an empty string otherwise — so a template
+        that references it can never leak braces into a message an admin pastes
+        to a colleague.
+      </p>
+      <p>
+        Also: in <code>change_tier</code>/<code>link_existing</code> mode the key
+        field is <em>optional, not suppressed</em>. Suppressing it made
+        <code>resolvedBody()</code> substitute the empty string into the seeded
+        Claude Console line <code>Your API key: {{licenseCode}}</code>, so the
+        pasted message read <em>&ldquo;Your API key: —&rdquo;</em>.
+      </p>
+
+      <!-- ============================================================ -->
+      <h2 id="sync">6 · Copilot sync authority</h2>
+
+      <p>
+        <code>syncSeatAssignments</code> rewrites <code>tier_id</code>,
+        <code>cost_at_assignment_cents</code>, <code>source</code> and
+        <code>workspace</code> from GitHub&rsquo;s <code>seat.plan_type</code>
+        with no history entry (<code>copilot-sync.ts:243-262</code>). GitHub owns
+        the entitlement; the Hub cannot win that argument.
+      </p>
+
+      <div class="callout">
+        <strong>Live bug.</strong>
+        <code>assignment-detail-client.tsx</code> contains <strong>zero</strong>
+        references to <code>source</code> and its <code>page.tsx</code> never
+        passes it, so the tier <code>&lt;Select&gt;</code> there is fully
+        editable for synced rows — <code>[SAVED]</code>, then silently reverted
+        by cron. Only <code>assignments-client.tsx</code> gates.
+      </div>
+
+      <div class="callout">
+        <strong>Blocking <code>source='copilot-sync'</code> is necessary but not
+        sufficient.</strong> Sync <em>takes over</em> manual rows
+        (<code>needsSourceUpdate</code>, <code>copilot-sync.ts:243</code>), so a
+        tier change on a <code>source='manual'</code> GitHub Copilot assignment
+        is equally reverted at the next cron — the same bug reached through a
+        different value. The honest gate is therefore
+        <strong>tool-based, not source-based</strong>: refuse tier changes on any
+        assignment whose tool is the Copilot-sync-managed tool while a Copilot
+        connection is active. Implemented as a single predicate so both the
+        server guard and the UI gate read the same rule.
+      </div>
+
+      <p>
+        <strong>This is why <code>link_existing</code> exists.</strong> Without
+        it, a Business &rarr; Enterprise request — the clearest upgrade ladder in
+        the system, on the tool with 63 live seats — has
+        <em>no approvable outcome at all</em>: refused by the create guard and by
+        the sync guard. With it, the flow matches 032-v2&rsquo;s provision-first
+        philosophy: the admin upgrades the plan in GitHub, approves the request
+        as <code>link_existing</code>, and the tier arrives on the next sync. The
+        dialog says exactly that.
+      </p>
+
+      <p class="meta">
+        Noted, not fixed (deferral D-5): sync&rsquo;s
+        <code>needsReactivate</code> branch resets
+        <code>assigned_at = new Date()</code> and
+        <code>revoked_at = null</code>, destroying a resurrected seat&rsquo;s
+        original start date and corrupting its period attribution.
+      </p>
+
+      <!-- ============================================================ -->
+      <h2 id="ui">7 · UI changes</h2>
+      <p>
+        Feedback via <code>StatusText</code>/<code>useInlineStatus</code> only —
+        no <code>sonner</code>.
+      </p>
+      <table>
+        <thead><tr><th>Surface</th><th>Change</th></tr></thead>
+        <tbody>
+          <tr>
+            <td><code>app/assignments/[id]/page.tsx</code> · <code>assignment-detail-client.tsx</code></td>
+            <td>
+              Pass <code>source</code>; gate the tier <code>&lt;Select&gt;</code>
+              for sync-managed rows with the existing &ldquo;Managed by
+              sync&rdquo; badge (<strong>bug fix</strong>); render a
+              <strong>tier timeline</strong> from <code>change_history</code>;
+              disclose that a tier change re-prices closed periods.
+            </td>
+          </tr>
+          <tr>
+            <td><code>app/users/[id]/user-detail-client.tsx</code></td>
+            <td>
+              The one genuinely missing affordance: a &ldquo;Change tier&rdquo;
+              link on each active row of the Assigned Tools card, routing to the
+              assignment detail page rather than duplicating a dialog.
+            </td>
+          </tr>
+          <tr>
+            <td><code>app/requests/[id]/approval-dialog.tsx</code></td>
+            <td>
+              Mode-aware step 1: detect collision by <code>toolId</code>; offer
+              <em>Change tier</em> for manual rows and
+              <em>Link existing seat</em> for sync-managed ones; keep the key
+              field optional; show a signed monthly delta.
+            </td>
+          </tr>
+          <tr>
+            <td><code>app/requests/[id]/record-assignment-dialog.tsx</code></td>
+            <td>Route the legacy v1 path through <code>link_existing</code> so an already-provisioned seat can finally be linked.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="meta">
+        <code>assignments-client.tsx</code> already has a working tier edit and
+        already gates synced rows — untouched. <code>profile-assignments.tsx</code>
+        stays read-only.
+      </p>
+
+      <!-- ============================================================ -->
+      <h2 id="tests">8 · Test plan</h2>
+
+      <div class="callout">
+        <strong>Integration tests do not run in CI</strong> —
+        <code>.github/workflows/ci.yml:96-117</code> has the
+        <code>integration-tests</code> job commented out; only
+        <code>pnpm test</code> (unit) gates a merge. v1 made an integration test
+        the sole guard for its central claim, which would never have blocked a
+        regression. The double-count guard is therefore a <strong>unit</strong>
+        test.
+      </div>
+
+      <h4>Unit — the regression guard</h4>
+      <ul>
+        <li class="check">
+          <strong>Extract the overlap predicate</strong> used by
+          <code>getBudgetWithCosts</code> into a pure exported function and test
+          it directly: given one in-place-changed row vs. an old+new row pair
+          spanning the same switch, assert the in-place result equals exactly one
+          tier price and the pair sums to two — pinning the double-count as a
+          <em>known property of the rejected design</em>, in CI, forever.
+        </li>
+        <li class="check"><code>buildTierChange</code>: no-op, sync refusal only when the tier differs, correct change map, signed delta both directions incl. Claude Console&rsquo;s non-monotonic prices.</li>
+        <li class="check">Non-admin &rarr; <code>Unauthorized</code>; inactive assignment refused; cross-tool tier refused; <strong>inactive tier refused on all three entry points</strong> (the <code>loadToolAndTier</code> gap).</li>
+        <li class="check">Race guard: zero-rows update &rarr; the refresh error, not a silent success.</li>
+        <li class="check">Mode matrix from §5, including that <code>change_tier</code> with no active assignment <strong>throws</strong> (asserting the user rolls back) and that same-tier still approves.</li>
+      </ul>
+
+      <h4>Integration — real DB, manual gate</h4>
+      <ul>
+        <li class="check">
+          <strong>Scoped, not global.</strong>
+          <code>getBudgetWithCosts</code> sums the entire
+          <code>license_assignments</code> table with no tool or budget scoping,
+          so a global before/after delta absorbs rows other suites create
+          concurrently. Assert instead on the seeded tool&rsquo;s own rows:
+          exactly one active row, and the predicate-matching sum equals the new
+          tier price alone.
+        </li>
+        <li class="check">
+          <strong>No active budget needed</strong> —
+          <code>getBudgetWithCosts</code> filters on <code>id</code> only
+          (<code>budget.ts:556-557</code>) and ignores
+          <code>status</code>. Seed it <code>archived</code>, outside every
+          claimed fiscal-year range. v1&rsquo;s &ldquo;claim FY &ge; 999,000&rdquo;
+          instruction would have collided with the suite that already owns that
+          window.
+        </li>
+        <li class="check">Approval round trip: <code>change_tier</code> retiers in place, preserves <code>id</code>/<code>assigned_at</code>/API key, links the request; failed <code>create</code> leaves <strong>no orphan user</strong>.</li>
+        <li class="check">Seeds its own tool/tiers/user — <code>seed.ts</code> creates only an admin.</li>
+      </ul>
+
+      <h4>Browser pass (Playwright via <code>agent-browser-session</code>)</h4>
+      <ul>
+        <li class="check">Change a tier on a manual assignment; assert the new tier, the timeline entry, <code>[SAVED]</code>.</li>
+        <li class="check">A sync-managed assignment offers no tier edit on the detail page (bug fix).</li>
+        <li class="check">Approve a request for an existing holder — manual (change tier) and Copilot (link existing).</li>
+        <li class="note">Use <code>page.innerText("body")</code>, not <code>textContent</code> (RSC flight payload); allow ~17s for the first <code>page.goto</code>.</li>
+      </ul>
+
+      <!-- ============================================================ -->
+      <h2 id="manifest">9 · File manifest</h2>
+      <p class="meta">No schema change. No migration. No new table.</p>
+      <table>
+        <thead><tr><th>File</th><th>Change</th></tr></thead>
+        <tbody>
+          <tr><td><code>src/actions/assignments.ts</code></td><td><code>buildTierChange</code>; race-safe conditional update; history inside the tx; corrected revalidation; delete dead <code>getExpectedSpendForPeriod</code> import if any</td></tr>
+          <tr><td><code>src/actions/budget.ts</code></td><td>delete dead <code>getExpectedSpendForPeriod</code>; export the overlap predicate for the unit test</td></tr>
+          <tr><td><code>src/actions/license-requests.ts</code></td><td>discriminated-union modes; throw-not-return on every in-tx rejection; <code>isActive</code> in <code>loadToolAndTier</code>; <code>tool_id</code>/<code>tier_id</code>/<code>source</code> in <code>ActiveAssignmentSummary</code>; always-bound <code>tier.previousName</code></td></tr>
+          <tr><td><code>src/lib/validators.ts</code></td><td><code>approveRequestSchema</code> &rarr; discriminated union</td></tr>
+          <tr><td><code>src/actions/history.ts</code></td><td>read helper for an entity&rsquo;s field timeline (tier history)</td></tr>
+          <tr><td><code>src/app/assignments/[id]/page.tsx</code> · <code>assignment-detail-client.tsx</code></td><td>pass <code>source</code>; gate; tier timeline; disclosure copy</td></tr>
+          <tr><td><code>src/app/users/[id]/user-detail-client.tsx</code></td><td>Change-tier link per active row</td></tr>
+          <tr><td><code>src/app/requests/[id]/approval-dialog.tsx</code> · <code>record-assignment-dialog.tsx</code></td><td>mode-aware approval; legacy path via <code>link_existing</code></td></tr>
+          <tr><td><code>tests/unit/actions/assignment-tier-change.test.ts</code></td><td><span class="pill new">new</span> incl. the double-count property test</td></tr>
+          <tr><td><code>tests/integration/actions/assignment-tier-change.test.ts</code></td><td><span class="pill new">new</span></td></tr>
+        </tbody>
+      </table>
+
+      <!-- ============================================================ -->
+      <h2 id="risks">10 · Decisions, deferrals &amp; risks</h2>
+      <table>
+        <thead><tr><th>#</th><th>Decision</th></tr></thead>
+        <tbody>
+          <tr><td>D-A</td><td>In-place mutation — on the honest grounds in §3, not the false &ldquo;strictly worse&rdquo; claim of v1. Accepts closed-period restatement and MoM blindness.</td></tr>
+          <tr><td>D-B</td><td>Tier changes refused for Copilot-sync-<em>managed</em> assignments by <strong>tool</strong>, not by <code>source</code> — because sync takes over manual rows too.</td></tr>
+          <tr><td>D-C</td><td>Three approval modes as a discriminated union. <code>link_existing</code> is what gives Copilot an approvable outcome and unsticks the legacy path.</td></tr>
+          <tr><td>D-D</td><td>No <code>maxLicenses</code> check — seat count unchanged; explicit because Copilot is at 63/63.</td></tr>
+          <tr><td>D-E</td><td>No migration. <code>change_history</code> is the tier timeline.</td></tr>
+          <tr><td>D-F</td><td>Tier-change history written <em>inside</em> the transaction — the stricter of the repo&rsquo;s two conventions, chosen because the audit trail is an acceptance criterion.</td></tr>
+        </tbody>
+      </table>
+
+      <table>
+        <thead><tr><th>#</th><th>Deferred</th><th>Why not now</th></tr></thead>
+        <tbody>
+          <tr><td>D-1</td><td>Effective-dated cost history — enables proration, scheduling, and boundary-snapped supersede (§3)</td><td>New table + <code>supersedes_assignment_id</code> chain + rewriting four per-period readers. The right long-term answer.</td></tr>
+          <tr><td>D-2</td><td>Restore MoM correctness after an in-place change</td><td>Needs D-1. Until then the KPI under-reports the month a tier moves.</td></tr>
+          <tr><td>D-3</td><td>Tier drift vs <code>tool_mappings</code></td><td>Needs a product rule for what drift means.</td></tr>
+          <tr><td>D-4</td><td>Partial unique index on one active assignment per user+tool</td><td>Sync can transiently produce duplicates; the constraint could break cron.</td></tr>
+          <tr><td>D-5</td><td>Sync&rsquo;s <code>needsReactivate</code> resetting <code>assigned_at</code></td><td>Real defect, unrelated blast radius.</td></tr>
+        </tbody>
+      </table>
+
+      <h4>Risks</h4>
+      <ul>
+        <li class="con">
+          <strong>Claude Console tiers are entitlement caps, not seat fees</strong>
+          — its cost is a monthly allowance while real spend arrives as metered
+          Anthropic usage. The dialog&rsquo;s delta copy must say
+          &ldquo;monthly tier cost&rdquo;, never imply the bill changes.
+        </li>
+        <li class="con">
+          <strong>Closed-period restatement is invisible from
+          <code>/budget</code></strong>, where the affected pill lives. Mitigation
+          is disclosure at the point of change plus the
+          <code>change_history</code> timeline; a real fix needs D-1.
+        </li>
+        <li class="con">
+          <strong>Four write sites still touch <code>license_assignments</code>
+          directly.</strong> This spec unifies the tier path and adds no fifth,
+          but does not unify them.
+        </li>
+      </ul>
+
+      <!-- ============================================================ -->
+      <h2 id="accept">11 · Acceptance checklist</h2>
+      <ul>
+        <li class="check">A request from someone who already holds the tool can be approved — as a tier change (manual) or a linked existing seat (sync-managed) — without revoking anything.</li>
+        <li class="check">A failed approval leaves <strong>no orphan Hub user</strong> (live-bug fix, regression-tested).</li>
+        <li class="check">A sync-managed assignment offers no tier edit on <em>any</em> surface, including the detail page (live-bug fix).</li>
+        <li class="check">After a tier change: one active row, same <code>id</code>, same <code>assigned_at</code>, comments and API key intact, timeline entry visible.</li>
+        <li class="check">A concurrent revoke during a tier change yields the refresh error, never a retiered revoked row.</li>
+        <li class="check">No approval path can put a live seat on a deactivated tier.</li>
+        <li class="check">The double-count property is pinned by a <strong>unit</strong> test that runs in CI.</li>
+        <li class="check">A pasted approval message never contains literal <code>{{&hellip;}}</code> braces or an em-dash API key.</li>
+        <li class="check"><code>pnpm typecheck</code> clean · eslint clean on changed files · <code>pnpm test</code> green · integration green locally · browser pass done.</li>
+      </ul>
+
+      <footer>
+        specs/042-assignment-tier-change/implementation-plan.html · v2, revised
+        2026-08-03 after a 5-lens adversarial panel · recon: 7-reader workflow +
+        gap critic · see implementation-notes.html for the full challenge log
+      </footer>
+    </main>
+  </body>
+</html>

--- a/specs/042-assignment-tier-change/implementation-plan.html
+++ b/specs/042-assignment-tier-change/implementation-plan.html
@@ -315,20 +315,27 @@
         (<code>src/actions/license-requests.ts:274-278</code>).
       </div>
 
-      <div class="callout">
-        <strong>Live bug found in the blast radius — a failed approval leaks a
-        Hub user.</strong> <code>ensureRequesterUser</code> inserts the requester
-        (<code>license-requests.ts:343</code>) and
-        <code>createAssignmentInTx</code>&rsquo;s duplicate-seat refusal is then
-        returned <em>out of</em> the transaction callback
-        (<code>:351</code>). In Drizzle a returned value <strong>commits</strong>
-        — only a <code>throw</code> rolls back, which is why the race guard at
-        <code>:371</code> throws <code>RACE_LOST</code>. So every time an admin
-        hit the blocker above for a requester who was not yet a Hub user, a
-        viewer account was silently created and left behind, while the request
-        stayed <code>pending_review</code>. This violates 032-v2&rsquo;s stated
-        rule that users are created at approval and never from failed ones.
-        Fixed here (§<a href="#requests">5</a>).
+      <div class="callout info">
+        <strong>A latent transaction hazard, corrected.</strong> In Drizzle a
+        value returned from the transaction callback <strong>commits</strong> —
+        only a <code>throw</code> rolls back, which is why the race guard at
+        <code>license-requests.ts:371</code> throws <code>RACE_LOST</code>. The
+        duplicate-seat refusal was <em>returned</em>, so on the face of it any
+        writes already made in that transaction would have been committed
+        alongside a failed approval.
+        <br /><br />
+        <strong>It was not actually reachable</strong>, and an earlier draft of
+        this plan wrongly claimed it leaked a Hub user. Traced properly:
+        <code>ensureRequesterUser</code> (<code>:283-295</code>) inserts a user
+        only when no row with that e-mail exists, and a brand-new user cannot
+        already hold an active assignment — so the duplicate-seat refusal can
+        never co-occur with a user insert. In the original code that refusal was
+        the only in-transaction error return, so nothing was ever orphaned.
+        <br /><br />
+        The discipline still has to change, because this spec <em>adds</em>
+        in-transaction rejections that come after a real write (a retier that
+        then loses the request-status race). Every in-transaction rejection now
+        throws (§<a href="#requests">5</a>) — hardening, not a bug fix.
       </div>
 
       <h2 id="toc">Contents</h2>
@@ -374,7 +381,7 @@
             map.
           </li>
           <li class="note">
-            <strong>Two live bugs fixed:</strong> the leaked Hub user above, and
+            <strong>One live bug fixed</strong> (plus the transaction hardening above):
             the unguarded tier <code>&lt;Select&gt;</code> on
             <code>/assignments/[id]</code> that lets an admin &ldquo;change&rdquo;
             a Copilot seat the next cron silently reverts
@@ -467,7 +474,7 @@
           <tr>
             <td><code>createAssignmentInTx</code><br /><span class="meta">license-requests.ts:266-278</span></td>
             <td>Refuses outright when an active assignment exists.</td>
-            <td><span class="pill warn">blocks the use case</span> and leaks a Hub user while doing it.</td>
+            <td><span class="pill warn">blocks the use case</span> and its only advice — revoke first — routes the admin into the worst of the three paths.</td>
           </tr>
         </tbody>
       </table>
@@ -743,11 +750,11 @@
         <thead><tr><th>mode</th><th>Existing active assignment</th><th>Outcome</th></tr></thead>
         <tbody>
           <tr><td><code>create</code></td><td>no</td><td>Insert, as today.</td></tr>
-          <tr><td><code>create</code></td><td>yes</td><td>Today&rsquo;s error — but now <strong>thrown</strong>, so the auto-created user rolls back (live-bug fix).</td></tr>
+          <tr><td><code>create</code></td><td>yes</td><td>Today&rsquo;s error, with updated advice (retier instead of revoke) — and now <strong>thrown</strong>, so the transaction rolls back.</td></tr>
           <tr><td><code>change_tier</code></td><td>yes, manual</td><td><span class="pill new">new</span> retier via <code>buildTierChange</code>; link <code>assignment_id</code>; approve.</td></tr>
           <tr><td><code>change_tier</code></td><td>yes, same tier</td><td>No-op on the row, but <strong>still approve and link</strong>.</td></tr>
           <tr><td><code>change_tier</code></td><td>no</td><td><strong>Throw</strong> to roll back: &ldquo;No active assignment to retier.&rdquo;</td></tr>
-          <tr><td><code>link_existing</code></td><td>yes</td><td><span class="pill new">new</span> mutate nothing; link <code>assignment_id</code>; approve. The answer for Copilot (§<a href="#sync">6</a>) and for the stuck legacy path.</td></tr>
+          <tr><td><code>link_existing</code></td><td>yes</td><td><span class="pill new">new</span> mutate nothing; link <code>assignment_id</code>; approve. The answer for Copilot (§<a href="#sync">6</a>).</td></tr>
         </tbody>
       </table>
 
@@ -894,7 +901,7 @@
           </tr>
           <tr>
             <td><code>app/requests/[id]/record-assignment-dialog.tsx</code></td>
-            <td>Route the legacy v1 path through <code>link_existing</code> so an already-provisioned seat can finally be linked.</td>
+            <td>Link an already-provisioned seat via the dedicated <code>linkExistingAssignment</code> action — <strong>not</strong> <code>approveRequest</code>, whose status guards are mutually exclusive with this dialog's. See the deviation note in implementation-notes.html.</td>
           </tr>
         </tbody>
       </table>
@@ -953,7 +960,7 @@
           instruction would have collided with the suite that already owns that
           window.
         </li>
-        <li class="check">Approval round trip: <code>change_tier</code> retiers in place, preserves <code>id</code>/<code>assigned_at</code>/API key, links the request; failed <code>create</code> leaves <strong>no orphan user</strong>.</li>
+        <li class="check">Approval round trip: <code>change_tier</code> retiers in place, preserves <code>id</code>/<code>assigned_at</code>/API key, links the request; a failed <code>create</code> commits nothing at all.</li>
         <li class="check">Seeds its own tool/tiers/user — <code>seed.ts</code> creates only an admin.</li>
       </ul>
 
@@ -978,7 +985,7 @@
           <tr><td><code>src/actions/history.ts</code></td><td>read helper for an entity&rsquo;s field timeline (tier history)</td></tr>
           <tr><td><code>src/app/assignments/[id]/page.tsx</code> · <code>assignment-detail-client.tsx</code></td><td>pass <code>source</code>; gate; tier timeline; disclosure copy</td></tr>
           <tr><td><code>src/app/users/[id]/user-detail-client.tsx</code></td><td>Change-tier link per active row</td></tr>
-          <tr><td><code>src/app/requests/[id]/approval-dialog.tsx</code> · <code>record-assignment-dialog.tsx</code></td><td>mode-aware approval; legacy path via <code>link_existing</code></td></tr>
+          <tr><td><code>src/app/requests/[id]/approval-dialog.tsx</code> · <code>record-assignment-dialog.tsx</code></td><td>mode-aware approval; legacy path via <code>linkExistingAssignment</code></td></tr>
           <tr><td><code>tests/unit/actions/assignment-tier-change.test.ts</code></td><td><span class="pill new">new</span> incl. the double-count property test</td></tr>
           <tr><td><code>tests/integration/actions/assignment-tier-change.test.ts</code></td><td><span class="pill new">new</span></td></tr>
         </tbody>
@@ -991,7 +998,7 @@
         <tbody>
           <tr><td>D-A</td><td>In-place mutation — on the honest grounds in §3, not the false &ldquo;strictly worse&rdquo; claim of v1. Accepts closed-period restatement and MoM blindness.</td></tr>
           <tr><td>D-B</td><td>Tier changes refused for Copilot-sync-<em>managed</em> assignments by <strong>tool</strong>, not by <code>source</code> — because sync takes over manual rows too.</td></tr>
-          <tr><td>D-C</td><td>Three approval modes as a discriminated union. <code>link_existing</code> is what gives Copilot an approvable outcome and unsticks the legacy path.</td></tr>
+          <tr><td>D-C</td><td>Three approval modes as a discriminated union. <code>link_existing</code> is what gives Copilot an approvable outcome. The legacy v1 path needed its own <code>linkExistingAssignment</code> action instead — <code>approveRequest</code> requires <code>pending_review</code> while those rows are already <code>approved</code>.</td></tr>
           <tr><td>D-D</td><td>No <code>maxLicenses</code> check — seat count unchanged; explicit because Copilot is at 63/63.</td></tr>
           <tr><td>D-E</td><td>No migration. <code>change_history</code> is the tier timeline.</td></tr>
           <tr><td>D-F</td><td>Tier-change history written <em>inside</em> the transaction — the stricter of the repo&rsquo;s two conventions, chosen because the audit trail is an acceptance criterion.</td></tr>
@@ -1034,7 +1041,7 @@
       <h2 id="accept">11 · Acceptance checklist</h2>
       <ul>
         <li class="check">A request from someone who already holds the tool can be approved — as a tier change (manual) or a linked existing seat (sync-managed) — without revoking anything.</li>
-        <li class="check">A failed approval leaves <strong>no orphan Hub user</strong> (live-bug fix, regression-tested).</li>
+        <li class="check">A failed approval commits <strong>nothing</strong> — no partial retier, no orphan user (regression-tested).</li>
         <li class="check">A sync-managed assignment offers no tier edit on <em>any</em> surface, including the detail page (live-bug fix).</li>
         <li class="check">After a tier change: one active row, same <code>id</code>, same <code>assigned_at</code>, comments and API key intact, timeline entry visible.</li>
         <li class="check">A concurrent revoke during a tier change yields the refresh error, never a retiered revoked row.</li>

--- a/src/actions/assignments.ts
+++ b/src/actions/assignments.ts
@@ -316,14 +316,21 @@ export async function updateAssignment(
   const now = new Date();
   updateValues.updatedAt = now;
 
-  // 042: guard the write on the state we actually read. Five concurrent
-  // producers can flip this row to inactive between the read above and here
-  // (revokeLicense, assignLicense's deactivate leg, deactivateUser's bulk
-  // revoke, copilot-sync's removed-seat revoke), and retiering a just-revoked
-  // row would corrupt the historical snapshot that revoked rows are supposed to
-  // preserve. The tierId predicate doubles as an optimistic lock against a
-  // concurrent tier price cascade (updateTier / syncBillingData) leaving the row
-  // stranded at a stale price.
+  // 042: guard the write on the state we actually read. The predicate covers
+  // exactly two races, and it is worth being precise about which:
+  //   - status flipped to inactive between the read above and here. Four
+  //     producers can do that (revokeLicense, assignLicense's deactivate leg,
+  //     deactivateUser's bulk revoke, copilot-sync's removed-seat revoke), and
+  //     retiering a just-revoked row would corrupt the historical snapshot that
+  //     revoked rows are supposed to preserve.
+  //   - tierId already moved, i.e. another admin retiered concurrently.
+  //
+  // It does NOT protect against a tier PRICE cascade (updateTier /
+  // syncBillingData): those rewrite cost_at_assignment_cents while leaving
+  // tier_id alone, so this predicate cannot see them, and our cost value —
+  // read before the transaction — would win. Narrow and self-correcting (the
+  // next cascade or retier fixes it); a real fix needs row-level
+  // compare-and-swap on updatedAt, which the plan scoped out deliberately.
   //
   // 042 (D-F): the update and its audit rows go in ONE transaction. Writing
   // history afterwards means a throw there leaves the tier moved with no record,

--- a/src/actions/assignments.ts
+++ b/src/actions/assignments.ts
@@ -8,7 +8,7 @@ import {
   users,
   assignmentComments,
 } from "@/lib/db/schema";
-import { eq, and, ne, count, asc, inArray, isNull, lte, gt, or } from "drizzle-orm";
+import { eq, and, count, asc, inArray, isNull, lte, gt, or } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import { requireAdmin } from "@/lib/auth-helpers";
@@ -231,7 +231,7 @@ export async function updateAssignment(
     const isSyncManaged =
       newTier.id === assignment.tierId
         ? false
-        : await isSyncManagedTool(assignment.toolId);
+        : await isSyncManagedTool(assignment.tool.name);
 
     const outcome = buildTierChange(
       {
@@ -357,7 +357,15 @@ export async function updateAssignment(
     };
   }
 
-  revalidateAssignmentCostPaths(assignment.userId, assignment.toolId);
+  // Only a tier move changes cost, and only that justifies busting the budget /
+  // report / dashboard caches. A workspace or API-key edit affects nothing but
+  // the assignment's own pages.
+  if ("tierId" in changes) {
+    revalidateAssignmentCostPaths(assignment.userId, assignment.toolId);
+  } else {
+    revalidatePath("/assignments");
+    revalidatePath(`/users/${assignment.userId}`);
+  }
   revalidatePath(`/assignments/${id}`);
 
   return { success: true, data: undefined, warning };

--- a/src/actions/assignments.ts
+++ b/src/actions/assignments.ts
@@ -8,7 +8,7 @@ import {
   users,
   assignmentComments,
 } from "@/lib/db/schema";
-import { eq, and, count, asc, inArray, isNull, lte, gt, or } from "drizzle-orm";
+import { eq, and, ne, count, asc, inArray, isNull, lte, gt, or } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import { requireAdmin } from "@/lib/auth-helpers";
@@ -21,6 +21,13 @@ import {
 import type { ActionResult } from "@/types";
 import { encryptApiKey, decryptApiKey } from "@/lib/crypto";
 import { recordCreation, recordStatusChange, recordUpdate } from "@/actions/history";
+import {
+  buildTierChange,
+  isTierChangeError,
+  isTierChangeNoop,
+} from "@/lib/assignments/tier-change";
+import { isSyncManagedTool } from "@/lib/assignments/sync-authority";
+import { revalidateAssignmentCostPaths } from "@/lib/assignments/revalidate";
 
 export async function assignLicense(
   input: unknown
@@ -204,8 +211,8 @@ export async function updateAssignment(
   const updateValues: Record<string, unknown> = {};
   let warning: string | undefined;
 
-  // --- tierId change ---
-  if (tierId !== undefined && tierId !== assignment.tierId) {
+  // --- tierId change (spec 042: shared semantics via buildTierChange) ---
+  if (tierId !== undefined) {
     // Validate new tier exists, is active, and belongs to the same tool
     const newTier = await db.query.accessTiers.findFirst({
       where: and(
@@ -218,15 +225,30 @@ export async function updateAssignment(
       return { success: false, error: "Tier not found or not available for this tool" };
     }
 
-    changes.tierId = { old: assignment.tierId, new: tierId };
-    updateValues.tierId = tierId;
+    // Only consult sync authority when the tier actually differs — the detail
+    // form always submits tierId, so checking it unconditionally would block
+    // workspace/API-key edits on a sync-managed seat.
+    const isSyncManaged =
+      newTier.id === assignment.tierId
+        ? false
+        : await isSyncManagedTool(assignment.toolId);
 
-    // Also update cost snapshot to the new tier's cost
-    changes.costAtAssignmentCents = {
-      old: assignment.costAtAssignmentCents,
-      new: newTier.monthlyCostCents,
-    };
-    updateValues.costAtAssignmentCents = newTier.monthlyCostCents;
+    const outcome = buildTierChange(
+      {
+        tierId: assignment.tierId,
+        costAtAssignmentCents: assignment.costAtAssignmentCents,
+        isSyncManaged,
+      },
+      { id: newTier.id, monthlyCostCents: newTier.monthlyCostCents },
+    );
+
+    if (isTierChangeError(outcome)) {
+      return { success: false, error: outcome.error };
+    }
+    if (!isTierChangeNoop(outcome)) {
+      Object.assign(updateValues, outcome.values);
+      Object.assign(changes, outcome.changes);
+    }
   }
 
   // --- assignedAt change ---
@@ -294,22 +316,49 @@ export async function updateAssignment(
   const now = new Date();
   updateValues.updatedAt = now;
 
-  await db
-    .update(licenseAssignments)
-    .set(updateValues)
-    .where(eq(licenseAssignments.id, id));
+  // 042: guard the write on the state we actually read. Five concurrent
+  // producers can flip this row to inactive between the read above and here
+  // (revokeLicense, assignLicense's deactivate leg, deactivateUser's bulk
+  // revoke, copilot-sync's removed-seat revoke), and retiering a just-revoked
+  // row would corrupt the historical snapshot that revoked rows are supposed to
+  // preserve. The tierId predicate doubles as an optimistic lock against a
+  // concurrent tier price cascade (updateTier / syncBillingData) leaving the row
+  // stranded at a stale price.
+  //
+  // 042 (D-F): the update and its audit rows go in ONE transaction. Writing
+  // history afterwards means a throw there leaves the tier moved with no record,
+  // and the zero-diff early return would then make a retry report success —
+  // silently falsifying the audit trail. recordUpdate already accepts a tx
+  // client, so the stricter of the repo's two conventions costs nothing here.
+  const applied = await db.transaction(async (tx) => {
+    const updated = await tx
+      .update(licenseAssignments)
+      .set(updateValues)
+      .where(
+        and(
+          eq(licenseAssignments.id, id),
+          eq(licenseAssignments.status, "active"),
+          eq(licenseAssignments.tierId, assignment.tierId),
+        ),
+      )
+      .returning({ id: licenseAssignments.id });
 
-  // Record changes in history
-  await recordUpdate(
-    "license_assignment",
-    id,
-    Number(admin.id),
-    changes
-  );
+    if (updated.length === 0) return false;
 
-  revalidatePath("/assignments");
-  revalidatePath(`/users/${assignment.userId}`);
-  revalidatePath("/reports");
+    await recordUpdate("license_assignment", id, Number(admin.id), changes, tx);
+    return true;
+  });
+
+  if (!applied) {
+    return {
+      success: false,
+      error:
+        "This assignment changed while you were editing it. Refresh and try again.",
+    };
+  }
+
+  revalidateAssignmentCostPaths(assignment.userId, assignment.toolId);
+  revalidatePath(`/assignments/${id}`);
 
   return { success: true, data: undefined, warning };
 }

--- a/src/actions/budget.ts
+++ b/src/actions/budget.ts
@@ -13,6 +13,7 @@ import {
 import { eq, and, sum, count, lte, gte, or, isNull, sql } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth-helpers";
+import { sumExpectedSpendCents } from "@/lib/budget-utils";
 import {
   budgetSchema,
   budgetAllocationSchema,
@@ -326,29 +327,12 @@ export async function getBudgets(): Promise<
   }));
 }
 
-// US5: Expected spend calculation for a budget period (based on active license assignments)
-export async function getExpectedSpendForPeriod(
-  startDate: string,
-  endDate: string,
-): Promise<number> {
-  const result = await db
-    .select({
-      total: sum(licenseAssignments.costAtAssignmentCents),
-    })
-    .from(licenseAssignments)
-    .where(
-      and(
-        eq(licenseAssignments.status, "active"),
-        lte(licenseAssignments.assignedAt, new Date(endDate)),
-        or(
-          isNull(licenseAssignments.revokedAt),
-          gte(licenseAssignments.revokedAt, new Date(startDate)),
-        ),
-      ),
-    );
-
-  return Number(result[0]?.total ?? 0);
-}
+// 042: getExpectedSpendForPeriod (US5) was removed here — it had no callers
+// anywhere in src/ or tests/ since spec 028 moved per-period expected spend into
+// getBudgetWithCosts. It also carried a status='active' filter the surviving
+// readers do not, so leaving it in place invited a future "reconcile these two"
+// refactor against a function nobody read. Per-period expected spend now has a
+// single implementation: sumExpectedSpendCents in lib/budget-utils.ts.
 
 // Helper: ensure period exists and its parent budget is not archived
 async function requireActivePeriod(periodId: number) {
@@ -616,14 +600,13 @@ export async function getBudgetWithCosts(
     const periodStart = new Date(period.startDate);
     const periodEnd = new Date(period.endDate);
 
-    // Filter assignments overlapping this period in-memory
-    const expectedSpendCents = overlappingAssignments
-      .filter(
-        (a) =>
-          a.assignedAt <= periodEnd &&
-          (a.revokedAt === null || a.revokedAt >= periodStart),
-      )
-      .reduce((total, a) => total + a.costAtAssignmentCents, 0);
+    // Filter assignments overlapping this period in-memory. The predicate lives
+    // in lib/budget-utils so a CI-visible unit test can pin it (spec 042).
+    const expectedSpendCents = sumExpectedSpendCents(
+      overlappingAssignments,
+      periodStart,
+      periodEnd,
+    );
 
     const billedTotalCents = period.billedCosts.reduce(
       (s, bc) => s + bc.amountCents,

--- a/src/actions/history.ts
+++ b/src/actions/history.ts
@@ -142,7 +142,9 @@ export async function getAssignmentTierHistory(
       eq(changeHistory.fieldName, "tierId"),
     ),
     orderBy: desc(changeHistory.createdAt),
-    with: { changedByUser: true },
+    // Only the actor's name is rendered. `changedByUser: true` would select the
+    // whole users row — password_hash included — into memory for no reason.
+    with: { changedByUser: { columns: { name: true } } },
   });
 
   if (records.length === 0) {

--- a/src/actions/history.ts
+++ b/src/actions/history.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { db } from "@/lib/db";
-import { changeHistory } from "@/lib/db/schema";
-import { eq, and, desc, count } from "drizzle-orm";
+import { changeHistory, accessTiers } from "@/lib/db/schema";
+import { eq, and, desc, count, inArray } from "drizzle-orm";
 import type { ActionResult, ChangeHistoryRecord } from "@/types";
 
 export async function recordCreation(
@@ -113,5 +113,66 @@ export async function getEntityHistory(
       records,
       total: totalRow?.count ?? 0,
     },
+  };
+}
+
+export interface TierChangeEntry {
+  id: number;
+  previousTierName: string | null;
+  newTierName: string | null;
+  changedByName: string;
+  createdAt: Date;
+}
+
+/**
+ * An assignment's tier-change timeline, newest first, with tier names
+ * resolved (change_history stores access_tiers.id as JSON-stringified text —
+ * see recordUpdate above and buildTierChange in
+ * src/lib/assignments/tier-change.ts) and the actor's name joined in. Spec 042
+ * reads this instead of adding a column: change_history already has old/new
+ * tierId, changedBy and createdAt for every retier.
+ */
+export async function getAssignmentTierHistory(
+  assignmentId: number,
+): Promise<ActionResult<TierChangeEntry[]>> {
+  const records = await db.query.changeHistory.findMany({
+    where: and(
+      eq(changeHistory.entityType, "license_assignment"),
+      eq(changeHistory.entityId, assignmentId),
+      eq(changeHistory.fieldName, "tierId"),
+    ),
+    orderBy: desc(changeHistory.createdAt),
+    with: { changedByUser: true },
+  });
+
+  if (records.length === 0) {
+    return { success: true, data: [] };
+  }
+
+  const tierIds = new Set<number>();
+  for (const record of records) {
+    if (record.previousValue) tierIds.add(JSON.parse(record.previousValue));
+    if (record.newValue) tierIds.add(JSON.parse(record.newValue));
+  }
+
+  const tiers = await db.query.accessTiers.findMany({
+    where: inArray(accessTiers.id, [...tierIds]),
+    columns: { id: true, name: true },
+  });
+  const tierNameById = new Map(tiers.map((t) => [t.id, t.name]));
+
+  return {
+    success: true,
+    data: records.map((record) => ({
+      id: record.id,
+      previousTierName: record.previousValue
+        ? (tierNameById.get(JSON.parse(record.previousValue)) ?? "an unknown tier")
+        : null,
+      newTierName: record.newValue
+        ? (tierNameById.get(JSON.parse(record.newValue)) ?? "an unknown tier")
+        : null,
+      changedByName: record.changedByUser.name,
+      createdAt: record.createdAt,
+    })),
   };
 }

--- a/src/actions/license-requests.ts
+++ b/src/actions/license-requests.ts
@@ -16,6 +16,7 @@ import { encryptApiKey, decryptApiKey } from "@/lib/crypto";
 import {
   approveRequestSchema,
   recordAssignmentSchema,
+  linkExistingAssignmentSchema,
   rejectRequestSchema,
   cancelRequestSchema,
 } from "@/lib/validators";
@@ -184,16 +185,19 @@ const RACE_LOST = Symbol("race-lost");
 /**
  * A rejection raised from INSIDE an approval transaction.
  *
- * 042 — this class exists to fix a live bug. In Drizzle, returning a value from
- * the transaction callback COMMITS; only a throw rolls back (which is why the
- * race guards throw RACE_LOST). The duplicate-seat refusal was *returned*, so
- * every "Requester already has an active assignment" rejection committed the
- * requester user that ensureRequesterUser had just inserted — leaving an
- * abandoned viewer account behind while the request stayed pending_review, in
- * direct violation of 032-v2's "users are created at approval, never from
- * rejected requests".
+ * 042 — in Drizzle, returning a value from the transaction callback COMMITS;
+ * only a throw rolls back, which is why the race guards throw RACE_LOST. The
+ * duplicate-seat refusal used to be *returned*.
  *
- * Every in-transaction rejection must therefore throw this, never return.
+ * That was harmless in practice: ensureRequesterUser inserts a user only when no
+ * row with that e-mail exists, and a freshly inserted user cannot already hold an
+ * active assignment — so the refusal and an insert were mutually exclusive, and
+ * it was the only in-transaction error return.
+ *
+ * It stops being harmless here, because this file now rejects in places that CAN
+ * follow a real write (a retier that then loses the request-status race). So the
+ * rule is absolute rather than incidental: every in-transaction rejection throws
+ * this, never returns.
  */
 class ApprovalError extends Error {}
 
@@ -709,6 +713,102 @@ export async function recordAssignment(
   revalidatePath(`/requests/${requestId}`);
   revalidatePath("/assignments");
   revalidatePath("/users");
+  return {
+    success: true,
+    data: { requestId, assignmentId: result.assignmentId },
+  };
+}
+
+/**
+ * 042: link an already-existing seat to a v1-approved request.
+ *
+ * The gap this closes: `recordAssignment` can only CREATE, so a legacy approved
+ * request whose requester already holds the tool was permanently stuck — the
+ * create path hits the duplicate-seat guard, and `approveRequest`'s new
+ * `link_existing` mode cannot help because it requires
+ * `status='pending_review'` while these rows are already `'approved'`. The two
+ * guards are mutually exclusive, so the legacy path needs its own linker.
+ *
+ * Mutates nothing on the assignment — it only fills in the missing link.
+ */
+export async function linkExistingAssignment(
+  input: unknown,
+): Promise<ActionResult<{ requestId: number; assignmentId: number }>> {
+  const admin = await requireAdmin();
+  if (!admin) return { success: false, error: "Unauthorized" };
+
+  const parsed = linkExistingAssignmentSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Validation failed",
+    };
+  }
+  const { requestId, assignmentId } = parsed.data;
+
+  const req = await db.query.licenseRequests.findFirst({
+    where: eq(licenseRequests.id, requestId),
+    columns: {
+      id: true,
+      status: true,
+      assignmentId: true,
+      requesterUserId: true,
+      requesterEmail: true,
+      requesterName: true,
+      requesterRole: true,
+      requesterProfile: true,
+    },
+  });
+  if (!req) return { success: false, error: "Request not found" };
+  if (req.status !== "approved" || req.assignmentId !== null) {
+    return {
+      success: false,
+      error: "Only approved requests without an assignment can link one.",
+    };
+  }
+
+  const result = await db
+    .transaction(async (tx) => {
+      // Same ownership/active checks as a retier — never creates a user.
+      const target = await loadTargetAssignmentInTx(tx, req, assignmentId);
+
+      const updated = await tx
+        .update(licenseRequests)
+        .set({
+          assignmentId: target.id,
+          requesterUserId: target.userId,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(licenseRequests.id, requestId),
+            eq(licenseRequests.status, "approved"),
+            sql`${licenseRequests.assignmentId} IS NULL`,
+          ),
+        )
+        .returning({ id: licenseRequests.id });
+      if (updated.length === 0) throw RACE_LOST;
+
+      return { assignmentId: target.id };
+    })
+    .catch((err) => {
+      if (err === RACE_LOST) return null;
+      if (err instanceof ApprovalError) return { error: err.message };
+      throw err;
+    });
+
+  if (result === null) {
+    return {
+      success: false,
+      error:
+        "This request was actioned by another admin while you were entering details. Refresh to see the latest state.",
+    };
+  }
+  if ("error" in result) return { success: false, error: result.error };
+
+  revalidatePath("/requests");
+  revalidatePath(`/requests/${requestId}`);
+  revalidatePath("/assignments");
   return {
     success: true,
     data: { requestId, assignmentId: result.assignmentId },

--- a/src/actions/license-requests.ts
+++ b/src/actions/license-requests.ts
@@ -545,11 +545,23 @@ export async function approveRequest(
         toolId = target.toolId;
 
         if (approval.mode === "change_tier") {
+          // loadToolAndTier proved the tier belongs to approval.toolId, but
+          // nothing so far ties the ASSIGNMENT to that tool. Without this, a
+          // stale dialog or a crafted payload could write another tool's tier
+          // onto this seat — and slip past the sync-managed refusal above, which
+          // keys off the SELECTED tool rather than the row's own. Mirrors the
+          // same-tool guard updateAssignment enforces via its accessTiers query.
+          if (target.toolId !== approval.toolId) {
+            throw new ApprovalError(
+              "That assignment is for a different tool than the one selected. Reopen the dialog and try again.",
+            );
+          }
+
           const outcome = buildTierChange(
             {
               tierId: target.tierId,
               costAtAssignmentCents: target.costAtAssignmentCents,
-              // Already refused above; the tool cannot change mid-transaction.
+              // Safe now that the tool is pinned to the one checked above.
               isSyncManaged: false,
             },
             { id: tier!.id, monthlyCostCents: tier!.monthlyCostCents },

--- a/src/actions/license-requests.ts
+++ b/src/actions/license-requests.ts
@@ -20,6 +20,19 @@ import {
   cancelRequestSchema,
 } from "@/lib/validators";
 import type { ActionResult } from "@/types";
+import { recordUpdate } from "@/actions/history";
+import {
+  buildTierChange,
+  isTierChangeError,
+  isTierChangeNoop,
+  SYNC_MANAGED_TIER_ERROR,
+  type ChangeMap,
+} from "@/lib/assignments/tier-change";
+import {
+  isSyncManagedTool,
+  getSyncManagedToolId,
+} from "@/lib/assignments/sync-authority";
+import { revalidateAssignmentCostPaths } from "@/lib/assignments/revalidate";
 
 export interface LicenseRequestRow {
   id: number;
@@ -168,10 +181,34 @@ function mapRow(row: Record<string, unknown>): LicenseRequestRow {
 // ActionResult instead of a 500.
 const RACE_LOST = Symbol("race-lost");
 
+/**
+ * A rejection raised from INSIDE an approval transaction.
+ *
+ * 042 — this class exists to fix a live bug. In Drizzle, returning a value from
+ * the transaction callback COMMITS; only a throw rolls back (which is why the
+ * race guards throw RACE_LOST). The duplicate-seat refusal was *returned*, so
+ * every "Requester already has an active assignment" rejection committed the
+ * requester user that ensureRequesterUser had just inserted — leaving an
+ * abandoned viewer account behind while the request stayed pending_review, in
+ * direct violation of 032-v2's "users are created at approval, never from
+ * rejected requests".
+ *
+ * Every in-transaction rejection must therefore throw this, never return.
+ */
+class ApprovalError extends Error {}
+
 interface AssignmentInputs {
   toolId: number;
   tierId: number;
   assignedAt: string;
+  licenseCode?: string;
+}
+
+/** Tool + tier only — what a retier needs. A retier has no assignedAt: that is
+ * the seat's original start and an upgrade must not rewrite it. */
+interface TierOnlyInputs {
+  toolId: number;
+  tierId: number;
   licenseCode?: string;
 }
 
@@ -183,9 +220,24 @@ interface RequesterFields {
   requesterProfile: "baseline" | "maxed" | "indie" | null;
 }
 
-/** Validate tool + tier and enforce the requires_api_key rule. Returns the
- * rows needed to build the assignment, or an error string. */
-async function loadToolAndTier(inputs: AssignmentInputs) {
+/** Validate tool + tier. Returns the rows needed to build or retier an
+ * assignment, or an error string.
+ *
+ * 042: `requireApiKey` is now a parameter rather than an unconditional rule.
+ * The API-key requirement is a CREATE-time rule — a retier or a link reuses the
+ * seat's stored key — and enforcing it unconditionally made every Claude Console
+ * upgrade fail with a misleading message. Claude Console is the only
+ * requires_api_key tool and has the deepest tier ladder, so that was precisely
+ * the case most likely to arise.
+ *
+ * 042: also adds the missing `accessTiers.isActive` check. Without it the
+ * request path could put a live seat on a deactivated tier — something both
+ * updateAssignment and assignLicense already refuse.
+ */
+async function loadToolAndTier(
+  inputs: TierOnlyInputs,
+  { requireApiKey }: { requireApiKey: boolean },
+) {
   const tool = await db.query.aiTools.findFirst({
     where: eq(aiTools.id, inputs.toolId),
     columns: { id: true, name: true, requiresApiKey: true },
@@ -193,12 +245,25 @@ async function loadToolAndTier(inputs: AssignmentInputs) {
   if (!tool) return { error: "Tool not found." as string, tool: null, tier: null };
   const tier = await db.query.accessTiers.findFirst({
     where: eq(accessTiers.id, inputs.tierId),
-    columns: { id: true, name: true, monthlyCostCents: true, toolId: true },
+    columns: {
+      id: true,
+      name: true,
+      monthlyCostCents: true,
+      toolId: true,
+      isActive: true,
+    },
   });
   if (!tier || tier.toolId !== tool.id) {
     return { error: "Tier does not belong to the selected tool.", tool: null, tier: null };
   }
-  if (tool.requiresApiKey && !inputs.licenseCode?.trim()) {
+  if (!tier.isActive) {
+    return {
+      error: `Tier "${tier.name}" is no longer available for ${tool.name}.`,
+      tool: null,
+      tier: null,
+    };
+  }
+  if (requireApiKey && tool.requiresApiKey && !inputs.licenseCode?.trim()) {
     return {
       error: `${tool.name} assignments carry an API key — enter the key you provisioned.`,
       tool: null,
@@ -256,13 +321,14 @@ async function ensureRequesterUser(
 }
 
 /** Duplicate-seat guard + assignment insert, shared by approve and the legacy
- * record-assignment path. Returns the new assignment id or an error string. */
+ * record-assignment path. Returns the new assignment id, or THROWS
+ * ApprovalError so the auto-created requester user rolls back with it. */
 async function createAssignmentInTx(
   tx: Tx,
   userId: number,
   inputs: AssignmentInputs,
   monthlyCostCents: number,
-): Promise<{ assignmentId: number } | { error: string }> {
+): Promise<{ assignmentId: number }> {
   const existingActive = await tx.query.licenseAssignments.findFirst({
     where: and(
       eq(licenseAssignments.userId, userId),
@@ -272,9 +338,12 @@ async function createAssignmentInTx(
     columns: { id: true },
   });
   if (existingActive) {
-    return {
-      error: `Requester already has an active assignment for this tool (assignment #${existingActive.id}). Revoke the existing assignment first, or cancel this request.`,
-    };
+    // 042: this is now a throw, not a return — see ApprovalError. The advice has
+    // also changed: retiering is a first-class outcome, so "revoke first" is no
+    // longer the only way out.
+    throw new ApprovalError(
+      `Requester already has an active assignment for this tool (assignment #${existingActive.id}). Approve it as a tier change instead, or cancel this request.`,
+    );
   }
 
   const apiKeyEncrypted = inputs.licenseCode?.trim()
@@ -296,10 +365,81 @@ async function createAssignmentInTx(
   return { assignmentId: assignment.id };
 }
 
+/**
+ * Load the assignment a retier/link targets and prove it belongs to this
+ * requester. Throws ApprovalError rather than returning, so nothing commits.
+ *
+ * Deliberately resolves the user FROM the assignment instead of calling
+ * ensureRequesterUser: these two modes require the seat to already exist, so the
+ * user necessarily exists too, and never touching the users table makes it
+ * impossible to leak one. The ownership check is by id when the request is
+ * already linked to a Hub user, otherwise by e-mail — matching how
+ * ensureRequesterUser resolves a requester, so a request whose requesterUserId
+ * is still NULL but whose e-mail matches an existing user behaves consistently.
+ */
+async function loadTargetAssignmentInTx(
+  tx: Tx,
+  req: RequesterFields,
+  assignmentId: number,
+): Promise<{
+  id: number;
+  userId: number;
+  toolId: number;
+  tierId: number;
+  costAtAssignmentCents: number;
+}> {
+  const assignment = await tx.query.licenseAssignments.findFirst({
+    where: eq(licenseAssignments.id, assignmentId),
+    columns: {
+      id: true,
+      userId: true,
+      toolId: true,
+      tierId: true,
+      costAtAssignmentCents: true,
+      status: true,
+    },
+    with: { user: { columns: { id: true, email: true } } },
+  });
+
+  if (!assignment) throw new ApprovalError("Assignment not found.");
+  if (assignment.status !== "active") {
+    throw new ApprovalError(
+      "That assignment is no longer active. Reopen the dialog and approve it as a new licence instead.",
+    );
+  }
+
+  const belongsToRequester = req.requesterUserId
+    ? assignment.userId === req.requesterUserId
+    : assignment.user.email.toLowerCase() === req.requesterEmail.toLowerCase();
+  if (!belongsToRequester) {
+    throw new ApprovalError(
+      "That assignment belongs to a different user than the requester.",
+    );
+  }
+
+  return {
+    id: assignment.id,
+    userId: assignment.userId,
+    toolId: assignment.toolId,
+    tierId: assignment.tierId,
+    costAtAssignmentCents: assignment.costAtAssignmentCents,
+  };
+}
+
 /** 032-v2: approval is the terminal happy path — provision-first. In one
  * transaction: auto-create the requester's Hub user when missing, create the
  * license assignment, and transition pending_review → approved with the
- * message stored (licenseCode token unresolved — see getRequestMessage). */
+ * message stored (licenseCode token unresolved — see getRequestMessage).
+ *
+ * 042: approval now has three shapes, because "the requester already holds this
+ * tool" is a normal case rather than an error:
+ *   create        — insert a new assignment (the original behaviour)
+ *   change_tier   — retier the seat they already hold, in place
+ *   link_existing — approve and link an already-provisioned seat, mutating
+ *                   nothing. The only approvable outcome for a sync-managed tool
+ *                   (GitHub owns Copilot entitlements), and the escape hatch for
+ *                   the legacy record-assignment path.
+ */
 export async function approveRequest(
   input: unknown,
 ): Promise<ActionResult<{ requestId: number; assignmentId: number }>> {
@@ -313,7 +453,8 @@ export async function approveRequest(
       error: parsed.error.issues[0]?.message ?? "Validation failed",
     };
   }
-  const { requestId, bodyMd, ...assignmentInputs } = parsed.data;
+  const approval = parsed.data;
+  const { requestId, bodyMd } = approval;
 
   const req = await db.query.licenseRequests.findFirst({
     where: eq(licenseRequests.id, requestId),
@@ -335,20 +476,83 @@ export async function approveRequest(
     };
   }
 
-  const { error: toolError, tier } = await loadToolAndTier(assignmentInputs);
-  if (toolError) return { success: false, error: toolError };
+  // Tool/tier validation happens outside the transaction, as before. The
+  // API-key rule is create-only: a retier reuses the seat's stored key.
+  let tier: { id: number; monthlyCostCents: number } | null = null;
+  if (approval.mode !== "link_existing") {
+    const loaded = await loadToolAndTier(approval, {
+      requireApiKey: approval.mode === "create",
+    });
+    if (loaded.error) return { success: false, error: loaded.error };
+    tier = loaded.tier;
+  }
+
+  // A retier on a sync-managed tool would be reverted by the next cron, so it is
+  // refused here rather than silently undone later. link_existing remains
+  // available and is the intended route for those seats.
+  if (approval.mode === "change_tier" && (await isSyncManagedTool(approval.toolId))) {
+    return { success: false, error: SYNC_MANAGED_TIER_ERROR };
+  }
 
   const result = await db
     .transaction(async (tx) => {
-      const userId = await ensureRequesterUser(tx, req);
+      let assignmentId: number;
+      let userId: number;
+      let toolId: number;
+      let changes: ChangeMap | null = null;
 
-      const created = await createAssignmentInTx(
-        tx,
-        userId,
-        assignmentInputs,
-        tier!.monthlyCostCents,
-      );
-      if ("error" in created) return created;
+      if (approval.mode === "create") {
+        userId = await ensureRequesterUser(tx, req);
+        const created = await createAssignmentInTx(
+          tx,
+          userId,
+          approval,
+          tier!.monthlyCostCents,
+        );
+        assignmentId = created.assignmentId;
+        toolId = approval.toolId;
+      } else {
+        const target = await loadTargetAssignmentInTx(
+          tx,
+          req,
+          approval.assignmentId,
+        );
+        assignmentId = target.id;
+        userId = target.userId;
+        toolId = target.toolId;
+
+        if (approval.mode === "change_tier") {
+          const outcome = buildTierChange(
+            {
+              tierId: target.tierId,
+              costAtAssignmentCents: target.costAtAssignmentCents,
+              // Already refused above; the tool cannot change mid-transaction.
+              isSyncManaged: false,
+            },
+            { id: tier!.id, monthlyCostCents: tier!.monthlyCostCents },
+          );
+          if (isTierChangeError(outcome)) {
+            throw new ApprovalError(outcome.error);
+          }
+          // A no-op still has to approve and link the request — returning early
+          // here would strand it in pending_review forever.
+          if (!isTierChangeNoop(outcome)) {
+            const retiered = await tx
+              .update(licenseAssignments)
+              .set({ ...outcome.values, updatedAt: new Date() })
+              .where(
+                and(
+                  eq(licenseAssignments.id, target.id),
+                  eq(licenseAssignments.status, "active"),
+                  eq(licenseAssignments.tierId, target.tierId),
+                ),
+              )
+              .returning({ id: licenseAssignments.id });
+            if (retiered.length === 0) throw RACE_LOST;
+            changes = outcome.changes;
+          }
+        }
+      }
 
       const updated = await tx
         .update(licenseRequests)
@@ -357,7 +561,7 @@ export async function approveRequest(
           decidedBy: Number(admin.id),
           decidedAt: new Date(),
           approvalMessageMd: bodyMd,
-          assignmentId: created.assignmentId,
+          assignmentId,
           requesterUserId: userId,
           updatedAt: new Date(),
         })
@@ -370,10 +574,21 @@ export async function approveRequest(
         .returning({ id: licenseRequests.id });
       if (updated.length === 0) throw RACE_LOST;
 
-      return { assignmentId: created.assignmentId };
+      if (changes) {
+        await recordUpdate(
+          "license_assignment",
+          assignmentId,
+          Number(admin.id),
+          changes,
+          tx,
+        );
+      }
+
+      return { assignmentId, userId, toolId };
     })
     .catch((err) => {
       if (err === RACE_LOST) return null;
+      if (err instanceof ApprovalError) return { error: err.message };
       throw err;
     });
 
@@ -388,8 +603,9 @@ export async function approveRequest(
 
   revalidatePath("/requests");
   revalidatePath(`/requests/${requestId}`);
-  revalidatePath("/assignments");
+  revalidatePath(`/assignments/${result.assignmentId}`);
   revalidatePath("/users");
+  revalidateAssignmentCostPaths(result.userId, result.toolId);
   return {
     success: true,
     data: { requestId, assignmentId: result.assignmentId },
@@ -435,7 +651,10 @@ export async function recordAssignment(
     };
   }
 
-  const { error: toolError, tier } = await loadToolAndTier(assignmentInputs);
+  // Create-time inputs, so the API-key rule applies here as it always did.
+  const { error: toolError, tier } = await loadToolAndTier(assignmentInputs, {
+    requireApiKey: true,
+  });
   if (toolError) return { success: false, error: toolError };
 
   const result = await db
@@ -447,7 +666,6 @@ export async function recordAssignment(
         assignmentInputs,
         tier!.monthlyCostCents,
       );
-      if ("error" in created) return created;
 
       const updated = await tx
         .update(licenseRequests)
@@ -466,10 +684,13 @@ export async function recordAssignment(
         .returning({ id: licenseRequests.id });
       if (updated.length === 0) throw RACE_LOST;
 
-      return { assignmentId: created.assignmentId };
+      return { assignmentId: created.assignmentId, userId };
     })
     .catch((err) => {
       if (err === RACE_LOST) return null;
+      // 042: the duplicate-seat refusal now throws, so this path inherits the
+      // rollback too — previously it committed an auto-created user as well.
+      if (err instanceof ApprovalError) return { error: err.message };
       throw err;
     });
 
@@ -481,6 +702,8 @@ export async function recordAssignment(
     };
   }
   if ("error" in result) return { success: false, error: result.error };
+
+  revalidateAssignmentCostPaths(result.userId, assignmentInputs.toolId);
 
   revalidatePath("/requests");
   revalidatePath(`/requests/${requestId}`);
@@ -582,8 +805,17 @@ export interface ToolOption {
 
 export interface ActiveAssignmentSummary {
   id: number;
+  // 042: toolId/tierId/syncManaged added so the approval dialog can decide what
+  // it is looking at. Matching the approver's selected tool by display NAME was
+  // the alternative, and it could not distinguish a sync-managed seat at all —
+  // which is the single most likely collision, Copilot being at 63/63 seats.
+  toolId: number;
   toolName: string;
+  tierId: number;
   tierName: string;
+  tierCostCents: number;
+  /** GitHub owns this seat's plan; it can be linked but not retiered. */
+  syncManaged: boolean;
   assignedAt: Date;
 }
 
@@ -612,24 +844,42 @@ export async function getRequestContext(requestId: number) {
   }));
 
   // The requester's existing active assignments — add-on review context (the
-  // guide's "one tool per profile; combining needs justification" rule).
-  let activeAssignments: ActiveAssignmentSummary[] = [];
-  if (detail.requesterUserId) {
-    const rows = await db.execute(sql`
-      SELECT la.id, t.name AS tool_name, ti.name AS tier_name, la.assigned_at
+  // guide's "one tool per profile; combining needs justification" rule) and,
+  // since 042, the basis for offering a tier change instead of a create.
+  //
+  // Resolved by user id when the request is already linked, otherwise by e-mail.
+  // approveRequest's ensureRequesterUser resolves the same way, so keying only on
+  // requesterUserId (as this did) meant a request whose user row exists but is
+  // not yet linked showed NO collision in the dialog and then failed server-side.
+  const syncManagedToolId = await getSyncManagedToolId();
+  const rows = await db.execute(sql`
+      SELECT la.id, la.tool_id, la.tier_id, la.assigned_at,
+             t.name AS tool_name,
+             ti.name AS tier_name, ti.monthly_cost_cents
       FROM license_assignments la
       JOIN ai_tools t ON t.id = la.tool_id
       JOIN access_tiers ti ON ti.id = la.tier_id
-      WHERE la.user_id = ${detail.requesterUserId} AND la.status = 'active'
+      JOIN users u ON u.id = la.user_id
+      WHERE la.status = 'active'
+        AND (
+          u.id = ${detail.requesterUserId ?? null}
+          OR lower(u.email) = ${detail.requesterEmail.toLowerCase()}
+        )
       ORDER BY la.assigned_at DESC
     `);
-    activeAssignments = (rows.rows as Array<Record<string, unknown>>).map((r) => ({
-      id: r.id as number,
-      toolName: r.tool_name as string,
-      tierName: r.tier_name as string,
-      assignedAt: toDate(r.assigned_at) ?? new Date(0),
-    }));
-  }
+  const activeAssignments: ActiveAssignmentSummary[] = (
+    rows.rows as Array<Record<string, unknown>>
+  ).map((r) => ({
+    id: r.id as number,
+    toolId: r.tool_id as number,
+    toolName: r.tool_name as string,
+    tierId: r.tier_id as number,
+    tierName: r.tier_name as string,
+    tierCostCents: Number(r.monthly_cost_cents ?? 0),
+    syncManaged:
+      syncManagedToolId !== null && (r.tool_id as number) === syncManagedToolId,
+    assignedAt: toDate(r.assigned_at) ?? new Date(0),
+  }));
 
   return { detail, tools, activeAssignments };
 }

--- a/src/actions/license-requests.ts
+++ b/src/actions/license-requests.ts
@@ -30,8 +30,8 @@ import {
   type ChangeMap,
 } from "@/lib/assignments/tier-change";
 import {
-  isSyncManagedTool,
-  getSyncManagedToolId,
+  isCopilotSyncActive,
+  isSyncManagedToolName,
 } from "@/lib/assignments/sync-authority";
 import { revalidateAssignmentCostPaths } from "@/lib/assignments/revalidate";
 
@@ -200,6 +200,17 @@ const RACE_LOST = Symbol("race-lost");
  * this, never returns.
  */
 class ApprovalError extends Error {}
+
+/**
+ * Shared `.catch` for the three request-mutating transactions. `null` means the
+ * first-write-wins race was lost; `{ error }` is a rejection raised inside the
+ * transaction. Anything else is a real fault and rethrows.
+ */
+function catchApprovalTx(err: unknown): null | { error: string } {
+  if (err === RACE_LOST) return null;
+  if (err instanceof ApprovalError) return { error: err.message };
+  throw err;
+}
 
 interface AssignmentInputs {
   toolId: number;
@@ -483,18 +494,26 @@ export async function approveRequest(
   // Tool/tier validation happens outside the transaction, as before. The
   // API-key rule is create-only: a retier reuses the seat's stored key.
   let tier: { id: number; monthlyCostCents: number } | null = null;
+  let toolName: string | null = null;
   if (approval.mode !== "link_existing") {
     const loaded = await loadToolAndTier(approval, {
       requireApiKey: approval.mode === "create",
     });
     if (loaded.error) return { success: false, error: loaded.error };
+    // Non-null once loaded.error is falsy — same contract the tier read relies on.
     tier = loaded.tier;
+    toolName = loaded.tool!.name;
   }
 
   // A retier on a sync-managed tool would be reverted by the next cron, so it is
   // refused here rather than silently undone later. link_existing remains
-  // available and is the intended route for those seats.
-  if (approval.mode === "change_tier" && (await isSyncManagedTool(approval.toolId))) {
+  // available and is the intended route for those seats. Reuses the tool row
+  // loadToolAndTier already fetched rather than looking it up again.
+  if (
+    approval.mode === "change_tier" &&
+    isSyncManagedToolName(toolName!) &&
+    (await isCopilotSyncActive())
+  ) {
     return { success: false, error: SYNC_MANAGED_TIER_ERROR };
   }
 
@@ -588,13 +607,16 @@ export async function approveRequest(
         );
       }
 
-      return { assignmentId, userId, toolId };
+      // `changes` is set only when a tier actually moved — a create always adds
+      // cost, a no-op retier and a link add none.
+      return {
+        assignmentId,
+        userId,
+        toolId,
+        costChanged: approval.mode === "create" || changes !== null,
+      };
     })
-    .catch((err) => {
-      if (err === RACE_LOST) return null;
-      if (err instanceof ApprovalError) return { error: err.message };
-      throw err;
-    });
+    .catch(catchApprovalTx);
 
   if (result === null) {
     return {
@@ -609,7 +631,13 @@ export async function approveRequest(
   revalidatePath(`/requests/${requestId}`);
   revalidatePath(`/assignments/${result.assignmentId}`);
   revalidatePath("/users");
-  revalidateAssignmentCostPaths(result.userId, result.toolId);
+  // A link, or a retier to the tier already held, changes no cost — so it must
+  // not bust the budget/report/dashboard caches.
+  if (result.costChanged) {
+    revalidateAssignmentCostPaths(result.userId, result.toolId);
+  } else {
+    revalidatePath("/assignments");
+  }
   return {
     success: true,
     data: { requestId, assignmentId: result.assignmentId },
@@ -690,13 +718,7 @@ export async function recordAssignment(
 
       return { assignmentId: created.assignmentId, userId };
     })
-    .catch((err) => {
-      if (err === RACE_LOST) return null;
-      // 042: the duplicate-seat refusal now throws, so this path inherits the
-      // rollback too — previously it committed an auto-created user as well.
-      if (err instanceof ApprovalError) return { error: err.message };
-      throw err;
-    });
+    .catch(catchApprovalTx);
 
   if (result === null) {
     return {
@@ -791,11 +813,7 @@ export async function linkExistingAssignment(
 
       return { assignmentId: target.id };
     })
-    .catch((err) => {
-      if (err === RACE_LOST) return null;
-      if (err instanceof ApprovalError) return { error: err.message };
-      throw err;
-    });
+    .catch(catchApprovalTx);
 
   if (result === null) {
     return {
@@ -951,8 +969,10 @@ export async function getRequestContext(requestId: number) {
   // approveRequest's ensureRequesterUser resolves the same way, so keying only on
   // requesterUserId (as this did) meant a request whose user row exists but is
   // not yet linked showed NO collision in the dialog and then failed server-side.
-  const syncManagedToolId = await getSyncManagedToolId();
-  const rows = await db.execute(sql`
+  // Independent of the row fetch, so issued concurrently with it.
+  const [syncActive, rows] = await Promise.all([
+    isCopilotSyncActive(),
+    db.execute(sql`
       SELECT la.id, la.tool_id, la.tier_id, la.assigned_at,
              t.name AS tool_name,
              ti.name AS tier_name, ti.monthly_cost_cents
@@ -966,7 +986,8 @@ export async function getRequestContext(requestId: number) {
           OR lower(u.email) = ${detail.requesterEmail.toLowerCase()}
         )
       ORDER BY la.assigned_at DESC
-    `);
+    `),
+  ]);
   const activeAssignments: ActiveAssignmentSummary[] = (
     rows.rows as Array<Record<string, unknown>>
   ).map((r) => ({
@@ -976,8 +997,8 @@ export async function getRequestContext(requestId: number) {
     tierId: r.tier_id as number,
     tierName: r.tier_name as string,
     tierCostCents: Number(r.monthly_cost_cents ?? 0),
-    syncManaged:
-      syncManagedToolId !== null && (r.tool_id as number) === syncManagedToolId,
+    // The join already gave us the tool name, so no extra lookup is needed.
+    syncManaged: syncActive && isSyncManagedToolName(r.tool_name as string),
     assignedAt: toDate(r.assigned_at) ?? new Date(0),
   }));
 

--- a/src/actions/reports.ts
+++ b/src/actions/reports.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db";
 import { aiTools, licenseAssignments } from "@/lib/db/schema";
 import { and, eq, gt, isNull, lte, or } from "drizzle-orm";
 import { getActiveBudget, getBudgetWithCosts } from "@/actions/budget";
-import { getRunningCostsForPeriod } from "@/lib/budget-utils";
+import { getRunningCostsForPeriod, overlapsPeriod } from "@/lib/budget-utils";
 import { buildBudgetForecast } from "@/lib/forecast";
 import { classifyPeriod } from "@/lib/reports/period-helpers";
 import type {
@@ -144,10 +144,9 @@ async function fetchPerToolByPeriod(
     const periodEnd = new Date(p.endDate);
     const bucket = empty.get(p.id)!;
     for (const r of rows) {
-      if (
-        r.assignedAt <= periodEnd &&
-        (r.revokedAt === null || r.revokedAt > periodStart)
-      ) {
+      // Shared with getBudgetWithCosts (spec 042); "exclusive" keeps this
+      // reader's long-standing strict `>` on the revoked bound.
+      if (overlapsPeriod(r, periodStart, periodEnd, "exclusive")) {
         const existing = bucket.get(r.toolId);
         if (existing) {
           existing.cents += r.costAtAssignmentCents;

--- a/src/actions/tools.ts
+++ b/src/actions/tools.ts
@@ -12,6 +12,7 @@ import {
   updateTierSchema,
 } from "@/lib/validators";
 import type { ActionResult, AiTool, AccessTier } from "@/types";
+import { revalidateCostSurfaces } from "@/lib/assignments/revalidate";
 import {
   recordCreation,
   recordUpdate,
@@ -317,12 +318,9 @@ export async function updateTier(input: unknown): Promise<ActionResult<void>> {
     });
     await recordUpdate("access_tier", id, Number(admin.id), changes);
 
+    // Same list as the assignment-level tier change — see revalidateCostSurfaces.
     if (newCostCents !== undefined) {
-      revalidatePath("/");
-      revalidatePath("/assignments");
-      revalidatePath("/budget");
-      revalidatePath("/reports");
-      revalidatePath("/reports/budget");
+      revalidateCostSurfaces();
     }
   }
 

--- a/src/app/assignments/[id]/assignment-detail-client.tsx
+++ b/src/app/assignments/[id]/assignment-detail-client.tsx
@@ -16,9 +16,10 @@ import {
   updateAssignmentSchema,
   type UpdateAssignmentInput,
 } from "@/lib/validators";
-import { formatCurrency, cn, formatDateOnly } from "@/lib/utils";
+import { formatCurrency, cn, formatDateOnly, formatDate } from "@/lib/utils";
 import type { AccessTier, UserDiscipline } from "@/types";
 import { DISCIPLINE_ICON, DISCIPLINE_LABEL, asDiscipline } from "@/lib/disciplines";
+import { SYNC_MANAGED_TIER_ERROR } from "@/lib/assignments/tier-change";
 import {
   Card,
   CardContent,
@@ -54,6 +55,11 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import {
   Eye,
   EyeOff,
   Copy,
@@ -84,16 +90,31 @@ interface CommentData {
   author: { name: string };
 }
 
+interface TierHistoryEntry {
+  id: number;
+  previousTierName: string | null;
+  newTierName: string | null;
+  changedByName: string;
+  createdAt: string;
+}
+
 interface Props {
   assignment: AssignmentData;
   comments: CommentData[];
   isAdmin: boolean;
+  // Gated on the tool, not assignment.source (spec 042) — see
+  // isSyncManagedTool in src/lib/assignments/sync-authority.ts. Only the tier
+  // control is affected; workspace, API key and assigned-date stay editable.
+  isSyncManaged: boolean;
+  tierHistory: TierHistoryEntry[];
 }
 
 export function AssignmentDetailClient({
   assignment,
   comments,
   isAdmin,
+  isSyncManaged,
+  tierHistory,
 }: Props) {
   const router = useRouter();
   const detailStatus = useInlineStatus();
@@ -290,19 +311,38 @@ export function AssignmentDetailClient({
                     <Badge variant="default">Active</Badge>
                   </div>
 
-                  {/* Tier (editable) */}
+                  {/* Tier (editable, unless sync-managed) */}
                   <FormField
                     control={form.control}
                     name="tierId"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel className="text-sm font-medium text-muted-foreground">
-                          Tier
-                        </FormLabel>
+                        <div className="flex items-center gap-2">
+                          <FormLabel className="text-sm font-medium text-muted-foreground">
+                            Tier
+                          </FormLabel>
+                          {isSyncManaged && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge
+                                  variant="outline"
+                                  className="cursor-default text-xs text-muted-foreground"
+                                >
+                                  Managed by sync
+                                </Badge>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                {SYNC_MANAGED_TIER_ERROR}
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
+                        </div>
                         <Select
                           value={String(field.value)}
                           onValueChange={(val) => field.onChange(Number(val))}
-                          disabled={loadingTiers || tiers.length === 0}
+                          disabled={
+                            loadingTiers || tiers.length === 0 || isSyncManaged
+                          }
                         >
                           <FormControl>
                             <SelectTrigger>
@@ -325,6 +365,13 @@ export function AssignmentDetailClient({
                           </SelectContent>
                         </Select>
                         <FormMessage />
+                        {!isSyncManaged && (
+                          <p className="text-xs text-muted-foreground">
+                            Changing tier re-prices the current month and
+                            restates already-closed budget periods at the new
+                            price.
+                          </p>
+                        )}
                       </FormItem>
                     )}
                   />
@@ -648,6 +695,33 @@ export function AssignmentDetailClient({
                 </>
               )}
             </div>
+          )}
+
+          {/* Tier timeline (spec 042) — the audit trail change_history already
+              keeps; assigned_at alone can't answer "since when is she on
+              Premium Seat?" once a tier change mutates the row in place. */}
+          {tierHistory.length > 0 && (
+            <>
+              <Separator className="my-4" />
+              <div className="space-y-1.5">
+                <p className="text-sm font-medium text-muted-foreground">
+                  Tier History
+                </p>
+                <ul className="space-y-1">
+                  {tierHistory.map((entry) => (
+                    <li
+                      key={entry.id}
+                      className="text-sm text-muted-foreground"
+                    >
+                      {entry.previousTierName ?? "—"} &rarr;{" "}
+                      {entry.newTierName ?? "—"} &middot;{" "}
+                      {formatDate(entry.createdAt)} &middot;{" "}
+                      {entry.changedByName}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </>
           )}
         </CardContent>
       </Card>

--- a/src/app/assignments/[id]/assignment-detail-client.tsx
+++ b/src/app/assignments/[id]/assignment-detail-client.tsx
@@ -28,6 +28,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { SyncManagedBadge } from "@/components/assignments/sync-managed-badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -322,19 +323,7 @@ export function AssignmentDetailClient({
                             Tier
                           </FormLabel>
                           {isSyncManaged && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Badge
-                                  variant="outline"
-                                  className="cursor-default text-xs text-muted-foreground"
-                                >
-                                  Managed by sync
-                                </Badge>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                {SYNC_MANAGED_TIER_ERROR}
-                              </TooltipContent>
-                            </Tooltip>
+                            <SyncManagedBadge tooltip={SYNC_MANAGED_TIER_ERROR} />
                           )}
                         </div>
                         <Select

--- a/src/app/assignments/[id]/assignment-detail-client.tsx
+++ b/src/app/assignments/[id]/assignment-detail-client.tsx
@@ -56,11 +56,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from "@/components/ui/tooltip";
-import {
   Eye,
   EyeOff,
   Copy,
@@ -335,13 +330,26 @@ export function AssignmentDetailClient({
                         >
                           <FormControl>
                             <SelectTrigger>
-                              <SelectValue
-                                placeholder={
-                                  loadingTiers
+                              {/* Render the label ourselves. Radix resolves the
+                                  displayed value by looking up the SELECTED
+                                  ITEM's children, and the items arrive
+                                  asynchronously from loadTiers — so the control
+                                  painted EMPTY on every assignment until the
+                                  list happened to be ready. A placeholder does
+                                  not help: it only shows when the value is
+                                  empty, and here it is a real tier id. */}
+                              <SelectValue>
+                                {(() => {
+                                  const sel = tiers.find(
+                                    (t) => t.id === field.value,
+                                  );
+                                  if (sel)
+                                    return `${sel.name} — ${formatCurrency(sel.monthlyCostCents)}/mo`;
+                                  return loadingTiers
                                     ? "Loading tiers..."
-                                    : "Select tier"
-                                }
-                              />
+                                    : assignment.tier.name;
+                                })()}
+                              </SelectValue>
                             </SelectTrigger>
                           </FormControl>
                           <SelectContent>

--- a/src/app/assignments/[id]/page.tsx
+++ b/src/app/assignments/[id]/page.tsx
@@ -32,7 +32,7 @@ export default async function AssignmentDetailPage({
     // Gated on the TOOL, not assignment.source — see isSyncManagedTool (spec
     // 042): sync takes over manual rows too, so source alone would leave a
     // manual GitHub Copilot row's tier editable right up to the next cron.
-    isSyncManagedTool(assignment.tool.id),
+    isSyncManagedTool(assignment.tool.name),
     getAssignmentTierHistory(assignmentId),
   ]);
   const tierHistory = tierHistoryResult.success ? tierHistoryResult.data : [];

--- a/src/app/assignments/[id]/page.tsx
+++ b/src/app/assignments/[id]/page.tsx
@@ -5,6 +5,8 @@ import {
   getAssignmentById,
   getAssignmentComments,
 } from "@/actions/assignments";
+import { getAssignmentTierHistory } from "@/actions/history";
+import { isSyncManagedTool } from "@/lib/assignments/sync-authority";
 import { maskApiKey, decryptApiKey } from "@/lib/crypto";
 import { AssignmentDetailClient } from "./assignment-detail-client";
 
@@ -25,7 +27,15 @@ export default async function AssignmentDetailPage({
   const assignment = await getAssignmentById(assignmentId);
   if (!assignment) notFound();
 
-  const comments = await getAssignmentComments(assignmentId);
+  const [comments, isSyncManaged, tierHistoryResult] = await Promise.all([
+    getAssignmentComments(assignmentId),
+    // Gated on the TOOL, not assignment.source — see isSyncManagedTool (spec
+    // 042): sync takes over manual rows too, so source alone would leave a
+    // manual GitHub Copilot row's tier editable right up to the next cron.
+    isSyncManagedTool(assignment.tool.id),
+    getAssignmentTierHistory(assignmentId),
+  ]);
+  const tierHistory = tierHistoryResult.success ? tierHistoryResult.data : [];
 
   // Compute masked API key server-side
   let maskedApiKey: string | null = null;
@@ -66,6 +76,14 @@ export default async function AssignmentDetailPage({
           author: { name: c.author.name },
         }))}
         isAdmin={isAdmin}
+        isSyncManaged={isSyncManaged}
+        tierHistory={tierHistory.map((h) => ({
+          id: h.id,
+          previousTierName: h.previousTierName,
+          newTierName: h.newTierName,
+          changedByName: h.changedByName,
+          createdAt: h.createdAt.toISOString(),
+        }))}
       />
     </AuthGuard>
   );

--- a/src/app/assignments/assignments-client.tsx
+++ b/src/app/assignments/assignments-client.tsx
@@ -28,6 +28,7 @@ import {
 import type { AiTool, User, AccessTier } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { SyncManagedBadge } from "@/components/assignments/sync-managed-badge";
 import {
   Dialog,
   DialogContent,
@@ -463,20 +464,10 @@ function AssignmentRowActions({
       {isAdmin &&
         assignment.status === "active" &&
         assignment.source === "copilot-sync" && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Badge
-                variant="outline"
-                className="ml-1 cursor-default text-xs text-muted-foreground"
-              >
-                Managed by sync
-              </Badge>
-            </TooltipTrigger>
-            <TooltipContent>
-              This assignment is managed by Copilot sync and cannot be edited or
-              revoked manually.
-            </TooltipContent>
-          </Tooltip>
+          <SyncManagedBadge
+            className="ml-1"
+            tooltip="This assignment is managed by Copilot sync and cannot be edited or revoked manually."
+          />
         )}
       {isAdmin &&
         assignment.status === "active" &&

--- a/src/app/requests/[id]/approval-dialog.tsx
+++ b/src/app/requests/[id]/approval-dialog.tsx
@@ -29,25 +29,51 @@ import {
 } from "@/components/ui/select";
 import { CopySnippetButton } from "@/components/copy-snippet";
 import { approveRequest } from "@/actions/license-requests";
-import type { LicenseRequestDetail, ToolOption } from "@/actions/license-requests";
+import type {
+  ActiveAssignmentSummary,
+  LicenseRequestDetail,
+  ToolOption,
+} from "@/actions/license-requests";
 import type { ApprovalTemplateRow } from "@/lib/license-requests/templates";
+import type { ApproveRequestInput } from "@/lib/validators";
 import {
   renderTemplate,
   type TemplateContext,
 } from "@/lib/license-requests/render-template";
 import { markdownToTeamsHtml } from "@/lib/teams/markdown";
+import { tierCostDeltaCents } from "@/lib/assignments/tier-change";
+import { formatCurrency, formatVariance } from "@/lib/utils";
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   detail: LicenseRequestDetail;
   tools: ToolOption[];
+  /** 042 — the requester's existing active assignments; drives the mode
+   * (create / change_tier / link_existing) via a toolId match. */
+  activeAssignments: ActiveAssignmentSummary[];
   approvalTemplates: ApprovalTemplateRow[];
   approver: { name: string; firstName: string };
   onSuccess: () => void;
 }
 
 type Step = 1 | 2 | "done";
+
+/** 042 — derived from the toolId/activeAssignments match, never chosen
+ * directly by the admin. See the `mode` computation in the component. */
+type ApprovalMode = "create" | "change_tier" | "link_existing";
+
+const FOOTER_HINT: Record<ApprovalMode, string> = {
+  create: "Approving creates the assignment.",
+  change_tier: "Approving retiers the existing assignment in place.",
+  link_existing: "Approving links the existing seat — nothing on it changes.",
+};
+
+const PRIMARY_LABEL: Record<ApprovalMode, string> = {
+  create: "Approve & create assignment",
+  change_tier: "Approve & change tier",
+  link_existing: "Approve & link existing seat",
+};
 
 const LICENSE_CODE_TOKEN = /\{\{\s*licenseCode\s*\}\}/g;
 
@@ -69,6 +95,7 @@ export function ApprovalDialog({
   onOpenChange,
   detail,
   tools,
+  activeAssignments,
   approvalTemplates,
   approver,
   onSuccess,
@@ -101,6 +128,23 @@ export function ApprovalDialog({
   const needsKey = selectedTool?.requiresApiKey ?? false;
   const willCreateUser = detail.requesterUserId === null;
 
+  // 042 — collision detection keys on toolId, never on display name (two tools
+  // can share a name across vendors; ActiveAssignmentSummary carries the id
+  // precisely so this doesn't have to guess). A sync-managed match can only be
+  // linked — GitHub owns that seat's plan — anything else is retiered in place.
+  const activeMatch =
+    toolId !== null
+      ? (activeAssignments.find((a) => a.toolId === toolId) ?? null)
+      : null;
+  const mode: ApprovalMode =
+    activeMatch === null
+      ? "create"
+      : activeMatch.syncManaged
+        ? "link_existing"
+        : "change_tier";
+  // link_existing never needs a tier pick — the seat's own tier is unaffected.
+  const canContinue = toolId !== null && (mode === "link_existing" || tierId !== null);
+
   function handleToolChange(value: string) {
     const id = Number.parseInt(value, 10);
     setToolId(id);
@@ -115,27 +159,72 @@ export function ApprovalDialog({
   }
 
   function handleAdvance() {
+    if (mode === "link_existing") {
+      if (!activeMatch) {
+        status.error("Select a tool");
+        return;
+      }
+      // Nothing is being mutated — tool/tier stay the seat's current ones, so
+      // tier.previousName has nothing to report and stays "".
+      const template = resolveTemplate(approvalTemplates, activeMatch.toolId, activeMatch.tierId);
+      const ctx = buildContext(detail, activeMatch.toolName, activeMatch.tierName, approver);
+      setBodyMd(template ? renderTemplate(template, ctx).rendered : "");
+      setStep(2);
+      return;
+    }
+
     if (!selectedTool || !selectedTier) {
       status.error("Select a tool and tier");
       return;
     }
-    if (needsKey && licenseCode.trim().length === 0) {
+    // The API-key rule is create-only: a retier reuses the seat's stored key.
+    if (mode === "create" && needsKey && licenseCode.trim().length === 0) {
       status.error(`${selectedTool.name} needs the API key you provisioned`);
       return;
     }
     // Render the template with everything EXCEPT licenseCode bound — the
     // token stays literal so the stored message never contains the key
-    // (see getRequestMessage in actions/license-requests.ts).
+    // (see getRequestMessage in actions/license-requests.ts). previousTierName
+    // is only ever non-empty on a retier — see TemplateContext.tier.
+    const previousTierName =
+      mode === "change_tier" && activeMatch ? activeMatch.tierName : "";
     const template = resolveTemplate(approvalTemplates, selectedTool.id, selectedTier.id);
-    const ctx = buildContext(detail, selectedTool.name, selectedTier.name, approver);
+    const ctx = buildContext(
+      detail,
+      selectedTool.name,
+      selectedTier.name,
+      approver,
+      previousTierName,
+    );
     setBodyMd(template ? renderTemplate(template, ctx).rendered : "");
     setStep(2);
   }
 
-  function handleApprove() {
-    if (!selectedTool || !selectedTier) return;
+  /** Fire the approval and resolve to the shared success/error handling —
+   * factored out so each mode's payload can be built with its own narrowed
+   * locals (selectedTool!/activeMatch! assertions would otherwise be needed
+   * inside the startTransition closure). */
+  function submitApproval(payload: ApproveRequestInput) {
     startTransition(async () => {
-      const result = await approveRequest({
+      const result = await approveRequest(payload);
+      if (result.success) {
+        setAssignmentId(result.data.assignmentId);
+        setStep("done");
+      } else {
+        // 042 — the server re-validates the mode against reality (e.g. the
+        // matched assignment was revoked between opening this dialog and
+        // approving) and can reject with an instruction to reopen the dialog.
+        // Surface it here rather than swallowing it.
+        status.error(result.error);
+      }
+    });
+  }
+
+  function handleApprove() {
+    if (mode === "create") {
+      if (!selectedTool || !selectedTier) return;
+      submitApproval({
+        mode: "create",
         requestId: detail.id,
         toolId: selectedTool.id,
         tierId: selectedTier.id,
@@ -143,12 +232,28 @@ export function ApprovalDialog({
         licenseCode: licenseCode.trim() || undefined,
         bodyMd,
       });
-      if (result.success) {
-        setAssignmentId(result.data.assignmentId);
-        setStep("done");
-      } else {
-        status.error(result.error);
-      }
+      return;
+    }
+    if (mode === "change_tier") {
+      if (!activeMatch || !selectedTool || !selectedTier) return;
+      submitApproval({
+        mode: "change_tier",
+        requestId: detail.id,
+        assignmentId: activeMatch.id,
+        toolId: selectedTool.id,
+        tierId: selectedTier.id,
+        licenseCode: licenseCode.trim() || undefined,
+        bodyMd,
+      });
+      return;
+    }
+    // link_existing — mutate nothing, just approve and link.
+    if (!activeMatch) return;
+    submitApproval({
+      mode: "link_existing",
+      requestId: detail.id,
+      assignmentId: activeMatch.id,
+      bodyMd,
     });
   }
 
@@ -165,9 +270,13 @@ export function ApprovalDialog({
 
   const previewHtml = markdownToTeamsHtml(resolvedBody());
   const hasTemplate =
-    selectedTool && selectedTier
-      ? resolveTemplate(approvalTemplates, selectedTool.id, selectedTier.id) !== null
-      : true;
+    mode === "link_existing"
+      ? activeMatch
+        ? resolveTemplate(approvalTemplates, activeMatch.toolId, activeMatch.tierId) !== null
+        : true
+      : selectedTool && selectedTier
+        ? resolveTemplate(approvalTemplates, selectedTool.id, selectedTier.id) !== null
+        : true;
 
   return (
     <Dialog
@@ -262,52 +371,137 @@ export function ApprovalDialog({
                   </p>
                 </div>
 
-                <div className="space-y-1.5">
-                  <label className="text-sm font-medium">Tier</label>
-                  <Select
-                    value={tierId !== null ? String(tierId) : undefined}
-                    onValueChange={(v) => setTierId(Number.parseInt(v, 10))}
-                    disabled={!selectedTool}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select tier" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {selectedTool?.tiers.map((t) => (
-                        <SelectItem key={t.id} value={String(t.id)}>
-                          {t.name} ({Math.round(t.monthlyCostCents / 100)} / mo)
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
+                {mode === "change_tier" && activeMatch && (
+                  <div className="rounded-md border bg-muted/40 p-3 text-sm">
+                    {detail.requesterName} already holds{" "}
+                    <strong>{activeMatch.toolName}</strong> at{" "}
+                    <strong>{activeMatch.tierName}</strong> (
+                    <Link
+                      href={`/assignments/${activeMatch.id}`}
+                      className="text-primary hover:underline"
+                    >
+                      assignment #{activeMatch.id}
+                    </Link>
+                    , since {format(activeMatch.assignedAt, "yyyy-MM-dd")}).
+                    Approving moves that seat to the tier selected below — its
+                    id, comments and API key are unchanged.
+                  </div>
+                )}
 
-                <div className="space-y-1.5">
-                  <label className="text-sm font-medium">Assignment date</label>
-                  <Input
-                    type="date"
-                    value={assignedAt}
-                    onChange={(e) => setAssignedAt(e.target.value)}
-                  />
-                </div>
-
-                {needsKey && (
-                  <div className="space-y-1.5">
-                    <label className="text-sm font-medium">API key</label>
-                    <Textarea
-                      value={licenseCode}
-                      onChange={(e) => setLicenseCode(e.target.value)}
-                      placeholder="Paste the key you provisioned"
-                      className="font-mono text-xs min-h-[80px]"
-                    />
+                {mode === "link_existing" && activeMatch && (
+                  <div className="space-y-1.5 rounded-md border bg-muted/40 p-3 text-sm">
+                    <p>
+                      {detail.requesterName} already holds{" "}
+                      <strong>{activeMatch.toolName}</strong> at{" "}
+                      <strong>{activeMatch.tierName}</strong> (
+                      <Link
+                        href={`/assignments/${activeMatch.id}`}
+                        className="text-primary hover:underline"
+                      >
+                        assignment #{activeMatch.id}
+                      </Link>
+                      ), managed by GitHub Copilot sync — GitHub owns this
+                      seat&apos;s plan, not the Hub.
+                    </p>
                     <p className="text-xs text-muted-foreground">
-                      Required for {selectedTool?.name}. Stored encrypted on the
-                      assignment; woven into the message on the next step.
+                      Change the plan in GitHub — it arrives here on the next
+                      sync. Approving just records the decision and links the
+                      existing seat; nothing on the assignment changes.
                     </p>
                   </div>
                 )}
 
-                {willCreateUser && (
+                {mode !== "link_existing" && (
+                  <>
+                    <div className="space-y-1.5">
+                      <label className="text-sm font-medium">
+                        {mode === "change_tier" ? "New tier" : "Tier"}
+                      </label>
+                      <Select
+                        value={tierId !== null ? String(tierId) : undefined}
+                        onValueChange={(v) => setTierId(Number.parseInt(v, 10))}
+                        disabled={!selectedTool}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select tier" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {selectedTool?.tiers.map((t) => (
+                            <SelectItem key={t.id} value={String(t.id)}>
+                              {t.name} ({Math.round(t.monthlyCostCents / 100)} / mo)
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      {mode === "change_tier" && activeMatch && selectedTier && (
+                        <p className="text-xs text-muted-foreground">
+                          {selectedTier.id === activeMatch.tierId ? (
+                            "Same tier as today — approving just links the request; nothing on the assignment changes."
+                          ) : (
+                            <>
+                              Monthly tier cost: {formatCurrency(activeMatch.tierCostCents)}
+                              {" → "}
+                              {formatCurrency(selectedTier.monthlyCostCents)} (
+                              {formatVariance(
+                                tierCostDeltaCents(
+                                  activeMatch.tierCostCents,
+                                  selectedTier.monthlyCostCents,
+                                ),
+                              )}
+                              /mo). That&apos;s the tier&apos;s monthly cost, not
+                              necessarily the bill — metered tools (Claude
+                              Console) charge separately for actual usage.
+                            </>
+                          )}
+                        </p>
+                      )}
+                    </div>
+
+                    {mode === "create" && (
+                      <div className="space-y-1.5">
+                        <label className="text-sm font-medium">Assignment date</label>
+                        <Input
+                          type="date"
+                          value={assignedAt}
+                          onChange={(e) => setAssignedAt(e.target.value)}
+                        />
+                      </div>
+                    )}
+
+                    {needsKey && (
+                      <div className="space-y-1.5">
+                        <label className="text-sm font-medium">
+                          API key{mode === "change_tier" ? " (optional)" : ""}
+                        </label>
+                        <Textarea
+                          value={licenseCode}
+                          onChange={(e) => setLicenseCode(e.target.value)}
+                          placeholder="Paste the key you provisioned"
+                          className="font-mono text-xs min-h-[80px]"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          {mode === "create" ? (
+                            <>
+                              Required for {selectedTool?.name}. Stored
+                              encrypted on the assignment; woven into the
+                              message on the next step.
+                            </>
+                          ) : (
+                            <>
+                              Optional — the seat keeps its stored key either
+                              way. Leave blank to keep using it as-is; the{" "}
+                              <code>{"{{licenseCode}}"}</code> token in the
+                              snippet stays unresolved unless you re-enter it
+                              here.
+                            </>
+                          )}
+                        </p>
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {mode === "create" && willCreateUser && (
                   <div className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
                     Hub user will be created: <strong>{detail.requesterName}</strong>{" "}
                     · viewer · no invite email. Rejecting instead creates nothing.
@@ -359,7 +553,7 @@ export function ApprovalDialog({
             <DialogFooter>
               <p className="mr-auto text-xs text-muted-foreground">
                 {step === 1
-                  ? "Approving creates the assignment."
+                  ? FOOTER_HINT[mode]
                   : "Nothing is sent automatically — you'll get a copy-ready message."}
               </p>
               <StatusText status={status.status} />
@@ -372,10 +566,7 @@ export function ApprovalDialog({
                   >
                     Cancel
                   </Button>
-                  <Button
-                    onClick={handleAdvance}
-                    disabled={toolId === null || tierId === null}
-                  >
+                  <Button onClick={handleAdvance} disabled={!canContinue}>
                     Continue →
                   </Button>
                 </>
@@ -388,7 +579,7 @@ export function ApprovalDialog({
                     onClick={handleApprove}
                     disabled={pending || bodyMd.trim().length === 0}
                   >
-                    {pending ? "Approving…" : "Approve & create assignment"}
+                    {pending ? "Approving…" : PRIMARY_LABEL[mode]}
                   </Button>
                 </>
               )}
@@ -405,6 +596,8 @@ function buildContext(
   toolName: string,
   tierName: string,
   approver: { name: string; firstName: string },
+  /** Tier being moved off, for a change_tier approval. "" on a create (042). */
+  previousTierName: string = "",
 ): TemplateContext {
   const firstName = detail.requesterName.split(/\s+/)[0] ?? detail.requesterName;
   return {
@@ -414,7 +607,7 @@ function buildContext(
       email: detail.requesterEmail,
     },
     tool: { name: toolName },
-    tier: { name: tierName },
+    tier: { name: tierName, previousName: previousTierName },
     // licenseCode deliberately NOT bound — the token stays literal in the
     // stored message; resolved only for preview/copy.
     approver,

--- a/src/app/requests/[id]/approval-dialog.tsx
+++ b/src/app/requests/[id]/approval-dialog.tsx
@@ -145,6 +145,25 @@ export function ApprovalDialog({
   // link_existing never needs a tier pick — the seat's own tier is unaffected.
   const canContinue = toolId !== null && (mode === "link_existing" || tierId !== null);
 
+  // Which tool/tier pair is actually in play, given the mode: the seat's own for
+  // a link, the admin's picks otherwise. Derived once so the template lookup and
+  // the has-a-template check cannot encode the rule differently.
+  const effective =
+    mode === "link_existing"
+      ? activeMatch && {
+          toolId: activeMatch.toolId,
+          toolName: activeMatch.toolName,
+          tierId: activeMatch.tierId,
+          tierName: activeMatch.tierName,
+        }
+      : selectedTool &&
+        selectedTier && {
+          toolId: selectedTool.id,
+          toolName: selectedTool.name,
+          tierId: selectedTier.id,
+          tierName: selectedTier.name,
+        };
+
   function handleToolChange(value: string) {
     const id = Number.parseInt(value, 10);
     setToolId(id);
@@ -160,14 +179,18 @@ export function ApprovalDialog({
 
   function handleAdvance() {
     if (mode === "link_existing") {
-      if (!activeMatch) {
+      if (!effective) {
         status.error("Select a tool");
         return;
       }
       // Nothing is being mutated — tool/tier stay the seat's current ones, so
       // tier.previousName has nothing to report and stays "".
-      const template = resolveTemplate(approvalTemplates, activeMatch.toolId, activeMatch.tierId);
-      const ctx = buildContext(detail, activeMatch.toolName, activeMatch.tierName, approver);
+      const template = resolveTemplate(
+        approvalTemplates,
+        effective.toolId,
+        effective.tierId,
+      );
+      const ctx = buildContext(detail, effective.toolName, effective.tierName, approver);
       setBodyMd(template ? renderTemplate(template, ctx).rendered : "");
       setStep(2);
       return;
@@ -269,14 +292,10 @@ export function ApprovalDialog({
   }
 
   const previewHtml = markdownToTeamsHtml(resolvedBody());
-  const hasTemplate =
-    mode === "link_existing"
-      ? activeMatch
-        ? resolveTemplate(approvalTemplates, activeMatch.toolId, activeMatch.tierId) !== null
-        : true
-      : selectedTool && selectedTier
-        ? resolveTemplate(approvalTemplates, selectedTool.id, selectedTier.id) !== null
-        : true;
+  // Nothing selected yet is not "no template" — don't warn prematurely.
+  const hasTemplate = effective
+    ? resolveTemplate(approvalTemplates, effective.toolId, effective.tierId) !== null
+    : true;
 
   return (
     <Dialog

--- a/src/app/requests/[id]/record-assignment-dialog.tsx
+++ b/src/app/requests/[id]/record-assignment-dialog.tsx
@@ -26,14 +26,26 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { recordAssignment } from "@/actions/license-requests";
-import type { LicenseRequestDetail, ToolOption } from "@/actions/license-requests";
+import {
+  recordAssignment,
+  linkExistingAssignment,
+} from "@/actions/license-requests";
+import type {
+  ActiveAssignmentSummary,
+  LicenseRequestDetail,
+  ToolOption,
+} from "@/actions/license-requests";
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   detail: LicenseRequestDetail;
   tools: ToolOption[];
+  /** 042 — the requester's existing active assignments. recordAssignment
+   * shares createAssignmentInTx's duplicate-seat guard with approveRequest's
+   * `create` mode, so a match here means Save will fail; surfaced up front
+   * rather than left to a failed round trip. */
+  activeAssignments: ActiveAssignmentSummary[];
   onSuccess: () => void;
 }
 
@@ -42,6 +54,7 @@ export function RecordAssignmentDialog({
   onOpenChange,
   detail,
   tools,
+  activeAssignments,
   onSuccess,
 }: Props) {
   const today = useMemo(() => format(new Date(), "yyyy-MM-dd"), []);
@@ -64,6 +77,18 @@ export function RecordAssignmentDialog({
   const selectedTool = tools.find((t) => t.id === toolId) ?? null;
   const needsKey = selectedTool?.requiresApiKey ?? false;
 
+  // 042 — recordAssignment can only CREATE, and it shares createAssignmentInTx's
+  // duplicate-seat guard, so a match here would fail Save. approveRequest's
+  // link_existing mode cannot help either: it requires
+  // status='pending_review', while this dialog only opens for status='approved'
+  // rows (isLegacyApproved) — the guards are mutually exclusive. Hence the
+  // dedicated linkExistingAssignment action, which fills in the missing link and
+  // touches nothing on the seat.
+  const activeMatch =
+    toolId !== null
+      ? (activeAssignments.find((a) => a.toolId === toolId) ?? null)
+      : null;
+
   function handleToolChange(value: string) {
     const id = Number.parseInt(value, 10);
     setToolId(id);
@@ -76,6 +101,23 @@ export function RecordAssignmentDialog({
   }
 
   function handleSave() {
+    // The seat already exists — link it instead of creating a duplicate.
+    if (activeMatch) {
+      startTransition(async () => {
+        const result = await linkExistingAssignment({
+          requestId: detail.id,
+          assignmentId: activeMatch.id,
+        });
+        if (result.success) {
+          onOpenChange(false);
+          onSuccess();
+        } else {
+          status.error(result.error);
+        }
+      });
+      return;
+    }
+
     if (toolId === null || tierId === null) {
       status.error("Select a tool and tier");
       return;
@@ -126,6 +168,18 @@ export function RecordAssignmentDialog({
               </SelectContent>
             </Select>
           </div>
+          {activeMatch && (
+            <div className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
+              {detail.requesterName} already has an active{" "}
+              <strong>{activeMatch.toolName}</strong> assignment at{" "}
+              <strong>{activeMatch.tierName}</strong> (assignment #
+              {activeMatch.id}, since{" "}
+              {format(activeMatch.assignedAt, "yyyy-MM-dd")}). This request will
+              be <strong>linked to that seat</strong> — nothing on it changes,
+              and no second assignment is created. The tier and date fields below
+              do not apply.
+            </div>
+          )}
           <div className="space-y-1.5">
             <label className="text-sm font-medium">Tier</label>
             <Select
@@ -173,8 +227,18 @@ export function RecordAssignmentDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={pending}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={pending || toolId === null || tierId === null}>
-            {pending ? "Saving…" : "Record assignment"}
+          <Button
+            onClick={handleSave}
+            // Linking needs no tool/tier pick — the seat already has both.
+            disabled={
+              pending || (!activeMatch && (toolId === null || tierId === null))
+            }
+          >
+            {pending
+              ? "Saving…"
+              : activeMatch
+                ? "Link existing seat"
+                : "Record assignment"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/app/requests/[id]/request-detail-client.tsx
+++ b/src/app/requests/[id]/request-detail-client.tsx
@@ -346,6 +346,7 @@ export function RequestDetailClient({
         onOpenChange={setApproveOpen}
         detail={detail}
         tools={tools}
+        activeAssignments={activeAssignments}
         approvalTemplates={approvalTemplates}
         approver={approver}
         onSuccess={() => router.refresh()}
@@ -361,6 +362,7 @@ export function RequestDetailClient({
         onOpenChange={setRecordOpen}
         detail={detail}
         tools={tools}
+        activeAssignments={activeAssignments}
         onSuccess={() => router.refresh()}
       />
     </div>

--- a/src/app/settings/license-templates/template-editor-dialog.tsx
+++ b/src/app/settings/license-templates/template-editor-dialog.tsx
@@ -46,7 +46,10 @@ const SAMPLE_CONTEXT: TemplateContext = {
     email: "sample@example.com",
   },
   tool: { name: "Sample Tool" },
-  tier: { name: "Sample Tier" },
+  // previousName is non-empty in the sample so an author previewing a template
+  // can see what {{tier.previousName}} renders on a tier-change approval. On a
+  // create-mode approval it resolves to the empty string.
+  tier: { name: "Sample Tier", previousName: "Previous Sample Tier" },
   licenseCode: "sk-sample-1234-redacted",
   approver: { name: "Sample Approver", firstName: "Sample" },
   requestUrl: "https://aihub.example.com/requests/0",
@@ -66,7 +69,12 @@ export function TemplateEditorDialog({ open, onOpenChange, state }: Props) {
     () => ({
       ...SAMPLE_CONTEXT,
       tool: { name: state.toolName },
-      tier: state.tierName ? { name: state.tierName } : SAMPLE_CONTEXT.tier,
+      tier: state.tierName
+        ? {
+            name: state.tierName,
+            previousName: SAMPLE_CONTEXT.tier?.previousName ?? "",
+          }
+        : SAMPLE_CONTEXT.tier,
       licenseCode: state.kind === "completion" ? SAMPLE_CONTEXT.licenseCode : undefined,
     }),
     [state.toolName, state.tierName, state.kind],

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -6,6 +6,10 @@ import { getGitHubProfile } from "@/actions/github";
 import { getUserCostData, getAvailableMonths } from "@/actions/anthropic-usage";
 import { UserDetailClient } from "./user-detail-client";
 import { AuthGuard } from "@/components/auth-guard";
+import {
+  isCopilotSyncActive,
+  COPILOT_SYNC_TOOL_NAME,
+} from "@/lib/assignments/sync-authority";
 
 export default async function UserDetailPage({
   params,
@@ -22,15 +26,26 @@ export default async function UserDetailPage({
   const user = await getUserById(userId);
   if (!user) notFound();
 
-  const [assignments, historyResult, ghResult, costData, costAvailableMonths] = await Promise.all([
+  const [
+    assignments,
+    historyResult,
+    ghResult,
+    costData,
+    costAvailableMonths,
+    syncActive,
+  ] = await Promise.all([
     getUserAssignments(userId),
     getEntityHistory("user", userId),
     getGitHubProfile(userId),
     getUserCostData(userId),
     getAvailableMonths(userId),
+    // 042: the tier gate is tool-based, not assignment.source-based — sync takes
+    // over manual rows, so a manual GitHub Copilot seat is just as sync-owned.
+    isCopilotSyncActive(),
   ]);
   const history = historyResult.success ? historyResult.data.records : [];
   const githubProfile = ghResult.success ? ghResult.data.profile : null;
+  const syncManagedToolNames = syncActive ? [COPILOT_SYNC_TOOL_NAME] : [];
 
   return (
     <AuthGuard requiredRole="admin">
@@ -42,6 +57,7 @@ export default async function UserDetailPage({
         githubProfile={githubProfile}
         costData={costData}
         costAvailableMonths={costAvailableMonths}
+        syncManagedToolNames={syncManagedToolNames}
       />
     </AuthGuard>
   );

--- a/src/app/users/[id]/user-detail-client.tsx
+++ b/src/app/users/[id]/user-detail-client.tsx
@@ -88,11 +88,6 @@ interface Assignment {
   revokedAt: Date | null;
   tool: { id: number; name: string; status: string };
   tier: { id: number; name: string };
-  // getUserAssignments returns the full row, so this is always present even
-  // though older call sites never needed it. Used only to hide "Change tier"
-  // on rows Copilot sync manages (spec 042) — the assignment detail page it
-  // links to is the tool-based source of truth for that gate.
-  source: string;
 }
 
 interface GitHubProfileData {
@@ -113,6 +108,10 @@ interface Props {
   githubProfile?: GitHubProfileData | null;
   costData: CostData;
   costAvailableMonths: string[];
+  /** Tools whose tier Copilot sync owns (spec 042). Empty when sync is off.
+   * Tool-based, not assignment.source-based: sync takes over manual rows, so a
+   * manual GitHub Copilot seat is just as sync-owned as an already-synced one. */
+  syncManagedToolNames: string[];
 }
 
 export function UserDetailClient({
@@ -123,6 +122,7 @@ export function UserDetailClient({
   githubProfile,
   costData,
   costAvailableMonths,
+  syncManagedToolNames,
 }: Props) {
   const router = useRouter();
   const status = useInlineStatus();
@@ -584,7 +584,7 @@ export function UserDetailClient({
                     </Badge>
                     {isAdmin &&
                       a.status === "active" &&
-                      a.source !== "copilot-sync" && (
+                      !syncManagedToolNames.includes(a.tool.name) && (
                         <Button size="sm" variant="outline" asChild>
                           <Link href={`/assignments/${a.id}`}>
                             <ArrowRightLeft className="mr-1 size-3" />

--- a/src/app/users/[id]/user-detail-client.tsx
+++ b/src/app/users/[id]/user-detail-client.tsx
@@ -34,6 +34,7 @@ import {
   RotateCcw,
   Eye,
   EyeOff,
+  ArrowRightLeft,
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
@@ -87,6 +88,11 @@ interface Assignment {
   revokedAt: Date | null;
   tool: { id: number; name: string; status: string };
   tier: { id: number; name: string };
+  // getUserAssignments returns the full row, so this is always present even
+  // though older call sites never needed it. Used only to hide "Change tier"
+  // on rows Copilot sync manages (spec 042) — the assignment detail page it
+  // links to is the tool-based source of truth for that gate.
+  source: string;
 }
 
 interface GitHubProfileData {
@@ -576,6 +582,16 @@ export function UserDetailClient({
                     >
                       {a.status}
                     </Badge>
+                    {isAdmin &&
+                      a.status === "active" &&
+                      a.source !== "copilot-sync" && (
+                        <Button size="sm" variant="outline" asChild>
+                          <Link href={`/assignments/${a.id}`}>
+                            <ArrowRightLeft className="mr-1 size-3" />
+                            Change tier
+                          </Link>
+                        </Button>
+                      )}
                     {isAdmin && a.status === "active" && (
                       <Button
                         size="sm"

--- a/src/components/assignments/sync-managed-badge.tsx
+++ b/src/components/assignments/sync-managed-badge.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
@@ -13,6 +14,13 @@ import {
  * explanations for the same condition — the assignments table said the
  * assignment "cannot be edited or revoked manually", the assignment detail page
  * said to change the plan in GitHub. One component, one message per caller.
+ *
+ * Carries its own TooltipProvider deliberately. The assignments table only works
+ * because DataTable happens to wrap its rows in one; the assignment detail page
+ * has none, and a bare Tooltip there throws "`Tooltip` must be used within
+ * `TooltipProvider`" — which crashed the whole page for exactly the sync-managed
+ * seats this badge exists to mark. Nesting providers is harmless, so owning one
+ * makes the component safe to drop anywhere.
  */
 export function SyncManagedBadge({
   tooltip,
@@ -22,16 +30,18 @@ export function SyncManagedBadge({
   className?: string;
 }) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Badge
-          variant="outline"
-          className={`cursor-default text-xs text-muted-foreground${className ? ` ${className}` : ""}`}
-        >
-          Managed by sync
-        </Badge>
-      </TooltipTrigger>
-      <TooltipContent>{tooltip}</TooltipContent>
-    </Tooltip>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge
+            variant="outline"
+            className={`cursor-default text-xs text-muted-foreground${className ? ` ${className}` : ""}`}
+          >
+            Managed by sync
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/src/components/assignments/sync-managed-badge.tsx
+++ b/src/components/assignments/sync-managed-badge.tsx
@@ -1,0 +1,37 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/**
+ * The "Managed by sync" marker shown wherever GitHub owns a seat rather than the
+ * Hub (spec 042).
+ *
+ * Shared because this badge existed in two places with two different
+ * explanations for the same condition — the assignments table said the
+ * assignment "cannot be edited or revoked manually", the assignment detail page
+ * said to change the plan in GitHub. One component, one message per caller.
+ */
+export function SyncManagedBadge({
+  tooltip,
+  className,
+}: {
+  tooltip: string;
+  className?: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          variant="outline"
+          className={`cursor-default text-xs text-muted-foreground${className ? ` ${className}` : ""}`}
+        >
+          Managed by sync
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/lib/assignments/revalidate.ts
+++ b/src/lib/assignments/revalidate.ts
@@ -1,26 +1,37 @@
 import { revalidatePath } from "next/cache";
 
 /**
- * Revalidate every surface that shows an assignment's cost (spec 042).
+ * The pages whose figures are derived from assignment cost (spec 042).
  *
- * Any change to tier_id / cost_at_assignment_cents moves per-period expected
- * spend, so the budget and report pages are as stale as the assignment pages.
- * updateAssignment previously revalidated only /assignments, /users/[id] and
- * /reports — leaving the budget health figures serving pre-change numbers.
- * Mirrors what the analogous tier price cascade in actions/tools.ts revalidates.
+ * Every spend aggregation sums license_assignments.cost_at_assignment_cents, so
+ * a cost change makes all of these stale at once. This is the single list —
+ * actions/tools.ts's tier price cascade calls it too, rather than keeping its own
+ * copy, which is what let the two drift apart in the first place.
+ *
+ * Only call this when a cost actually changed. Each entry forces the next visitor
+ * to recompute that page (the dashboard alone runs ~13 queries), so invalidating
+ * on a workspace or API-key edit is pure waste.
  *
  * Lives in a plain module because "use server" files may only export async
  * functions.
+ */
+export function revalidateCostSurfaces(): void {
+  revalidatePath("/");
+  revalidatePath("/assignments");
+  revalidatePath("/budget");
+  revalidatePath("/reports");
+  revalidatePath("/reports/budget");
+}
+
+/**
+ * A single assignment's cost changed: the shared cost surfaces plus the two
+ * pages scoped to this seat's user and tool.
  */
 export function revalidateAssignmentCostPaths(
   userId: number,
   toolId: number,
 ): void {
-  revalidatePath("/assignments");
+  revalidateCostSurfaces();
   revalidatePath(`/users/${userId}`);
   revalidatePath(`/tools/${toolId}`);
-  revalidatePath("/reports");
-  revalidatePath("/reports/budget");
-  revalidatePath("/budget");
-  revalidatePath("/");
 }

--- a/src/lib/assignments/revalidate.ts
+++ b/src/lib/assignments/revalidate.ts
@@ -1,0 +1,26 @@
+import { revalidatePath } from "next/cache";
+
+/**
+ * Revalidate every surface that shows an assignment's cost (spec 042).
+ *
+ * Any change to tier_id / cost_at_assignment_cents moves per-period expected
+ * spend, so the budget and report pages are as stale as the assignment pages.
+ * updateAssignment previously revalidated only /assignments, /users/[id] and
+ * /reports — leaving the budget health figures serving pre-change numbers.
+ * Mirrors what the analogous tier price cascade in actions/tools.ts revalidates.
+ *
+ * Lives in a plain module because "use server" files may only export async
+ * functions.
+ */
+export function revalidateAssignmentCostPaths(
+  userId: number,
+  toolId: number,
+): void {
+  revalidatePath("/assignments");
+  revalidatePath(`/users/${userId}`);
+  revalidatePath(`/tools/${toolId}`);
+  revalidatePath("/reports");
+  revalidatePath("/reports/budget");
+  revalidatePath("/budget");
+  revalidatePath("/");
+}

--- a/src/lib/assignments/sync-authority.ts
+++ b/src/lib/assignments/sync-authority.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { aiTools, githubConnections } from "@/lib/db/schema";
+import { githubConnections } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 
 /**
@@ -8,6 +8,31 @@ import { eq, and } from "drizzle-orm";
  * sync is concerned.
  */
 export const COPILOT_SYNC_TOOL_NAME = "GitHub Copilot";
+
+/**
+ * Is Copilot sync actually running? One query.
+ *
+ * Callers that already hold a tool row combine this with
+ * `isSyncManagedToolName` themselves; there is deliberately no id-based variant,
+ * because every caller turned out to have the tool's name in hand already and an
+ * id-based lookup meant a second `ai_tools` round trip for data the caller had
+ * just fetched and discarded.
+ */
+export async function isCopilotSyncActive(): Promise<boolean> {
+  const connection = await db.query.githubConnections.findFirst({
+    where: and(
+      eq(githubConnections.status, "active"),
+      eq(githubConnections.copilotSyncEnabled, true),
+    ),
+    columns: { id: true },
+  });
+  return connection !== undefined;
+}
+
+/** Pure name check — pair with isCopilotSyncActive(). */
+export function isSyncManagedToolName(toolName: string): boolean {
+  return toolName === COPILOT_SYNC_TOOL_NAME;
+}
 
 /**
  * Is this tool's tier assignment owned by GitHub rather than the Hub? (spec 042)
@@ -19,33 +44,11 @@ export const COPILOT_SYNC_TOOL_NAME = "GitHub Copilot";
  * cron just as surely as one on an already-synced row. Gating on source would
  * have left exactly that hole open.
  *
- * Returns false when Copilot sync is not actually running (no active connection,
- * or the connection has sync disabled), because then nothing will overwrite a
- * manual change and there is no reason to forbid it.
+ * Returns false when sync is not running (no active connection, or sync disabled
+ * on it), because then nothing will overwrite a manual change and there is no
+ * reason to forbid it.
  */
-export async function isSyncManagedTool(toolId: number): Promise<boolean> {
-  const syncManagedToolId = await getSyncManagedToolId();
-  return syncManagedToolId !== null && syncManagedToolId === toolId;
-}
-
-/**
- * The id of the tool Copilot sync currently owns, or null when sync is not
- * running. One query pair, so callers that need to mark up a whole list (e.g. the
- * approval dialog's collision check) do not call isSyncManagedTool per row.
- */
-export async function getSyncManagedToolId(): Promise<number | null> {
-  const connection = await db.query.githubConnections.findFirst({
-    where: and(
-      eq(githubConnections.status, "active"),
-      eq(githubConnections.copilotSyncEnabled, true),
-    ),
-    columns: { id: true },
-  });
-  if (!connection) return null;
-
-  const tool = await db.query.aiTools.findFirst({
-    where: eq(aiTools.name, COPILOT_SYNC_TOOL_NAME),
-    columns: { id: true },
-  });
-  return tool?.id ?? null;
+export async function isSyncManagedTool(toolName: string): Promise<boolean> {
+  if (!isSyncManagedToolName(toolName)) return false;
+  return isCopilotSyncActive();
 }

--- a/src/lib/assignments/sync-authority.ts
+++ b/src/lib/assignments/sync-authority.ts
@@ -1,0 +1,51 @@
+import { db } from "@/lib/db";
+import { aiTools, githubConnections } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+
+/**
+ * The name syncBillingData upserts the Copilot tool under. That upsert is keyed
+ * on the name (lib/copilot-sync.ts), so it is the tool's real identity as far as
+ * sync is concerned.
+ */
+export const COPILOT_SYNC_TOOL_NAME = "GitHub Copilot";
+
+/**
+ * Is this tool's tier assignment owned by GitHub rather than the Hub? (spec 042)
+ *
+ * Gated on the TOOL, not on assignment.source, and that distinction is the whole
+ * point. syncSeatAssignments takes over manual rows — it sets
+ * source='copilot-sync' whenever it sees a seat it does not already own — so a
+ * tier change on a source='manual' Copilot assignment is reverted by the next
+ * cron just as surely as one on an already-synced row. Gating on source would
+ * have left exactly that hole open.
+ *
+ * Returns false when Copilot sync is not actually running (no active connection,
+ * or the connection has sync disabled), because then nothing will overwrite a
+ * manual change and there is no reason to forbid it.
+ */
+export async function isSyncManagedTool(toolId: number): Promise<boolean> {
+  const syncManagedToolId = await getSyncManagedToolId();
+  return syncManagedToolId !== null && syncManagedToolId === toolId;
+}
+
+/**
+ * The id of the tool Copilot sync currently owns, or null when sync is not
+ * running. One query pair, so callers that need to mark up a whole list (e.g. the
+ * approval dialog's collision check) do not call isSyncManagedTool per row.
+ */
+export async function getSyncManagedToolId(): Promise<number | null> {
+  const connection = await db.query.githubConnections.findFirst({
+    where: and(
+      eq(githubConnections.status, "active"),
+      eq(githubConnections.copilotSyncEnabled, true),
+    ),
+    columns: { id: true },
+  });
+  if (!connection) return null;
+
+  const tool = await db.query.aiTools.findFirst({
+    where: eq(aiTools.name, COPILOT_SYNC_TOOL_NAME),
+    columns: { id: true },
+  });
+  return tool?.id ?? null;
+}

--- a/src/lib/assignments/tier-change.ts
+++ b/src/lib/assignments/tier-change.ts
@@ -1,0 +1,101 @@
+/**
+ * Tier-change semantics for an active licence assignment (spec 042).
+ *
+ * Pure module — no db, no transaction, no "use server". It is the single place
+ * these rules live, so the two real call sites (updateAssignment's tier branch
+ * and approveRequest's change_tier mode) cannot drift apart, and so the rules
+ * are unit-testable in CI.
+ *
+ * A tier change mutates the assignment row IN PLACE rather than closing it and
+ * opening a new one. That is a deliberate, documented trade-off: the flat
+ * monthly cost is attributed to every budget period the row's held-window
+ * overlaps, with no proration, so two rows spanning the switch period would
+ * both be counted and the person would be billed twice that month. See
+ * specs/042-assignment-tier-change/implementation-plan.html §3 for the full
+ * argument, including what in-place mutation costs (closed periods restate).
+ */
+
+/** Field diff shape consumed by recordUpdate in actions/history. */
+export type ChangeMap = Record<string, { old: unknown; new: unknown }>;
+
+export const SYNC_MANAGED_TIER_ERROR =
+  "This seat's plan is managed by GitHub Copilot sync. Change the plan in GitHub — it will arrive on the next sync.";
+
+export interface TierChangeResult {
+  values: { tierId: number; costAtAssignmentCents: number };
+  changes: ChangeMap;
+}
+
+export type BuildTierChangeOutcome =
+  | TierChangeResult
+  | { noop: true }
+  | { error: string };
+
+/**
+ * Build the field updates + audit diff for a deliberate tier change.
+ *
+ * Callers own three things:
+ *  - validating that the target tier exists, is active, and belongs to the same
+ *    tool (each caller has a different tool context);
+ *  - deciding what a no-op means — updateAssignment skips the write, while
+ *    approveRequest must still approve and link the request;
+ *  - persisting the returned change map to history.
+ *
+ * Order matters: the no-op check comes FIRST. The assignment detail form always
+ * submits tierId, so refusing sync-managed rows before checking whether the tier
+ * actually differs would reject every workspace/API-key edit on a synced seat.
+ */
+export function buildTierChange(
+  current: {
+    tierId: number;
+    costAtAssignmentCents: number;
+    isSyncManaged: boolean;
+  },
+  newTier: { id: number; monthlyCostCents: number },
+): BuildTierChangeOutcome {
+  if (newTier.id === current.tierId) return { noop: true };
+
+  if (current.isSyncManaged) return { error: SYNC_MANAGED_TIER_ERROR };
+
+  return {
+    values: {
+      tierId: newTier.id,
+      costAtAssignmentCents: newTier.monthlyCostCents,
+    },
+    changes: {
+      tierId: { old: current.tierId, new: newTier.id },
+      costAtAssignmentCents: {
+        old: current.costAtAssignmentCents,
+        new: newTier.monthlyCostCents,
+      },
+    },
+  };
+}
+
+export function isTierChangeNoop(
+  outcome: BuildTierChangeOutcome,
+): outcome is { noop: true } {
+  return "noop" in outcome;
+}
+
+export function isTierChangeError(
+  outcome: BuildTierChangeOutcome,
+): outcome is { error: string } {
+  return "error" in outcome;
+}
+
+/**
+ * Signed monthly delta of a tier change, for UI copy only.
+ *
+ * Deliberately not an "upgrade/downgrade" verdict: access_tiers carries no rank
+ * and price order is not an entitlement ladder — Claude Console's indie-profile
+ * (€125) sits between boost-expert (€100) and boost-leader (€200) — so a
+ * price-derived label would read wrongly for real tiers. Callers show the
+ * number and let the admin judge.
+ */
+export function tierCostDeltaCents(
+  fromCostCents: number,
+  toCostCents: number,
+): number {
+  return toCostCents - fromCostCents;
+}

--- a/src/lib/budget-utils.ts
+++ b/src/lib/budget-utils.ts
@@ -90,33 +90,43 @@ export interface AssignmentCostWindow {
 }
 
 /**
+ * How a revocation landing exactly on periodStart is treated.
+ *
+ * The two per-period readers disagree, and always have: getBudgetWithCosts
+ * counts that assignment (`>=`), fetchPerToolByPeriod does not (`>`). The
+ * difference is one edge case and predates spec 042, so it is preserved rather
+ * than silently changed here — but it is now a parameter of one shared predicate
+ * instead of two independently-inlined copies, so the two can no longer drift on
+ * anything else.
+ */
+export type RevokedBound = "inclusive" | "exclusive";
+
+/**
  * Does an assignment's held-window overlap a budget period?
  *
  * Extracted (spec 042) so the double-counting property can be pinned by a unit
  * test that actually runs in CI — integration tests are disabled there
- * (.github/workflows/ci.yml). getBudgetWithCosts inlined this predicate, which
- * meant the single most consequential arithmetic rule in the app had no
- * automated guard.
+ * (.github/workflows/ci.yml). Both readers inlined this predicate, which meant
+ * the single most consequential arithmetic rule in the app had no automated
+ * guard.
  *
  * Cost is the flat monthly tier price with NO proration, so an assignment that
  * overlaps a period by one day contributes a full month. That is what makes
  * "close the old row and open a new one" double-count the switch period: both
  * rows overlap it. A tier change must therefore mutate in place — see
  * specs/042-assignment-tier-change.
- *
- * Note the asymmetry with fetchPerToolByPeriod (actions/reports.ts), which uses
- * a strict `>` on the revoked bound. Both double-count; they differ only on a
- * revocation landing exactly on periodStart.
  */
 export function overlapsPeriod(
   assignment: AssignmentCostWindow,
   periodStart: Date,
   periodEnd: Date,
+  revokedBound: RevokedBound = "inclusive",
 ): boolean {
-  return (
-    assignment.assignedAt <= periodEnd &&
-    (assignment.revokedAt === null || assignment.revokedAt >= periodStart)
-  );
+  if (assignment.assignedAt > periodEnd) return false;
+  if (assignment.revokedAt === null) return true;
+  return revokedBound === "inclusive"
+    ? assignment.revokedAt >= periodStart
+    : assignment.revokedAt > periodStart;
 }
 
 /** Sum the flat monthly cost of every assignment overlapping a period. */
@@ -124,9 +134,10 @@ export function sumExpectedSpendCents(
   assignments: readonly AssignmentCostWindow[],
   periodStart: Date,
   periodEnd: Date,
+  revokedBound: RevokedBound = "inclusive",
 ): number {
   return assignments
-    .filter((a) => overlapsPeriod(a, periodStart, periodEnd))
+    .filter((a) => overlapsPeriod(a, periodStart, periodEnd, revokedBound))
     .reduce((total, a) => total + a.costAtAssignmentCents, 0);
 }
 

--- a/src/lib/budget-utils.ts
+++ b/src/lib/budget-utils.ts
@@ -79,6 +79,57 @@ export async function findPeriodForDate(
   return rows[0] ?? null;
 }
 
+/**
+ * An assignment, reduced to what per-period cost attribution needs.
+ * `revokedAt === null` means still held.
+ */
+export interface AssignmentCostWindow {
+  assignedAt: Date;
+  revokedAt: Date | null;
+  costAtAssignmentCents: number;
+}
+
+/**
+ * Does an assignment's held-window overlap a budget period?
+ *
+ * Extracted (spec 042) so the double-counting property can be pinned by a unit
+ * test that actually runs in CI — integration tests are disabled there
+ * (.github/workflows/ci.yml). getBudgetWithCosts inlined this predicate, which
+ * meant the single most consequential arithmetic rule in the app had no
+ * automated guard.
+ *
+ * Cost is the flat monthly tier price with NO proration, so an assignment that
+ * overlaps a period by one day contributes a full month. That is what makes
+ * "close the old row and open a new one" double-count the switch period: both
+ * rows overlap it. A tier change must therefore mutate in place — see
+ * specs/042-assignment-tier-change.
+ *
+ * Note the asymmetry with fetchPerToolByPeriod (actions/reports.ts), which uses
+ * a strict `>` on the revoked bound. Both double-count; they differ only on a
+ * revocation landing exactly on periodStart.
+ */
+export function overlapsPeriod(
+  assignment: AssignmentCostWindow,
+  periodStart: Date,
+  periodEnd: Date,
+): boolean {
+  return (
+    assignment.assignedAt <= periodEnd &&
+    (assignment.revokedAt === null || assignment.revokedAt >= periodStart)
+  );
+}
+
+/** Sum the flat monthly cost of every assignment overlapping a period. */
+export function sumExpectedSpendCents(
+  assignments: readonly AssignmentCostWindow[],
+  periodStart: Date,
+  periodEnd: Date,
+): number {
+  return assignments
+    .filter((a) => overlapsPeriod(a, periodStart, periodEnd))
+    .reduce((total, a) => total + a.costAtAssignmentCents, 0);
+}
+
 /** Return type for getRunningCostsForPeriod */
 export interface RunningCostsResult {
   runningCostCents: number;

--- a/src/lib/license-requests/render-template.ts
+++ b/src/lib/license-requests/render-template.ts
@@ -10,7 +10,18 @@
 export interface TemplateContext {
   requester: { name: string; firstName: string; email: string };
   tool: { name: string };
-  tier: { name: string } | null;
+  /**
+   * 042: `previousName` is the tier the seat is moving OFF for a tier-change
+   * approval, and the empty string otherwise.
+   *
+   * It is always bound, never optional, and that is deliberate: renderTemplate
+   * leaves an unresolvable path as the LITERAL `{{tier.previousName}}` so the
+   * template editor can flag it. Templates are keyed only by
+   * (tool_id, tier_id, kind) with no tier-change kind, so one approval body
+   * serves create and change_tier alike — an optional field would therefore leak
+   * raw braces into a message an admin pastes to a colleague.
+   */
+  tier: { name: string; previousName: string } | null;
   /** Completion-only — undefined at approve time. */
   licenseCode?: string;
   /** Approver / completer's identity, for `{{approver.firstName}}` etc. */
@@ -76,6 +87,7 @@ export const KNOWN_VARIABLE_PATHS: readonly string[] = [
   "requester.email",
   "tool.name",
   "tier.name",
+  "tier.previousName",
   "licenseCode",
   "approver.name",
   "approver.firstName",

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -635,7 +635,15 @@ export type MessageTemplateInput = z.infer<typeof messageTemplateSchema>;
 // already done the vendor-side work). toolId is the derived tool, an override,
 // or the indie pick; licenseCode is enforced server-side for requires_api_key
 // tools (needs a tool lookup, so not expressible here).
-export const approveRequestSchema = z.object({
+//
+// 042: a discriminated union rather than a flat `mode` flag, deliberately.
+// loadToolAndTier runs before the transaction and hard-errors when a
+// requires_api_key tool arrives without a licenseCode — so create-only rules
+// have to be unreachable from the other modes, not merely skipped. Claude
+// Console is the only requires_api_key tool and has the deepest tier ladder,
+// i.e. exactly the upgrades a shared shape would have broken.
+const approveCreateSchema = z.object({
+  mode: z.literal("create"),
   requestId: z.number().int().positive(),
   toolId: z.number().int().positive(),
   tierId: z.number().int().positive(),
@@ -643,7 +651,38 @@ export const approveRequestSchema = z.object({
   licenseCode: z.string().min(1).max(700).optional(),
   bodyMd: z.string().min(1).max(8000),
 });
+
+// Retier the seat the requester already holds. No assignedAt: that is the
+// seat's original start and an upgrade must not rewrite it. licenseCode stays
+// optional — the stored key is preserved, but the approval message may still
+// need the token resolved for the copy-paste snippet.
+const approveChangeTierSchema = z.object({
+  mode: z.literal("change_tier"),
+  requestId: z.number().int().positive(),
+  assignmentId: z.number().int().positive(),
+  toolId: z.number().int().positive(),
+  tierId: z.number().int().positive(),
+  licenseCode: z.string().min(1).max(700).optional(),
+  bodyMd: z.string().min(1).max(8000),
+});
+
+// Approve and link an already-provisioned seat, mutating nothing. The only
+// approvable outcome for sync-managed tools (GitHub owns the entitlement), and
+// the escape hatch for the legacy v1 record-assignment path.
+const approveLinkExistingSchema = z.object({
+  mode: z.literal("link_existing"),
+  requestId: z.number().int().positive(),
+  assignmentId: z.number().int().positive(),
+  bodyMd: z.string().min(1).max(8000),
+});
+
+export const approveRequestSchema = z.discriminatedUnion("mode", [
+  approveCreateSchema,
+  approveChangeTierSchema,
+  approveLinkExistingSchema,
+]);
 export type ApproveRequestInput = z.infer<typeof approveRequestSchema>;
+export type ApproveRequestMode = ApproveRequestInput["mode"];
 
 // 032-v2: legacy migration path — attach the missing assignment to a request
 // approved under v1 semantics (status approved, assignment_id NULL). No

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -696,6 +696,19 @@ export const recordAssignmentSchema = z.object({
 });
 export type RecordAssignmentInput = z.infer<typeof recordAssignmentSchema>;
 
+// 042: the legacy record-assignment path's missing case. recordAssignment can
+// only CREATE, so a v1-approved request whose requester already holds the tool
+// was permanently stuck — the create hits the duplicate-seat guard, and
+// approveRequest cannot help because it requires status='pending_review' while
+// this row is already 'approved'. This links the seat that already exists.
+export const linkExistingAssignmentSchema = z.object({
+  requestId: z.number().int().positive(),
+  assignmentId: z.number().int().positive(),
+});
+export type LinkExistingAssignmentInput = z.infer<
+  typeof linkExistingAssignmentSchema
+>;
+
 export const rejectRequestSchema = z.object({
   requestId: z.number().int().positive(),
   decisionNote: z.string().min(1).max(2000),

--- a/tests/integration/actions/license-requests.test.ts
+++ b/tests/integration/actions/license-requests.test.ts
@@ -61,7 +61,10 @@ async function seedRequest(
       teamsChatId: "ch",
       ...overrides,
     })
-    .returning({ id: licenseRequests.id, requesterEmail: licenseRequests.requesterEmail });
+    .returning({
+      id: licenseRequests.id,
+      requesterEmail: licenseRequests.requesterEmail,
+    });
   createdRequestIds.push(row.id);
   createdUserEmails.push(row.requesterEmail);
   return row;
@@ -130,6 +133,7 @@ describe("approveRequest (032-v2)", () => {
   it("creates user + assignment + approved status in one action", async () => {
     const req = await seedRequest();
     const result = await approveRequest({
+      mode: "create" as const,
       requestId: req.id,
       toolId: seatToolId,
       tierId: seatTierId,
@@ -170,6 +174,7 @@ describe("approveRequest (032-v2)", () => {
     createdUserEmails.push(email);
     const first = await seedRequest({ requesterEmail: email });
     const firstResult = await approveRequest({
+      mode: "create" as const,
       requestId: first.id,
       toolId: seatToolId,
       tierId: seatTierId,
@@ -180,6 +185,7 @@ describe("approveRequest (032-v2)", () => {
 
     const second = await seedRequest({ requesterEmail: email });
     const secondResult = await approveRequest({
+      mode: "create" as const,
       requestId: second.id,
       toolId: seatToolId,
       tierId: seatTierId,
@@ -201,6 +207,7 @@ describe("approveRequest (032-v2)", () => {
     const req = await seedRequest();
     const attempt = () =>
       approveRequest({
+        mode: "create" as const,
         requestId: req.id,
         toolId: seatToolId,
         tierId: seatTierId,
@@ -236,6 +243,7 @@ describe("approveRequest (032-v2)", () => {
     });
 
     const withoutKey = await approveRequest({
+      mode: "create" as const,
       requestId: req.id,
       toolId: keyToolId,
       tierId: keyTierId,
@@ -245,6 +253,7 @@ describe("approveRequest (032-v2)", () => {
     expect(withoutKey.success).toBe(false);
 
     const withKey = await approveRequest({
+      mode: "create" as const,
       requestId: req.id,
       toolId: keyToolId,
       tierId: keyTierId,
@@ -291,6 +300,187 @@ describe("approveRequest (032-v2)", () => {
     if (revealed.success) {
       expect(revealed.data.bodyMd).toContain("sk-test-abc123");
     }
+  });
+});
+
+/**
+ * Spec 042 — "the requester already holds this tool" is a normal outcome now,
+ * not an error. These run against the real DB because the thing worth proving is
+ * that the row is mutated IN PLACE: same id, same assigned_at, key intact, one
+ * active row. A mocked test can assert the call shape but not the end state.
+ *
+ * Note: the double-counting property that motivates in-place mutation is pinned
+ * by tests/unit/assignment-tier-change.test.ts, NOT here — the integration job
+ * is commented out in CI (.github/workflows/ci.yml), so it cannot gate a merge.
+ */
+describe("approveRequest tier changes (042)", () => {
+  /** Approve a fresh request as a create, returning the seat it made. */
+  async function seedActiveSeat(email: string, tierId = seatTierId) {
+    const req = await seedRequest({ requesterEmail: email });
+    const result = await approveRequest({
+      mode: "create" as const,
+      requestId: req.id,
+      toolId: seatToolId,
+      tierId,
+      assignedAt: "2026-07-09",
+      bodyMd: "initial",
+    });
+    if (!result.success) throw new Error(`seed failed: ${result.error}`);
+    return result.data.assignmentId;
+  }
+
+  /** A second tier on the seat tool, or null when the tool has only one. */
+  async function otherTierId(): Promise<number | null> {
+    const tiers = await db
+      .select({ id: accessTiers.id })
+      .from(accessTiers)
+      .where(and(eq(accessTiers.toolId, seatToolId), eq(accessTiers.isActive, true)));
+    return tiers.find((t) => t.id !== seatTierId)?.id ?? null;
+  }
+
+  it("retiers the existing seat in place, preserving id and assigned_at", async () => {
+    const target = await otherTierId();
+    if (target === null) {
+      console.warn("Seat tool has only one active tier — skipping");
+      return;
+    }
+    const email = `${RUN_TAG}-retier@test.local`;
+    createdUserEmails.push(email);
+    const assignmentId = await seedActiveSeat(email);
+
+    const before = await db.query.licenseAssignments.findFirst({
+      where: eq(licenseAssignments.id, assignmentId),
+    });
+
+    const second = await seedRequest({ requesterEmail: email });
+    const result = await approveRequest({
+      mode: "change_tier" as const,
+      requestId: second.id,
+      assignmentId,
+      toolId: seatToolId,
+      tierId: target,
+      bodyMd: "Moved you to {{tier.name}} from {{tier.previousName}}.",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    // Same row — not a new one.
+    expect(result.data.assignmentId).toBe(assignmentId);
+
+    const after = await db.query.licenseAssignments.findFirst({
+      where: eq(licenseAssignments.id, assignmentId),
+    });
+    expect(after?.tierId).toBe(target);
+    expect(after?.status).toBe("active");
+    // The seat's start date is history, not something an upgrade rewrites.
+    expect(after?.assignedAt.getTime()).toBe(before!.assignedAt.getTime());
+    expect(after?.apiKeyEncrypted).toBe(before!.apiKeyEncrypted);
+    // Cost follows the new tier (spec 037's convention for active rows).
+    const tier = await db.query.accessTiers.findFirst({
+      where: eq(accessTiers.id, target),
+    });
+    expect(after?.costAtAssignmentCents).toBe(tier!.monthlyCostCents);
+
+    // Exactly one active row for this user+tool — no supersede, no duplicate.
+    const active = await db
+      .select({ id: licenseAssignments.id })
+      .from(licenseAssignments)
+      .where(
+        and(
+          eq(licenseAssignments.userId, after!.userId),
+          eq(licenseAssignments.toolId, seatToolId),
+          eq(licenseAssignments.status, "active"),
+        ),
+      );
+    expect(active).toHaveLength(1);
+
+    const row = await db.query.licenseRequests.findFirst({
+      where: eq(licenseRequests.id, second.id),
+    });
+    expect(row?.status).toBe("approved");
+    expect(row?.assignmentId).toBe(assignmentId);
+    // {{tier.previousName}} must resolve, never survive as literal braces.
+    expect(row?.approvalMessageMd).not.toContain("{{tier.previousName}}");
+  });
+
+  it("approves and links without mutating anything in link_existing mode", async () => {
+    const email = `${RUN_TAG}-link@test.local`;
+    createdUserEmails.push(email);
+    const assignmentId = await seedActiveSeat(email);
+    const before = await db.query.licenseAssignments.findFirst({
+      where: eq(licenseAssignments.id, assignmentId),
+    });
+
+    const second = await seedRequest({ requesterEmail: email });
+    const result = await approveRequest({
+      mode: "link_existing" as const,
+      requestId: second.id,
+      assignmentId,
+      bodyMd: "Your existing seat covers this.",
+    });
+    expect(result.success).toBe(true);
+
+    const after = await db.query.licenseAssignments.findFirst({
+      where: eq(licenseAssignments.id, assignmentId),
+    });
+    expect(after?.tierId).toBe(before!.tierId);
+    expect(after?.costAtAssignmentCents).toBe(before!.costAtAssignmentCents);
+    expect(after?.updatedAt.getTime()).toBe(before!.updatedAt.getTime());
+
+    const row = await db.query.licenseRequests.findFirst({
+      where: eq(licenseRequests.id, second.id),
+    });
+    expect(row?.status).toBe("approved");
+    expect(row?.assignmentId).toBe(assignmentId);
+  });
+
+  it("still refuses a create when the requester already holds the tool", async () => {
+    const email = `${RUN_TAG}-dup2@test.local`;
+    createdUserEmails.push(email);
+    await seedActiveSeat(email);
+
+    const second = await seedRequest({ requesterEmail: email });
+    const result = await approveRequest({
+      mode: "create" as const,
+      requestId: second.id,
+      toolId: seatToolId,
+      tierId: seatTierId,
+      assignedAt: "2026-07-09",
+      bodyMd: "ok",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toContain("already has an active assignment");
+
+    const row = await db.query.licenseRequests.findFirst({
+      where: eq(licenseRequests.id, second.id),
+    });
+    expect(row?.status).toBe("pending_review");
+  });
+
+  it("refuses a retier onto another user's assignment", async () => {
+    const ownerEmail = `${RUN_TAG}-owner@test.local`;
+    createdUserEmails.push(ownerEmail);
+    const ownerAssignmentId = await seedActiveSeat(ownerEmail);
+
+    // A different requester pointing at someone else's seat.
+    const stranger = await seedRequest();
+    const result = await approveRequest({
+      mode: "change_tier" as const,
+      requestId: stranger.id,
+      assignmentId: ownerAssignmentId,
+      toolId: seatToolId,
+      tierId: seatTierId,
+      bodyMd: "nope",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toContain("different user");
+
+    const row = await db.query.licenseRequests.findFirst({
+      where: eq(licenseRequests.id, stranger.id),
+    });
+    expect(row?.status).toBe("pending_review");
   });
 });
 

--- a/tests/integration/actions/license-requests.test.ts
+++ b/tests/integration/actions/license-requests.test.ts
@@ -10,6 +10,7 @@ import {
   aiTools,
   accessTiers,
   users,
+  changeHistory,
 } from "@/lib/db/schema";
 import { and, eq, inArray, like } from "drizzle-orm";
 import { decryptApiKey } from "@/lib/crypto";
@@ -125,6 +126,12 @@ afterAll(async () => {
       .where(inArray(licenseRequests.id, createdRequestIds));
   }
   if (userIds.length > 0) {
+    // 042: change_history.changed_by is onDelete RESTRICT, and approving as a
+    // tier change now writes audit rows attributed to the test admin — so the
+    // users delete below fails with a FK violation unless these go first.
+    await db
+      .delete(changeHistory)
+      .where(inArray(changeHistory.changedBy, userIds));
     await db.delete(users).where(inArray(users.id, userIds));
   }
 });
@@ -399,8 +406,15 @@ describe("approveRequest tier changes (042)", () => {
     });
     expect(row?.status).toBe("approved");
     expect(row?.assignmentId).toBe(assignmentId);
-    // {{tier.previousName}} must resolve, never survive as literal braces.
-    expect(row?.approvalMessageMd).not.toContain("{{tier.previousName}}");
+    // bodyMd is stored VERBATIM — approveRequest never renders templates. The
+    // approval dialog renders and passes the finished markdown (and deliberately
+    // leaves {{licenseCode}} unresolved so the key never lands in the DB; see the
+    // requires_api_key test above). Binding {{tier.previousName}} is therefore a
+    // client concern, covered by tests/unit/license-requests/render-template.test.ts
+    // — asserting it here would be testing the wrong layer.
+    expect(row?.approvalMessageMd).toBe(
+      "Moved you to {{tier.name}} from {{tier.previousName}}.",
+    );
   });
 
   it("approves and links without mutating anything in link_existing mode", async () => {

--- a/tests/unit/actions/assignment-tier-change.test.ts
+++ b/tests/unit/actions/assignment-tier-change.test.ts
@@ -7,7 +7,7 @@ const {
   mockTx,
   mockRequireAdmin,
   mockIsSyncManagedTool,
-  mockGetSyncManagedToolId,
+  mockIsCopilotSyncActive,
   mockRecordUpdate,
 } = vi.hoisted(() => {
   const mockTx = {
@@ -32,7 +32,7 @@ const {
     mockTx,
     mockRequireAdmin: vi.fn(),
     mockIsSyncManagedTool: vi.fn(),
-    mockGetSyncManagedToolId: vi.fn(),
+    mockIsCopilotSyncActive: vi.fn(),
     mockRecordUpdate: vi.fn(),
   };
 });
@@ -47,8 +47,11 @@ vi.mock("@/actions/history", () => ({
   recordStatusChange: vi.fn(),
 }));
 vi.mock("@/lib/assignments/sync-authority", () => ({
+  // Name-based since the 042 simplify pass — callers already hold the tool row,
+  // so an id-based lookup meant a redundant ai_tools query.
   isSyncManagedTool: mockIsSyncManagedTool,
-  getSyncManagedToolId: mockGetSyncManagedToolId,
+  isCopilotSyncActive: mockIsCopilotSyncActive,
+  isSyncManagedToolName: (name: string) => name === "GitHub Copilot",
 }));
 vi.mock("@/lib/crypto", () => ({
   encryptApiKey: vi.fn(async (s: string) => `enc:${s}`),
@@ -103,7 +106,13 @@ function baseAssignment(overrides: Record<string, unknown> = {}) {
     costAtAssignmentCents: 2500,
     revokedAt: null,
     updatedAt: new Date("2026-01-01T00:00:00Z"),
-    tool: { id: 2, createdAt: new Date("2024-01-01T00:00:00Z") },
+    // name matters since the 042 simplify pass: the sync gate is checked against
+    // the tool name the action already has in hand, not a second id lookup.
+    tool: {
+      id: 2,
+      name: "GitHub Copilot",
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    },
     user: { id: 3 },
     ...overrides,
   };
@@ -114,6 +123,7 @@ describe("updateAssignment", () => {
     vi.clearAllMocks();
     mockRequireAdmin.mockResolvedValue(ADMIN);
     mockIsSyncManagedTool.mockResolvedValue(false);
+    mockIsCopilotSyncActive.mockResolvedValue(false);
   });
 
   it("non-admin: Unauthorized, and the DB is never touched", async () => {
@@ -186,7 +196,7 @@ describe("updateAssignment", () => {
     const result = await updateAssignment({ id: 100, tierId: 6 });
 
     expect(result).toEqual({ success: false, error: SYNC_MANAGED_TIER_ERROR });
-    expect(mockIsSyncManagedTool).toHaveBeenCalledWith(2);
+    expect(mockIsSyncManagedTool).toHaveBeenCalledWith("GitHub Copilot");
     expect(mockDb.transaction).not.toHaveBeenCalled();
   });
 
@@ -356,7 +366,7 @@ describe("approveRequest", () => {
       isActive: true,
       monthlyCostCents: 5000,
     });
-    mockIsSyncManagedTool.mockResolvedValue(true);
+    mockIsCopilotSyncActive.mockResolvedValue(true);
 
     const result = await approveRequest({
       mode: "change_tier",

--- a/tests/unit/actions/assignment-tier-change.test.ts
+++ b/tests/unit/actions/assignment-tier-change.test.ts
@@ -1,0 +1,533 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const {
+  mockDb,
+  mockTx,
+  mockRequireAdmin,
+  mockIsSyncManagedTool,
+  mockGetSyncManagedToolId,
+  mockRecordUpdate,
+} = vi.hoisted(() => {
+  const mockTx = {
+    query: {
+      licenseAssignments: { findFirst: vi.fn() },
+      users: { findFirst: vi.fn() },
+    },
+    insert: vi.fn(),
+    update: vi.fn(),
+  };
+  const mockDb = {
+    query: {
+      licenseAssignments: { findFirst: vi.fn() },
+      accessTiers: { findFirst: vi.fn() },
+      aiTools: { findFirst: vi.fn() },
+      licenseRequests: { findFirst: vi.fn() },
+    },
+    transaction: vi.fn(async (cb: (tx: typeof mockTx) => unknown) => cb(mockTx)),
+  };
+  return {
+    mockDb,
+    mockTx,
+    mockRequireAdmin: vi.fn(),
+    mockIsSyncManagedTool: vi.fn(),
+    mockGetSyncManagedToolId: vi.fn(),
+    mockRecordUpdate: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/auth-helpers", () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/actions/history", () => ({
+  recordCreation: vi.fn(),
+  recordUpdate: mockRecordUpdate,
+  recordStatusChange: vi.fn(),
+}));
+vi.mock("@/lib/assignments/sync-authority", () => ({
+  isSyncManagedTool: mockIsSyncManagedTool,
+  getSyncManagedToolId: mockGetSyncManagedToolId,
+}));
+vi.mock("@/lib/crypto", () => ({
+  encryptApiKey: vi.fn(async (s: string) => `enc:${s}`),
+  decryptApiKey: vi.fn(async (s: string) => s),
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+import { updateAssignment } from "@/actions/assignments";
+import { approveRequest } from "@/actions/license-requests";
+import { licenseAssignments, licenseRequests } from "@/lib/db/schema";
+import { SYNC_MANAGED_TIER_ERROR } from "@/lib/assignments/tier-change";
+
+/**
+ * Spec 042. Covers the two real call sites of the shared tier-change rules
+ * (buildTierChange is unit-tested directly in tests/unit/assignment-tier-change.test.ts):
+ * updateAssignment's in-place retier branch, and approveRequest's mode matrix
+ * (create / change_tier / link_existing).
+ */
+
+// Chainable tx/db.update(...).set(...).where(...).returning(...) mock, shared by
+// updateAssignment's retier write and approveRequest's licenseRequests /
+// licenseAssignments writes — all three follow the same shape.
+function chainedUpdateReturning(returningValue: unknown[]) {
+  const returning = vi.fn().mockResolvedValue(returningValue);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  return { update: { set }, set, where, returning };
+}
+
+// tx.insert(users).values(...).onConflictDoNothing().returning(...) — the
+// shape ensureRequesterUser needs.
+function chainedInsertUsers(returningValue: Array<{ id: number }>) {
+  const returning = vi.fn().mockResolvedValue(returningValue);
+  const onConflictDoNothing = vi.fn().mockReturnValue({ returning });
+  const values = vi.fn().mockReturnValue({ onConflictDoNothing });
+  return { insert: { values }, values, onConflictDoNothing, returning };
+}
+
+const ADMIN = { id: "1", role: "admin" };
+
+function baseAssignment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 100,
+    userId: 3,
+    toolId: 2,
+    tierId: 5,
+    status: "active",
+    assignedAt: new Date("2026-01-01T00:00:00Z"),
+    workspace: null,
+    apiKeyEncrypted: null,
+    costAtAssignmentCents: 2500,
+    revokedAt: null,
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    tool: { id: 2, createdAt: new Date("2024-01-01T00:00:00Z") },
+    user: { id: 3 },
+    ...overrides,
+  };
+}
+
+describe("updateAssignment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(ADMIN);
+    mockIsSyncManagedTool.mockResolvedValue(false);
+  });
+
+  it("non-admin: Unauthorized, and the DB is never touched", async () => {
+    mockRequireAdmin.mockResolvedValue(null);
+
+    const result = await updateAssignment({ id: 100, tierId: 5 });
+
+    expect(result).toEqual({ success: false, error: "Unauthorized" });
+    expect(mockDb.query.licenseAssignments.findFirst).not.toHaveBeenCalled();
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it("inactive assignment: refuses the edit", async () => {
+    mockDb.query.licenseAssignments.findFirst.mockResolvedValue(
+      baseAssignment({ status: "inactive" }),
+    );
+
+    const result = await updateAssignment({ id: 100, tierId: 5 });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Cannot edit an inactive assignment",
+    });
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it("tierId from a different tool (or inactive): 'Tier not found or not available for this tool'", async () => {
+    mockDb.query.licenseAssignments.findFirst.mockResolvedValue(baseAssignment());
+    // The toolId + isActive predicates are baked into the query itself; a tier
+    // that fails either comes back as undefined, same as "doesn't exist".
+    mockDb.query.accessTiers.findFirst.mockResolvedValue(undefined);
+
+    const result = await updateAssignment({ id: 100, tierId: 999 });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Tier not found or not available for this tool",
+    });
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it("current tierId resubmitted with no other changes: success, no update, no history write", async () => {
+    mockDb.query.licenseAssignments.findFirst.mockResolvedValue(baseAssignment());
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 5,
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 2500,
+    });
+
+    const result = await updateAssignment({ id: 100, tierId: 5 });
+
+    expect(result).toEqual({ success: true, data: undefined });
+    // Same tier short-circuits before the sync-authority check even runs.
+    expect(mockIsSyncManagedTool).not.toHaveBeenCalled();
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockRecordUpdate).not.toHaveBeenCalled();
+  });
+
+  it("a real tier change on a sync-managed tool: refused with SYNC_MANAGED_TIER_ERROR", async () => {
+    mockDb.query.licenseAssignments.findFirst.mockResolvedValue(baseAssignment());
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 6,
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 5000,
+    });
+    mockIsSyncManagedTool.mockResolvedValue(true);
+
+    const result = await updateAssignment({ id: 100, tierId: 6 });
+
+    expect(result).toEqual({ success: false, error: SYNC_MANAGED_TIER_ERROR });
+    expect(mockIsSyncManagedTool).toHaveBeenCalledWith(2);
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Regression guard: the detail form always submits tierId, even when the
+   * admin only meant to edit workspace/API key. If the sync-managed check ran
+   * unconditionally (rather than only when the tier actually differs), this
+   * would be wrongly refused too.
+   */
+  it("same tierId + a workspace change on a sync-managed tool: succeeds", async () => {
+    mockDb.query.licenseAssignments.findFirst.mockResolvedValue(baseAssignment());
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 5,
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 2500,
+    });
+    // Prove the short-circuit, not just its effect: even a tool the sync
+    // authority would otherwise refuse must never be consulted here.
+    mockIsSyncManagedTool.mockResolvedValue(true);
+    mockTx.update.mockReturnValueOnce(chainedUpdateReturning([{ id: 100 }]).update);
+
+    const result = await updateAssignment({
+      id: 100,
+      tierId: 5,
+      workspace: "new-workspace",
+    });
+
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(mockIsSyncManagedTool).not.toHaveBeenCalled();
+    expect(mockTx.update).toHaveBeenCalledWith(licenseAssignments);
+    expect(mockRecordUpdate).toHaveBeenCalledWith(
+      "license_assignment",
+      100,
+      1,
+      expect.objectContaining({ workspace: { old: null, new: "new-workspace" } }),
+      mockTx,
+    );
+  });
+
+  it("race guard: a zero-row conditional UPDATE reports the changed-while-editing error, not success", async () => {
+    mockDb.query.licenseAssignments.findFirst.mockResolvedValue(baseAssignment());
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 6,
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 5000,
+    });
+    mockIsSyncManagedTool.mockResolvedValue(false);
+    // The row moved out from under the WHERE predicate — returning() yields [].
+    mockTx.update.mockReturnValueOnce(chainedUpdateReturning([]).update);
+
+    const result = await updateAssignment({ id: 100, tierId: 6 });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "This assignment changed while you were editing it. Refresh and try again.",
+    });
+    expect(mockRecordUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("approveRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(ADMIN);
+    mockIsSyncManagedTool.mockResolvedValue(false);
+  });
+
+  function baseRequest(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 50,
+      status: "pending_review",
+      requesterUserId: null,
+      requesterEmail: "alice@example.com",
+      requesterName: "Alice",
+      requesterRole: "developer",
+      requesterProfile: "baseline",
+      ...overrides,
+    };
+  }
+
+  function activeTargetAssignment(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 10,
+      userId: 3,
+      toolId: 2,
+      tierId: 5,
+      costAtAssignmentCents: 2500,
+      status: "active",
+      user: { id: 3, email: "alice@example.com" },
+      ...overrides,
+    };
+  }
+
+  it("mode create: duplicate active assignment throws (not returns), so the transaction rolls back", async () => {
+    mockDb.query.licenseRequests.findFirst.mockResolvedValue(baseRequest());
+    mockDb.query.aiTools.findFirst.mockResolvedValue({
+      id: 2,
+      name: "Claude Console",
+      requiresApiKey: false,
+    });
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 5,
+      name: "Standard",
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 2500,
+    });
+
+    // ensureRequesterUser: no existing hub user, so it inserts one.
+    mockTx.query.users.findFirst.mockResolvedValue(undefined);
+    mockTx.insert.mockReturnValueOnce(chainedInsertUsers([{ id: 77 }]).insert);
+    // createAssignmentInTx's duplicate-seat check finds an existing active seat.
+    mockTx.query.licenseAssignments.findFirst.mockResolvedValue({ id: 42 });
+
+    // Capture whatever the transaction callback itself does, independent of
+    // approveRequest's own .catch() — this is the only way to prove the
+    // rejection reached db.transaction (and would trigger a real ROLLBACK)
+    // rather than the duplicate-seat check merely `return`ing an error object.
+    let callbackRejection: unknown;
+    mockDb.transaction.mockImplementationOnce(
+      async (cb: (tx: typeof mockTx) => unknown) => {
+        try {
+          return await cb(mockTx);
+        } catch (err) {
+          callbackRejection = err;
+          throw err;
+        }
+      },
+    );
+
+    const result = await approveRequest({
+      mode: "create",
+      requestId: 50,
+      toolId: 2,
+      tierId: 5,
+      assignedAt: "2026-01-01",
+      bodyMd: "Approved",
+    });
+
+    expect(callbackRejection).toBeInstanceOf(Error);
+    expect((callbackRejection as Error).message).toMatch(
+      /already has an active assignment/,
+    );
+    // The auto-created user insert ran BEFORE the throw — this is exactly the
+    // write that a `return` (instead of `throw`) used to leave committed.
+    expect(mockTx.insert).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("already has an active assignment"),
+    });
+  });
+
+  it("mode change_tier on a sync-managed tool: refused before any transaction runs", async () => {
+    mockDb.query.licenseRequests.findFirst.mockResolvedValue(baseRequest());
+    mockDb.query.aiTools.findFirst.mockResolvedValue({
+      id: 2,
+      name: "GitHub Copilot",
+      requiresApiKey: false,
+    });
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 6,
+      name: "Business",
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 5000,
+    });
+    mockIsSyncManagedTool.mockResolvedValue(true);
+
+    const result = await approveRequest({
+      mode: "change_tier",
+      requestId: 50,
+      assignmentId: 10,
+      toolId: 2,
+      tierId: 6,
+      bodyMd: "Approved",
+    });
+
+    expect(result).toEqual({ success: false, error: SYNC_MANAGED_TIER_ERROR });
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it("mode change_tier where the target assignment is not active: refused", async () => {
+    mockDb.query.licenseRequests.findFirst.mockResolvedValue(baseRequest());
+    mockDb.query.aiTools.findFirst.mockResolvedValue({
+      id: 2,
+      name: "Claude Console",
+      requiresApiKey: false,
+    });
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 6,
+      name: "Premium",
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 5000,
+    });
+    mockTx.query.licenseAssignments.findFirst.mockResolvedValue(
+      activeTargetAssignment({ status: "inactive" }),
+    );
+
+    const result = await approveRequest({
+      mode: "change_tier",
+      requestId: 50,
+      assignmentId: 10,
+      toolId: 2,
+      tierId: 6,
+      bodyMd: "Approved",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("no longer active"),
+    });
+  });
+
+  it("mode change_tier where the target assignment belongs to a different user: refused", async () => {
+    mockDb.query.licenseRequests.findFirst.mockResolvedValue(baseRequest());
+    mockDb.query.aiTools.findFirst.mockResolvedValue({
+      id: 2,
+      name: "Claude Console",
+      requiresApiKey: false,
+    });
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 6,
+      name: "Premium",
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 5000,
+    });
+    mockTx.query.licenseAssignments.findFirst.mockResolvedValue(
+      activeTargetAssignment({
+        userId: 99,
+        user: { id: 99, email: "bob@example.com" },
+      }),
+    );
+
+    const result = await approveRequest({
+      mode: "change_tier",
+      requestId: 50,
+      assignmentId: 10,
+      toolId: 2,
+      tierId: 6,
+      bodyMd: "Approved",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("different user"),
+    });
+  });
+
+  /**
+   * Regression guard: a naive copy of updateAssignment's zero-diff early
+   * return would leave the request stuck in pending_review whenever the
+   * approver picks the tier the seat already has. Approval must still land —
+   * only the retier write to license_assignments is skipped.
+   */
+  it("mode change_tier with the tier the seat already has: still approves and links; licenseRequests UPDATE still runs", async () => {
+    mockDb.query.licenseRequests.findFirst.mockResolvedValue(baseRequest());
+    mockDb.query.aiTools.findFirst.mockResolvedValue({
+      id: 2,
+      name: "Claude Console",
+      requiresApiKey: false,
+    });
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 5,
+      name: "Standard",
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 2500,
+    });
+    mockTx.query.licenseAssignments.findFirst.mockResolvedValue(
+      activeTargetAssignment({ tierId: 5, costAtAssignmentCents: 2500 }),
+    );
+    mockTx.update.mockReturnValueOnce(
+      chainedUpdateReturning([{ id: 50 }]).update,
+    );
+
+    const result = await approveRequest({
+      mode: "change_tier",
+      requestId: 50,
+      assignmentId: 10,
+      toolId: 2,
+      tierId: 5,
+      bodyMd: "Approved",
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: { requestId: 50, assignmentId: 10 },
+    });
+    // Exactly one update in the transaction — licenseRequests — and it is NOT
+    // the (skipped) licenseAssignments retier.
+    expect(mockTx.update).toHaveBeenCalledTimes(1);
+    expect(mockTx.update).toHaveBeenCalledWith(licenseRequests);
+    expect(mockRecordUpdate).not.toHaveBeenCalled();
+  });
+
+  it("mode link_existing: approves and links, with NO update to license_assignments", async () => {
+    mockDb.query.licenseRequests.findFirst.mockResolvedValue(baseRequest());
+    mockTx.query.licenseAssignments.findFirst.mockResolvedValue(
+      activeTargetAssignment(),
+    );
+    mockTx.update.mockReturnValueOnce(
+      chainedUpdateReturning([{ id: 50 }]).update,
+    );
+
+    const result = await approveRequest({
+      mode: "link_existing",
+      requestId: 50,
+      assignmentId: 10,
+      bodyMd: "Approved",
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: { requestId: 50, assignmentId: 10 },
+    });
+    expect(mockTx.update).toHaveBeenCalledTimes(1);
+    expect(mockTx.update).toHaveBeenCalledWith(licenseRequests);
+    expect(mockTx.update).not.toHaveBeenCalledWith(licenseAssignments);
+  });
+
+  it("a request not in pending_review: 'Cannot approve a request in status \"...\"'", async () => {
+    mockDb.query.licenseRequests.findFirst.mockResolvedValue(
+      baseRequest({ status: "approved" }),
+    );
+
+    const result = await approveRequest({
+      mode: "link_existing",
+      requestId: 50,
+      assignmentId: 10,
+      bodyMd: "Approved",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Cannot approve a request in status "approved".',
+    });
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/actions/assignment-tier-change.test.ts
+++ b/tests/unit/actions/assignment-tier-change.test.ts
@@ -451,6 +451,50 @@ describe("approveRequest", () => {
   });
 
   /**
+   * Regression guard for a real defect caught in review (PR #125). The tier is
+   * validated against the SELECTED tool, so without an explicit check tying the
+   * assignment to that same tool, a stale dialog or crafted payload could write
+   * another tool's tier onto this seat — and slip past the sync-managed refusal,
+   * which also keys off the selected tool rather than the row's own.
+   */
+  it("mode change_tier where the assignment belongs to a different tool: refused", async () => {
+    mockDb.query.licenseRequests.findFirst.mockResolvedValue(baseRequest());
+    // Selected tool 2 with a tier that legitimately belongs to tool 2...
+    mockDb.query.aiTools.findFirst.mockResolvedValue({
+      id: 2,
+      name: "Claude Console",
+      requiresApiKey: false,
+    });
+    mockDb.query.accessTiers.findFirst.mockResolvedValue({
+      id: 6,
+      name: "Premium",
+      toolId: 2,
+      isActive: true,
+      monthlyCostCents: 5000,
+    });
+    // ...but the target assignment is for a DIFFERENT tool.
+    mockTx.query.licenseAssignments.findFirst.mockResolvedValue(
+      activeTargetAssignment({ toolId: 7 }),
+    );
+
+    const result = await approveRequest({
+      mode: "change_tier",
+      requestId: 50,
+      assignmentId: 10,
+      toolId: 2,
+      tierId: 6,
+      bodyMd: "Approved",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("different tool"),
+    });
+    // Nothing may be written to the assignment.
+    expect(mockTx.update).not.toHaveBeenCalled();
+  });
+
+  /**
    * Regression guard: a naive copy of updateAssignment's zero-diff early
    * return would leave the request stuck in pending_review whenever the
    * approver picks the tier the seat already has. Approval must still land —

--- a/tests/unit/assignment-tier-change.test.ts
+++ b/tests/unit/assignment-tier-change.test.ts
@@ -211,6 +211,45 @@ describe("per-period cost attribution — why the tier change is in-place", () =
       ).toBe(true);
     });
 
+    /**
+     * The one edge case where the two per-period readers disagree, and always
+     * have: getBudgetWithCosts counts a revocation landing on periodStart,
+     * fetchPerToolByPeriod does not. Pinned so the difference stays deliberate
+     * — it is now a parameter of one shared predicate rather than two inlined
+     * copies, and this is the only behaviour that may differ between them.
+     */
+    it("differs only on a revocation exactly at periodStart", () => {
+      const revokedAtPeriodStart = {
+        assignedAt: HELD_SINCE,
+        revokedAt: AUG_START,
+        costAtAssignmentCents: 1,
+      };
+      expect(
+        overlapsPeriod(revokedAtPeriodStart, AUG_START, AUG_END, "inclusive"),
+      ).toBe(true);
+      expect(
+        overlapsPeriod(revokedAtPeriodStart, AUG_START, AUG_END, "exclusive"),
+      ).toBe(false);
+
+      // Everywhere else the two bounds agree.
+      const stillHeld = {
+        assignedAt: HELD_SINCE,
+        revokedAt: null,
+        costAtAssignmentCents: 1,
+      };
+      for (const bound of ["inclusive", "exclusive"] as const) {
+        expect(overlapsPeriod(stillHeld, AUG_START, AUG_END, bound)).toBe(true);
+        expect(
+          overlapsPeriod(
+            { ...stillHeld, revokedAt: JUL_END },
+            AUG_START,
+            AUG_END,
+            bound,
+          ),
+        ).toBe(false);
+      }
+    });
+
     it("excludes an assignment revoked before the period opens", () => {
       expect(
         overlapsPeriod(

--- a/tests/unit/assignment-tier-change.test.ts
+++ b/tests/unit/assignment-tier-change.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildTierChange,
+  isTierChangeError,
+  isTierChangeNoop,
+  tierCostDeltaCents,
+  SYNC_MANAGED_TIER_ERROR,
+} from "@/lib/assignments/tier-change";
+import {
+  overlapsPeriod,
+  sumExpectedSpendCents,
+  type AssignmentCostWindow,
+} from "@/lib/budget-utils";
+
+/**
+ * Spec 042. These are pure-logic tests on purpose: the integration suite is not
+ * wired into CI (.github/workflows/ci.yml has the integration-tests job
+ * commented out), so anything that must *block a merge* has to live here.
+ */
+
+// Live prices, verified against production via MCP list_ai_tools.
+const CLAUDE_STANDARD = { id: 10, monthlyCostCents: 2500 };
+const CLAUDE_PREMIUM = { id: 11, monthlyCostCents: 12_500 };
+
+describe("buildTierChange", () => {
+  const activeStandardSeat = {
+    tierId: CLAUDE_STANDARD.id,
+    costAtAssignmentCents: CLAUDE_STANDARD.monthlyCostCents,
+    isSyncManaged: false,
+  };
+
+  it("moves tier and re-snapshots cost, with an audit diff for both fields", () => {
+    const outcome = buildTierChange(activeStandardSeat, CLAUDE_PREMIUM);
+
+    expect(isTierChangeNoop(outcome)).toBe(false);
+    expect(isTierChangeError(outcome)).toBe(false);
+    if (isTierChangeNoop(outcome) || isTierChangeError(outcome)) return;
+
+    expect(outcome.values).toEqual({
+      tierId: CLAUDE_PREMIUM.id,
+      costAtAssignmentCents: 12_500,
+    });
+    expect(outcome.changes).toEqual({
+      tierId: { old: CLAUDE_STANDARD.id, new: CLAUDE_PREMIUM.id },
+      costAtAssignmentCents: { old: 2500, new: 12_500 },
+    });
+  });
+
+  it("treats the same tier as a no-op, so nothing is written", () => {
+    expect(isTierChangeNoop(buildTierChange(activeStandardSeat, CLAUDE_STANDARD))).toBe(
+      true,
+    );
+  });
+
+  it("refuses a sync-managed seat, because the next cron would revert it", () => {
+    const outcome = buildTierChange(
+      { ...activeStandardSeat, isSyncManaged: true },
+      CLAUDE_PREMIUM,
+    );
+    expect(isTierChangeError(outcome)).toBe(true);
+    if (!isTierChangeError(outcome)) return;
+    expect(outcome.error).toBe(SYNC_MANAGED_TIER_ERROR);
+  });
+
+  /**
+   * Order matters. The assignment detail form always submits tierId, so if the
+   * sync-managed check ran before the no-op check, every workspace or API-key
+   * edit on a synced seat would be rejected too.
+   */
+  it("reports a no-op BEFORE refusing a sync-managed seat", () => {
+    const outcome = buildTierChange(
+      { ...activeStandardSeat, isSyncManaged: true },
+      CLAUDE_STANDARD,
+    );
+    expect(isTierChangeNoop(outcome)).toBe(true);
+    expect(isTierChangeError(outcome)).toBe(false);
+  });
+
+  it("works in both directions — the helper has no notion of up or down", () => {
+    const premiumSeat = {
+      tierId: CLAUDE_PREMIUM.id,
+      costAtAssignmentCents: CLAUDE_PREMIUM.monthlyCostCents,
+      isSyncManaged: false,
+    };
+    const outcome = buildTierChange(premiumSeat, CLAUDE_STANDARD);
+    if (isTierChangeNoop(outcome) || isTierChangeError(outcome)) {
+      throw new Error("expected a change");
+    }
+    expect(outcome.values.costAtAssignmentCents).toBe(2500);
+  });
+});
+
+describe("tierCostDeltaCents", () => {
+  it("signs the delta both ways", () => {
+    expect(tierCostDeltaCents(2500, 12_500)).toBe(10_000);
+    expect(tierCostDeltaCents(12_500, 2500)).toBe(-10_000);
+    expect(tierCostDeltaCents(2500, 2500)).toBe(0);
+  });
+
+  /**
+   * Claude Console's real ladder is not monotonic in price: indie-profile (€125)
+   * sits between boost-expert (€100) and boost-leader (€200). This is why the
+   * feature shows a signed number and never derives an "upgrade"/"downgrade"
+   * label from cost.
+   */
+  it("does not imply an entitlement ordering (Claude Console indie-profile)", () => {
+    const boostExpert = 10_000;
+    const indieProfile = 12_500;
+    const boostLeader = 20_000;
+
+    expect(tierCostDeltaCents(boostExpert, indieProfile)).toBeGreaterThan(0);
+    expect(tierCostDeltaCents(indieProfile, boostLeader)).toBeGreaterThan(0);
+    // ...yet indie-profile is not "between" expert and leader in entitlement
+    // terms at all. Price order alone cannot tell you that, hence no label.
+    expect(indieProfile).toBeGreaterThan(boostExpert);
+    expect(indieProfile).toBeLessThan(boostLeader);
+  });
+});
+
+/**
+ * The reason a tier change mutates in place instead of closing one row and
+ * opening another. Per-period expected spend attributes the FULL flat monthly
+ * tier price to every period an assignment's held-window overlaps, with no
+ * proration — so two rows spanning the switch period are both counted.
+ *
+ * This test pins that as a known property of the rejected design. If someone
+ * later "simplifies" the tier change into a deactivate+insert (as assignLicense
+ * does), the double-count assertion here is what should stop them.
+ */
+describe("per-period cost attribution — why the tier change is in-place", () => {
+  const AUG_START = new Date("2026-08-01");
+  const AUG_END = new Date("2026-08-31");
+  const JUL_START = new Date("2026-07-01");
+  const JUL_END = new Date("2026-07-31");
+  const SEP_START = new Date("2026-09-01");
+  const SEP_END = new Date("2026-09-30");
+
+  const HELD_SINCE = new Date("2026-03-10");
+  const SWITCHED_ON = new Date("2026-08-15");
+
+  /** What this spec does: one row, tier and cost mutated. */
+  const inPlace: AssignmentCostWindow[] = [
+    {
+      assignedAt: HELD_SINCE,
+      revokedAt: null,
+      costAtAssignmentCents: CLAUDE_PREMIUM.monthlyCostCents,
+    },
+  ];
+
+  /** What assignLicense does: close the old row, open a new one. */
+  const deactivateAndInsert: AssignmentCostWindow[] = [
+    {
+      assignedAt: HELD_SINCE,
+      revokedAt: SWITCHED_ON,
+      costAtAssignmentCents: CLAUDE_STANDARD.monthlyCostCents,
+    },
+    {
+      assignedAt: SWITCHED_ON,
+      revokedAt: null,
+      costAtAssignmentCents: CLAUDE_PREMIUM.monthlyCostCents,
+    },
+  ];
+
+  it("in-place bills the switch month once, at the new tier", () => {
+    expect(sumExpectedSpendCents(inPlace, AUG_START, AUG_END)).toBe(12_500);
+  });
+
+  it("deactivate+insert DOUBLE-COUNTS the switch month — one seat, two prices", () => {
+    expect(sumExpectedSpendCents(deactivateAndInsert, AUG_START, AUG_END)).toBe(
+      2500 + 12_500,
+    );
+  });
+
+  it("the double count is confined to the switch period", () => {
+    // July: the new row has not started yet.
+    expect(sumExpectedSpendCents(deactivateAndInsert, JUL_START, JUL_END)).toBe(2500);
+    // September: the old row is long revoked.
+    expect(sumExpectedSpendCents(deactivateAndInsert, SEP_START, SEP_END)).toBe(12_500);
+  });
+
+  /**
+   * The cost of the chosen design, asserted rather than merely documented:
+   * closed periods restate at the new price. deactivate+insert would have kept
+   * July at €25. This is the accepted trade-off (see plan §3) and the reason the
+   * UI discloses it at the point of change.
+   */
+  it("in-place restates already-closed periods at the new price", () => {
+    expect(sumExpectedSpendCents(inPlace, JUL_START, JUL_END)).toBe(12_500);
+    expect(sumExpectedSpendCents(deactivateAndInsert, JUL_START, JUL_END)).toBe(2500);
+  });
+
+  describe("overlapsPeriod boundaries", () => {
+    it("counts an assignment that starts on the last day of a period", () => {
+      expect(
+        overlapsPeriod(
+          { assignedAt: AUG_END, revokedAt: null, costAtAssignmentCents: 1 },
+          AUG_START,
+          AUG_END,
+        ),
+      ).toBe(true);
+    });
+
+    it("counts an assignment revoked exactly on periodStart (the >= bound)", () => {
+      expect(
+        overlapsPeriod(
+          { assignedAt: HELD_SINCE, revokedAt: AUG_START, costAtAssignmentCents: 1 },
+          AUG_START,
+          AUG_END,
+        ),
+      ).toBe(true);
+    });
+
+    it("excludes an assignment revoked before the period opens", () => {
+      expect(
+        overlapsPeriod(
+          { assignedAt: HELD_SINCE, revokedAt: JUL_END, costAtAssignmentCents: 1 },
+          AUG_START,
+          AUG_END,
+        ),
+      ).toBe(false);
+    });
+
+    it("excludes an assignment that starts after the period closes", () => {
+      expect(
+        overlapsPeriod(
+          { assignedAt: SEP_START, revokedAt: null, costAtAssignmentCents: 1 },
+          AUG_START,
+          AUG_END,
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/tests/unit/license-requests/render-template.test.ts
+++ b/tests/unit/license-requests/render-template.test.ts
@@ -11,7 +11,7 @@ const ctx: TemplateContext = {
     email: "anna.schmid@unic.com",
   },
   tool: { name: "GitHub Copilot" },
-  tier: { name: "Business" },
+  tier: { name: "Business", previousName: "" },
   licenseCode: "sk-test-1234",
   approver: { name: "Tobias Studer", firstName: "Tobias" },
   requestUrl: "https://aihub.example.com/requests/42",


### PR DESCRIPTION
## Summary

A tier-upgrade request arrived for a licence someone already held, and the Hub had no way to action it. Approving it failed outright:

> Requester already has an active assignment for this tool (assignment #N). Revoke the existing assignment first, or cancel this request.

Revoke-then-recreate wasn't a workaround — it orphans the comment thread, resets `assigned_at`, drops the stored API key, and **double-bills the person in the switch month**.

The root problem turned out not to be a missing feature but **three unreconciled implementations** of the same operation. This unifies them and makes "change the tier of an active assignment" approvable. **No schema change, no migration.**

Spec, plan and full running log: [`specs/042-assignment-tier-change/`](specs/042-assignment-tier-change/) — `implementation-plan.html` for the design, `implementation-notes.html` for the challenge pass, deviations, corrections and verification.

### Licence-request approval now has three modes

`approveRequestSchema` becomes a **discriminated union**, not a flat flag:

| mode | Requester already holds the tool | Outcome |
|---|---|---|
| `create` | no | Insert, exactly as before |
| `create` | yes | Refused (advice updated: retier instead of revoke) |
| `change_tier` | yes, manual seat | **New** — retier in place, link the request |
| `change_tier` | yes, same tier | No-op on the row, but **still** approves and links |
| `link_existing` | yes | **New** — approve and link, mutate nothing |

A union rather than a flag because `loadToolAndTier` runs *before* the transaction and unconditionally demanded an API key — so create-only rules had to be **unreachable** from the other modes, not merely skipped. Claude Console is the only `requires_api_key` tool *and* has the deepest tier ladder, i.e. exactly the upgrades a shared shape would have broken.

`link_existing` is what gives **GitHub Copilot** an approvable outcome at all: all 63 live seats are sync-managed, so a Business→Enterprise request was refused by the create guard *and* by the sync guard. Now it matches 032-v2's provision-first philosophy — upgrade the plan in GitHub, approve as linked, the tier arrives via sync.

### Why the tier change mutates in place

Per-period expected spend sums `cost_at_assignment_cents` by date overlap, flat monthly price, **no proration**. Closing one row and opening another therefore double-counts the switch period — one seat, two prices.

Both options are wrong, in different places:

| | Error | Where |
|---|---|---|
| Close old + open new | `1 period × old price` | The switch month only |
| **In place** (chosen) | `N closed periods × delta` | Every closed period the row spans |

In-place is the **larger** total error. It was chosen anyway because it is the convention this codebase already committed to — `actions/tools.ts` states it in a comment and migration `0024` backfilled production to match — and because the double count corrupts the *current* month, the figure people act on. A feature whose purpose is to reconcile three rival semantics shouldn't introduce a fourth costing model. Confirmed with the requester after the trade-off was laid out; alternatives (boundary-snapped supersede, proration, freezing expected spend at period close) are on record as deferral D-1.

### Bugs fixed along the way

- **The assignment detail page crashed for every sync-managed seat** — `Tooltip` used without a `TooltipProvider`; the assignments *table* only works because `DataTable` happens to supply one. Found by the browser pass.
- **The tier control rendered empty on every assignment** — radix resolves a `Select`'s display value from the selected *item's* children, which load asynchronously. Pre-existing, but this feature's primary control.
- **The detail page's tier `<Select>` was unguarded against Copilot sync** — an admin could change a synced seat's tier, see `[SAVED]`, and have cron silently revert it. The gate is **tool-based, not `source`-based**, because sync takes over manual rows too.
- **`loadToolAndTier` never checked `access_tiers.is_active`** — the request path could put a live seat on a deactivated tier, which both other entry points already refuse.
- **The tier write had no `status` guard** — a concurrent revoke could be retiered, corrupting the historical snapshot that revoked rows are supposed to preserve. Now a conditional UPDATE on observed `status` + `tier_id` (which doubles as an optimistic lock against the price cascade) with a zero-rows sentinel.
- **Cost invalidation was both wrong and wasteful** — it duplicated `updateTier`'s path list (already drifted) and fired on every edit, including workspace/API-key-only changes and no-ops. Now one shared list, gated on cost actually changing.
- **Dead code removed** — `getExpectedSpendForPeriod` had zero callers and carried a `status` filter the surviving readers don't, inviting a future "reconcile these two" against a function nobody read.

### Notable non-changes

Tier semantics live in one pure module (`lib/assignments/tier-change.ts`) shared by `updateAssignment` and `approveRequest`. No new action, no new dialog, and no `tier_changed_at` column — `change_history` already stores old/new `tierId` with actor and timestamp, and now backs a tier timeline on the assignment page.

## Verification

| Gate | Result |
|---|---|
| `pnpm typecheck` | clean |
| `pnpm test` | **659 passed**, 53 files (from 629) |
| `pnpm lint` / eslint on changed files | clean |
| `pnpm test:integration` (full directory) | **8 files, 56 passed**, 7 todo, 2 skipped |
| Playwright browser pass | **9/9 checks** |

Integration and browser runs were against a **branch of the real database** — 223 users, 5 tools, 309 active assignments, 27 requests, 1933 change-history rows.

**The double-count property is pinned by a *unit* test.** The overlap predicate was extracted from `getBudgetWithCosts` specifically so it runs in CI: the `integration-tests` job in `.github/workflows/ci.yml` is commented out, so an integration test could never have gated a merge. `fetchPerToolByPeriod` now shares that predicate too, with its long-standing `>` vs `>=` edge case preserved as an explicit parameter and its own test.

**Browser pass, end to end:** a real Claude seat moved Standard Seat → Premium Seat → Standard Seat (both directions); header and cost followed ($25.00 ↔ $125.00); feedback as inline `[SAVED]`, not a toast; the timeline rendered both hops attributed and dated. Confirmed directly in the database afterwards: **exactly one active row** for that user+tool, with `tierId` 5→6 and `costAtAssignmentCents` 2500→12500 written under a single timestamp. A real `copilot-sync` seat showed "Managed by sync", tier control disabled but still legible, and no re-pricing disclosure.

**Two integration-test defects the run exposed**, both fixed here: this spec's audit rows broke the suite's teardown via `change_history.changed_by`'s `onDelete RESTRICT` (the suite reported *12/12 tests passing and a failed file*); and one of my own assertions tested the wrong layer, expecting `approveRequest` to render a template it deliberately stores verbatim.

**Process:** plan → 5-lens adversarial challenge pass (2 blocking + several major findings adopted; scope roughly halved, and it disproved the plan's original costing argument) → implement → `/simplify` (4 lenses, 10 applied, 4 skipped with reasons) → verify. All logged in `implementation-notes.html`, including two claims I had to retract.

**Known limitations:** the approval dialog's three modes are covered server-side but weren't clicked through in a browser. Copilot's sync-managed path was verified as *gated*, not as an end-to-end GitHub round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
