### PR TITLE
fix(044): stop connection faults from crashing the instance and starving the pool

### DIFF
--- a/specs/044-db-connection-reliability/implementation-notes.html
+++ b/specs/044-db-connection-reliability/implementation-notes.html
@@ -124,6 +124,21 @@ uncaught after connect-timeout: NONE</pre>
     <p>A <code>_comment</code> key was added to explain the stagger, then removed: <code>vercel.json</code> is schema-validated and unknown top-level keys fail the deploy. Rationale lives in the plan doc instead.</p>
   </div>
 
+  <h2>Review pass</h2>
+  <p>PR <a href="https://github.com/unic/ai-developer-hub/pull/126">#126</a>. Sole reviewer: the GitHub Copilot review bot. One inline comment, accepted.</p>
+
+  <div class="entry ok">
+    <h3>Accepted · the reaper could out-live-run a long backfill<span class="tag ok">fixed</span></h3>
+    <p>Copilot: <i>"an active backfill that legitimately exceeds 60 minutes can be incorrectly reaped on the next cron attempt, even though the job is still running."</i></p>
+    <p>Valid, and the same hazard the challenge pass raised independently. In practice the <code>maxDuration = 300</code> added in this same PR bounds every entrypoint — cron routes and the <code>/settings/sync</code> segment that dispatches the manual trigger and backfill server actions — so no run can currently reach 60 minutes. But that made the sweep's safety rest on an <b>implicit</b> invariant: raise the ceiling later and it would silently begin reaping live backfills.</p>
+    <p>Fixed by making the invariant explicit and giving backfills their own headroom:</p>
+    <ul>
+      <li><code>SYNC_MAX_DURATION_SECONDS</code> now mirrors the route ceiling in the same module, so the margin is expressed against the thing that actually bounds a run.</li>
+      <li><code>STALE_EVENT_AFTER_MS</code> became per-operation — 1h regular (12× the ceiling), 6h backfill (72×) — and the sweep predicate is now an <code>OR</code> over <code>operationType</code>.</li>
+      <li>Two invariant tests: every cutoff must exceed 10× the ceiling, and backfill must exceed regular. These fail if someone raises <code>maxDuration</code> without revisiting the cutoffs.</li>
+    </ul>
+  </div>
+
   <h2>Verification</h2>
   <div class="scroll">
   <table>

--- a/specs/044-db-connection-reliability/implementation-notes.html
+++ b/specs/044-db-connection-reliability/implementation-notes.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Implementation Notes — Database Connection Reliability (044)</title>
+  <style>
+    :root {
+      --bg:#0b0d12; --bg-elev:#11141b; --bg-card:#161a24; --border:#232938; --border-strong:#2f3850;
+      --fg:#e7ebf3; --fg-muted:#9aa3b5; --fg-dim:#6b7488;
+      --accent:#f0a072; --accent-2:#7dd3fc; --good:#86efac; --warn:#fcd34d; --bad:#fca5a5;
+      --mono: ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+      --sans: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    }
+    * { box-sizing:border-box; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--fg); font-family:var(--sans); line-height:1.55; }
+    body { padding:48px 24px 96px; }
+    main { max-width:1000px; margin:0 auto; }
+    h1 { font-size:30px; margin:0 0 6px; letter-spacing:-0.01em; }
+    h2 { font-size:20px; margin:44px 0 4px; padding-bottom:8px; border-bottom:1px solid var(--border); }
+    h3 { font-size:15px; margin:22px 0 4px; }
+    p { margin:0 0 10px; }
+    a { color:var(--accent); }
+    code { font-family:var(--mono); font-size:0.88em; background:var(--bg-elev); padding:1px 5px; border-radius:4px; border:1px solid var(--border); }
+    .lede { color:var(--fg-muted); font-size:15.5px; max-width:80ch; }
+    .meta { color:var(--fg-dim); font-size:13px; margin-top:8px; font-family:var(--mono); }
+    .badge { display:inline-block; font-size:11px; font-family:var(--mono); padding:2px 8px; border-radius:999px; border:1px solid var(--border-strong); color:var(--fg-muted); background:var(--bg-elev); }
+    .badge.ok { color:var(--good); border-color:rgba(134,239,172,0.35); }
+    .entry { background:var(--bg-card); border:1px solid var(--border); border-radius:10px; padding:18px 20px; margin:14px 0; }
+    .entry.dd { border-left:3px solid var(--accent-2); }
+    .entry.dev { border-left:3px solid var(--warn); }
+    .entry.to { border-left:3px solid var(--accent); }
+    .entry.oq { border-left:3px solid var(--bad); }
+    .entry.ok { border-left:3px solid var(--good); }
+    .entry h3 { margin-top:0; }
+    .tag { font-family:var(--mono); font-size:10px; text-transform:uppercase; letter-spacing:0.1em; padding:2px 7px; border-radius:3px; vertical-align:middle; margin-left:8px; }
+    .tag.dd { color:var(--accent-2); border:1px solid rgba(125,211,252,0.3); }
+    .tag.dev { color:var(--warn); border:1px solid rgba(252,211,77,0.3); }
+    .tag.to { color:var(--accent); border:1px solid rgba(240,160,114,0.3); }
+    .tag.oq { color:var(--bad); border:1px solid rgba(252,165,165,0.3); }
+    .tag.ok { color:var(--good); border:1px solid rgba(134,239,172,0.3); }
+    .entry p { font-size:13.5px; color:var(--fg-muted); }
+    .entry b { color:var(--fg); }
+    ul { padding-left:20px; margin:6px 0 10px; } li { margin:3px 0; font-size:13.5px; color:var(--fg-muted); }
+    .ts { font-family:var(--mono); font-size:11px; color:var(--fg-dim); }
+    table { border-collapse:collapse; width:100%; margin:12px 0; font-size:13px; }
+    th,td { text-align:left; padding:8px 10px; border-bottom:1px solid var(--border); vertical-align:top; }
+    th { color:var(--fg-dim); font-family:var(--mono); font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
+    td { color:var(--fg-muted); }
+    td b { color:var(--fg); }
+    .scroll { overflow-x:auto; }
+    pre { background:var(--bg-elev); border:1px solid var(--border); border-radius:8px; padding:12px 14px; overflow-x:auto; font-family:var(--mono); font-size:12px; color:var(--fg-muted); }
+    footer { color:var(--fg-dim); font-size:12.5px; margin-top:56px; padding-top:20px; border-top:1px solid var(--border); font-family:var(--mono); }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Implementation Notes — 044</h1>
+  <p class="lede">Running log for the database connection reliability incident fix: how the diagnosis was grounded, what the challenge pass changed, and what was verified.</p>
+  <p class="meta">2026-08-04 · <span class="badge ok">implemented &amp; verified</span></p>
+
+  <h2>Investigation</h2>
+
+  <div class="entry dd">
+    <h3>Diagnosis grounded in production data, not inference<span class="tag dd">method</span></h3>
+    <p>Root causes were derived from Vercel runtime error groups and logs rather than from reading code and guessing. That is what dated the incident (symptoms first appear 2026-06-16/17), tied symptom A to the <code>:00</code>-past-the-hour cron collision, and <b>excluded</b> today's deploy <code>ea50404</code> as the trigger.</p>
+  </div>
+
+  <div class="entry dd">
+    <h3>The pooled-vs-direct question decided everything<span class="tag dd">key fact</span></h3>
+    <p>Whether raising <code>max</code> is safe or catastrophic depends entirely on which Neon endpoint is deployed. Resolved by extracting the host (credentials redacted) from the main checkout's <code>.env.local</code>: <code>ep-little-frost-alw6tlsf-pooler…</code>. Pooled — so raising <code>max</code> adds PgBouncer client sockets, not Postgres backends.</p>
+    <p>The same fact makes RC-3 worse: Neon's docs list session advisory locks as unsupported on exactly this endpoint.</p>
+  </div>
+
+  <h2>Challenge pass</h2>
+  <p>Five parallel code explorers (Sonnet), one plan drafter and three adversarial lenses — concurrency, correctness, blast radius (Opus, high effort). All three lenses returned <code>not-ready</code> on the draft: 5 fatal, 13 serious, 4 minor objections. Every load-bearing objection was independently verified before being accepted or rejected.</p>
+
+  <div class="entry dev">
+    <h3>Workflow defect: the incident brief never reached the agents<span class="tag dev">deviation</span></h3>
+    <p><code>args</code> was passed as a JSON-encoded <b>string</b> rather than a JSON value, so <code>args.rootCause</code> was <code>undefined</code> and every prompt interpolated the literal text "undefined". The drafting agent flagged this itself.</p>
+    <p>Impact was contained: the five explorer prompts were self-contained and code-grounded, so exploration was unaffected. The planner and challengers reasoned without symptom data — which is precisely why their conclusions were re-verified against the real logs rather than adopted.</p>
+  </div>
+
+  <div class="entry ok">
+    <h3>Objection accepted: <code>pool.on("error")</code> alone is insufficient<span class="tag ok">verified</span></h3>
+    <p>Claim: checked-out clients have no error listener. Verified by probing the vendored driver:</p>
+    <pre>_acquireClient removes idle listener: true
+_release re-attaches:                true
+query() adds its own once('error'):  false
+connect() adds its own:              false</pre>
+    <p>Worse than the objection stated — it assumed <code>query()</code> compensated; in 1.0.2 it does not. So a socket death between statements inside a <code>db.transaction()</code> had nothing listening. Also verified that <code>_acquireClient</code> removes only its <b>named</b> listener, so a listener added via <code>pool.on("connect")</code> survives checkout. Both handlers shipped.</p>
+  </div>
+
+  <div class="entry oq">
+    <h3>Objection rejected: the "null <code>ws</code>" TypeError crash<span class="tag oq">disproved</span></h3>
+    <p>The strongest fatal objection claimed the real crash was an uncaught <code>TypeError: Cannot read properties of null (reading 'close')</code> from the driver's connect-timeout path, invisible to <code>pool.on("error")</code> — and therefore that <code>max</code> must not be raised until it was neutralised.</p>
+    <p>The code path is real: <code>destroy()</code> → <code>end()</code> → <code>write(alloc(0))</code> short-circuits and synchronously calls <code>this.ws.close()</code>. But on the Node runtime <code>this.ws</code> is assigned <b>synchronously</b> inside <code>connect()</code>, which <code>newClient</code> calls immediately after arming the timer. The null window only exists on the fetch-fallback (Cloudflare Workers) path, which this app never takes.</p>
+    <p>Confirmed by direct probe against a non-routable host:</p>
+    <pre>error listeners at construction: 0
+CASE1 emit w/o listener: THREW Error - synthetic idle-client error
+CASE2 rejected: Error - Connection terminated due to connection timeout
+uncaught after connect-timeout: NONE</pre>
+    <p>The connect-timeout path rejects cleanly. Independently, no TypeError group appears in the 7-day production error aggregation, while the EventEmitter path appears 18 times. <b>Conclusion:</b> the objection's mechanism is not reachable here; the gate on raising <code>max</code> was dropped. Its secondary point — 10s is tight against a scale-to-zero compute — was accepted, hence <code>connectionTimeoutMillis: 15_000</code>.</p>
+  </div>
+
+  <div class="entry ok">
+    <h3>Objection accepted: <code>invoice-sync.ts</code> is dead code<span class="tag ok">verified</span></h3>
+    <p>The exploration dossier called it a live second advisory-lock implementation and recommended migrating it. A later lens contradicted this. Checked directly: the lock is guarded by <code>if (!dryRun)</code>, and the only caller in the repo (<code>scheduled-jobs-table.tsx:101</code>) passes <code>{ dryRun: true }</code>. Unreachable. Removed from scope entirely — this deleted a whole risky workstream.</p>
+  </div>
+
+  <div class="entry ok">
+    <h3>Objection accepted: the dashboard poll is a self-sustaining load source<span class="tag ok">adopted</span></h3>
+    <p>Not in the original diagnosis and genuinely valuable: a single stranded <code>in_progress</code> row made every open admin tab issue a real query every 5s forever, with no <code>document.hidden</code> check. Fixed both server-side (unconditional sweep) and client-side (10-minute cap plus an abandoned-id guard so the 30s loop cannot immediately re-arm on the same row).</p>
+  </div>
+
+  <div class="entry dev">
+    <h3>Scope call: the TTL lease was deferred<span class="tag dev">deviation</span></h3>
+    <p>The challenge pass argued hard for replacing the advisory lock now. Deferred deliberately — it needs a migration, and this repo has no automated migration step, so it requires a schema-first deploy verified against production. It also cannot be tested here: the worktree has no credentials, and the integration suite crashes the vitest worker without them rather than failing cleanly.</p>
+    <p>What shipped instead makes the existing lock <b>loud and self-healing</b> rather than silent: no-op releases are logged, the release is total, bookkeeping can no longer mask a real error, and stranded rows are swept. The observed manifestation of symptom A was connection starvation, which RC-1's fix addresses directly.</p>
+  </div>
+
+  <div class="entry dev">
+    <h3><code>vercel.json</code> comment reverted<span class="tag dev">deviation</span></h3>
+    <p>A <code>_comment</code> key was added to explain the stagger, then removed: <code>vercel.json</code> is schema-validated and unknown top-level keys fail the deploy. Rationale lives in the plan doc instead.</p>
+  </div>
+
+  <h2>Verification</h2>
+  <div class="scroll">
+  <table>
+    <tr><th>Check</th><th>Result</th></tr>
+    <tr><td><code>pnpm typecheck</code></td><td><b>clean</b> (baseline also clean, captured before any edit)</td></tr>
+    <tr><td><code>eslint</code> on all touched paths, <code>--max-warnings 0</code></td><td><b>clean</b></td></tr>
+    <tr><td><code>pnpm test</code></td><td><b>55 files / 672 tests passed</b> — baseline was 53/660; +12 new, no regressions</td></tr>
+    <tr><td><code>pnpm build</code></td><td><b>succeeded</b> — validates the new <code>maxDuration</code> route-segment exports</td></tr>
+    <tr><td>Mutation check on the centrepiece fix</td><td>Commenting out <code>pool.on("error")</code> fails exactly the 2 tests that assert it; restored and re-verified</td></tr>
+  </table>
+  </div>
+
+  <div class="entry ok">
+    <h3>Tests are non-vacuous by construction<span class="tag ok">method</span></h3>
+    <p>The fake Pool in <code>tests/unit/db/pool-error-handling.test.ts</code> reproduces Node's contract that an <code>'error'</code> emit with no listener <b>throws</b>. So the tests fail if the handler is removed, rather than passing on a listener count that could be satisfied by attaching to the wrong object. Verified by actually removing the fix and observing the failures.</p>
+  </div>
+
+  <div class="entry oq">
+    <h3>Not verified here<span class="tag oq">limits</span></h3>
+    <ul>
+      <li>No integration or browser pass — the worktree has no <code>.env.local</code> and no database credentials.</li>
+      <li>The <code>max: 10</code> value is reasoned, not measured. Meaningful verification is operational: watch for the disappearance of connect timeouts, plus Neon connection-count and CPU graphs, on a preview or canary before production.</li>
+      <li>Nothing here clears an advisory lock already leaked in production.</li>
+    </ul>
+  </div>
+</main>
+<footer>specs/044-db-connection-reliability · implementation-notes.html</footer>
+</body>
+</html>

--- a/specs/044-db-connection-reliability/implementation-plan.html
+++ b/specs/044-db-connection-reliability/implementation-plan.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Implementation Plan — Database Connection Reliability (044)</title>
+  <style>
+    :root {
+      --bg:#0b0d12; --bg-elev:#11141b; --bg-card:#161a24; --border:#232938; --border-strong:#2f3850;
+      --fg:#e7ebf3; --fg-muted:#9aa3b5; --fg-dim:#6b7488;
+      --accent:#f0a072; --accent-2:#7dd3fc; --good:#86efac; --warn:#fcd34d; --bad:#fca5a5;
+      --mono: ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+      --sans: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    }
+    * { box-sizing:border-box; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--fg); font-family:var(--sans); line-height:1.55; }
+    body { padding:48px 24px 96px; }
+    main { max-width:1000px; margin:0 auto; }
+    h1 { font-size:30px; margin:0 0 6px; letter-spacing:-0.01em; }
+    h2 { font-size:20px; margin:44px 0 4px; padding-bottom:8px; border-bottom:1px solid var(--border); }
+    h3 { font-size:15px; margin:22px 0 4px; }
+    p { margin:0 0 10px; }
+    a { color:var(--accent); }
+    code { font-family:var(--mono); font-size:0.88em; background:var(--bg-elev); padding:1px 5px; border-radius:4px; border:1px solid var(--border); }
+    .lede { color:var(--fg-muted); font-size:15.5px; max-width:80ch; }
+    .meta { color:var(--fg-dim); font-size:13px; margin-top:8px; font-family:var(--mono); }
+    .badge { display:inline-block; font-size:11px; font-family:var(--mono); padding:2px 8px; border-radius:999px; border:1px solid var(--border-strong); color:var(--fg-muted); background:var(--bg-elev); }
+    .badge.ok { color:var(--good); border-color:rgba(134,239,172,0.35); }
+    .entry { background:var(--bg-card); border:1px solid var(--border); border-radius:10px; padding:18px 20px; margin:14px 0; }
+    .entry.dd { border-left:3px solid var(--accent-2); }
+    .entry.dev { border-left:3px solid var(--warn); }
+    .entry.to { border-left:3px solid var(--accent); }
+    .entry.oq { border-left:3px solid var(--bad); }
+    .entry h3 { margin-top:0; }
+    .tag { font-family:var(--mono); font-size:10px; text-transform:uppercase; letter-spacing:0.1em; padding:2px 7px; border-radius:3px; vertical-align:middle; margin-left:8px; }
+    .tag.dd { color:var(--accent-2); border:1px solid rgba(125,211,252,0.3); }
+    .tag.dev { color:var(--warn); border:1px solid rgba(252,211,77,0.3); }
+    .tag.to { color:var(--accent); border:1px solid rgba(240,160,114,0.3); }
+    .tag.oq { color:var(--bad); border:1px solid rgba(252,165,165,0.3); }
+    .entry p { font-size:13.5px; color:var(--fg-muted); }
+    .entry b { color:var(--fg); }
+    ul { padding-left:20px; margin:6px 0 10px; } li { margin:3px 0; font-size:13.5px; color:var(--fg-muted); }
+    .ts { font-family:var(--mono); font-size:11px; color:var(--fg-dim); }
+    table { border-collapse:collapse; width:100%; margin:12px 0; font-size:13px; }
+    th,td { text-align:left; padding:8px 10px; border-bottom:1px solid var(--border); vertical-align:top; }
+    th { color:var(--fg-dim); font-family:var(--mono); font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
+    td { color:var(--fg-muted); }
+    td b { color:var(--fg); }
+    .scroll { overflow-x:auto; }
+    footer { color:var(--fg-dim); font-size:12.5px; margin-top:56px; padding-top:20px; border-top:1px solid var(--border); font-family:var(--mono); }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Database Connection Reliability</h1>
+  <p class="lede">Production incident fix. Three error signatures on <code>ai-developer-hub</code> traced to the shared Neon connection layer: process-killing crashes from unhandled connection faults, connection starvation from a <code>max: 1</code> pool under Fluid Compute, and a sync lock that cannot work on Neon's pooled endpoint.</p>
+  <p class="meta">Spec 044 · branch <code>worktree-044-db-connection-reliability</code> · <span class="badge ok">Challenged &amp; revised — implemented</span></p>
+
+  <h2>1. Observed symptoms</h2>
+  <p>From Vercel runtime error groups, 7-day window ending 2026-08-04.</p>
+  <div class="scroll">
+  <table>
+    <tr><th>ID</th><th>Signature</th><th>Count</th><th>Routes</th></tr>
+    <tr><td><b>A</b></td><td><code>Cron … sync failed: Failed query: SELECT pg_try_advisory_lock($1)</code></td><td>51 + 12</td><td><code>/api/sync/anthropic-api-costs</code>, <code>/api/sync/anthropic-usage</code></td></tr>
+    <tr><td><b>B</b></td><td><code>timeout exceeded when trying to connect</code> (as <code>cause</code>)</td><td>2+</td><td><code>/</code> (admin dashboard)</td></tr>
+    <tr><td><b>C</b></td><td><code>Unhandled error. ()</code> at <code>idleListener</code> → <code>exit status: 129</code></td><td>18</td><td><code>/</code>, <code>/api/mcp</code>, <code>/api/auth</code>, <code>/api/profile</code>, <code>/api/oauth/token</code></td></tr>
+  </table>
+  </div>
+  <p>Every symptom-A occurrence is timestamped at <code>:00</code>–<code>:01</code> past the hour. Today's production deploy (<code>ea50404</code>, 08:42 UTC) is not implicated: it touched no DB, pool, or dashboard code, and all routes served 200 at 10:27–10:37 before the 12:00 cron tick.</p>
+
+  <h2>2. Root causes</h2>
+
+  <div class="entry dd">
+    <h3>RC-1 · <code>max: 1</code> pool starved by concurrent work<span class="tag dd">symptom A + B</span></h3>
+    <p><code>src/lib/db/index.ts</code> constructs a module-level singleton with <code>max: 1</code>. The original design note (<code>specs/001 research.md:24</code>) justifies this as "one connection per serverless function instance" — an assumption that predates Fluid Compute, which reuses one instance across <b>concurrent</b> invocations.</p>
+    <p>Three amplifiers stack on it: both hourly crons fired at <code>0 * * * *</code>; <code>src/actions/dashboard.ts:126</code> fans out 9 concurrent queries then 3 more; <code>getAssignments()</code> (<code>src/actions/assignments.ts:637</code>) is unbounded with three lateral joins.</p>
+    <p>Evidence chain at 12:00 UTC: api-costs cron starts 12:00:41 → usage cron's <i>first</i> query fails 12:00:49 → <code>GET /</code> fails 12:00:50 and 12:01:06, all with connect timeouts.</p>
+  </div>
+
+  <div class="entry dd">
+    <h3>RC-2 · No error listener on either pool object<span class="tag dd">symptom C</span></h3>
+    <p>Verified empirically against <code>@neondatabase/serverless</code> 1.0.2. Two distinct objects, both unguarded:</p>
+    <ul>
+      <li><b>Idle clients</b> — the driver re-emits a dead socket's error onto the Pool. <code>pool.emit("error", …)</code> with no listener <b>throws synchronously</b> (confirmed by probe). This is the production stack: <code>idleListener</code> → <code>emit</code> → <code>Unhandled error</code>.</li>
+      <li><b>Checked-out clients</b> — <code>_acquireClient</code> removes the driver's idle listener on checkout, and in 1.0.2 <b>neither <code>query()</code> nor <code>connect()</code> re-attaches one</b> (probed: both false). While a query is in flight the error rejects that promise; between statements inside a <code>db.transaction()</code> there is nothing to route it to.</li>
+    </ul>
+    <p>Under Fluid Compute one uncaught exception tears down an instance serving many concurrent invocations — hence exit 129 across unrelated routes.</p>
+  </div>
+
+  <div class="entry dd">
+    <h3>RC-3 · Session advisory locks are unsupported on the pooled endpoint<span class="tag dd">latent</span></h3>
+    <p>Production <code>DATABASE_URL</code> is <code>ep-little-frost-…-pooler…</code>. Neon's connection-pooling documentation lists <b>"Session-level advisory locks"</b> under <i>Not supported with pooled connections</i> (PgBouncer <code>pool_mode=transaction</code>).</p>
+    <p>The repo already knew: <code>vitest.config.integration.mts:14</code> documents this exact failure and works around it by repointing <code>DATABASE_URL</code> at <code>DATABASE_URL_UNPOOLED</code> — but <b>only for tests</b>. Production was never protected.</p>
+    <p>So <code>withSyncLock</code>'s mutual exclusion is not merely racy across checkouts; it is structurally unreliable, and can fail in both directions (a leaked lock that blocks forever, or a re-entrant false grant on a shared session).</p>
+  </div>
+
+  <div class="entry dd">
+    <h3>RC-4 · Failures were invisible, and one stranded row generated permanent load</h3>
+    <p><code>cron-handler.ts</code> returned HTTP 200 for <b>every</b> outcome, including unexpected errors — which is why 63 cron failures over seven weeks never showed as anything but a green tick.</p>
+    <p>Separately, the sync dashboard's 5s fast poll exits only when nothing is <code>in_progress</code>, and the 30s poll re-arms it whenever it sees one. A row stranded by a killed sync therefore made <b>every open admin tab query the database every 5 seconds indefinitely</b> — and unlike the 30s loop, the fast loop did not check <code>document.hidden</code>.</p>
+  </div>
+
+  <h2>3. Changes made</h2>
+  <div class="scroll">
+  <table>
+    <tr><th>#</th><th>File</th><th>Change</th><th>Addresses</th></tr>
+    <tr><td>1</td><td><code>src/lib/db/index.ts</code></td><td><code>pool.on("error")</code> + <code>pool.on("connect", c =&gt; c.on("error"))</code></td><td>C</td></tr>
+    <tr><td>2</td><td><code>src/lib/db/index.ts</code></td><td><code>max</code> 1 → 10; <code>connectionTimeoutMillis</code> 10s → 15s</td><td>A, B</td></tr>
+    <tr><td>3</td><td><code>vercel.json</code></td><td>Stagger crons: <code>20 * * * *</code> and <code>40 6 * * *</code></td><td>A, B</td></tr>
+    <tr><td>4</td><td><code>src/lib/sync/framework.ts</code></td><td>Total release; guarded bookkeeping on <b>both</b> paths; event insert moved inside <code>try</code>; no-op-unlock detection</td><td>A</td></tr>
+    <tr><td>5</td><td><code>src/lib/sync/framework.ts</code></td><td>Unconditional stale-<code>in_progress</code> sweep (60 min cutoff, no migration)</td><td>RC-4</td></tr>
+    <tr><td>6</td><td><code>src/lib/sync/cron-handler.ts</code></td><td>409 for contention, 500 for unexpected errors</td><td>RC-4</td></tr>
+    <tr><td>7</td><td><code>sync-dashboard.tsx</code></td><td>10-minute fast-poll cap, <code>document.hidden</code> skip, abandoned-id guard against re-arming</td><td>RC-4</td></tr>
+    <tr><td>8</td><td>3 cron routes + <code>settings/sync/page.tsx</code></td><td><code>maxDuration = 300</code></td><td>A</td></tr>
+  </table>
+  </div>
+
+  <h3>Why <code>max: 10</code> is safe here</h3>
+  <p>Neon's pooler accepts <code>max_client_conn=10000</code> and sizes its server pool at <code>0.9 × max_connections</code>. Raising the client-side <code>max</code> adds sockets to PgBouncer, not Postgres backends. Had <code>DATABASE_URL</code> been the <i>direct</i> endpoint this change would be unsafe — that was the gating question, and it is resolved.</p>
+
+  <h2>4. Deliberately deferred</h2>
+  <p>The adversarial pass surfaced a wider set of real defects. These are excluded from the incident fix because each needs a migration, live database credentials, or a data audit — none of which are available in a credential-less worktree, and none of which should be entangled with a fix that needs to ship.</p>
+
+  <div class="entry to">
+    <h3>D-1 · Replace the advisory lock with a TTL row lease<span class="tag to">next</span></h3>
+    <p>A <code>sync_locks</code> table (<code>source_type</code> PK, <code>holder</code>, <code>expires_at</code>) with an atomic <code>INSERT … ON CONFLICT … WHERE expires_at &lt; now()</code> acquire and a holder-guarded release. Immune to both the scatter and re-entrancy failures of RC-3.</p>
+    <p><b>Blocked by:</b> needs migration 0030 and there is no automated migration step (<code>build</code> is <code>next build</code>; <code>db:migrate</code> is manual), so it requires a schema-first deploy verified against production before the reading code ships. Also needs the real concurrency test at <code>tests/integration/sync/lock.test.ts:22</code>, still an <code>it.todo</code>.</p>
+  </div>
+
+  <div class="entry to">
+    <h3>D-2 · Convergent writes for invoice matching<span class="tag to">money</span></h3>
+    <p><code>billed_costs</code> has no unique constraint, and invoice matching corrects via DELETE+INSERT keyed on its own snapshot. Every safety argument there rests entirely on the lock. A partial unique index on <code>(period_id, vendor_reference)</code> plus an upsert would make it safe regardless of lock behaviour. Needs a duplicate audit first, since overlapping runs may already have occurred.</p>
+  </div>
+
+  <div class="entry to">
+    <h3>D-3 · Retry once on connection-level errors</h3>
+    <p><code>idleTimeoutMillis</code> is a <code>setTimeout</code>, and timers do not advance while a Fluid instance is frozen between invocations — so the first query after a resume can still be handed a stale socket. A single retry would close this. Deferred because doing it properly means a query-layer wrapper across ~57 consumers and wants real-DB testing.</p>
+  </div>
+
+  <div class="entry to">
+    <h3>D-4 · Performance follow-ups</h3>
+    <p>Dashboard fan-out dedup (<code>getBudgetWithCosts</code> is computed three times per render); bounding <code>getAssignments()</code>; backfill resumability (a 24-month Copilot backfill cannot fit in any <code>maxDuration</code> and has no checkpoint).</p>
+  </div>
+
+  <div class="entry to">
+    <h3>D-5 · Dead code: <code>invoice-sync.ts</code> advisory lock</h3>
+    <p>Its lock is guarded by <code>if (!dryRun)</code> and the sole caller (<code>scheduled-jobs-table.tsx:101</code>) passes <code>dryRun: true</code>. Unreachable — hence excluded from the framework rewrite rather than migrated alongside it. Separate cleanup.</p>
+  </div>
+
+  <h2>5. Operational notes</h2>
+  <div class="entry oq">
+    <h3>Pre-existing leaked locks are not cleared by this change<span class="tag oq">action</span></h3>
+    <p>If an advisory lock is currently leaked on a pooler backend, nothing here releases it — it persists until that backend recycles. If a source stops syncing after deploy, a Neon compute restart is the fastest remedy.</p>
+  </div>
+  <div class="entry oq">
+    <h3>Behaviour change: cron responses<span class="tag oq">monitoring</span></h3>
+    <p>Cron endpoints now return 409/500 instead of a blanket 200. Any monitoring that asserted "cron returns 200" will start reporting the failures that were always happening. That is the point, but it should be expected rather than mistaken for a new regression.</p>
+  </div>
+</main>
+<footer>specs/044-db-connection-reliability · implementation-plan.html</footer>
+</body>
+</html>

--- a/specs/044-db-connection-reliability/implementation-plan.html
+++ b/specs/044-db-connection-reliability/implementation-plan.html
@@ -108,7 +108,7 @@
     <tr><td>2</td><td><code>src/lib/db/index.ts</code></td><td><code>max</code> 1 → 10; <code>connectionTimeoutMillis</code> 10s → 15s</td><td>A, B</td></tr>
     <tr><td>3</td><td><code>vercel.json</code></td><td>Stagger crons: <code>20 * * * *</code> and <code>40 6 * * *</code></td><td>A, B</td></tr>
     <tr><td>4</td><td><code>src/lib/sync/framework.ts</code></td><td>Total release; guarded bookkeeping on <b>both</b> paths; event insert moved inside <code>try</code>; no-op-unlock detection</td><td>A</td></tr>
-    <tr><td>5</td><td><code>src/lib/sync/framework.ts</code></td><td>Unconditional stale-<code>in_progress</code> sweep (60 min cutoff, no migration)</td><td>RC-4</td></tr>
+    <tr><td>5</td><td><code>src/lib/sync/framework.ts</code></td><td>Unconditional stale-<code>in_progress</code> sweep, per-operation cutoffs (1h regular / 6h backfill, no migration)</td><td>RC-4</td></tr>
     <tr><td>6</td><td><code>src/lib/sync/cron-handler.ts</code></td><td>409 for contention, 500 for unexpected errors</td><td>RC-4</td></tr>
     <tr><td>7</td><td><code>sync-dashboard.tsx</code></td><td>10-minute fast-poll cap, <code>document.hidden</code> skip, abandoned-id guard against re-arming</td><td>RC-4</td></tr>
     <tr><td>8</td><td>3 cron routes + <code>settings/sync/page.tsx</code></td><td><code>maxDuration = 300</code></td><td>A</td></tr>

--- a/src/app/api/sync/anthropic-api-costs/route.ts
+++ b/src/app/api/sync/anthropic-api-costs/route.ts
@@ -2,4 +2,6 @@ import { run } from "@/lib/sync/sources/anthropic-workspace";
 import { makeCronSyncRoute } from "@/lib/sync/cron-handler";
 
 export const dynamic = "force-dynamic";
+// See the note in ../anthropic-usage/route.ts.
+export const maxDuration = 300;
 export const { GET, POST } = makeCronSyncRoute(run, "Anthropic API costs");

--- a/src/app/api/sync/anthropic-usage/route.ts
+++ b/src/app/api/sync/anthropic-usage/route.ts
@@ -2,4 +2,8 @@ import { run } from "@/lib/sync/sources/anthropic-usage";
 import { makeCronSyncRoute } from "@/lib/sync/cron-handler";
 
 export const dynamic = "force-dynamic";
+// Bound the run explicitly rather than inheriting the platform default, so a
+// stuck sync has a known kill point well under the 60-minute stale-event cutoff
+// in src/lib/sync/framework.ts.
+export const maxDuration = 300;
 export const { GET, POST } = makeCronSyncRoute(run, "Anthropic usage");

--- a/src/app/api/sync/github-copilot/route.ts
+++ b/src/app/api/sync/github-copilot/route.ts
@@ -2,4 +2,6 @@ import { run } from "@/lib/sync/sources/github-copilot";
 import { makeCronSyncRoute } from "@/lib/sync/cron-handler";
 
 export const dynamic = "force-dynamic";
+// See the note in ../anthropic-usage/route.ts.
+export const maxDuration = 300;
 export const { GET, POST } = makeCronSyncRoute(run, "GitHub Copilot");

--- a/src/app/settings/sync/page.tsx
+++ b/src/app/settings/sync/page.tsx
@@ -5,6 +5,11 @@ import { redirect } from "next/navigation";
 import { SyncDashboard } from "./sync-dashboard";
 import { LoadingState, InlineSpinner } from "@/components/ui/loading-state";
 
+// The manual "Sync now" / backfill triggers are Server Actions dispatched
+// against this route segment, so the cron routes' own maxDuration does not
+// govern them — without this they run under the platform default.
+export const maxDuration = 300;
+
 export default async function SyncSettingsPage() {
   const admin = await requireAdmin();
   if (!admin) redirect("/settings");

--- a/src/app/settings/sync/sync-dashboard.tsx
+++ b/src/app/settings/sync/sync-dashboard.tsx
@@ -14,6 +14,18 @@ interface SyncDashboardProps {
   initialManualEvents: SyncEventRow[];
 }
 
+/**
+ * How long the 5s fast poll may run before giving up.
+ *
+ * The fast poll used to exit only when nothing was `in_progress`. A sync whose
+ * process died mid-run leaves that row `in_progress` permanently, so every open
+ * admin tab queried the database every 5 seconds indefinitely — a
+ * self-inflicted, self-sustaining load that outlived the sync that caused it.
+ * Server-side reaping now terminates such rows, but the client must not depend
+ * on that to stop polling.
+ */
+const MAX_FAST_POLL_MS = 10 * 60 * 1000;
+
 /** Compare previous and updated sources; returns true if any event changed. */
 function hasSourcesChanged(
   prev: SyncSourceWithLastEvent[],
@@ -38,6 +50,11 @@ export function SyncDashboard({
   const manualEvents = initialManualEvents;
   const sourcesRef = useRef(initialSources);
   const [sources, setSources] = useState(initialSources);
+  // Events we have stopped waiting on. Without this the 30s loop below would
+  // immediately re-arm fast polling on the very row the fast loop just gave up
+  // on, restoring the infinite cycle. Keyed by event id so a genuinely NEW run
+  // still re-arms.
+  const abandonedEventIdsRef = useRef<Set<number>>(new Set());
   const [isPolling, setIsPolling] = useState(() =>
     initialSources.some((s) => s.lastEvent?.outcome === "in_progress")
   );
@@ -64,7 +81,12 @@ export function SyncDashboard({
 
       if (hasSourcesChanged(sourcesRef.current, result.data)) {
         setSources(result.data);
-        if (result.data.some((s) => s.lastEvent?.outcome === "in_progress")) {
+        const hasFreshInProgress = result.data.some(
+          (s) =>
+            s.lastEvent?.outcome === "in_progress" &&
+            !abandonedEventIdsRef.current.has(s.lastEvent.id)
+        );
+        if (hasFreshInProgress) {
           setIsPolling(true);
         }
       }
@@ -77,7 +99,25 @@ export function SyncDashboard({
   useEffect(() => {
     if (!isPolling) return;
 
+    const startedAt = Date.now();
+
     const intervalId = setInterval(async () => {
+      // Background tabs contributed the same 5s query load as focused ones.
+      if (document.hidden) return;
+
+      if (Date.now() - startedAt > MAX_FAST_POLL_MS) {
+        for (const source of sourcesRef.current) {
+          if (source.lastEvent?.outcome === "in_progress") {
+            abandonedEventIdsRef.current.add(source.lastEvent.id);
+          }
+        }
+        setIsPolling(false);
+        status.error(
+          "A sync has been in progress for over 10 minutes — stopped auto-refreshing. Reload to check again."
+        );
+        return;
+      }
+
       const result = await getSyncStatus();
       if (!result.success) return;
 

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,17 +1,67 @@
-import { Pool } from "@neondatabase/serverless";
+import { Pool, type PoolClient } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-serverless";
 import * as schema from "./schema";
 import { env } from "@/lib/env";
 
 const pool = new Pool({
   connectionString: env.DATABASE_URL,
-  max: 1,
+  // DATABASE_URL is Neon's POOLED (`-pooler`) endpoint — PgBouncer in
+  // transaction mode, which fronts up to 10k client connections and sizes its
+  // own server pool at 90% of max_connections. So this number is only how many
+  // sockets ONE warm instance may open, not pressure on Postgres backends.
+  //
+  // It was 1, from the original design note ("max: 1 per serverless function
+  // instance", specs/001 research.md) — an assumption that predates Fluid
+  // Compute. Fluid reuses one instance across CONCURRENT invocations, so max:1
+  // made every concurrent request on that instance queue behind a single
+  // socket: the admin dashboard alone fans out 9 queries, and an hourly cron
+  // holding the socket pushed page renders past connectionTimeoutMillis into
+  // "timeout exceeded when trying to connect".
+  max: 10,
   // Neon's proxy closes idle websockets after a few minutes without a close
   // event reaching us — the pooled socket then looks alive but fails the next
   // query (ErrorEvent, "first page load after a pause errors"). Retire idle
   // connections early so a fresh socket is dialed instead.
   idleTimeoutMillis: 30_000,
-  connectionTimeoutMillis: 10_000,
+  // Headroom for a scale-to-zero compute: 10s is tight against a cold Neon
+  // wake, and this timer is what turns a slow dial into a request-visible
+  // failure.
+  connectionTimeoutMillis: 15_000,
+});
+
+// --- Connection-fault handling -------------------------------------------
+//
+// Both listeners below exist to stop a dead socket from killing the whole
+// process. Under Fluid Compute one instance serves many concurrent
+// invocations, so a single uncaught exception takes down every in-flight
+// request on it — that is the "Node.js process exited with exit status: 129"
+// signature seen in production.
+//
+// The two cases are genuinely different objects and BOTH are needed:
+
+// 1. IDLE clients. The driver re-emits an idle pooled client's socket error
+//    onto the Pool (`pool.emit("error", err, client)`). Node throws on an
+//    unhandled 'error' event, so with no listener this crashes the process.
+//    Verified against @neondatabase/serverless 1.0.2: a bare
+//    `pool.emit("error", new Error(...))` throws synchronously.
+//    The client is already evicted by the time we are called — the next query
+//    dials a fresh socket — so logging is the whole job.
+pool.on("error", (err: Error) => {
+  console.error("[db] idle pool client error (connection retired):", err);
+});
+
+// 2. CHECKED-OUT clients. `_acquireClient` removes the driver's own idle
+//    listener on checkout, and in 1.0.2 neither `query()` nor `connect()`
+//    re-attaches one — so a checked-out client has ZERO 'error' listeners.
+//    While a query is in flight the error rejects that query's promise, but
+//    between statements (i.e. inside a `db.transaction()`) there is nothing to
+//    route it to, and the Client emits 'error' into the void → uncaught.
+//    Attaching per-connect is safe: `_acquireClient` removes only its own
+//    named listener by reference, so this one survives checkout/release.
+pool.on("connect", (client: PoolClient) => {
+  client.on("error", (err: Error) => {
+    console.error("[db] checked-out client error:", err);
+  });
 });
 
 export const db = drizzle(pool, { schema });

--- a/src/lib/sync/cron-handler.ts
+++ b/src/lib/sync/cron-handler.ts
@@ -15,10 +15,18 @@ export function makeCronSyncRoute(runner: SyncRunner, label: string) {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (message === "Sync already in progress") {
-        return NextResponse.json({ ok: false, reason: "sync_in_progress" });
+        // 409, not 200: contention is a real outcome the caller should see.
+        // Still not an alertable failure — Vercel cron treats 4xx as handled.
+        return NextResponse.json(
+          { ok: false, reason: "sync_in_progress" },
+          { status: 409 }
+        );
       }
       console.error(`Cron ${label} sync failed:`, message);
-      return NextResponse.json({ ok: false, reason: message });
+      // 500, not 200. Every unexpected failure previously returned 200, which
+      // is why 63 cron failures over seven weeks never surfaced as anything
+      // but a healthy-looking green tick in cron monitoring.
+      return NextResponse.json({ ok: false, reason: message }, { status: 500 });
     }
   }
 

--- a/src/lib/sync/framework.ts
+++ b/src/lib/sync/framework.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { syncEvents, syncSourceTypeEnum, syncOperationTypeEnum } from "@/lib/db/schema";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, lt, sql } from "drizzle-orm";
 
 // ---------------------------------------------------------------------------
 // Types — derived from schema enums
@@ -109,13 +109,68 @@ export async function updateSyncEvent(
 // withSyncLock — advisory lock + event lifecycle
 // ---------------------------------------------------------------------------
 
+/**
+ * How long an `in_progress` row may sit before it is treated as abandoned.
+ *
+ * Deliberately far above any bounded run (cron routes cap at maxDuration =
+ * 300s) so a live sync can never be reaped out from under itself. Long
+ * admin-triggered backfills are the one thing that can legitimately exceed
+ * this; the dashboard's own poll bail-out — not this reaper — is what stops
+ * the UI spinning in that case, so erring long here costs nothing.
+ */
+const STALE_EVENT_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Terminate `in_progress` rows that no live run can still own.
+ *
+ * A sync whose process is killed mid-run (function timeout, instance eviction,
+ * a connection fault before the catch block lands) leaves its row at
+ * `in_progress` forever. That row is not merely cosmetic: the sync dashboard
+ * treats any `in_progress` source as reason to poll `getSyncStatus()` every 5s,
+ * so a single stranded row turns every open admin tab into permanent database
+ * load. Sweeping on every attempt keeps the cleanup unconditional rather than
+ * dependent on a later run of the same source succeeding.
+ */
+async function reapAbandonedEvents(sourceType: SyncSourceType): Promise<void> {
+  const cutoff = new Date(Date.now() - STALE_EVENT_AFTER_MS);
+  await db
+    .update(syncEvents)
+    .set({
+      outcome: "failed",
+      completedAt: new Date(),
+      errorMessage: "Abandoned — no completion recorded before the stale cutoff",
+    })
+    .where(
+      and(
+        eq(syncEvents.sourceType, sourceType),
+        eq(syncEvents.outcome, "in_progress"),
+        lt(syncEvents.startedAt, cutoff)
+      )
+    );
+}
+
 export async function withSyncLock(
   params: WithSyncLockParams,
   fn: (eventId: number) => Promise<SyncCounts>
 ): Promise<{ eventId: number }> {
   const lockId = hashSourceType(params.sourceType);
 
-  // Try to acquire advisory lock
+  // Unconditional, and before the lock: a stranded row must be cleared even on
+  // attempts that go on to lose the race below.
+  try {
+    await reapAbandonedEvents(params.sourceType);
+  } catch (reapErr) {
+    console.error(`[sync] failed to reap abandoned ${params.sourceType} events:`, reapErr);
+  }
+
+  // NOTE: this advisory lock is not load-bearing against Neon's pooled
+  // endpoint. PgBouncer runs in transaction mode, where Neon documents
+  // session-level advisory locks as unsupported — successive statements can
+  // land on different backends, so the unlock below may release nothing and
+  // the acquire may even succeed re-entrantly on a session that already holds
+  // it. Replacing this with a TTL row lease needs a migration and is tracked
+  // as follow-up work (see specs/044). Until then the goal here is narrower:
+  // never leak silently, and never let lock bookkeeping mask a real error.
   const lockResult = await db.execute(
     sql`SELECT pg_try_advisory_lock(${Number(lockId)})`
   );
@@ -125,51 +180,92 @@ export async function withSyncLock(
     throw new Error("Sync already in progress");
   }
 
-  // Insert in-progress event
-  const [event] = await db
-    .insert(syncEvents)
-    .values({
-      sourceType: params.sourceType,
-      operationType: params.operationType ?? "regular",
-      backfillStartDate: params.backfillStartDate
-        ? params.backfillStartDate.toISOString().split("T")[0]
-        : null,
-      triggeredBy: params.triggeredBy ?? null,
-    })
-    .returning({ id: syncEvents.id });
-
   try {
-    const counts = await fn(event.id);
+    // Inside the try: if this insert throws, the finally still releases the
+    // lock. Previously it sat between acquire and try, so a failure here
+    // stranded the lock with no release path at all.
+    const [event] = await db
+      .insert(syncEvents)
+      .values({
+        sourceType: params.sourceType,
+        operationType: params.operationType ?? "regular",
+        backfillStartDate: params.backfillStartDate
+          ? params.backfillStartDate.toISOString().split("T")[0]
+          : null,
+        triggeredBy: params.triggeredBy ?? null,
+      })
+      .returning({ id: syncEvents.id });
 
-    // Determine outcome
-    const outcome =
-      counts.errorCount > 0 && counts.createdCount + counts.updatedCount > 0
-        ? "partial"
-        : counts.errorCount > 0
-          ? "failed"
-          : "success";
+    try {
+      const counts = await fn(event.id);
 
-    await updateSyncEvent(event.id, {
-      outcome,
-      completedAt: new Date(),
-      createdCount: counts.createdCount,
-      updatedCount: counts.updatedCount,
-      skippedCount: counts.skippedCount,
-      errorCount: counts.errorCount,
-      errorMessage: counts.errorMessage ?? null,
-    });
+      // Determine outcome
+      const outcome =
+        counts.errorCount > 0 && counts.createdCount + counts.updatedCount > 0
+          ? "partial"
+          : counts.errorCount > 0
+            ? "failed"
+            : "success";
 
-    return { eventId: event.id };
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : String(err);
-    await updateSyncEvent(event.id, {
-      outcome: "failed",
-      completedAt: new Date(),
-      errorMessage: message.slice(0, 1000),
-    });
-    throw err;
+      // Best-effort: the sync itself already succeeded and its data is
+      // written. If this status write fails (typically on a dead connection),
+      // recording that must not convert a completed run into a thrown failure
+      // — the reaper above will terminate the row on the next attempt.
+      try {
+        await updateSyncEvent(event.id, {
+          outcome,
+          completedAt: new Date(),
+          createdCount: counts.createdCount,
+          updatedCount: counts.updatedCount,
+          skippedCount: counts.skippedCount,
+          errorCount: counts.errorCount,
+          errorMessage: counts.errorMessage ?? null,
+        });
+      } catch (bookkeepingErr) {
+        console.error(
+          `[sync] ${params.sourceType} succeeded but recording event ${event.id} failed:`,
+          bookkeepingErr
+        );
+      }
+
+      return { eventId: event.id };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Same reasoning inverted: a failure to record the failure must never
+      // replace the original error, which is the one worth surfacing.
+      try {
+        await updateSyncEvent(event.id, {
+          outcome: "failed",
+          completedAt: new Date(),
+          errorMessage: message.slice(0, 1000),
+        });
+      } catch (bookkeepingErr) {
+        console.error(
+          `[sync] failed to mark event ${event.id} as failed:`,
+          bookkeepingErr
+        );
+      }
+      throw err;
+    }
   } finally {
-    await db.execute(sql`SELECT pg_advisory_unlock(${Number(lockId)})`);
+    // Total: an unlock that throws must not replace the error being propagated.
+    try {
+      const releaseResult = await db.execute(
+        sql`SELECT pg_advisory_unlock(${Number(lockId)})`
+      );
+      const released = (releaseResult.rows?.[0] as Record<string, unknown>)
+        ?.pg_advisory_unlock;
+      if (released === false) {
+        console.error(
+          `[sync] advisory unlock was a no-op for ${params.sourceType} — the ` +
+            `lock was taken on a different backend session and is now leaked`
+        );
+      }
+    } catch (unlockErr) {
+      console.error(
+        `[sync] advisory unlock threw for ${params.sourceType}:`,
+        unlockErr
+      );
+    }
   }
 }

--- a/src/lib/sync/framework.ts
+++ b/src/lib/sync/framework.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { syncEvents, syncSourceTypeEnum, syncOperationTypeEnum } from "@/lib/db/schema";
-import { and, eq, lt, sql } from "drizzle-orm";
+import { and, eq, lt, or, sql } from "drizzle-orm";
 
 // ---------------------------------------------------------------------------
 // Types — derived from schema enums
@@ -110,15 +110,37 @@ export async function updateSyncEvent(
 // ---------------------------------------------------------------------------
 
 /**
- * How long an `in_progress` row may sit before it is treated as abandoned.
+ * The platform ceiling that bounds every sync entrypoint, in seconds.
  *
- * Deliberately far above any bounded run (cron routes cap at maxDuration =
- * 300s) so a live sync can never be reaped out from under itself. Long
- * admin-triggered backfills are the one thing that can legitimately exceed
- * this; the dashboard's own poll bail-out — not this reaper — is what stops
- * the UI spinning in that case, so erring long here costs nothing.
+ * Mirrors `export const maxDuration` on the three cron routes and on the
+ * `/settings/sync` segment that dispatches the manual trigger + backfill server
+ * actions. Kept here so the reaper's safety margin below is expressed against
+ * the thing that actually bounds a run, rather than as a bare number.
  */
-const STALE_EVENT_AFTER_MS = 60 * 60 * 1000;
+const SYNC_MAX_DURATION_SECONDS = 300;
+
+/**
+ * How long an `in_progress` row of each operation type may sit before it is
+ * treated as abandoned.
+ *
+ * The invariant: a cutoff MUST exceed the longest a live run of that type can
+ * possibly take, so the sweep can never terminate a row that is still being
+ * written. Every entrypoint is bounded by SYNC_MAX_DURATION_SECONDS, so these
+ * carry a large multiple of that ceiling rather than sitting just above it.
+ *
+ * Backfills are separated out deliberately: they iterate per day (Copilot) or
+ * per 31-day window (Anthropic) with external API calls per step, so they are
+ * the runs most likely to grow if that ceiling is ever raised. Sharing a single
+ * cutoff would make "raise maxDuration" silently able to start reaping live
+ * backfills.
+ */
+export const STALE_EVENT_AFTER_MS: Record<SyncOperationType, number> = {
+  regular: 60 * 60 * 1000, // 1h — 12x the ceiling
+  backfill: 6 * 60 * 60 * 1000, // 6h — 72x the ceiling
+};
+
+/** Exported for the invariant test; see STALE_EVENT_AFTER_MS. */
+export const SYNC_MAX_DURATION_MS = SYNC_MAX_DURATION_SECONDS * 1000;
 
 /**
  * Terminate `in_progress` rows that no live run can still own.
@@ -132,7 +154,7 @@ const STALE_EVENT_AFTER_MS = 60 * 60 * 1000;
  * dependent on a later run of the same source succeeding.
  */
 async function reapAbandonedEvents(sourceType: SyncSourceType): Promise<void> {
-  const cutoff = new Date(Date.now() - STALE_EVENT_AFTER_MS);
+  const now = Date.now();
   await db
     .update(syncEvents)
     .set({
@@ -144,7 +166,24 @@ async function reapAbandonedEvents(sourceType: SyncSourceType): Promise<void> {
       and(
         eq(syncEvents.sourceType, sourceType),
         eq(syncEvents.outcome, "in_progress"),
-        lt(syncEvents.startedAt, cutoff)
+        // Per-operation cutoffs — a long backfill must not be reaped on the
+        // schedule that suits a regular hourly run.
+        or(
+          and(
+            eq(syncEvents.operationType, "regular"),
+            lt(
+              syncEvents.startedAt,
+              new Date(now - STALE_EVENT_AFTER_MS.regular)
+            )
+          ),
+          and(
+            eq(syncEvents.operationType, "backfill"),
+            lt(
+              syncEvents.startedAt,
+              new Date(now - STALE_EVENT_AFTER_MS.backfill)
+            )
+          )
+        )
       )
     );
 }

--- a/tests/unit/db/pool-error-handling.test.ts
+++ b/tests/unit/db/pool-error-handling.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * Regression cover for the production crash signature
+ * "Node.js process exited with exit status: 129".
+ *
+ * The Neon driver re-emits a dead socket's error onto the Pool, and strips its
+ * own idle listener from any client that is checked out. With nothing listening
+ * in either case, Node's unhandled-'error'-event rule turns a routine
+ * connection fault into an uncaught exception — which under Fluid Compute kills
+ * an instance serving many concurrent requests.
+ *
+ * The fake emitter below deliberately reproduces that Node semantic (an 'error'
+ * emit with no listener throws), so these tests fail loudly if the handlers are
+ * removed rather than silently passing on a listener count.
+ */
+const mocks = vi.hoisted(() => {
+  type Listener = (...args: unknown[]) => void;
+
+  class Emitter {
+    private listeners: Record<string, Listener[]> = {};
+
+    on(event: string, fn: Listener): this {
+      (this.listeners[event] ??= []).push(fn);
+      return this;
+    }
+
+    listenerCount(event: string): number {
+      return this.listeners[event]?.length ?? 0;
+    }
+
+    emit(event: string, ...args: unknown[]): boolean {
+      const registered = this.listeners[event];
+      if (!registered || registered.length === 0) {
+        // Node's EventEmitter contract: an unhandled 'error' event is thrown.
+        if (event === "error") throw args[0];
+        return false;
+      }
+      for (const fn of registered) fn(...args);
+      return true;
+    }
+  }
+
+  const pools: Array<Emitter & { options: Record<string, unknown> }> = [];
+
+  class FakePool extends Emitter {
+    options: Record<string, unknown>;
+    constructor(options: Record<string, unknown>) {
+      super();
+      this.options = options;
+      pools.push(this);
+    }
+  }
+
+  return { Emitter, FakePool, pools };
+});
+
+vi.mock("@neondatabase/serverless", () => ({ Pool: mocks.FakePool }));
+vi.mock("@/lib/env", () => ({
+  env: { DATABASE_URL: "postgresql://u:p@ep-test-pooler.neon.tech/db" },
+}));
+vi.mock("drizzle-orm/neon-serverless", () => ({ drizzle: () => ({}) }));
+
+// Imported for the module side effects that register the handlers.
+import "@/lib/db";
+
+function thePool() {
+  expect(mocks.pools).toHaveLength(1);
+  return mocks.pools[0];
+}
+
+describe("db pool connection-fault handling", () => {
+  it("registers a pool-level error listener", () => {
+    expect(thePool().listenerCount("error")).toBeGreaterThan(0);
+  });
+
+  it("does not throw when the driver reports an idle client error", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Exactly what @neondatabase/serverless does on a dead idle socket.
+    expect(() =>
+      thePool().emit("error", new Error("Connection terminated unexpectedly"))
+    ).not.toThrow();
+    consoleSpy.mockRestore();
+  });
+
+  it("attaches an error listener to each newly connected client", () => {
+    const client = new mocks.Emitter();
+    thePool().emit("connect", client);
+    expect(client.listenerCount("error")).toBeGreaterThan(0);
+  });
+
+  it("does not throw when a checked-out client errors between statements", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const client = new mocks.Emitter();
+    thePool().emit("connect", client);
+    // A transaction holds one client across statements; a socket death in that
+    // window has no in-flight query promise to reject into.
+    expect(() =>
+      client.emit("error", new Error("Connection terminated unexpectedly"))
+    ).not.toThrow();
+    consoleSpy.mockRestore();
+  });
+
+  it("opens more than one connection so concurrent work cannot self-starve", () => {
+    // max:1 made every concurrent request on a warm instance queue behind a
+    // single socket, which is what produced "timeout exceeded when trying to
+    // connect" on the dashboard while a cron held the connection.
+    expect(thePool().options.max).toBeGreaterThan(1);
+  });
+});

--- a/tests/unit/sync/with-sync-lock.test.ts
+++ b/tests/unit/sync/with-sync-lock.test.ts
@@ -11,7 +11,11 @@ const dbMock = vi.hoisted(() => ({
 
 vi.mock("@/lib/db", () => ({ db: dbMock }));
 
-import { withSyncLock } from "@/lib/sync/framework";
+import {
+  withSyncLock,
+  STALE_EVENT_AFTER_MS,
+  SYNC_MAX_DURATION_MS,
+} from "@/lib/sync/framework";
 
 /** update(...).set(...).where(...) — resolves. */
 function okUpdate() {
@@ -43,6 +47,28 @@ const OK_COUNTS = {
   skippedCount: 0,
   errorCount: 0,
 };
+
+describe("stale-event cutoffs", () => {
+  // The sweep must never terminate a row a live run could still be writing.
+  // Both properties below are the invariant that makes that true; if someone
+  // raises the route ceiling without revisiting the cutoffs, this fails.
+  it("keeps every cutoff well above the platform ceiling that bounds a run", () => {
+    for (const [operation, cutoff] of Object.entries(STALE_EVENT_AFTER_MS)) {
+      expect(
+        cutoff,
+        `${operation} cutoff must exceed the ${SYNC_MAX_DURATION_MS}ms run ceiling`
+      ).toBeGreaterThan(SYNC_MAX_DURATION_MS * 10);
+    }
+  });
+
+  it("gives backfills a longer cutoff than regular runs", () => {
+    // Backfills iterate per day / per 31-day window with external calls per
+    // step, so they are the runs most likely to outlive a regular cutoff.
+    expect(STALE_EVENT_AFTER_MS.backfill).toBeGreaterThan(
+      STALE_EVENT_AFTER_MS.regular
+    );
+  });
+});
 
 describe("withSyncLock", () => {
   it("rejects when the lock is already held", async () => {

--- a/tests/unit/sync/with-sync-lock.test.ts
+++ b/tests/unit/sync/with-sync-lock.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// withSyncLock issues real queries, so the db module must be stubbed before the
+// unit under test is imported (see anthropic-sync-window.test.ts). Without this
+// the suite would dial a real connection and stall for connectionTimeoutMillis.
+const dbMock = vi.hoisted(() => ({
+  execute: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+
+import { withSyncLock } from "@/lib/sync/framework";
+
+/** update(...).set(...).where(...) — resolves. */
+function okUpdate() {
+  return { set: () => ({ where: () => Promise.resolve() }) };
+}
+
+/** update(...).set(...).where(...) — rejects, e.g. a dead connection. */
+function failingUpdate(err: Error) {
+  return { set: () => ({ where: () => Promise.reject(err) }) };
+}
+
+function insertReturning(id: number) {
+  return { values: () => ({ returning: () => Promise.resolve([{ id }]) }) };
+}
+
+const LOCK_ACQUIRED = { rows: [{ pg_try_advisory_lock: true }] };
+const UNLOCK_OK = { rows: [{ pg_advisory_unlock: true }] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: reaper + any bookkeeping write succeed.
+  dbMock.update.mockImplementation(() => okUpdate());
+  dbMock.insert.mockImplementation(() => insertReturning(42));
+});
+
+const OK_COUNTS = {
+  createdCount: 1,
+  updatedCount: 0,
+  skippedCount: 0,
+  errorCount: 0,
+};
+
+describe("withSyncLock", () => {
+  it("rejects when the lock is already held", async () => {
+    dbMock.execute.mockResolvedValueOnce({
+      rows: [{ pg_try_advisory_lock: false }],
+    });
+
+    await expect(
+      withSyncLock({ sourceType: "anthropic_api_usage" }, async () => OK_COUNTS)
+    ).rejects.toThrow("Sync already in progress");
+  });
+
+  it("sweeps abandoned events before attempting to acquire", async () => {
+    dbMock.execute.mockResolvedValueOnce({
+      rows: [{ pg_try_advisory_lock: false }],
+    });
+
+    await expect(
+      withSyncLock({ sourceType: "anthropic_api_usage" }, async () => OK_COUNTS)
+    ).rejects.toThrow("Sync already in progress");
+
+    // The sweep must be unconditional — including on attempts that then lose
+    // the race, which is the case that used to leave rows stranded forever.
+    expect(dbMock.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the lock even when the event insert fails", async () => {
+    dbMock.execute
+      .mockResolvedValueOnce(LOCK_ACQUIRED)
+      .mockResolvedValueOnce(UNLOCK_OK);
+    dbMock.insert.mockImplementation(() => ({
+      values: () => ({ returning: () => Promise.reject(new Error("insert boom")) }),
+    }));
+
+    await expect(
+      withSyncLock({ sourceType: "anthropic_api_usage" }, async () => OK_COUNTS)
+    ).rejects.toThrow("insert boom");
+
+    // execute call 2 is the unlock; previously the insert sat outside the try
+    // and a failure here stranded the lock with no release path.
+    expect(dbMock.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates the original error, not a bookkeeping failure", async () => {
+    dbMock.execute
+      .mockResolvedValueOnce(LOCK_ACQUIRED)
+      .mockResolvedValueOnce(UNLOCK_OK);
+    dbMock.update
+      .mockImplementationOnce(() => okUpdate()) // reaper
+      .mockImplementationOnce(() => failingUpdate(new Error("bookkeeping boom")));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      withSyncLock({ sourceType: "anthropic_api_usage" }, async () => {
+        throw new Error("the real cause");
+      })
+    ).rejects.toThrow("the real cause");
+
+    consoleSpy.mockRestore();
+  });
+
+  it("propagates the original error when the unlock itself throws", async () => {
+    dbMock.execute
+      .mockResolvedValueOnce(LOCK_ACQUIRED)
+      .mockRejectedValueOnce(new Error("unlock boom"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      withSyncLock({ sourceType: "anthropic_api_usage" }, async () => {
+        throw new Error("the real cause");
+      })
+    ).rejects.toThrow("the real cause");
+
+    consoleSpy.mockRestore();
+  });
+
+  it("still reports success when the completion write fails", async () => {
+    dbMock.execute
+      .mockResolvedValueOnce(LOCK_ACQUIRED)
+      .mockResolvedValueOnce(UNLOCK_OK);
+    dbMock.update
+      .mockImplementationOnce(() => okUpdate()) // reaper
+      .mockImplementationOnce(() => failingUpdate(new Error("bookkeeping boom")));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // The sync ran and its data is committed; failing to record that must not
+    // turn a completed run into a thrown failure.
+    const result = await withSyncLock(
+      { sourceType: "anthropic_api_usage" },
+      async () => OK_COUNTS
+    );
+
+    expect(result).toEqual({ eventId: 42 });
+    consoleSpy.mockRestore();
+  });
+
+  it("logs when the unlock releases nothing", async () => {
+    dbMock.execute
+      .mockResolvedValueOnce(LOCK_ACQUIRED)
+      .mockResolvedValueOnce({ rows: [{ pg_advisory_unlock: false }] });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await withSyncLock({ sourceType: "anthropic_api_usage" }, async () => OK_COUNTS);
+
+    // A no-op release means the lock was taken on a different pooler backend
+    // and is now leaked — previously silent.
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("advisory unlock was a no-op")
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/sync/github-copilot",
-      "schedule": "0 6 * * *"
+      "schedule": "40 6 * * *"
     },
     {
       "path": "/api/sync/anthropic-usage",
@@ -10,7 +10,7 @@
     },
     {
       "path": "/api/sync/anthropic-api-costs",
-      "schedule": "0 * * * *"
+      "schedule": "20 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Three production error signatures over seven weeks, all traced to the shared Neon connection layer. Diagnosed from Vercel runtime error groups rather than inference — the 2026-08-04 deploy (`ea50404`) is **not** implicated (it touched no DB, pool or dashboard code, and all routes served 200 at 10:27–10:37 before the 12:00 cron tick).

| ID | Signature | Count | Routes |
|---|---|---|---|
| A | `Cron … failed: Failed query: SELECT pg_try_advisory_lock($1)` | 63 | `/api/sync/anthropic-api-costs`, `/api/sync/anthropic-usage` |
| B | `timeout exceeded when trying to connect` | 2+ | `/` |
| C | `Unhandled error. () at idleListener` → `exit status: 129` | 18 | `/`, `/api/mcp`, `/api/auth`, `/api/profile`, `/api/oauth/token` |

Every symptom-A occurrence is timestamped `:00`–`:01` past the hour.

### Root causes

**1. `max: 1` starved by concurrent work.** Justified in `specs/001` as "one connection per serverless function instance" — an assumption predating Fluid Compute, which reuses one instance across *concurrent* invocations. Both hourly crons fired at `0 * * * *`; the admin dashboard fans out 9+3 queries. At 12:00 UTC: api-costs cron takes the socket 12:00:41 → usage cron's first query fails 12:00:49 → `GET /` fails 12:00:50 and 12:01:06.

**2. No error listener on either pool object.** Probed against `@neondatabase/serverless` 1.0.2: `pool.emit("error", …)` with no listener throws synchronously (that is signature C), and `_acquireClient` strips the idle listener while **neither `query()` nor `connect()` re-attaches one** — so a socket death between statements inside a `db.transaction()` had nothing to reject into. Under Fluid Compute one uncaught exception takes down every in-flight request on the instance.

**3. Session advisory locks are unsupported on Neon's pooled endpoint** (PgBouncer transaction mode). `DATABASE_URL` is the `-pooler` host. The repo already knew — `vitest.config.integration.mts:14` documents this exact failure and works around it **for tests only**; production was never protected.

### Changes

| # | File | Change | Addresses |
|---|---|---|---|
| 1 | `src/lib/db/index.ts` | `pool.on("error")` + `pool.on("connect", c => c.on("error"))` | C |
| 2 | `src/lib/db/index.ts` | `max` 1 → 10; `connectionTimeoutMillis` 10s → 15s | A, B |
| 3 | `vercel.json` | Stagger crons to `20 * * * *` / `40 6 * * *` | A, B |
| 4 | `src/lib/sync/framework.ts` | Total release + no-op-unlock detection; bookkeeping guarded on **both** paths; event insert moved inside `try` | A |
| 5 | `src/lib/sync/framework.ts` | Unconditional stale-`in_progress` sweep (60 min, no migration) | — |
| 6 | `src/lib/sync/cron-handler.ts` | 409 for contention, 500 for unexpected errors | — |
| 7 | `sync-dashboard.tsx` | 10-min fast-poll cap, `document.hidden` skip, abandoned-id guard | — |
| 8 | 3 cron routes + `settings/sync/page.tsx` | `maxDuration = 300` | A |

`max: 10` is safe specifically because the endpoint is pooled: PgBouncer accepts `max_client_conn=10000` and sizes its server pool at `0.9 × max_connections`, so this adds sockets to the pooler, not Postgres backends. On the *direct* endpoint it would be unsafe — that was the gating question and it is resolved.

The per-client handler attaches on `connect`, which `_acquireClient` emits **before** `removeListener("error", …)` and **only** for new clients — so it survives checkout without accumulating per checkout.

### Deferred (with reasons)

Full write-up in `specs/044-db-connection-reliability/`.

- **TTL row lease** replacing the advisory lock — needs migration 0030, and this repo has no automated migration step (`build` is `next build`; `db:migrate` is manual), so it requires a schema-first deploy verified against production, plus the concurrency test still sitting as `it.todo` at `tests/integration/sync/lock.test.ts:22`. What ships here makes the existing lock **loud and self-healing** rather than silent.
- **Convergent writes for `billed_costs`** (no unique constraint; every safety argument rests on the lock) — needs a duplicate audit first.
- **Retry-on-stale-connection**, dashboard fan-out dedup, bounding `getAssignments()`, backfill resumability.

### Operational notes

- This does **not** release an advisory lock already leaked in production. If a source stops syncing after deploy, a Neon compute restart is the fastest remedy.
- Cron endpoints now return 409/500 instead of a blanket 200. Monitoring that asserted "cron returns 200" will start reporting failures that were always happening — expected, not a new regression.

## Verification

| Check | Result |
|---|---|
| `pnpm typecheck` | clean (baseline captured clean before any edit) |
| `eslint` on touched paths, `--max-warnings 0` | clean, exit 0 |
| `pnpm test` | **55 files / 672 tests passed** — baseline 53/660, +12 new, no regressions |
| `pnpm build` | succeeded — validates the new `maxDuration` route-segment exports |
| Mutation check | commenting out `pool.on("error")` fails exactly the 2 tests asserting it |

The fake Pool in `tests/unit/db/pool-error-handling.test.ts` reproduces Node's throw-on-unhandled-`error` contract, so the tests fail on absence rather than passing on a listener count.

**Not verified here:** no integration or browser pass — the worktree has no credentials. `max: 10` is reasoned from Neon's documented pooler limits, not measured; it wants a canary with connection-count and CPU graphs before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

